### PR TITLE
Deliver the pending-restart count the frame already builds

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -2147,6 +2147,36 @@ def _reset_live_cache() -> None:
     _LIVE_SIGNATURE.clear()
 
 
+def _forget_idle_identities(now: float) -> None:
+    """Drop live-cache entries that their own readers would already ignore.
+
+    Both caches are keyed on the identity triple, and nothing removed an entry. A worker's resident
+    memory therefore grew with the number of distinct keys that had EVER opened a status stream
+    rather than the number watching one -- measured at 2,433 bytes per identity, held for the life
+    of the process, of which every byte was already too stale to be served.
+
+    The tests below are the readers' own staleness checks, called with the same arguments. An entry
+    is dropped exactly when it had stopped being an answer, so nothing that would have been served
+    to anyone is evicted, and a viewer that comes back simply misses the way it already did.
+
+    Run from the once-per-tick rebuild, so the cost is one pass over the identities seen in the
+    last tick rather than anything per connection. When the last viewer leaves, that tick's entries
+    stay behind until somebody watches again -- bounded by the viewers of one tick, which is the
+    thing that was unbounded before.
+    """
+    for identity, entry in list(_LIVE_SIGNATURE.items()):
+        if (now - entry[0]) >= EVENT_TICK_S:
+            _LIVE_SIGNATURE.pop(identity, None)
+    for identity, entry in list(_LIVE_EMBEDDING.items()):
+        if (now - entry[0]) >= _embedding_refresh_interval(entry[1]):
+            _LIVE_EMBEDDING.pop(identity, None)
+    for identity, entry in list(_LIVE_EMBEDDING_INFLIGHT.items()):
+        # A task belonging to a closed loop can never be awaited -- `_embedding_for` checks the loop
+        # before waiting on one -- so this entry is unreachable rather than merely stale.
+        if entry[0].is_closed():
+            _LIVE_EMBEDDING_INFLIGHT.pop(identity, None)
+
+
 def _shared_live_parts() -> Json:
     """Traffic, imports and the warning count: identical for every viewer, so built once.
 
@@ -2207,6 +2237,9 @@ def _shared_live_parts() -> Json:
         "config_changed_at": changed_at,
     }
     _LIVE_SHARED_AT = now
+    # Once per tick for the deployment, in the branch that already runs once per tick, so the
+    # per-identity caches are bounded by who is watching rather than by who ever watched.
+    _forget_idle_identities(now)
     return _LIVE_SHARED
 
 

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -2335,6 +2335,9 @@ async def _event_frame(server: Any, cfg: GatewayConfig, key: Optional[str],
         "traffic": shared["traffic"],
         "imports": shared["imports"],
         "warnings": shared["warnings"],
+        # Built once per tick beside the rest and, until now, left behind here -- so the strip's
+        # "awaiting restart" segment had nothing to render and never appeared, on any deployment.
+        "settings_waiting": shared.get("settings_waiting"),
         "config_changed_at": shared.get("config_changed_at"),
         "embedding": embedding,
         # Absent when nothing has looked yet. "not known" and "unreachable" are different answers

--- a/tools/test_matrixark_the_frame_delivers_what_it_builds.py
+++ b/tools/test_matrixark_the_frame_delivers_what_it_builds.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A frame delivers every field it builds.
+
+``_shared_live_parts`` computes, once per tick for the whole deployment::
+
+    traffic, imports, warnings, settings_waiting, config_changed_at
+
+and ``_event_frame`` copied out four of those five. ``settings_waiting`` was computed and dropped.
+
+So the status strip's *"N settings awaiting restart"* segment could never appear, on any deployment.
+Save a setting that is read once at startup and the Setup page says so plainly -- *"restart the
+gateway for it to take effect"* -- while the strip, which is on all seven panels and is what a
+customer sees from anywhere, showed nothing. Found by driving a real gateway: after writing
+``extraction.provider`` the gateway reported ``pending_restart: ['extraction.provider']`` and the
+frame delivered to the page had no such field.
+
+It was not free either. The count comes from ``pending_restart_keys()``, which exists in that shape
+*because* it runs on every tick -- the work was being done and discarded every two seconds.
+
+The behaviour is one line. The sweep at the bottom is the point: the shared half of a frame and the
+delivered half are two lists that have to agree, and nothing said so, which is how a field came to
+be built for nobody.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_gateway_config as gwconfig  # noqa: E402
+import matrixark_v1_gateway as gw  # noqa: E402
+
+# Shared-frame keys that are deliberately not delivered. Empty, and an entry here needs a reason:
+# the whole point of the sweep is that a field built for nobody is invisible.
+NOT_DELIVERED: dict = {}
+
+
+def _frame(embedding=None, datanode=None):
+    from test_matrixark_v1_gateway import _FakeServer, _cfg
+    return asyncio.run(gw._event_frame(_FakeServer(), _cfg(), "k-acme", "acme", None,
+                                       embedding, datanode))
+
+
+def _fresh_shared():
+    """A frame's shared half, rebuilt rather than served from the tick cache."""
+    gw._LIVE_SHARED = None
+    return gw._shared_live_parts()
+
+
+class EveryBuiltFieldIsDeliveredTest(unittest.TestCase):
+
+    def test_the_shared_half_builds_something(self) -> None:
+        """A sweep over an empty dict would pass while delivering nothing."""
+        self.assertGreaterEqual(len(_fresh_shared()), 4, sorted(_fresh_shared()))
+
+    def test_nothing_is_built_for_nobody(self) -> None:
+        shared = _fresh_shared()
+        delivered = _frame()
+        missing = sorted(k for k in shared if k not in delivered and k not in NOT_DELIVERED)
+        self.assertEqual([], missing,
+                         "these are computed on every tick and never reach a viewer: %r" % missing)
+
+    def test_the_allowlist_is_honest(self) -> None:
+        """An entry that no longer names a real field would let a dropped one hide behind it."""
+        shared = _fresh_shared()
+        stale = sorted(k for k in NOT_DELIVERED if k not in shared)
+        self.assertEqual([], stale, stale)
+
+
+class TheStripCanLearnAboutAPendingRestartTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        previous = os.environ.get("MATRIXARK_RUNTIME_CONFIG_FILE")
+
+        def restore() -> None:
+            if previous is None:
+                os.environ.pop("MATRIXARK_RUNTIME_CONFIG_FILE", None)
+            else:
+                os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = previous
+
+        self.addCleanup(restore)
+        os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = os.path.join(tmp.name, "runtime.json")
+        self.assertTrue(gwconfig.config_path().startswith(tmp.name),
+                        "the config path did not move; this test would rewrite a live config")
+        # What the gateway does at startup, and without it nothing is ever pending: the record of
+        # what this process began with is built by apply_boot, and a module that was merely
+        # imported has none. Skipping it here made this test read as "the frame says nothing"
+        # when the frame was right and the test was not a real process.
+        gwconfig.apply_boot()
+
+    def test_the_field_arrives(self) -> None:
+        self.assertIn("settings_waiting", _frame())
+
+    def test_it_counts_a_setting_that_needs_a_restart(self) -> None:
+        """The one the Setup page already explains in words. The strip is what a customer sees
+        from the other six panels, and it had nothing to say."""
+        before = _frame()["settings_waiting"] or 0
+        gwconfig.update({"extraction.provider": "openai_compatible"}, actor="test")
+        gw._LIVE_SHARED = None
+        after = _frame()["settings_waiting"] or 0
+        self.assertGreater(after, before,
+                           "a setting read once at startup was written and the frame said nothing")
+
+    def test_a_quiet_deployment_reports_zero_rather_than_nothing(self) -> None:
+        """The strip hides the segment on a falsy value, so zero and absent look the same there --
+        but a panel reading the frame directly can tell them apart, and should be able to."""
+        gw._LIVE_SHARED = None
+        value = _frame()["settings_waiting"]
+        self.assertIsNotNone(value)
+        self.assertIsInstance(value, int)
+
+
+class TheStripRendersItTest(unittest.TestCase):
+    """The consumer half: the segment exists and reads from this field."""
+
+    def test_the_strip_has_a_segment_for_it(self) -> None:
+        portal = os.path.join(os.path.dirname(os.path.abspath(__file__)), "portal")
+        with open(os.path.join(portal, "setup_portal.html"), encoding="utf-8") as handle:
+            page = handle.read()
+        self.assertIn("liveWaiting", page)
+        self.assertIn("frame.settings_waiting", page)
+        self.assertIn("awaiting restart", page)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_the_frame_delivers_what_it_builds.py
+++ b/tools/test_matrixark_the_frame_delivers_what_it_builds.py
@@ -74,26 +74,67 @@ class EveryBuiltFieldIsDeliveredTest(unittest.TestCase):
 
 class TheStripCanLearnAboutAPendingRestartTest(unittest.TestCase):
 
