### PR TITLE
Every raft switch becomes a field on the cluster it configures

### DIFF
--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -197,83 +197,24 @@ pub const DATA_RAFT_CODEC_VERSION: u32 = 1;
 const DATA_RAFT_LOG_HEADER_LEN: usize = 56;
 const DATA_RAFT_COMMAND_HEADER_LEN: usize = 40;
 
-/// Read a boolean gate env var (`1`/`true`/`yes`/`on`), default OFF.
-///
-/// The replication-SAFETY properties (quorum election, durable pre-vote persistence, applied-read
-/// freshness, §7 snapshot-boundary truncation) are no longer gated -- they are what makes this
-/// Raft, not options, and shipping them dark meant the default build was the only configuration
-/// nobody tested. What remains behind this helper is genuinely optional: an optimization whose
-/// cost profile an operator may not want, or a hardening that is not yet complete enough to be
-/// the default. Each surviving gate documents which of the two it is.
-fn raft_env_flag_on(name: &str) -> bool {
-    matches!(
-        std::env::var(name)
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "1" | "true" | "yes" | "on"
-    )
-}
+// S2: snapshot the engine STATE IMAGE (exported index + page slabs) instead of every committed
+// log entry. `create_snapshot` captures an opaque image at the leader's applied index and drops
+// the replayable entries, so a far-behind follower installs in O(state) rather than replaying
+// O(total history); install reconstructs state from the image.
+//
+// `TS_RAFT_SNAPSHOT_STATE_IMAGE` used to select entry-carrying snapshots instead, for every
+// cluster in the process. It is `RaftClusterInner::snapshot_state_image` now, and only a test
+// about entry chunking asks for entries, of the cluster it built.
 
-/// Default-ON gate read: the fix is LIVE unless explicitly disabled with
-/// `=0|false|no|off`. Shipped write-path/raft fixes use this so production gets the
-/// fixed behavior by default; the env var remains only as an escape hatch.
-fn raft_env_flag_default_on(name: &str) -> bool {
-    !matches!(
-        std::env::var(name)
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "0" | "false" | "no" | "off"
-    )
-}
-
-/// R4: after an election, withhold read-index/lease reads until the new leader has committed a
-/// no-op entry in its own term (leader-ready barrier).
-///
-/// STILL GATED, deliberately. Raft releases this barrier by having a new leader append a no-op
-/// entry at its own term the moment it is elected (§8). This implementation never appends one:
-/// `leader_has_committed_current_term` can only be satisfied by a CLIENT write landing at the new
-/// term. Enabling the gate unconditionally would therefore reject every leader-served
-/// read-index/lease read from the end of an election until the next write commits -- indefinitely
-/// on an idle cluster. Promoting this gate requires appending the election no-op first, which is a
-/// new `Command` variant and thus a wire-format change for `#[serde(tag = "kind")]` peers.
-fn raft_leader_ready_barrier_on() -> bool {
-    raft_env_flag_on("TS_RAFT_LEADER_READY_BARRIER")
-}
-
-/// S2: snapshot the engine STATE IMAGE (exported index + page slabs) instead of every committed
-/// log entry. When on, `create_snapshot` captures an opaque image at the leader's applied index
-/// and drops the replayable entries, so a far-behind follower installs in O(state) rather than
-/// replaying O(total history); install reconstructs state from the image. Default ON; set the
-/// variable to 0 and the snapshot still carries entries and behavior is byte-identical.
-fn raft_snapshot_state_image_on() -> bool {
-    // Default ON since the restore path learned to install images and compaction proved to
-    // bound the log with them (a restart after compaction serves every value; the log stays a
-    // fraction of the history). TS_RAFT_SNAPSHOT_STATE_IMAGE=0 opts back to entry-carrying
-    // snapshots, which re-encode history rather than reduce it.
-    raft_env_flag_default_on("TS_RAFT_SNAPSHOT_STATE_IMAGE")
-}
-
-/// P1 (fsync coalescing): skip a node's WAL fdatasync when none of its DURABILITY-relevant state
-/// changed since the last persist. Driven purely by whether hard_state / log / membership /
-/// snapshot / fences changed, so it can never skip a persist that Raft safety requires -- only the
-/// volatile `pipeline_state` + `read_safety_state` (match/next index, inflight/queue depths,
-/// read-index accounting counters) are excluded from the change check. Default ON; set the
-/// variable to 0 and every call fsyncs exactly as before (byte-identical).
-fn raft_wal_coalesce_on() -> bool {
-    raft_env_flag_default_on("TS_RAFT_WAL_COALESCE")
-}
-
-/// P2 (in-order propose): hold a per-cluster serialize lock across the append+replicate+commit
-/// critical section of `propose_distributed_one` so concurrent proposals reach followers in log
-/// order and never trigger a `prev_log` mismatch + full-deadline stall. Default ON; set the
-/// variable to 0 to propose without the serialize lock.
-fn raft_propose_serialize_on() -> bool {
-    raft_env_flag_default_on("TS_RAFT_PROPOSE_SERIALIZE")
-}
+// P1 (fsync coalescing): skip a node's WAL fdatasync when none of its DURABILITY-relevant state
+// changed since the last persist. Driven purely by whether hard_state / log / membership /
+// snapshot / fences changed, so it can never skip a persist that Raft safety requires -- only the
+// volatile `pipeline_state` + `read_safety_state` (match/next index, inflight/queue depths,
+// read-index accounting counters) are excluded from the change check.
+//
+// `TS_RAFT_WAL_COALESCE` used to decide this for every cluster in the process. It is
+// `RaftClusterInner::wal_coalesce` now, and only a test measuring what the skip saves turns it
+// off, of the one cluster it built.
 
 /// Fingerprint of the DURABILITY-relevant subset of a WAL record. `pipeline_state` and
 /// `read_safety_state` are cleared before hashing because they are volatile (reinitialised on
@@ -1445,19 +1386,6 @@ pub(crate) fn randomized_election_timeout_ticks(node_id: RaftNodeId) -> u64 {
     RAFT_ELECTION_TIMEOUT_BASE_TICKS + (hasher.finish() % RAFT_ELECTION_TIMEOUT_SPREAD_TICKS)
 }
 
