### PR TITLE
Write the page handle as a number

### DIFF
--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -169,7 +169,8 @@ pub struct IndexItem {
         rename = "pk",
         alias = "page_ref_key",
         default,
-        deserialize_with = "page_ref_key_either_shape"
+        deserialize_with = "page_ref_key_either_shape",
+        serialize_with = "page_ref_key_as_number_when_it_is_one"
     )]
     pub page_ref_key: String,
     #[serde(rename = "ok", alias = "object_key", default)]
@@ -210,6 +211,28 @@ fn is_zero_u64(value: &u64) -> bool {
 ///
 /// The handle is a `u64`; it has been carried as decimal text. This lets a reader consume a log
 /// whose writer has moved to the number, so the writer can move whenever every reader has this.
+/// Write the page-ref key as a NUMBER when it is one, and as text when it is not.
+///
+/// This is the second half of the two-step change the reader half landed for. The key is a `u64`
+/// everywhere else and the write path stringifies it on the way in; as decimal text it was 20
+/// bytes of a 161-byte item, and as a msgpack integer it is about nine.
+///
+/// Safe to flip because `page_ref_key_either_shape` already takes both, and it has shipped: a
+/// reader that had only ever seen the string would have had msgpack refuse the type outright
+/// rather than degrade, which is exactly why the reader went first.
+///
+/// A key that does NOT parse as a number still goes out as text, so nothing depends on the write
+/// path's stringification being reversible.
+fn page_ref_key_as_number_when_it_is_one<S>(value: &str, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    match value.parse::<u64>() {
+        Ok(number) => serializer.serialize_u64(number),
+        Err(_) => serializer.serialize_str(value),
+    }
+}
+
 fn page_ref_key_either_shape<'de, D>(deserializer: D) -> Result<String, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -2382,13 +2405,34 @@ mod tests {
         let round_tripped: IndexItem = decode_index_payload(&as_text).expect("text must decode");
         assert_eq!(round_tripped.page_ref_key, handle.to_string());
 
-        // Nothing writes the number yet: that is the second step, and it needs every reader to
-        // have this one first.
+        // The writer now emits the number, so `as_text` above is ALSO numeric and the two are no
+        // longer a text-vs-number comparison -- they are two different structs. `NumericHandle`
+        // is a hand-rolled mirror that does not skip its false bools, where `IndexItem` does, so
+        // it comes out SEVEN BYTES LARGER despite carrying the same handle. Comparing them was
+        // only ever meaningful while the text penalty outweighed that difference.
+        //
+        // Compare like with like instead: the same item, with a handle that parses as a number
+        // and one of the same length that does not.
+        let mut unparseable = textual.clone();
+        unparseable.page_ref_key = format!("x{}", &handle.to_string()[1..]);
+        assert_eq!(
+            unparseable.page_ref_key.len(),
+            handle.to_string().len(),
+            "the two handles must be the same length or the comparison measures the length"
+        );
+        let as_forced_text =
+            encode_index_payload(&unparseable).expect("encode the unparseable handle");
         assert!(
-            as_text.len() > as_number.len(),
-            "the numeric shape should be the smaller one: text {} vs number {}",
+            as_forced_text.len() > as_text.len(),
+            "a handle that parses should be written as a number and be smaller: text {} vs number {}",
+            as_forced_text.len(),
+            as_text.len()
+        );
+        println!(
+            "  HANDLE same item, 20-char handle: as text {} B, as a number {} B (saves {} B a record)",
+            as_forced_text.len(),
             as_text.len(),
-            as_number.len()
+            as_forced_text.len() - as_text.len()
         );
         println!(
             "  HANDLE text {} B vs number {} B ({} B a record if the writer ever moves)",


### PR DESCRIPTION
The index-log item carries its page handle as decimal text. It is a `u64` everywhere else —
`BlockLookupRef::page_ref_key` is one — and the write path stringifies it on the way in.

The reader half of this change shipped separately and first: `page_ref_key_either_shape` takes both
shapes, and every build that can be rolled back to has it. That ordering was not optional — msgpack
refuses a type mismatch outright rather than degrading, so a writer that moved first would hand a
reader a number it could not parse at all. **Nothing wrote a number yet. This is that second half.**

### Measured

The same item, with a 20-character handle that parses as a number and one of the same length that
does not:

```
  as text 101 B, as a number 89 B  (saves 12 B a record)
```

**12 bytes per index-log item, 11.9%.** The index log is the largest remaining amplification
surface at roughly 230 B/record — measured end to end across 2,000 to 20,000 records — so this is
about 5% of it.

A handle that does not parse as a number still goes out as text, so nothing depends on the write
path's stringification being reversible.

### The test it broke, and why that was the useful part

`a_page_handle_reads_as_a_number_or_a_string` failed with:

```
the numeric shape should be the smaller one: text 89 vs number 96
```

which reads like "this change made records bigger". It did not. That assertion compared an
`IndexItem` against a hand-rolled `NumericHandle` mirror — and the mirror does not skip its `false`
bools where `IndexItem` does, so it is seven bytes larger carrying the same handle. That difference
was invisible only while the twelve-byte text penalty outweighed it; removing the penalty exposed
it.

Trusting the message would have reverted a real saving. Dismissing it as a stale test would have
shipped without knowing whether the number was +12 or −7. The assertion now compares the SAME item
with a parseable and an unparseable handle of identical length, so it measures the encoding rather
than the struct, and prints the figure.