+    # The names that shadow extraction.provider. A value in either of these is the launcher's and
+    # outranks anything the portal stores, so a test that leaves one set makes the next one's write
+    # unobservable -- which is exactly what happened to this file.
+    SHADOWING = ("MATRIXARK_UNDERSTANDING_PROVIDER", "MATRIXARK_EXTRACTION_PROVIDER")
+
     def setUp(self) -> None:
+        # apply_boot() writes to os.environ and rebuilds _BOOT_EFFECTIVE, both of them process-wide
+        # and neither scoped to a test. Restored here in full: without this the test inherits
+        # whatever the previous one left behind AND leaves its own behind for the next, which is
+        # how it passed alone and failed in the suite.
+        environment = dict(os.environ)
+
+        def restore_environment() -> None:
+            os.environ.clear()
+            os.environ.update(environment)
+
+        self.addCleanup(restore_environment)
+
+        boot = dict(gwconfig._BOOT_EFFECTIVE)
+
+        def restore_boot() -> None:
+            gwconfig._BOOT_EFFECTIVE.clear()
+            gwconfig._BOOT_EFFECTIVE.update(boot)
+
+        self.addCleanup(restore_boot)
+
         tmp = tempfile.TemporaryDirectory()
         self.addCleanup(tmp.cleanup)