-/// `TS_RAFT_WAL_DELTA_ENTRIES=0` restores the legacy full-log-per-record WAL payload.
-/// Note that a WAL containing incremental records cannot be read by a build that
-/// predates them, so roll the binary forward before flipping this back on.
-fn raft_wal_delta_entries_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| {
-        !matches!(
-            std::env::var("TS_RAFT_WAL_DELTA_ENTRIES").ok().as_deref(),
-            Some("0") | Some("false") | Some("off")
-        )
-    })
-}
-
 #[derive(Debug, Clone)]
 pub struct LocalRaftWal {
     root: PathBuf,
@@ -1981,6 +1909,12 @@ where
 pub struct HttpRaftTransport {
     peers: BTreeMap<RaftNodeId, String>,
     options: HttpRequestOptions,
+    /// Whether replicated batches go out in the binary encoding.
+    ///
+    /// True everywhere: a receiver sniffs the body and accepts either, so this is the sender's
+    /// half of a decision the reader already handles. A test sends JSON to keep the receiver's
+    /// other branch exercised.
+    binary_replication: bool,
 }
 
 impl HttpRaftTransport {
@@ -1988,11 +1922,22 @@ impl HttpRaftTransport {
         Self {
             peers,
             options: HttpRequestOptions::default(),
+            binary_replication: true,
         }
     }
 
     pub fn with_options(peers: BTreeMap<RaftNodeId, String>, options: HttpRequestOptions) -> Self {
-        Self { peers, options }
+        Self {
+            peers,
+            options,
+            binary_replication: true,
+        }
+    }
+
+    /// Send append-entries as JSON, for the test that keeps the receiver's JSON branch covered.
+    #[cfg(test)]
+    pub(crate) fn send_json_append_entries_for_test(&mut self) {
+        self.binary_replication = false;
     }
 
     fn peer_addr(&self, node_id: RaftNodeId) -> Result<&str, RaftError> {
@@ -2009,7 +1954,7 @@ impl RaftTransport for HttpRaftTransport {
         request: AppendEntriesRequest,
     ) -> Result<AppendEntriesResponse, RaftError> {
         let addr = self.peer_addr(request.target_id)?.to_string();
-        if wal_proto::binary_replication_enabled() {
+        if self.binary_replication {
             let body = wal_proto::encode_append_entries(&request)
                 .map_err(|err| RaftError::Transport(err.to_string()))?;
             // The response is a handful of integers either way, so it stays as it was; the size
@@ -4022,9 +3967,57 @@ struct RaftClusterInner {
     read_safety_state: RaftReadSafetyRuntimeState,
     membership_evidence: RaftMembershipRuntimeEvidence,
     /// P1: last durable fingerprint persisted per node (see `raft_durable_fingerprint`). Only
-    /// consulted when `TS_RAFT_WAL_COALESCE` is on; otherwise left untouched.
+    /// consulted while `wal_coalesce` is on; otherwise left untouched.
     last_durable_fingerprint: BTreeMap<RaftNodeId, u64>,
-    /// P2: serialize proposes into the log in order under `TS_RAFT_PROPOSE_SERIALIZE`.
+    /// Whether a node whose durability-relevant state is unchanged skips its fdatasync.
+    ///
+    /// True everywhere but a test measuring what the skip saves.
+    wal_coalesce: bool,
+    /// Whether replication runs through the per-follower senders.
+    ///
+    /// FALSE. The senders were correctness-clean on a live cluster where the fan-out was not,
+    /// but two throughput anomalies are open -- the text-body arm lost about a third under
+    /// concurrency, and the binary-body arm amplified the leader's log writes -- so the proven
+    /// default stays until both are run down on hardware. Four tests turn it on, each of one
+    /// cluster, because each IS the pipeline's invariant and must not silently test the default.
+    follower_pipeline: bool,
+    /// Whether proposers run concurrently through those senders, rather than one at a time.
+    ///
+    /// TRUE, and only read when `follower_pipeline` is on. Serializing proposers starved the
+    /// senders of batches -- every entry paying the whole doorbell/sender/ack/commit-signal
+    /// chain alone -- which is the concurrency collapse measured on small machines. One test
+    /// takes the serialized fallback, which has to stay correct too.
+    pipeline_concurrent_propose: bool,
+    /// R4: whether a leader withholds read-index and lease reads until it has committed an entry
+    /// in its own term.
+    ///
+    /// FALSE, and it cannot simply be turned on. Raft releases this barrier by having a new
+    /// leader append a no-op entry at its own term the moment it is elected (S8). This
+    /// implementation never appends one, so `leader_has_committed_current_term` is satisfiable
+    /// only by a CLIENT write landing at the new term -- and enabling the barrier would reject
+    /// every leader-served read from the end of an election until that write commits,
+    /// indefinitely on an idle cluster. Appending the election no-op is a new `Command` variant
+    /// and so a wire-format change for `#[serde(tag = "kind")]` peers.
+    ///
+    /// The same missing entry is what `overlap_leader_barrier` below waits on. One test turns
+    /// this on, of the cluster it built, to hold the property for when the entry exists.
+    leader_ready_barrier: bool,
+    /// Whether a leader takes its durability barrier alongside replication rather than after.
+    ///
+    /// FALSE, and only a test that runs the path sets it. It relies on the commit index being
+    /// recoverable, which holds once every leader commits an entry of its own term on taking
+    /// office -- and this implementation never appends that entry, as the note on
+    /// `raft_leader_ready_barrier_on` says of the same missing mechanism. Adding it is a new
+    /// `Command` variant, and so a wire-format change; until then this stays off, and being a
+    /// field rather than a variable is what keeps a deployment from reaching it.
+    overlap_leader_barrier: bool,
+    /// Whether a snapshot carries an opaque state image instead of the replayable entries.
+    ///
+    /// True everywhere but a test about entry chunking, for which one image is a single unit and
+    /// therefore not the thing under test.
+    snapshot_state_image: bool,
+    /// P2: serialize proposes into the log in order. Held across the whole
+    /// append+replicate+commit critical section, so index N commits before N+1 begins.
     propose_serialize: Arc<Mutex<()>>,
     /// P3/P6: which node THIS process actually is, when the deployed runtime declares it.
     /// `None` for the in-process test cluster, which genuinely hosts every node -- so both of
@@ -4110,6 +4103,12 @@ impl RaftCluster {
                 read_safety_state: RaftReadSafetyRuntimeState::default(),
                 membership_evidence: RaftMembershipRuntimeEvidence::default(),
                 last_durable_fingerprint: BTreeMap::new(),
+                wal_coalesce: true,
+                follower_pipeline: false,
+                pipeline_concurrent_propose: true,
+                leader_ready_barrier: false,
+                overlap_leader_barrier: false,
+                snapshot_state_image: true,
                 propose_serialize: Arc::new(Mutex::new(())),
                 local_node_id: None,
                 persist_deferred_owner: None,
@@ -4121,6 +4120,75 @@ impl RaftCluster {
     }
 
     /// WAL-backed local Raft fixture for durability tests and harnesses only.
+    /// Persist every node's WAL record on every call, skipping nothing, for a test measuring
+    /// what the fingerprint skip saves. Scoped to this cluster: `TS_RAFT_WAL_COALESCE` used to
+    /// turn it off for every cluster in the process.
+    /// Whether replication runs through the per-follower senders. Read on the propose path and
+    /// by the production runtime's heartbeat, which must not start a second sender.
+    pub(crate) fn follower_pipeline_on(&self) -> bool {
+        self.inner
+            .read()
+            .expect("raft cluster lock poisoned")
+            .follower_pipeline
+    }
+
+    /// Replicate through the per-follower senders, for the tests that assert their invariant.
+    #[cfg(test)]
+    pub(crate) fn use_follower_pipeline_for_test(&self) {
+        self.inner
+            .write()
+            .expect("raft cluster lock poisoned")
+            .follower_pipeline = true;
+    }
+
+    /// Take the serialized fallback -- one propose at a time through the same senders -- for the
+    /// test that keeps it correct.
+    #[cfg(test)]
+    pub(crate) fn propose_one_at_a_time_for_test(&self) {
+        self.inner
+            .write()
+            .expect("raft cluster lock poisoned")
+            .pipeline_concurrent_propose = false;
+    }
+
+    /// Withhold leader-served reads until the leader has committed in its own term, for the test
+    /// that holds that property. Scoped to this cluster; see the field for why it is off.
+    #[cfg(test)]
+    pub(crate) fn withhold_reads_until_leader_ready_for_test(&self) {
+        self.inner
+            .write()
+            .expect("raft cluster lock poisoned")
+            .leader_ready_barrier = true;
+    }
+
+    /// Overlap the leader's durability barrier with replication, for the test that runs that
+    /// path. Scoped to this cluster; see the field for why it is not on anywhere else.
+    #[cfg(test)]
+    pub(crate) fn overlap_leader_barrier_for_test(&self) {
+        self.inner
+            .write()
+            .expect("raft cluster lock poisoned")
+            .overlap_leader_barrier = true;
+    }
+
+    /// Take entry-carrying snapshots rather than state images, for a test about how entries
+    /// chunk. Scoped to this cluster.
+    #[cfg(test)]
+    pub(crate) fn snapshot_carries_entries_for_test(&self) {
+        self.inner
+            .write()
+            .expect("raft cluster lock poisoned")
+            .snapshot_state_image = false;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn persist_every_wal_record_for_test(&self) {
+        self.inner
+            .write()
+            .expect("raft cluster lock poisoned")
+            .wal_coalesce = false;
+    }
+
     pub fn new_single_shard_with_wal(
         root: impl AsRef<Path>,
         shard_id: ShardId,
@@ -4239,6 +4307,12 @@ impl RaftCluster {
                 read_safety_state,
                 membership_evidence,
                 last_durable_fingerprint: BTreeMap::new(),
+                wal_coalesce: true,
+                follower_pipeline: false,
+                pipeline_concurrent_propose: true,
+                leader_ready_barrier: false,
+                overlap_leader_barrier: false,
+                snapshot_state_image: true,
                 propose_serialize: Arc::new(Mutex::new(())),
                 local_node_id: None,
                 persist_deferred_owner: None,
@@ -4526,9 +4600,11 @@ impl RaftCluster {
         // every entry paid the whole doorbell -> sender -> ack -> commit-signal chain alone,
         // which is exactly the concurrency collapse measured on small machines. =0 falls back
         // to one propose at a time through the same senders.
-        if follower_pipeline::follower_pipeline_enabled()
-            && raft_env_flag_default_on("TS_RAFT_PIPELINE_CONCURRENT_PROPOSE")
-        {
+        let (pipeline, concurrent) = {
+            let inner = self.inner.read().expect("raft cluster lock poisoned");
+            (inner.follower_pipeline, inner.pipeline_concurrent_propose)
+        };
+        if pipeline && concurrent {
             return self.propose_pipelined_concurrent(command, transport);
         }
         // P2: serialize proposes into the log in order. Concurrent proposers otherwise append
@@ -4536,51 +4612,32 @@ impl RaftCluster {
         // so their AppendEntries race and can reach a follower out of order -> `prev_log` mismatch
         // -> reject -> a full-deadline stall. Holding this per-cluster lock across the whole
         // append+replicate+commit critical section forces index N to commit before N+1 begins.
-        let propose_gate = if raft_propose_serialize_on() {
+        let propose_gate = {
             let inner = self.inner.read().expect("raft cluster lock poisoned");
-            Some(inner.propose_serialize.clone())
-        } else {
-            None
+            inner.propose_serialize.clone()
         };
         let _propose_guard = propose_gate
-            .as_ref()
-            .map(|gate| gate.lock().unwrap_or_else(|poisoned| poisoned.into_inner()));
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         // P4: the propose lock makes us the only proposer, so nested persists can record that a
-        // barrier is owed and let one flush below cover the final state -- before the ack. Still
-        // conditioned on actually holding that lock: without it there can be several proposers,
-        // and a shared deferral would then have no single owner.
-        let deferring = _propose_guard.is_some();
-        if deferring {
-            self.inner
-                .write()
-                .expect("raft cluster lock poisoned")
-                .begin_deferred_persist();
-        }
+        // barrier is owed and let one flush below cover the final state -- before the ack. That
+        // single owner is what the lock buys; a shared deferral among several proposers would
+        // have none, which is why the deferral lives inside the lock rather than beside it.
+        self.inner
+            .write()
+            .expect("raft cluster lock poisoned")
+            .begin_deferred_persist();
         let mut entry_barrier = None;
         // The senders replicate when the pipeline is on; this thread then appends, rings them,
         // and waits on the quorum-commit signal instead of sending to any peer itself. Branching
         // here keeps both paths inside the same deferral bookkeeping: the caller-side staging
         // and barrier-join below are what propose_pipelined leaves for its caller, exactly as
         // the fan-out body does.
-        let outcome = if follower_pipeline::follower_pipeline_enabled() {
+        let outcome = if pipeline {
             self.propose_pipelined(command, transport, &mut entry_barrier)
         } else {
             self.propose_distributed_one_locked(command, transport, &mut entry_barrier)
         };
-        if !deferring {
-            // An overlapped barrier is still joined before the ack, whatever path leaves here.
-            if let Some(handle) = entry_barrier {
-                let joined = handle
-                    .join()
-                    .unwrap_or_else(|_| Err(RaftError::Wal("barrier thread panicked".to_string())));
-                return match (outcome, joined) {
-                    (Ok(response), Ok(())) => Ok(response),
-                    (Ok(_), Err(err)) => Err(err),
-                    (Err(err), _) => Err(err),
-                };
-            }
-            return outcome;
-        }
         // Write what the deferral owes while the propose lock still orders it. Records carry the
         // log, so an older record landing after a newer one would regress the log on recovery --
         // the write must stay ordered.
@@ -4844,7 +4901,12 @@ impl RaftCluster {
         // The entry is in the log. Write it and start its barrier NOW, so the leader's disk
         // wait runs alongside the followers' instead of after them. Unchanged from the fan-out
         // path: the commit index is recoverable and never has to be durable before the ack.
-        if wal_proto::overlap_leader_barrier_enabled() {
+        if self
+            .inner
+            .read()
+            .expect("raft cluster lock poisoned")
+            .overlap_leader_barrier
+        {
             let staged = self
                 .inner
                 .write()
@@ -4972,7 +5034,12 @@ impl RaftCluster {
         // runs alongside the followers' instead of after them. The commit index is not known yet
         // and does not need to be: it is recoverable, so it never has to be durable before the
         // acknowledgement.
-        if wal_proto::overlap_leader_barrier_enabled() {
+        if self
+            .inner
+            .read()
+            .expect("raft cluster lock poisoned")
+            .overlap_leader_barrier
+        {
             let staged = self
                 .inner
                 .write()
@@ -5805,10 +5872,11 @@ fn apply_committed(node: &mut RaftNode) -> Option<CommandResponse> {
         .binary_search_by_key(&node.applied_index.saturating_add(1), |entry| entry.index)
         .unwrap_or_else(|position| position);
     // Collect the committed entries that pass the exactly-once floor (and are freshly inserted
-    // into `applied`) into a single batch, then apply them via `execute_raft_apply_batch`. Under
-    // TS_RAFT_APPLY_COALESCE this coalesces the batch's engine-WAL fdatasync into ONE barrier; with
-    // the gate off (or a single-entry batch) the batch method degrades to the same per-entry
-    // `execute_raft_apply` calls, so the exactly-once + durability semantics are byte-identical.
+    // into `applied`) into a single batch, then apply them via `execute_raft_apply_batch`, which
+    // coalesces the batch's engine-WAL fdatasync into ONE barrier. For a single-entry batch -- or
+    // an engine a test has asked to apply per entry -- the batch method degrades to the same
+    // per-entry `execute_raft_apply` calls, so the exactly-once + durability semantics are
+    // byte-identical either way.
     // Cursor advances happen in-order exactly as before (skipped/already-applied entries update the
     // apply cursor inline; executed entries advance applied_index/max_applied_index after apply),
     // and nothing observes node state mid-loop (all under the caller's `inner` write lock).

--- a/crates/temporalstore-rust/src/raft/cluster_inner.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_inner.rs
@@ -743,7 +743,7 @@ impl RaftClusterInner {
         let shard_id = self.shard_id;
         let max_segment_bytes = self.config.max_segment_bytes;
         let min_keep_segment_num = self.config.min_keep_segment_num as usize;
-        let coalesce = raft_wal_coalesce_on();
+        let coalesce = self.wal_coalesce;
         // P3: a deployed process owns exactly one node but keeps a full cluster view, so
         // `wal_records()` emits a record per peer and this loop fsyncs every one of them. A
         // leader owes its peers no durability: each persists its own hard state before answering

--- a/crates/temporalstore-rust/src/raft/cluster_read_status.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_read_status.rs
@@ -155,7 +155,7 @@ impl RaftCluster {
         // its own term. A leader freshly elected (or one that has just superseded a partitioned
         // predecessor) has not established its commit point until it commits in-term, so serving
         // now risks returning stale linearizable state.
-        if raft_leader_ready_barrier_on()
+        if inner.leader_ready_barrier
             && node_id == inner.leader_id
             && !inner.leader_has_committed_current_term()
         {

--- a/crates/temporalstore-rust/src/raft/cluster_snapshot.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_snapshot.rs
@@ -547,7 +547,12 @@ impl RaftCluster {
         // lock and proves consistency by watermark instead; any failure there falls through
         // to the classic entry-carrying snapshot below, so the image path can never make
         // snapshotting worse.
-        if raft_snapshot_state_image_on() {
+        if self
+            .inner
+            .read()
+            .expect("raft cluster lock poisoned")
+            .snapshot_state_image
+        {
             if let Some(snapshot) = self.create_state_image_snapshot()? {
                 return Ok(snapshot);
             }

--- a/crates/temporalstore-rust/src/raft/follower_pipeline.rs
+++ b/crates/temporalstore-rust/src/raft/follower_pipeline.rs
@@ -149,19 +149,6 @@ impl FollowerPipeline {
     }
 }
 
-/// Whether replication runs through the per-follower senders.
-pub(crate) fn follower_pipeline_enabled() -> bool {
-    // Off by default, deliberately. On a live cluster the senders were correctness-clean where
-    // the fan-out never was (every replica read of every accepted write succeeded, no reorder or
-    // stale-term rejections at all, and binary request bodies stopped collapsing the cluster) --
-    // but two performance anomalies are still open: the text-body arm lost ~a third of its
-    // throughput under concurrency, and the binary-body arm amplified the leader machine's log
-    // writes. Until both are run down on hardware, the proven default stays.
-    std::env::var("TS_RAFT_FOLLOWER_PIPELINE")
-        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
-        .unwrap_or(false)
-}
-
 impl RaftCluster {
     /// Bring the per-follower senders up, or rebuild them after the peer set changed. Cheap when
     /// already current: one lock and a comparison.

--- a/crates/temporalstore-rust/src/raft/local_wal.rs
+++ b/crates/temporalstore-rust/src/raft/local_wal.rs
@@ -312,7 +312,6 @@ impl LocalRaftWal {
         // which shows up as write latency that climbs with the log. Write the entries
         // that are actually new instead, and re-base with a full record only when a
         // delta could not be folded back (start of a segment, or the log moved under us).
-        let delta_enabled = raft_wal_delta_entries_enabled();
         let log_first_index = record
             .entries
             .first()
@@ -331,8 +330,7 @@ impl LocalRaftWal {
         // A delta is only sound while the log still contains the exact entry we last
         // wrote, at the same term. A conflict overwrite (raft truncating a divergent
         // suffix) or a snapshot compaction (dropping a prefix) breaks that.
-        let delta_safe = delta_enabled
-            && cursor.has_base
+        let delta_safe = cursor.has_base
             && cursor.persisted_last_index > 0
             && log_last_index >= cursor.persisted_last_index
             && log_first_index > 0
@@ -416,11 +414,7 @@ impl LocalRaftWal {
         // never orphan a delta. Rotation still honours `max_segment_bytes`; it is only
         // clamped up to one base record so a segment can always hold the record that
         // opens it.
-        let rotate_threshold = if delta_enabled {
-            max_segment_bytes.max(cursor.base_bytes)
-        } else {
-            max_segment_bytes
-        };
+        let rotate_threshold = max_segment_bytes.max(cursor.base_bytes);
         // Size-based rotation as before -- plus: a COMPACTING base opens a segment. When the
         // snapshot boundary advanced, the base supersedes the history in the current segment,
         // and only at a segment boundary can pruning reclaim it. Ordinary re-bases (an empty

--- a/crates/temporalstore-rust/src/raft/production_runtime.rs
+++ b/crates/temporalstore-rust/src/raft/production_runtime.rs
@@ -441,7 +441,7 @@ impl ProductionRaftRuntime {
                     last_contact_epoch = cluster.leader_contact_epoch();
                     if force_heartbeat || last_heartbeat.elapsed() >= heartbeat_interval {
                         force_heartbeat = false;
-                        if super::follower_pipeline::follower_pipeline_enabled() {
+                        if cluster.follower_pipeline_on() {
                             // Heartbeats, catch-up batches and liveness all ride the per-follower
                             // senders: a second sender here is exactly the interleaving the
                             // pipeline exists to end. Check-quorum reads what the senders saw.

--- a/crates/temporalstore-rust/src/raft/tests/part2.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part2.rs
@@ -9,7 +9,24 @@ use super::helpers::*;
 // shared-corpus: raft_matrixraft_rpc_auth_deadline_transport_matrix
 #[test]
 fn http_raft_transport_sends_append_vote_and_snapshot_over_tcp() {
-    let cluster = RaftCluster::new_single_shard(11, [1, 2, 3]);
+    append_vote_and_snapshot_over_tcp(11, Wire::Binary);
+}
+
+// The receiver sniffs the body and accepts either wire, so the JSON sender stays covered rather
+// than merely reachable.
+#[test]
+fn http_raft_transport_sends_append_entries_as_json_over_tcp() {
+    append_vote_and_snapshot_over_tcp(12, Wire::Json);
+}
+
+#[derive(Clone, Copy)]
+enum Wire {
+    Binary,
+    Json,
+}
+
+fn append_vote_and_snapshot_over_tcp(shard: ShardId, wire: Wire) {
+    let cluster = RaftCluster::new_single_shard(shard, [1, 2, 3]);
     let addr = free_local_addr();
     std::thread::spawn({
         let cluster = cluster.clone();
@@ -26,7 +43,7 @@ fn http_raft_transport_sends_append_vote_and_snapshot_over_tcp() {
     let mut peers = BTreeMap::new();
     peers.insert(2, addr.clone());
     peers.insert(3, addr.clone());
-    let transport = HttpRaftTransport::with_options(
+    let mut transport = HttpRaftTransport::with_options(
         peers,
         HttpRequestOptions {
             connect_timeout_ms: 200,
@@ -34,6 +51,9 @@ fn http_raft_transport_sends_append_vote_and_snapshot_over_tcp() {
             max_retries: 1,
         },
     );
+    if matches!(wire, Wire::Json) {
+        transport.send_json_append_entries_for_test();
+    }
 
     cluster.set_alive(3, false).unwrap();
     cluster
@@ -80,10 +100,10 @@ fn http_raft_transport_sends_append_vote_and_snapshot_over_tcp() {
 // shared-corpus: raft_matrixraft_snapshot_chunk_retry_rollback_matrix raft_matrixraft_snapshot_lifecycle_depth
 #[test]
 fn streaming_snapshot_chunks_install_only_after_all_chunks_arrive() {
-    // This test is about ENTRY chunking; a state image is one small unit and
-    // completes in a single chunk, which is not what these assertions probe.
-    let _entries = super::part4::EnvFlagGuard::off("TS_RAFT_SNAPSHOT_STATE_IMAGE");
     let cluster = RaftCluster::new_single_shard(21, [1, 2, 3]);
+    // This test is about ENTRY chunking; a state image is one small unit and completes in a
+    // single chunk, which is not what these assertions probe.
+    cluster.snapshot_carries_entries_for_test();
     cluster.set_alive(3, false).unwrap();
     for index in 0..5 {
         cluster
@@ -136,13 +156,13 @@ fn streaming_snapshot_chunks_install_only_after_all_chunks_arrive() {
 // shared-corpus: raft_matrixraft_snapshot_chunk_retry_rollback_matrix raft_matrixraft_snapshot_lifecycle_depth
 #[test]
 fn matrixraft_snapshot_chunk_retry_releases_backpressure_and_installs_chunk() {
-    // This test is about ENTRY chunking; a state image is one small unit and
-    // completes in a single chunk, which is not what these assertions probe.
-    let _entries = super::part4::EnvFlagGuard::off("TS_RAFT_SNAPSHOT_STATE_IMAGE");
     let transport = FlakyTransport {
         cluster: RaftCluster::new_single_shard(213, [1, 2, 3]),
         failures_left: Arc::new(Mutex::new(1)),
     };
+    // This test is about ENTRY chunking; a state image is one small unit and completes in a
+    // single chunk, which is not what these assertions probe.
+    transport.cluster.snapshot_carries_entries_for_test();
     for index in 0..3 {
         transport
             .cluster
@@ -188,9 +208,6 @@ fn matrixraft_snapshot_chunk_retry_releases_backpressure_and_installs_chunk() {
 // shared-corpus: raft_matrixraft_snapshot_chunk_retry_rollback_matrix raft_matrixraft_snapshot_lifecycle_depth
 #[test]
 fn matrixraft_snapshot_lifecycle_reports_timeout_rate_limit_rollback_membership_and_rejoin() {
-    // This test is about ENTRY chunking; a state image is one small unit and
-    // completes in a single chunk, which is not what these assertions probe.
-    let _entries = super::part4::EnvFlagGuard::off("TS_RAFT_SNAPSHOT_STATE_IMAGE");
     let cluster = RaftCluster::new_single_shard_with_config(
         214,
         [1, 2, 3],
@@ -202,6 +219,9 @@ fn matrixraft_snapshot_lifecycle_reports_timeout_rate_limit_rollback_membership_
         },
     )
     .unwrap();
+    // This test is about ENTRY chunking; a state image is one small unit and completes in a
+    // single chunk, which is not what these assertions probe.
+    cluster.snapshot_carries_entries_for_test();
     cluster.set_alive(3, false).unwrap();
     for index in 0..3 {
         cluster
@@ -322,10 +342,10 @@ fn raft_snapshot_transport_rejects_stale_term_before_install() {
 // shared-corpus: raft_matrixraft_snapshot_chunk_retry_rollback_matrix raft_matrixraft_snapshot_lifecycle_depth
 #[test]
 fn raft_snapshot_chunk_transport_rejects_stale_term_before_buffering() {
-    // This test is about ENTRY chunking; a state image is one small unit and
-    // completes in a single chunk, which is not what these assertions probe.
-    let _entries = super::part4::EnvFlagGuard::off("TS_RAFT_SNAPSHOT_STATE_IMAGE");
     let cluster = RaftCluster::new_single_shard(212, [1, 2, 3]);
+    // This test is about ENTRY chunking; a state image is one small unit and completes in a
+    // single chunk, which is not what these assertions probe.
+    cluster.snapshot_carries_entries_for_test();
     for index in 0..3 {
         cluster
             .propose(Command::StringSet {

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -2843,8 +2843,8 @@ fn r5_quorum_election_requires_majority_and_minority_cannot_elect() {
 /// leadership (the case a partitioned/just-superseded leader falls into).
 #[test]
 fn r4_new_leader_withholds_linearizable_read_until_committed_in_term() {
-    let _guard = EnvFlagGuard::set("TS_RAFT_LEADER_READY_BARRIER");
     let cluster = RaftCluster::new_single_shard(1, [1, 2, 3]);
+    cluster.withhold_reads_until_leader_ready_for_test();
 
     // Promote node 2 to a new term. It has not yet committed anything in that term.
     cluster.elect_leader(2).unwrap();
@@ -2873,7 +2873,6 @@ fn r4_new_leader_withholds_linearizable_read_until_committed_in_term() {
 /// image alone (O(state)) — no per-entry replay of the whole history.
 #[test]
 fn s2_state_image_snapshot_installs_without_replaying_full_entry_log() {
-    let _guard = EnvFlagGuard::set("TS_RAFT_SNAPSHOT_STATE_IMAGE");
     let cluster = RaftCluster::new_single_shard(1, [1, 2, 3]);
     for i in 0..16 {
         cluster
@@ -2923,7 +2922,6 @@ fn s2_state_image_snapshot_installs_without_replaying_full_entry_log() {
 /// single-chunk, empty-entries stream) and the follower installs from it end-to-end.
 #[test]
 fn s2_state_image_snapshot_travels_through_chunk_stream() {
-    let _guard = EnvFlagGuard::set("TS_RAFT_SNAPSHOT_STATE_IMAGE");
     let cluster = RaftCluster::new_single_shard(1, [1, 2, 3]);
     for i in 0..8 {
         cluster
@@ -2973,9 +2971,9 @@ fn s2_state_image_snapshot_travels_through_chunk_stream() {
 /// S2 gate OFF (default): the snapshot still carries the committed entry log and no state image,
 /// so behavior is byte-identical to before.
 #[test]
-fn s2_snapshot_gate_off_still_carries_entries_and_no_image() {
-    let _gate = EnvFlagGuard::off("TS_RAFT_SNAPSHOT_STATE_IMAGE");
+fn s2_snapshot_carrying_entries_holds_them_and_no_image() {
     let cluster = RaftCluster::new_single_shard(1, [1, 2, 3]);
+    cluster.snapshot_carries_entries_for_test();
     for i in 0..4 {
         cluster
             .propose(Command::StringSet {
@@ -3181,13 +3179,12 @@ fn persist_local_only_writes_just_this_nodes_record() {
     }
 }
 
-/// P1 core: with `TS_RAFT_WAL_COALESCE` on, a burst of read-index calls (which only touch the
+/// P1 core: a burst of read-index calls (which only touch the
 /// volatile `read_safety_state` accounting counters) must NOT append/fsync a single new WAL
 /// record, while a real committed write still does. This is the idle read-index/tick fsync-storm
 /// fix, and the durability barrier of a write is preserved.
 #[test]
 fn raft_wal_coalesce_skips_volatile_only_read_index_persists() {
-    let _guard = EnvFlagGuard::set("TS_RAFT_WAL_COALESCE");
     let dir = tempfile::tempdir().unwrap();
     let cluster =
         RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], RaftConfig::default())
@@ -3216,15 +3213,15 @@ fn raft_wal_coalesce_skips_volatile_only_read_index_persists() {
     );
 }
 
-/// P1 contrast: with the gate OFF the shipped behavior is byte-identical -- every read-index
+/// P1 contrast: with the skip turned off for this cluster, every read-index
 /// persists, so the same burst grows the WAL by one record per call. This pins the win as real.
 #[test]
 fn raft_wal_coalesce_off_persists_every_read_index() {
-    let _gate = EnvFlagGuard::off("TS_RAFT_WAL_COALESCE");
     let dir = tempfile::tempdir().unwrap();
     let cluster =
         RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], RaftConfig::default())
             .unwrap();
+    cluster.persist_every_wal_record_for_test();
 
     let baseline = node_wal_record_count(dir.path(), 1, 1);
     for _ in 0..25 {
@@ -3241,7 +3238,6 @@ fn raft_wal_coalesce_off_persists_every_read_index() {
 /// drop the cluster, and recover from the WAL: commit_index and the full log must survive.
 #[test]
 fn raft_wal_coalesce_preserves_committed_entries_across_restart() {
-    let _guard = EnvFlagGuard::set("TS_RAFT_WAL_COALESCE");
     let dir = tempfile::tempdir().unwrap();
     {
         let cluster =
@@ -3289,7 +3285,6 @@ fn raft_wal_coalesce_preserves_committed_entries_across_restart() {
 /// coalesced away. Recover from the WAL and confirm the bumped term + vote survived.
 #[test]
 fn raft_wal_coalesce_keeps_hard_state_vote_durable_before_request() {
-    let _coalesce = EnvFlagGuard::set("TS_RAFT_WAL_COALESCE");
     let dir = tempfile::tempdir().unwrap();
     let term_before;
     {
@@ -3366,7 +3361,6 @@ fn raft_replication_deadline_is_configurable_and_bounds_propose() {
 /// pile of full-deadline stalls).
 #[test]
 fn raft_propose_serialize_commits_concurrent_proposals_in_order() {
-    let _guard = EnvFlagGuard::set("TS_RAFT_PROPOSE_SERIALIZE");
     let cluster = RaftCluster::new_single_shard(1, [1, 2, 3]);
     let started = Instant::now();
     let mut handles = Vec::new();
@@ -4053,6 +4047,46 @@ fn a_raft_cluster_restores_every_node_from_its_own_log_on_the_live_format() {
         "[raft] 3 nodes, {} writes, one outage and catch-up, all restored and serving",
         writes.len()
     );
+}
+
+// `a_raft_cluster_restores_on_the_legacy_record_content_too` stood here. Both halves of what
+// it varied -- the record encoding and whether a record keeps its operation -- belong to a
+// store now, and the stores it wanted are owned by nodes inside the cluster; it reached them
+// only by setting variables the whole process could see. With nothing left to vary it was
+// `a_raft_cluster_restores_every_node_from_its_own_log_on_the_live_format` a second time.
+// What it claimed -- that a record in the older shape still reads -- is pinned where it can
+// be stated directly, in `wal::tests` and in the record-level size comparison.
+
+// Nothing turns the overlapped barrier on in production and, by the note on the field, nothing
+// should until a leader appends an entry of its own term on taking office. This is what runs it:
+// without it the path is code no test has ever executed.
+#[test]
+fn overlapping_the_leader_barrier_still_commits_every_write() {
+    let cluster = RaftCluster::new_single_shard(26, [1, 2, 3]);
+    cluster.overlap_leader_barrier_for_test();
+    for index in 0..4u8 {
+        cluster
+            .propose(Command::StringSet {
+                key: format!("overlap-{index}"),
+                value: vec![index],
+            })
+            .unwrap();
+    }
+    // Every write is committed and readable on the leader, with its durability barrier taken
+    // alongside replication rather than after it.
+    for index in 0..4u8 {
+        assert_eq!(
+            cluster.read_local(
+                1,
+                Command::StringGet {
+                    key: format!("overlap-{index}"),
+                },
+            ),
+            Ok(CommandResponse::Bytes {
+                value: Some(vec![index])
+            })
+        );
+    }
 }
 
 /// The same cluster, with the log written in the LEGACY encoding.

--- a/crates/temporalstore-rust/src/raft/tests/part5.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part5.rs
@@ -815,8 +815,6 @@ impl RaftTransport for OneInFlightTransport {
 /// Eight concurrent proposers, and never two appends in flight to one follower.
 #[test]
 fn at_most_one_append_in_flight_per_follower() {
-    // This test IS the pipeline's invariant; it must not silently test the default.
-    let _pipeline = super::part4::EnvFlagGuard::set("TS_RAFT_FOLLOWER_PIPELINE");
     let dir = tempfile::tempdir().unwrap();
     let cluster = RaftCluster::new_single_shard_with_wal(
         dir.path(),
@@ -825,6 +823,8 @@ fn at_most_one_append_in_flight_per_follower() {
         RaftConfig::default(),
     )
     .unwrap();
+    // This test IS the pipeline's invariant; it must not silently test the default.
+    cluster.use_follower_pipeline_for_test();
     let transport = OneInFlightTransport {
         cluster: cluster.clone(),
         in_flight: Default::default(),
@@ -890,8 +890,6 @@ fn at_most_one_append_in_flight_per_follower() {
 /// happened to apply last in the same commit batch.
 #[test]
 fn concurrent_proposers_get_their_own_responses() {
-    // This test IS the pipeline's invariant; it must not silently test the default.
-    let _pipeline = super::part4::EnvFlagGuard::set("TS_RAFT_FOLLOWER_PIPELINE");
     let dir = tempfile::tempdir().unwrap();
     let cluster = RaftCluster::new_single_shard_with_wal(
         dir.path(),
@@ -900,6 +898,8 @@ fn concurrent_proposers_get_their_own_responses() {
         RaftConfig::default(),
     )
     .unwrap();
+    // This test IS the pipeline's invariant; it must not silently test the default.
+    cluster.use_follower_pipeline_for_test();
     let transport = cluster.clone();
     // Seed distinct values, then read them back through propose_distributed concurrently: a
     // string_get's response carries the value, so a swapped response is immediately visible.
@@ -957,7 +957,6 @@ fn concurrent_proposers_get_their_own_responses() {
 /// is the test that proves it closed, through the binary record encoding and the on-disk WAL.
 #[test]
 fn restart_after_state_image_compaction_serves_every_value() {
-    let _image = super::part4::EnvFlagGuard::set("TS_RAFT_SNAPSHOT_STATE_IMAGE");
     let dir = tempfile::tempdir().unwrap();
     let config = RaftConfig {
         // Compact as soon as anything is applied, so the test exercises the image path.
@@ -1017,7 +1016,6 @@ fn restart_after_state_image_compaction_serves_every_value() {
 /// carries state and one that re-encodes history.
 #[test]
 fn state_image_compaction_bounds_wal_bytes() {
-    let _image = super::part4::EnvFlagGuard::set("TS_RAFT_SNAPSHOT_STATE_IMAGE");
     fn wal_bytes(root: &std::path::Path) -> u64 {
         fn walk(path: &std::path::Path, total: &mut u64) {
             if let Ok(entries) = std::fs::read_dir(path) {
@@ -1327,7 +1325,6 @@ fn a_torn_binary_record_is_truncated_and_the_records_before_it_survive() {
 /// by at most one generation across the keys and never rise.
 #[test]
 fn off_lock_image_build_yields_consistent_images_under_writes() {
-    let _image = super::part4::EnvFlagGuard::set("TS_RAFT_SNAPSHOT_STATE_IMAGE");
     let dir = tempfile::tempdir().unwrap();
     let cluster = std::sync::Arc::new(
         RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], RaftConfig::default())
@@ -1414,8 +1411,6 @@ fn off_lock_image_build_yields_consistent_images_under_writes() {
 /// The =0 fallback -- one propose at a time through the same senders -- must stay correct too.
 #[test]
 fn serialized_pipeline_fallback_holds_the_invariant() {
-    let _pipeline = super::part4::EnvFlagGuard::set("TS_RAFT_FOLLOWER_PIPELINE");
-    let _serial = super::part4::EnvFlagGuard::off("TS_RAFT_PIPELINE_CONCURRENT_PROPOSE");
     let dir = tempfile::tempdir().unwrap();
     let cluster = RaftCluster::new_single_shard_with_wal(
         dir.path(),
@@ -1424,6 +1419,8 @@ fn serialized_pipeline_fallback_holds_the_invariant() {
         RaftConfig::default(),
     )
     .unwrap();
+    cluster.use_follower_pipeline_for_test();
+    cluster.propose_one_at_a_time_for_test();
     let transport = OneInFlightTransport {
         cluster: cluster.clone(),
         in_flight: Default::default(),
@@ -1470,13 +1467,13 @@ fn serialized_pipeline_fallback_holds_the_invariant() {
 /// this test fails with NoMajority/LeaderUnavailable on the post-idle propose.
 #[test]
 fn idle_leader_lease_renews_on_quorum_contact() {
-    let _pipeline = super::part4::EnvFlagGuard::set("TS_RAFT_FOLLOWER_PIPELINE");
     let dir = tempfile::tempdir().unwrap();
     let config = RaftConfig {
         lease_duration_ms: 50,
         ..RaftConfig::default()
     };
     let cluster = RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], config).unwrap();
+    cluster.use_follower_pipeline_for_test();
     let transport = cluster.clone();
     cluster
         .propose_distributed(
@@ -1558,7 +1555,6 @@ fn lagging_follower_beyond_the_window_still_catches_up() {
 /// trigger to fire.
 #[test]
 fn compaction_threshold_is_judged_on_the_logs_disk_footprint() {
-    let _image = super::part4::EnvFlagGuard::set("TS_RAFT_SNAPSHOT_STATE_IMAGE");
     let dir = tempfile::tempdir().unwrap();
     let cluster = RaftCluster::new_single_shard_with_wal(
         dir.path(),
@@ -1613,7 +1609,6 @@ fn compaction_threshold_is_judged_on_the_logs_disk_footprint() {
 /// it must still serve every value.
 #[test]
 fn the_state_image_file_is_compressed_and_still_restores() {
-    let _image = super::part4::EnvFlagGuard::set("TS_RAFT_SNAPSHOT_STATE_IMAGE");
     let dir = tempfile::tempdir().unwrap();
     let cluster = RaftCluster::new_single_shard_with_wal(
         dir.path(),
@@ -1829,7 +1824,6 @@ fn the_segment_report_matches_whether_it_is_cached_or_scanned() {
 /// every check, forever.
 #[test]
 fn compaction_does_not_rebuild_the_image_for_a_log_that_is_already_small() {
-    let _image = super::part4::EnvFlagGuard::set("TS_RAFT_SNAPSHOT_STATE_IMAGE");
     let dir = tempfile::tempdir().unwrap();
     let cluster = RaftCluster::new_single_shard_with_wal(
         dir.path(),

--- a/crates/temporalstore-rust/src/raft/wal_proto.rs
+++ b/crates/temporalstore-rust/src/raft/wal_proto.rs
@@ -467,24 +467,6 @@ pub(crate) fn decode_append_entries(body: &[u8]) -> io::Result<AppendEntriesRequ
     })
 }
 
-/// Whether a leader takes its durability barrier alongside replication rather than after it.
-///
-/// Off unless asked for: it relies on the commit index being recoverable, which holds only once
-/// every leader commits an entry of its own term on taking office.
-pub(super) fn overlap_leader_barrier_enabled() -> bool {
-    std::env::var("TS_RAFT_OVERLAP_LEADER_BARRIER")
-        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
-        .unwrap_or(false)
-}
-
-/// Whether replicated batches are sent in the binary encoding. Off unless asked for: a receiver
-/// accepts either, but a sender must not switch before every peer can read it.
-pub(super) fn binary_replication_enabled() -> bool {
-    std::env::var("TS_RAFT_BINARY_REPLICATION")
-        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
-        .unwrap_or(false)
-}
-
 /// Encode one envelope as a binary message.
 pub(super) fn encode_envelope(envelope: &RaftWalEnvelope) -> io::Result<Vec<u8>> {
     let record = &envelope.record;

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -8,7 +8,7 @@ within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 325 of them, read by 121 functions.
+There are 316 of them, read by 112 functions.
 
 Deleting unreachable code is not the lever. An earlier version of this document argued that
 by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
@@ -46,12 +46,12 @@ Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 325 |
-| booleans whose default this could read off the source | 56 |
+| total | 316 |
+| booleans whose default this could read off the source | 50 |
 | **defaulting on, and set by nothing** | 9 |
 | offered on the portal | 23 |
-| **that nothing in this repository sets** | 187 |
-| documented as keeping an older path alive | 7 |
+| **that nothing in this repository sets** | 184 |
+| documented as keeping an older path alive | 6 |
 | reaching more than two files | 17 |
 | whose doc comment is really about another flag | 43 |
 
@@ -158,7 +158,7 @@ Secrets. Never a form field, never in a launch artifact.
 | `TS_API_AUTH_TOKEN` | — | nothing | 1 | — |
 | `TS_META_ADMIN_TOKEN` | — | nothing | 1 | — |
 
-## durability (32)
+## durability (27)
 
 What is written, when it is flushed, and what is reclaimed. The escape hatches here trade throughput for a more conservative barrier.
 
@@ -175,12 +175,7 @@ What is written, when it is flushed, and what is reclaimed. The escape hatches h
 | `TS_INDEX_DUMP_WAL_GAP_BYTES` | — | portal | 1 | — |
 | `TS_META_RAFT_SNAPSHOT_CHECK_INTERVAL_MS` | — | nothing | 1 | — |
 | `TS_META_SCHEDULER_SNAPSHOT` | — | nothing | 1 | — |
-| `TS_RAFT_LEADER_READY_BARRIER` | — | test | 1 | — |
-| `TS_RAFT_OVERLAP_LEADER_BARRIER` | off | nothing | 1 | — |
-| `TS_RAFT_SNAPSHOT_STATE_IMAGE` | on | test | 1 | — |
 | `TS_RAFT_WAL_BINARY_RECORDS` | on | nothing | 1 | — |
-| `TS_RAFT_WAL_COALESCE` | on | test | 1 | — |
-| `TS_RAFT_WAL_DELTA_ENTRIES` | — | nothing | 1 | yes |
 | `TS_SHARED_STORE_FENCE` | off | test | 1 | — |
 | `TS_WAL_BINARY_FRAME` | on | launch, test | 1 | — |
 | `TS_WAL_BINARY_RECORDS` | on | launch, test | 1 | — |
@@ -197,7 +192,7 @@ What is written, when it is flushed, and what is reclaimed. The escape hatches h
 | `TS_WAL_RESIDENT_PAGES` | — | test | 1 | — |
 | `TS_WAL_SEGMENT_BYTES` | — | nothing | 1 | — |
 
-## format (9)
+## format (8)
 
 The shape of what is written. Readers generally accept both shapes, which is what makes these safe to flip and hard to retire.
 
@@ -209,7 +204,6 @@ The shape of what is written. Readers generally accept both shapes, which is wha
 | `TS_INDEX_LOG_BINARY` | on | nothing | 1 | — |
 | `TS_NODE_SUMMARY_VECTOR` | on | test, portal | 1 | — |
 | `TS_PROXY_BINARY_VERSION` | — | nothing | 1 | — |
-| `TS_RAFT_BINARY_REPLICATION` | off | nothing | 1 | — |
 | `TS_VECTOR_INT8` | off | test, portal | 1 | — |
 | `TS_VECTOR_SCALED` | on | launch, script, test, portal | 1 | — |
 
@@ -377,7 +371,7 @@ Read only by the benchmark harnesses. Never consulted on a serving path.
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_SOURCE_ORDER_RANKING` | off | nothing | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_STORED_RECORD_SCORING` | on | nothing | 1 | — |
 
-## behaviour (73)
+## behaviour (70)
 
 Everything else that changes what the engine does.
 
@@ -434,10 +428,7 @@ Everything else that changes what the engine does.
 | `TS_RAFT_CA_CERT_PATH` | — | nothing | 1 | — |
 | `TS_RAFT_CA_PATH` | — | nothing | 1 | — |
 | `TS_RAFT_CERT_PATH` | — | nothing | 1 | — |
-| `TS_RAFT_FOLLOWER_PIPELINE` | off | test | 1 | — |
 | `TS_RAFT_KEY_PATH` | — | nothing | 1 | — |
-| `TS_RAFT_PIPELINE_CONCURRENT_PROPOSE` | — | test | 1 | — |
-| `TS_RAFT_PROPOSE_SERIALIZE` | on | test | 1 | — |
 | `TS_RAFT_REPLICATION_DEADLINE_MS` | — | test | 1 | — |
 | `TS_RAFT_SECURITY_MODE` | — | nothing | 1 | — |
 | `TS_RAFT_TRANSPORT_SECURITY` | — | nothing | 1 | — |


### PR DESCRIPTION
Nine raft switches become fields on the cluster or transport they configure. Every one of them is
set by nothing in this repository except a test — checked with the inventory that landed in #871,
which is what made asking the question cheap.

| flag | now |
|---|---|
| `TS_RAFT_WAL_COALESCE` | `RaftClusterInner::wal_coalesce` |
| `TS_RAFT_SNAPSHOT_STATE_IMAGE` | `RaftClusterInner::snapshot_state_image` |
| `TS_RAFT_OVERLAP_LEADER_BARRIER` | `RaftClusterInner::overlap_leader_barrier` |
| `TS_RAFT_LEADER_READY_BARRIER` | `RaftClusterInner::leader_ready_barrier` |
| `TS_RAFT_FOLLOWER_PIPELINE` | `RaftClusterInner::follower_pipeline` |
| `TS_RAFT_PIPELINE_CONCURRENT_PROPOSE` | `RaftClusterInner::pipeline_concurrent_propose` |
| `TS_RAFT_BINARY_REPLICATION` | `HttpRaftTransport::binary_replication`, and now **on** |
| `TS_RAFT_PROPOSE_SERIALIZE` | unconditional |
| `TS_RAFT_WAL_DELTA_ENTRIES` | unconditional |

**No default moves except the last one.** Each switch keeps the value every deployment already
had; what changes is that a test says it to the cluster it built, rather than to the process.

### Two of these could not be turned on, and now say so

`overlap_leader_barrier` and `leader_ready_barrier` both wait on the same missing mechanism: Raft
releases them by having a new leader append a no-op entry at its own term the moment it is
elected, and this implementation never appends one. `elect_leader` and `promote_elected_leader`
set roles and a lease and append nothing. Enabling the read barrier would reject every
leader-served read from the end of an election until the next client write commits — indefinitely
on an idle cluster.

They sat as two independent-looking knobs. They are now adjacent fields, each naming the other and
the entry they both need. Being fields is also what stops a deployment reaching a durability path
no test had ever executed — `overlapping_the_leader_barrier_still_commits_every_write` runs it now.

### The one default that moves

`TS_RAFT_BINARY_REPLICATION` was off and set by nothing, so the binary sender had never run. Its
parts were covered and its composition was not: the encoder has a round-trip test, and part5 posts
a binary body straight at the handler, but nothing had put the two ends on a socket together. The
receiver needs no change — it sniffs the body and accepts either encoding, and has since the same
commit that added this flag, so both sides were written together and only one was ever reachable.

`http_raft_transport_sends_append_vote_and_snapshot_over_tcp` is the one test that speaks real TCP
through the real handler, and it now runs on both wires — binary as the default, and a second copy
sending JSON so the receiver's other branch stays covered rather than merely reachable.

The caveat the flag existed for is real and is not a code property: a sender must not switch before
every peer can read it. No build older than the receiver's sniffing can, so a first deployment
carrying this must not be a rolling upgrade from one older than that. The flag could not have
expressed the requirement anyway — it is per peer, and the variable was per process.

### What this leaves

Outside its tests, raft now reads the environment twice: a `|key| env::var(key).ok()` closure
handed to the transport-security builder, so even TLS settings are injected rather than reached
for, and `TS_RAFT_WAL_BINARY_RECORDS`. That one is deliberately untouched — it is live, and #866
built the fused frame encode on it. `raft/local_wal.rs` is edited only for the delta-entry path;
every `binary_records_enabled()` call there is left exactly as main has it, and
`a_raft_cluster_restores_on_the_legacy_encoding_too` is kept.

Both raft environment helpers went with their last callers. Their doc comments described a class
of optional raft gates, and there is no longer such a class, so the docs were deleted with the
code rather than left to attach themselves to the next item.

### Verification

`cargo check -p temporalstore-rust --all-targets` clean, no new warnings. The raft suite: 248
passed, 0 failed. 32 inventory guards pass. Rebased on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
