### PR TITLE
Guard the batch key-state capture, and step the recovery scan over a block footer

### DIFF
--- a/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
+++ b/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
@@ -261,6 +261,10 @@ impl TemporalEngine {
         // Accumulate the object keys every mutating command in the batch touched, for the
         // single O(delta) index-log append below (delta path). Empty when the flag is off.
         let mut delta_command_keys: Vec<String> = Vec::new();
+        // Did ANY command in this batch remove something? Only then does the per-key membership
+        // capture below have anything to preserve -- see the single-command execute path, whose
+        // guard this mirrors.
+        let mut batch_membership_shrank = false;
         // Some(components) while every mutating command in the batch is a pure page-upsert;
         // one non-upsert write downgrades the whole record to snapshot semantics.
         let mut batch_upsert_components: Option<Vec<(&'static str, String, Option<String>)>> =
@@ -314,6 +318,16 @@ impl TemporalEngine {
                 continue;
             }
             let command_for_post_write = command.clone();
+            // What the touched keys held before this command, so the capture below can be
+            // skipped when nothing was removed. Sizes only -- no allocation.
+            let membership_before: Vec<(String, usize)> =
+                command_object_keys(&command_for_post_write)
+                    .into_iter()
+                    .map(|key| {
+                        let size = key_membership_size(shard, &key);
+                        (key, size)
+                    })
+                    .collect();
             let outcome = execute_on_shard(
                 &self.cache,
                 &self.page_store,
@@ -342,6 +356,11 @@ impl TemporalEngine {
                 mutated_any = true;
                 let object_keys = command_object_keys(&command_for_post_write);
                 delta_command_keys.extend(object_keys.iter().cloned());
+                if !batch_membership_shrank {
+                    batch_membership_shrank = membership_before
+                        .iter()
+                        .any(|(key, before)| key_membership_size(shard, key) < *before);
+                }
                 match (
                     &mut batch_upsert_components,
                     command_upsert_components(&command_for_post_write, shard),
@@ -518,7 +537,16 @@ impl TemporalEngine {
                         false,
                     ),
                 };
-                let key_states = capture_key_states(shard, &delta_command_keys);
+                // Capturing serializes every entry the per-key maps hold for each key, so
+                // appending to a posting of length N serialized all N -- 99.5% of the index log
+                // on a real corpus (3.53 GB against 16 MB for the same 20,001 messages). A write
+                // that only ADDED leaves nothing to resurrect, so it is skipped there, exactly as
+                // the single-command execute path already does.
+                let key_states = if batch_membership_shrank {
+                    capture_key_states(shard, &delta_command_keys)
+                } else {
+                    Vec::new()
+                };
                 let _ = self.index_log_store.append_delta(
                     request.shard_id,
                     items,

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -1554,6 +1554,20 @@ impl LocalWriteAheadLogStore {
             let mut reader = BufReader::new(file);
             let mut log_id = base;
             loop {
+                // Step over a block footer this lands on. The zero-run check below only catches a
+                // boundary that has padding in front of its footer; a block whose records end
+                // flush against the footer has none, and the footer would then be read as a
+                // record -- its first byte is not a frame marker, so the reader falls to
+                // newline-delimited mode and hands back a fragment. `last_wal_sequence_forward`
+                // takes this same first step; the two walkers read one format and must agree.
+                let at = header_len.saturating_add(log_id.saturating_sub(base));
+                let stepped = skip_block_footer_if_due(&mut reader, at, header_len)?;
+                if stepped != at {
+                    // Log ids are byte positions in the log's history, so the footer bytes
+                    // stepped over are counted here exactly as the closed-block branch counts
+                    // the ones it skips.
+                    log_id = log_id.saturating_add(stepped.saturating_sub(at));
+                }
                 // Reads a record by the length it declares when it is framed that way, and to
                 // the newline when it is not, so one loop walks a log holding both. The
                 // preallocated zero run that trails the records ends the loop from inside the


### PR DESCRIPTION
Two defects found while loading an 84,302-message corpus onto a one-box node. Together they made
the store impossible to reopen: the first grew the index until recovery ran out of memory, and the
second stopped the recovery scan reading a log once it grew past a few blocks.

## The batch write path captured whole per-key membership on every write

`capture_key_states` serializes every entry the per-key maps hold for each key a write touched. For
a context index that is the entire posting list, so appending to a posting of length N serialized
all N — the index log then costs the sum of posting lengths and grows with the square of the
longest posting.

The single-command execute path already guards this, and its comment says why: *"A write that only
ADDED leaves nothing to resurrect: replay rebuilds the same membership from the same pages."* It
captures only when membership SHRANK. The batch path — which is what `/batch_execute`, and so every
real ingest, uses — never got that guard. This ports it: sizes are recorded before each command
(sizes only, no allocation), and the capture runs only if some command actually removed something.

Measured on the corpus, 20,001 messages, same code path, only this change:

| | before | after |
|---|---|---|
| index log | 3.53 GB | 16 MB |
| bytes/record | 176,813 | 841, flat |

## The recovery scan read a block footer as a record

A WAL block is records, then zero padding, then a footer at the block's end. The scan noticed
boundaries only by hitting the padding: `read_raw_record` returns `None` on a zero byte, and that
branch calls `block_is_closed` to step across. A block whose records end flush against its footer
has no padding, so the scan read the footer as a record — its first byte is not a frame marker, the
reader fell to newline-delimited mode and handed back a fragment, and the shard refused to load:

```
WAL scan failed during recovery for shard 1; refusing load rather than serving a truncated prefix:
  wal record integrity error: record carries payloads but does not say how long they are
```

Walking the frames located it exactly — 31,025 frames and 68 boundaries read cleanly, then byte
`0x21` at offset 9,043,840, which is `block_footer_at(68)`. It looks like a size threshold and is
not one: it is probabilistic, so a log with more blocks is likelier to have one that ends flush.
20,001 and 28,000 records reopened; 32,000 and above did not.

`last_wal_sequence_forward` already walks this format correctly, taking `skip_block_footer_if_due`
at the top of every iteration. This gives the recovery scan that same first step, counting the
stepped bytes into `log_id` since log ids are byte positions in the log's history.

## Effect on the corpus

All 84,302 messages, one-box node, before and after both changes:

| | before | after |
|---|---|---|
| index on disk | 21.95 GB | 69 MB |
| ingest wall clock | 1,034 s | 514 s |
| ingest rate | 81.5 rec/s | 163.9 rec/s |
| write p50 | 9.58 ms | 5.79 ms |
| write p99 | 30.34 ms | 9.50 ms |
| restart | out of memory at 31.7 GB, then refused | loads and serves |

## How this was checked

- `cargo test -p temporalstore-rust --lib -- --test-threads=1` on this branch: 1,625 passed,
  3 failed. All three also fail on the unpatched base commit, so none is new here:
  - `emptied_buckets_are_dropped_without_walking_the_map` — fails on the base; it asserts a timing
    ratio and says itself that it cannot attribute a cause.
  - `the_index_wire_keys_are_what_they_were` — fails on the base; the served key set has gained
    `by_component`, `object_page_lookup`, `page_ref_key` and `refs` that its expectation lacks.
  - `distributed_raft_chunks_large_sequence_add_under_default_entry_limit` — flaky on the base,
    failing once in five runs there and once in three on this branch. It trips on
    `inflight_bytes: 32692` against a `byte_limit: 32768`, which is 76 bytes of headroom.
- Ingest 40,000 messages, stop, restart, and compare reads taken before and after: postings, block
  counts and character counts per session all match. A single node read is not enough to check a
  recovery — it succeeds against an index that has lost almost everything, which is how
  `TS_WAL_LEGACY_RECOVERY` looked healthy until the counts were compared.

## Not addressed here

- Two sibling scan sites in `wal.rs` share the footer shape and have not been given the same step.
- `TS_WAL_LEGACY_RECOVERY=1` loads a large store and serves one posting entry per key with no
  error, and ingests about six times slower. It is documented as an escape hatch and is not safe
  as one.
- The five `wal_single_barrier_recovery` tests remain red. They wipe every non-WAL file and rebuild
  from the log alone, which neither change here touches.
- A reload costs about 3.2x the resident memory of the ingest that produced the same data
  (1,131 MB against 351 MB), and the block cache is not the cause.