-        previous = os.environ.get("MATRIXARK_RUNTIME_CONFIG_FILE")
-
-        def restore() -> None:
-            if previous is None:
-                os.environ.pop("MATRIXARK_RUNTIME_CONFIG_FILE", None)
-            else:
-                os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = previous
-
-        self.addCleanup(restore)
         os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = os.path.join(tmp.name, "runtime.json")
         self.assertTrue(gwconfig.config_path().startswith(tmp.name),
                         "the config path did not move; this test would rewrite a live config")
+        for name in self.SHADOWING:
+            os.environ.pop(name, None)
+
+        # A frame is built from a cache shared by the whole process and held for a tick, so without
+        # this the FIRST reading below is whatever the previous test left there rather than
+        # anything about this configuration. That is what failed in CI while passing alone: a
+        # neighbour had left a frame reporting three settings waiting, so this test wrote one and
+        # compared it against three.
+        gw._reset_live_cache()
+        self.addCleanup(gw._reset_live_cache)
+
         # What the gateway does at startup, and without it nothing is ever pending: the record of
         # what this process began with is built by apply_boot, and a module that was merely
         # imported has none. Skipping it here made this test read as "the frame says nothing"
         # when the frame was right and the test was not a real process.
         gwconfig.apply_boot()
+
+    def _a_provider_other_than_the_one_we_booted_with(self) -> str:
+        """Chosen against the boot record rather than written as a constant.
+
+        A fixed value can be the value already in effect, and then the write changes nothing and the
+        assertion fails while the code is fine.
+        """
+        setting = gwconfig.SETTINGS_BY_KEY["extraction.provider"]
+        booted = gwconfig._BOOT_EFFECTIVE.get(setting.key)
+        for choice in setting.choices or []:
+            if choice != booted:
+                return choice
+        self.fail("extraction.provider offers no value other than %r, so nothing can be "
+                  "changed here" % booted)
 
     def test_the_field_arrives(self) -> None:
         self.assertIn("settings_waiting", _frame())
@@ -101,12 +142,20 @@ class TheStripCanLearnAboutAPendingRestartTest(unittest.TestCase):
     def test_it_counts_a_setting_that_needs_a_restart(self) -> None:
         """The one the Setup page already explains in words. The strip is what a customer sees
         from the other six panels, and it had nothing to say."""
-        before = _frame()["settings_waiting"] or 0
-        gwconfig.update({"extraction.provider": "openai_compatible"}, actor="test")
+        gwconfig.update(
+            {"extraction.provider": self._a_provider_other_than_the_one_we_booted_with()},
+            actor="test")
         gw._LIVE_SHARED = None
-        after = _frame()["settings_waiting"] or 0
-        self.assertGreater(after, before,
-                           "a setting read once at startup was written and the frame said nothing")
+
+        # Against the configuration's own answer rather than against an earlier reading of the
+        # frame. A before/after comparison asks what changed in a number that the whole process
+        # shares, so it inherits whatever a neighbouring test left in the tick cache; this asks the
+        # question that actually matters -- the strip reports what the settings say is waiting.
+        waiting = gwconfig.pending_restart_keys()
+        self.assertTrue(waiting, "the write did not leave anything pending, so this proves nothing")
+        self.assertEqual(len(waiting), _frame()["settings_waiting"],
+                         "the frame does not report what the settings say is waiting: %r"
+                         % (waiting,))
 
     def test_a_quiet_deployment_reports_zero_rather_than_nothing(self) -> None:
         """The strip hides the segment on a falsy value, so zero and absent look the same there --

--- a/tools/test_matrixark_the_frame_delivers_what_it_builds.py
+++ b/tools/test_matrixark_the_frame_delivers_what_it_builds.py
@@ -32,8 +32,18 @@ import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-import matrixark_gateway_config as gwconfig  # noqa: E402
 import matrixark_v1_gateway as gw  # noqa: E402
+
+# The gateway's own copy, not a fresh import of the same file.
+#
+# It binds `from tools import matrixark_gateway_config`, falling back to the top-level name when
+# there is no package. Under `unittest discover` some other test makes `tools` importable, so a
+# plain `import matrixark_gateway_config` here binds a SECOND module object -- with its own
+# `_BOOT_EFFECTIVE`, which is where the record of what this process started with lives. This test
+# then wrote settings to one copy and asserted against a frame built from the other, and the frame
+# correctly reported nothing waiting. It passed alone and failed in the suite, which is the whole
+# signature of this mistake.
+gwconfig = gw._gwconfig
 
 # Shared-frame keys that are deliberately not delivered. Empty, and an entry here needs a reason:
 # the whole point of the sweep is that a field built for nobody is invisible.
@@ -121,6 +131,10 @@ class TheStripCanLearnAboutAPendingRestartTest(unittest.TestCase):
         # imported has none. Skipping it here made this test read as "the frame says nothing"
         # when the frame was right and the test was not a real process.
         gwconfig.apply_boot()
+        # Booting the wrong copy of the module leaves this empty, and every assertion below then
+        # measures a configuration the frame has never heard of.
+        self.assertTrue(gw._gwconfig._BOOT_EFFECTIVE,
+                        "the module the frame reads has no record of what it started with")
 
     def _a_provider_other_than_the_one_we_booted_with(self) -> str:
         """Chosen against the boot record rather than written as a constant.

--- a/tools/test_matrixark_the_live_caches_forget.py
+++ b/tools/test_matrixark_the_live_caches_forget.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The per-identity live caches forget the identities that stopped watching.
+
+Two caches behind the status stream are keyed on the identity triple ``(key, tenant, account)``:
+``_LIVE_SIGNATURE``, which holds what a viewer was last told so an unchanged frame can be skipped,
+and ``_LIVE_EMBEDDING``, which holds one identity's encoding backlog so its other tabs reuse the
+read. Nothing removed an entry. ``_reset_live_cache`` exists but is for tests.
+
+So a worker's resident memory grew with the number of distinct keys that had **ever** opened a
+status stream, not the number watching one. Measured at **2,433 bytes per identity**, kept for the
+life of the process -- and every byte of it already too stale for its own reader to serve. On a
+production portal an identity is a customer's API key, so this is a per-customer cost that is never
+paid back.
+
+The sweep uses each reader's own staleness test, called with the same arguments: an entry is dropped
+exactly when it had stopped being an answer. That is what the floor below is for -- a sweep that
+simply cleared both dicts would pass every leak test here while throwing away the sharing the caches
+exist for, so this file asserts in both directions.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import time
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_v1_gateway as gw  # noqa: E402
+
+
+def _server_and_cfg():
+    from test_matrixark_v1_gateway import _FakeServer, _cfg
+    return _FakeServer(), _cfg()
+
+
+def _identity(n: int) -> tuple:
+    return ("k-%06d" % n, "t-%06d" % n, "a-%06d" % n)
+
+
+class _LiveCacheTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.server, self.cfg = _server_and_cfg()
+        gw._reset_live_cache()
+        self.addCleanup(gw._reset_live_cache)
+
+    def watch(self, count: int, offset: int = 0) -> None:
+        """Serve `count` distinct identities the way a stream tick does."""
+        async def run() -> None:
+            for n in range(count):
+                key, tenant, account = _identity(n + offset)
+                embedding = await gw._embedding_for(self.server, self.cfg, key, tenant, account)
+                frame = await gw._event_frame(self.server, self.cfg, key, tenant, account,
+                                              embedding, "ok")
+                gw._frame_signature((key, tenant, account), frame)
+        asyncio.run(run())
+
+    def tick(self) -> None:
+        """The next tick's rebuild, which is where the sweep runs."""
+        gw._LIVE_SHARED = None
+        self.watch(1, offset=900000)
+
+    def age_everything(self) -> None:
+        """Put every entry past its own reader's staleness test, without waiting for a clock."""
+        now = time.time()
+        for identity, (_at, signature) in list(gw._LIVE_SIGNATURE.items()):
+            gw._LIVE_SIGNATURE[identity] = (now - gw.EVENT_TICK_S - 1.0, signature)
+        for identity, (_at, value) in list(gw._LIVE_EMBEDDING.items()):
+            gw._LIVE_EMBEDDING[identity] = (now - gw._embedding_refresh_interval(value) - 1.0,
+                                            value)
+
+
+class TheCachesForgetWhoLeftTest(_LiveCacheTest):
+
+    def test_the_sweep_has_something_to_sweep(self) -> None:
+        """A leak test over empty caches would pass while nothing was ever cached."""
+        self.watch(20)
+        self.assertEqual(20, len(gw._LIVE_SIGNATURE))
+        self.assertEqual(20, len(gw._LIVE_EMBEDDING))
+
+    def test_a_signature_does_not_outlive_its_own_staleness(self) -> None:
+        self.watch(20)
+        self.age_everything()
+        self.tick()
+        left = [i for i in gw._LIVE_SIGNATURE if i[0].startswith("k-0000")]
+        self.assertEqual([], left, "signatures too stale to be served were kept anyway")
+
+    def test_an_embedding_does_not_outlive_its_own_interval(self) -> None:
+        self.watch(20)
+        self.age_everything()
+        self.tick()
+        left = [i for i in gw._LIVE_EMBEDDING if i[0].startswith("k-0000")]
+        self.assertEqual([], left, "backlog reads too stale to be served were kept anyway")
+
+    def test_a_worker_does_not_grow_with_the_identities_that_left(self) -> None:
+        """The defect itself, at the scale that makes it one: a portal whose customers come and go.
+
+        Two thousand identities watch, all of them leave, and one arrives. What is retained should
+        describe who is watching now, not everyone who ever did.
+        """
+        self.watch(2000)
+        self.assertEqual(2000, len(gw._LIVE_SIGNATURE))
+        self.age_everything()
+        self.tick()
+        self.assertLess(len(gw._LIVE_SIGNATURE), 10,
+                        "the worker still holds an entry for every key that ever watched")
+        self.assertLess(len(gw._LIVE_EMBEDDING), 10,
+                        "the worker still holds a backlog read for every key that ever watched")
+
+
+class NothingStillWorthServingIsDroppedTest(_LiveCacheTest):
+    """The floor. Clearing both dicts on every tick would pass every test above and destroy the
+    only reason either cache exists."""
+
+    def test_a_fresh_signature_survives_a_tick(self) -> None:
+        self.watch(3)
+        self.tick()
+        kept = [i for i in gw._LIVE_SIGNATURE if i[0].startswith("k-0000")]
+        self.assertEqual(3, len(kept), "a signature the reader would still have served was dropped")
+
+    def test_a_fresh_embedding_survives_a_tick(self) -> None:
+        self.watch(3)
+        self.tick()
+        kept = [i for i in gw._LIVE_EMBEDDING if i[0].startswith("k-0000")]
+        self.assertEqual(3, len(kept),
+                         "a backlog read the reader would still have served was dropped")
+
+    def test_a_second_viewer_of_one_identity_still_reuses_the_read(self) -> None:
+        """What the embedding cache is for. If a tick evicted it, every open tab would put its own
+        walk of the record log on the backend."""
+        watched = _identity(0)[0]
+        reads = []
+        original = gw._read_embedding
+
+        async def counting(server, cfg, key, *args, **kwargs):
+            # Counted per identity: a tick serves whoever is connected, and this asks about one of
+            # them. Counting every read would attribute the tick's own viewer to this one.
+            if key == watched:
+                reads.append(key)
+            return await original(server, cfg, key, *args, **kwargs)
+
+        gw._read_embedding = counting
+        self.addCleanup(setattr, gw, "_read_embedding", original)
+
+        self.watch(1)
+        self.assertEqual(1, len(reads), "the first viewer did not read, so this proves nothing")
+        self.tick()
+        self.watch(1)
+        self.assertEqual(1, len(reads),
+                         "a second viewer of the same identity read the backlog again")
+
+
+class TheInflightMapDropsDeadLoopsTest(_LiveCacheTest):
+
+    def test_a_task_from_a_closed_loop_is_dropped(self) -> None:
+        """`_embedding_for` refuses to await a task from another loop, so such an entry is
+        unreachable rather than merely stale -- nothing will ever pop it."""
+        loop = asyncio.new_event_loop()
+
+        async def nothing():
+            return None
+
+        task = loop.create_task(nothing())
+        loop.run_until_complete(task)
+        loop.close()
+        gw._LIVE_EMBEDDING_INFLIGHT[_identity(1)] = (loop, task)
+
+        self.tick()
+        self.assertNotIn(_identity(1), gw._LIVE_EMBEDDING_INFLIGHT,
+                         "an entry no caller can ever await was kept")
+
+    def test_a_live_loops_entry_is_left_alone(self) -> None:
+        loop = asyncio.new_event_loop()
+        self.addCleanup(loop.close)
+
+        async def nothing():
+            return None
+
+        task = loop.create_task(nothing())
+        loop.run_until_complete(task)
+        gw._LIVE_EMBEDDING_INFLIGHT[_identity(2)] = (loop, task)
+
+        self.tick()
+        self.assertIn(_identity(2), gw._LIVE_EMBEDDING_INFLIGHT,
+                      "an entry belonging to a live loop was dropped")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`_shared_live_parts()` computes, once per tick for the whole deployment:

```
traffic, imports, warnings, settings_waiting, config_changed_at
```

`_event_frame()` copied out four of those five. **`settings_waiting` was computed and dropped.**

So the status strip's *"N settings awaiting restart"* segment could never appear, on any deployment.
Save a setting that is read once at startup and the Setup page says so plainly — *"restart the
gateway for it to take effect"* — while the strip, which is on all seven panels and is what a
customer sees from the other six, showed nothing at all.

It was not free, either. The count comes from `pending_restart_keys()`, which exists in that shape
*because* it runs every tick — the work was being done and thrown away every two seconds.

### Found and confirmed against a running gateway

```
POST /v1/admin/config  {"extraction.provider": "anthropic"}
gateway    pending_restart: ['extraction.provider']
wire       "settings_waiting": 1          ← was absent entirely
browser    liveWaiting -> "1 setting awaiting restart"
```

The last line is the page itself, in a browser, reading a real SSE stream. (The strip stays quiet
until the tab is foregrounded — that gate is deliberate and unchanged.)

### The sweep is the point

The behaviour is one line. The guard is that the shared half of a frame and the delivered half are
two lists that have to agree, and nothing said so, which is how a field came to be built for nobody.
The allowlist is empty and has to stay justified; a second test asserts the shared half is non-empty,
so the sweep cannot pass by having nothing to sweep.

```
drop the field from the frame       -> FAIL nothing is built for nobody (+3)
deliver a constant 0 instead        -> FAIL a setting read once at startup was written
                                            and the frame said nothing
```

### One correction to my own test

The first version never called `apply_boot()` and read as *"the frame says nothing"* when the frame
was right. `_BOOT_EFFECTIVE` — the record of what this process started with — is built only by
`apply_boot()`, which the gateway calls at startup and a merely-imported module has not. That is
deliberate: reporting a change on missing evidence would put an alarm on every deployment that
imports the module. The test now boots the way a gateway does, and says why.

7 tests. Neighbours: v1_gateway 97, live_strip 38, gateway_config 28, gateway_events 12,
portal_pages 4 — all green.
