### PR TITLE
Read the label the gateway writes on the stream

### DIFF
--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -1267,6 +1267,12 @@
   }
 
   var controller = null, backoff = 1000, buffer = "";
+  /* Set when the gateway says it is closing on purpose, cleared by the reopen it
+     causes. A planned recycle and a gateway that stopped answering look identical
+     from here without it, and only one of them is      one of them is worth telling anybody about. */
+  var planned = false;
+  /* When the current connection was established; see the floor in the reopen above. */
+  var openedAt = 0;
   /* Set the first time this deployment refuses an anonymous read. Until then there is
      no reason to assume a key is needed; afterwards there is no reason to ask again
      without one. */
@@ -1295,18 +1301,35 @@
       if (!r.ok || !r.body) { throw new Error("stream " + r.status); }
       dot.className = "live-dot";
       backoff = 1000;
+      openedAt = Date.now();
       var reader = r.body.getReader(), decoder = new TextDecoder();
       function pump() {
         return reader.read().then(function (chunk) {
-          if (chunk.done) { throw new Error("stream ended"); }
+          if (chunk.done) {
+            /* Closed on purpose once the stream reached its maximum age. Reconnect at once and
+               leave the dot alone: this is the gateway keeping its own rule, not one that stopped
+               answering, and marking it stale every ten minutes teaches people to ignore the
+               one signal the strip has. */
+            var kept = planned && (Date.now() - openedAt) > 1000;
+            planned = false;
+            if (kept) { controller = null; backoff = 1000; open(); return; }
+            throw new Error("stream ended");
+          }
           buffer += decoder.decode(chunk.value, { stream: true });
           var parts = buffer.split("\n\n");
           buffer = parts.pop();
           parts.forEach(function (block) {
+            /* Read the label. A goodbye carries a data line of its own, and rendering it as a
+               frame empties every segment of the strip -- on all five pages that read the stream
+               through here, every ten minutes. */
+            var name = "", payload = null;
             block.split("\n").forEach(function (line) {
-              if (line.indexOf("data:") !== 0) { return; }
-              try { render(JSON.parse(line.slice(5).trim())); } catch (err) { /* ignore */ }
+              if (line.indexOf("event:") === 0) { name = line.slice(6).trim(); }
+              else if (line.indexOf("data:") === 0) { payload = line.slice(5).trim(); }
             });
+            if (name === "bye") { planned = true; return; }
+            if (name !== "status" || !payload) { return; }
+            try { render(JSON.parse(payload)); } catch (err) { /* ignore */ }
           });
           return pump();
         });

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -985,6 +985,12 @@
   }
 
   var controller = null, backoff = 1000, buffer = "";
+  /* Set when the gateway says it is closing on purpose, cleared by the reopen it
+     causes. A planned recycle and a gateway that stopped answering look identical
+     from here without it, and only one of them is      one of them is worth telling anybody about. */
+  var planned = false;
+  /* When the current connection was established; see the floor in the reopen above. */
+  var openedAt = 0;
   /* Set the first time this deployment refuses an anonymous read. Until then there is
      no reason to assume a key is needed; afterwards there is no reason to ask again
      without one. */
@@ -1013,18 +1019,35 @@
       if (!r.ok || !r.body) { throw new Error("stream " + r.status); }
       dot.className = "live-dot";
       backoff = 1000;
+      openedAt = Date.now();
       var reader = r.body.getReader(), decoder = new TextDecoder();
       function pump() {
         return reader.read().then(function (chunk) {
-          if (chunk.done) { throw new Error("stream ended"); }
+          if (chunk.done) {
+            /* Closed on purpose once the stream reached its maximum age. Reconnect at once and
+               leave the dot alone: this is the gateway keeping its own rule, not one that stopped
+               answering, and marking it stale every ten minutes teaches people to ignore the
+               one signal the strip has. */
+            var kept = planned && (Date.now() - openedAt) > 1000;
+            planned = false;
+            if (kept) { controller = null; backoff = 1000; open(); return; }
+            throw new Error("stream ended");
+          }
           buffer += decoder.decode(chunk.value, { stream: true });
           var parts = buffer.split("\n\n");
           buffer = parts.pop();
           parts.forEach(function (block) {
+            /* Read the label. A goodbye carries a data line of its own, and rendering it as a
+               frame empties every segment of the strip -- on all five pages that read the stream
+               through here, every ten minutes. */
+            var name = "", payload = null;
             block.split("\n").forEach(function (line) {
-              if (line.indexOf("data:") !== 0) { return; }
-              try { render(JSON.parse(line.slice(5).trim())); } catch (err) { /* ignore */ }
+              if (line.indexOf("event:") === 0) { name = line.slice(6).trim(); }
+              else if (line.indexOf("data:") === 0) { payload = line.slice(5).trim(); }
             });
+            if (name === "bye") { planned = true; return; }
+            if (name !== "status" || !payload) { return; }
+            try { render(JSON.parse(payload)); } catch (err) { /* ignore */ }
           });
           return pump();
         });

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -526,6 +526,12 @@ NAV_JS = r'''<script>
   }
 
   var controller = null, backoff = 1000, buffer = "";
+  /* Set when the gateway says it is closing on purpose, cleared by the reopen it
+     causes. A planned recycle and a gateway that stopped answering look identical
+     from here without it, and only one of them is      one of them is worth telling anybody about. */
+  var planned = false;
+  /* When the current connection was established; see the floor in the reopen above. */
+  var openedAt = 0;
   /* Set the first time this deployment refuses an anonymous read. Until then there is
      no reason to assume a key is needed; afterwards there is no reason to ask again
      without one. */
@@ -554,18 +560,35 @@ NAV_JS = r'''<script>
       if (!r.ok || !r.body) { throw new Error("stream " + r.status); }
       dot.className = "live-dot";
       backoff = 1000;
+      openedAt = Date.now();
       var reader = r.body.getReader(), decoder = new TextDecoder();
       function pump() {
         return reader.read().then(function (chunk) {
-          if (chunk.done) { throw new Error("stream ended"); }
+          if (chunk.done) {
+            /* Closed on purpose once the stream reached its maximum age. Reconnect at once and
+               leave the dot alone: this is the gateway keeping its own rule, not one that stopped
+               answering, and marking it stale every ten minutes teaches people to ignore the
+               one signal the strip has. */
+            var kept = planned && (Date.now() - openedAt) > 1000;
+            planned = false;
+            if (kept) { controller = null; backoff = 1000; open(); return; }
+            throw new Error("stream ended");
+          }
           buffer += decoder.decode(chunk.value, { stream: true });
           var parts = buffer.split("\n\n");
           buffer = parts.pop();
           parts.forEach(function (block) {
+            /* Read the label. A goodbye carries a data line of its own, and rendering it as a
+               frame empties every segment of the strip -- on all five pages that read the stream
+               through here, every ten minutes. */
+            var name = "", payload = null;
             block.split("\n").forEach(function (line) {
-              if (line.indexOf("data:") !== 0) { return; }
-              try { render(JSON.parse(line.slice(5).trim())); } catch (err) { /* ignore */ }
+              if (line.indexOf("event:") === 0) { name = line.slice(6).trim(); }
+              else if (line.indexOf("data:") === 0) { payload = line.slice(5).trim(); }
             });
+            if (name === "bye") { planned = true; return; }
+            if (name !== "status" || !payload) { return; }
+            try { render(JSON.parse(payload)); } catch (err) { /* ignore */ }
           });
           return pump();
         });
@@ -674,6 +697,13 @@ function liveStream(options) {
   var onState = options.onState || function () {};
   var headers = options.headers || function () { return {}; };
   var controller = null, stopped = false, backoff = 1000, buffer = "";
+  /* Set when the gateway says it is closing on purpose, cleared by the reopen it
+     causes. Without it a planned recycle is indistinguishable from a gateway that
+     fell over. */
+  var planned = false;
+  /* When the current connection was established, so a goodbye can be sanity-checked against how
+     long the stream actually lasted. */
+  var openedAt = 0;
 
   function schedule() {
     if (stopped) { return; }
@@ -683,12 +713,32 @@ function liveStream(options) {
   }
 
   function handle(block) {
-    var payload = null;
+    var name = "", payload = null;
     block.split("\n").forEach(function (line) {
-      if (line.indexOf("data: ") === 0) { payload = line.slice(6); }
+      if (line.indexOf("event: ") === 0) { name = line.slice(7).trim(); }
+      else if (line.indexOf("data: ") === 0) { payload = line.slice(6); }
     });
-    if (!payload) { return; }
+    /* Read the label, not just the payload. A goodbye carries a data line of its own, so a reader
+       that looks only for `data:` hands {"reason": "stream_max_age"} to the frame handler as
+       though it were the deployment's state -- and a page rendering from an object with none of
+       the fields blanks the traffic table, the failures panel and the strip, every ten minutes. */
+    if (name === "bye") { planned = true; return; }
+    if (name !== "status" || !payload) { return; }
     try { onFrame(JSON.parse(payload)); } catch (e) { /* a partial frame; the next one is whole */ }
+  }
+
+  /* A stream is closed on purpose once it reaches its maximum age, and the gateway says so before
+     it goes. That is not a fault: reporting it through the backoff path puts "down" on every open
+     page on a timer, and delays the reconnect for a second to no purpose. */
+  function reopen() {
+    /* The label says whether to report a fault; the clock says whether to believe it. A stream
+       that said goodbye within a second of opening is not one that reached its ten-minute age,
+       and reconnecting at once because it claimed to would be a hot loop for as long as the
+       deployment kept doing it. */
+    var kept = planned && (Date.now() - openedAt) > 1000;
+    planned = false;
+    if (kept) { backoff = 1000; open(); return; }
+    schedule();
   }
 
   function open() {
@@ -704,11 +754,12 @@ function liveStream(options) {
         if (!response.body) { return Promise.reject("nostream"); }
         onState("live");
         backoff = 1000;
+        openedAt = Date.now();
         var reader = response.body.getReader();
         var decoder = new TextDecoder();
         function pump() {
           return reader.read().then(function (chunk) {
-            if (chunk.done) { schedule(); return; }
+            if (chunk.done) { reopen(); return; }
             buffer += decoder.decode(chunk.value, { stream: true });
             var blocks = buffer.split("\n\n");
             buffer = blocks.pop();

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -1102,6 +1102,12 @@
   }
 
   var controller = null, backoff = 1000, buffer = "";
+  /* Set when the gateway says it is closing on purpose, cleared by the reopen it
+     causes. A planned recycle and a gateway that stopped answering look identical
+     from here without it, and only one of them is      one of them is worth telling anybody about. */
+  var planned = false;
+  /* When the current connection was established; see the floor in the reopen above. */
+  var openedAt = 0;
   /* Set the first time this deployment refuses an anonymous read. Until then there is
      no reason to assume a key is needed; afterwards there is no reason to ask again
      without one. */
@@ -1130,18 +1136,35 @@
       if (!r.ok || !r.body) { throw new Error("stream " + r.status); }
       dot.className = "live-dot";
       backoff = 1000;
+      openedAt = Date.now();
       var reader = r.body.getReader(), decoder = new TextDecoder();
       function pump() {
         return reader.read().then(function (chunk) {
-          if (chunk.done) { throw new Error("stream ended"); }
+          if (chunk.done) {
+            /* Closed on purpose once the stream reached its maximum age. Reconnect at once and
+               leave the dot alone: this is the gateway keeping its own rule, not one that stopped
+               answering, and marking it stale every ten minutes teaches people to ignore the
+               one signal the strip has. */
+            var kept = planned && (Date.now() - openedAt) > 1000;
+            planned = false;
+            if (kept) { controller = null; backoff = 1000; open(); return; }
+            throw new Error("stream ended");
+          }
           buffer += decoder.decode(chunk.value, { stream: true });
           var parts = buffer.split("\n\n");
           buffer = parts.pop();
           parts.forEach(function (block) {
+            /* Read the label. A goodbye carries a data line of its own, and rendering it as a
+               frame empties every segment of the strip -- on all five pages that read the stream
+               through here, every ten minutes. */
+            var name = "", payload = null;
             block.split("\n").forEach(function (line) {
-              if (line.indexOf("data:") !== 0) { return; }
-              try { render(JSON.parse(line.slice(5).trim())); } catch (err) { /* ignore */ }
+              if (line.indexOf("event:") === 0) { name = line.slice(6).trim(); }
+              else if (line.indexOf("data:") === 0) { payload = line.slice(5).trim(); }
             });
+            if (name === "bye") { planned = true; return; }
+            if (name !== "status" || !payload) { return; }
+            try { render(JSON.parse(payload)); } catch (err) { /* ignore */ }
           });
           return pump();
         });

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -2059,6 +2059,12 @@
   }
 
   var controller = null, backoff = 1000, buffer = "";
+  /* Set when the gateway says it is closing on purpose, cleared by the reopen it
+     causes. A planned recycle and a gateway that stopped answering look identical
+     from here without it, and only one of them is      one of them is worth telling anybody about. */
+  var planned = false;
+  /* When the current connection was established; see the floor in the reopen above. */
+  var openedAt = 0;
   /* Set the first time this deployment refuses an anonymous read. Until then there is
      no reason to assume a key is needed; afterwards there is no reason to ask again
      without one. */
@@ -2087,18 +2093,35 @@
       if (!r.ok || !r.body) { throw new Error("stream " + r.status); }
       dot.className = "live-dot";
       backoff = 1000;
+      openedAt = Date.now();
       var reader = r.body.getReader(), decoder = new TextDecoder();
       function pump() {
         return reader.read().then(function (chunk) {
-          if (chunk.done) { throw new Error("stream ended"); }
+          if (chunk.done) {
+            /* Closed on purpose once the stream reached its maximum age. Reconnect at once and
+               leave the dot alone: this is the gateway keeping its own rule, not one that stopped
+               answering, and marking it stale every ten minutes teaches people to ignore the
+               one signal the strip has. */
+            var kept = planned && (Date.now() - openedAt) > 1000;
+            planned = false;
+            if (kept) { controller = null; backoff = 1000; open(); return; }
+            throw new Error("stream ended");
+          }
           buffer += decoder.decode(chunk.value, { stream: true });
           var parts = buffer.split("\n\n");
           buffer = parts.pop();
           parts.forEach(function (block) {
+            /* Read the label. A goodbye carries a data line of its own, and rendering it as a
+               frame empties every segment of the strip -- on all five pages that read the stream
+               through here, every ten minutes. */
+            var name = "", payload = null;
             block.split("\n").forEach(function (line) {
-              if (line.indexOf("data:") !== 0) { return; }
-              try { render(JSON.parse(line.slice(5).trim())); } catch (err) { /* ignore */ }
+              if (line.indexOf("event:") === 0) { name = line.slice(6).trim(); }
+              else if (line.indexOf("data:") === 0) { payload = line.slice(5).trim(); }
             });
+            if (name === "bye") { planned = true; return; }
+            if (name !== "status" || !payload) { return; }
+            try { render(JSON.parse(payload)); } catch (err) { /* ignore */ }
           });
           return pump();
         });

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -994,6 +994,12 @@
   }
 
   var controller = null, backoff = 1000, buffer = "";
+  /* Set when the gateway says it is closing on purpose, cleared by the reopen it
+     causes. A planned recycle and a gateway that stopped answering look identical
+     from here without it, and only one of them is      one of them is worth telling anybody about. */
+  var planned = false;
+  /* When the current connection was established; see the floor in the reopen above. */
+  var openedAt = 0;
   /* Set the first time this deployment refuses an anonymous read. Until then there is
      no reason to assume a key is needed; afterwards there is no reason to ask again
      without one. */
@@ -1022,18 +1028,35 @@
       if (!r.ok || !r.body) { throw new Error("stream " + r.status); }
       dot.className = "live-dot";
       backoff = 1000;
+      openedAt = Date.now();
       var reader = r.body.getReader(), decoder = new TextDecoder();
       function pump() {
         return reader.read().then(function (chunk) {
-          if (chunk.done) { throw new Error("stream ended"); }
+          if (chunk.done) {
+            /* Closed on purpose once the stream reached its maximum age. Reconnect at once and
+               leave the dot alone: this is the gateway keeping its own rule, not one that stopped
+               answering, and marking it stale every ten minutes teaches people to ignore the
+               one signal the strip has. */
+            var kept = planned && (Date.now() - openedAt) > 1000;
+            planned = false;
+            if (kept) { controller = null; backoff = 1000; open(); return; }
+            throw new Error("stream ended");
+          }
           buffer += decoder.decode(chunk.value, { stream: true });
           var parts = buffer.split("\n\n");
           buffer = parts.pop();
           parts.forEach(function (block) {
+            /* Read the label. A goodbye carries a data line of its own, and rendering it as a
+               frame empties every segment of the strip -- on all five pages that read the stream
+               through here, every ten minutes. */
+            var name = "", payload = null;
             block.split("\n").forEach(function (line) {
-              if (line.indexOf("data:") !== 0) { return; }
-              try { render(JSON.parse(line.slice(5).trim())); } catch (err) { /* ignore */ }
+              if (line.indexOf("event:") === 0) { name = line.slice(6).trim(); }
+              else if (line.indexOf("data:") === 0) { payload = line.slice(5).trim(); }
             });
+            if (name === "bye") { planned = true; return; }
+            if (name !== "status" || !payload) { return; }
+            try { render(JSON.parse(payload)); } catch (err) { /* ignore */ }
           });
           return pump();
         });

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -505,6 +505,13 @@ function liveStream(options) {
   var onState = options.onState || function () {};
   var headers = options.headers || function () { return {}; };
   var controller = null, stopped = false, backoff = 1000, buffer = "";
+  /* Set when the gateway says it is closing on purpose, cleared by the reopen it
+     causes. Without it a planned recycle is indistinguishable from a gateway that
+     fell over. */
+  var planned = false;
+  /* When the current connection was established, so a goodbye can be sanity-checked against how
+     long the stream actually lasted. */
+  var openedAt = 0;
 
   function schedule() {
     if (stopped) { return; }
@@ -514,12 +521,32 @@ function liveStream(options) {
   }
 
   function handle(block) {
-    var payload = null;
+    var name = "", payload = null;
     block.split("\n").forEach(function (line) {
-      if (line.indexOf("data: ") === 0) { payload = line.slice(6); }
+      if (line.indexOf("event: ") === 0) { name = line.slice(7).trim(); }
+      else if (line.indexOf("data: ") === 0) { payload = line.slice(6); }
     });
-    if (!payload) { return; }
+    /* Read the label, not just the payload. A goodbye carries a data line of its own, so a reader
+       that looks only for `data:` hands {"reason": "stream_max_age"} to the frame handler as
+       though it were the deployment's state -- and a page rendering from an object with none of
+       the fields blanks the traffic table, the failures panel and the strip, every ten minutes. */
+    if (name === "bye") { planned = true; return; }
+    if (name !== "status" || !payload) { return; }
     try { onFrame(JSON.parse(payload)); } catch (e) { /* a partial frame; the next one is whole */ }
+  }
+
+  /* A stream is closed on purpose once it reaches its maximum age, and the gateway says so before
+     it goes. That is not a fault: reporting it through the backoff path puts "down" on every open
+     page on a timer, and delays the reconnect for a second to no purpose. */
+  function reopen() {
+    /* The label says whether to report a fault; the clock says whether to believe it. A stream
+       that said goodbye within a second of opening is not one that reached its ten-minute age,
+       and reconnecting at once because it claimed to would be a hot loop for as long as the
+       deployment kept doing it. */
+    var kept = planned && (Date.now() - openedAt) > 1000;
+    planned = false;
+    if (kept) { backoff = 1000; open(); return; }
+    schedule();
   }
 
   function open() {
@@ -535,11 +562,12 @@ function liveStream(options) {
         if (!response.body) { return Promise.reject("nostream"); }
         onState("live");
         backoff = 1000;
+        openedAt = Date.now();
         var reader = response.body.getReader();
         var decoder = new TextDecoder();
         function pump() {
           return reader.read().then(function (chunk) {
-            if (chunk.done) { schedule(); return; }
+            if (chunk.done) { reopen(); return; }
             buffer += decoder.decode(chunk.value, { stream: true });
             var blocks = buffer.split("\n\n");
             buffer = blocks.pop();
@@ -1129,6 +1157,12 @@ function liveStream(options) {
   }
 
   var controller = null, backoff = 1000, buffer = "";
+  /* Set when the gateway says it is closing on purpose, cleared by the reopen it
+     causes. A planned recycle and a gateway that stopped answering look identical
+     from here without it, and only one of them is      one of them is worth telling anybody about. */
+  var planned = false;
+  /* When the current connection was established; see the floor in the reopen above. */
+  var openedAt = 0;
   /* Set the first time this deployment refuses an anonymous read. Until then there is
      no reason to assume a key is needed; afterwards there is no reason to ask again
      without one. */
@@ -1157,18 +1191,35 @@ function liveStream(options) {
       if (!r.ok || !r.body) { throw new Error("stream " + r.status); }
       dot.className = "live-dot";
       backoff = 1000;
+      openedAt = Date.now();
       var reader = r.body.getReader(), decoder = new TextDecoder();
       function pump() {
         return reader.read().then(function (chunk) {
-          if (chunk.done) { throw new Error("stream ended"); }
+          if (chunk.done) {
+            /* Closed on purpose once the stream reached its maximum age. Reconnect at once and
+               leave the dot alone: this is the gateway keeping its own rule, not one that stopped
+               answering, and marking it stale every ten minutes teaches people to ignore the
+               one signal the strip has. */
+            var kept = planned && (Date.now() - openedAt) > 1000;
+            planned = false;
+            if (kept) { controller = null; backoff = 1000; open(); return; }
+            throw new Error("stream ended");
+          }
           buffer += decoder.decode(chunk.value, { stream: true });
           var parts = buffer.split("\n\n");
           buffer = parts.pop();
           parts.forEach(function (block) {
+            /* Read the label. A goodbye carries a data line of its own, and rendering it as a
+               frame empties every segment of the strip -- on all five pages that read the stream
+               through here, every ten minutes. */
+            var name = "", payload = null;
             block.split("\n").forEach(function (line) {
-              if (line.indexOf("data:") !== 0) { return; }
-              try { render(JSON.parse(line.slice(5).trim())); } catch (err) { /* ignore */ }
+              if (line.indexOf("event:") === 0) { name = line.slice(6).trim(); }
+              else if (line.indexOf("data:") === 0) { payload = line.slice(5).trim(); }
             });
+            if (name === "bye") { planned = true; return; }
+            if (name !== "status" || !payload) { return; }
+            try { render(JSON.parse(payload)); } catch (err) { /* ignore */ }
           });
           return pump();
         });

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -812,6 +812,13 @@ function liveStream(options) {
   var onState = options.onState || function () {};
   var headers = options.headers || function () { return {}; };
   var controller = null, stopped = false, backoff = 1000, buffer = "";
+  /* Set when the gateway says it is closing on purpose, cleared by the reopen it
+     causes. Without it a planned recycle is indistinguishable from a gateway that
+     fell over. */
+  var planned = false;
+  /* When the current connection was established, so a goodbye can be sanity-checked against how
+     long the stream actually lasted. */
+  var openedAt = 0;
 
   function schedule() {
     if (stopped) { return; }
@@ -821,12 +828,32 @@ function liveStream(options) {
   }
 
   function handle(block) {
-    var payload = null;
+    var name = "", payload = null;
     block.split("\n").forEach(function (line) {
-      if (line.indexOf("data: ") === 0) { payload = line.slice(6); }
+      if (line.indexOf("event: ") === 0) { name = line.slice(7).trim(); }
+      else if (line.indexOf("data: ") === 0) { payload = line.slice(6); }
     });
-    if (!payload) { return; }
+    /* Read the label, not just the payload. A goodbye carries a data line of its own, so a reader
+       that looks only for `data:` hands {"reason": "stream_max_age"} to the frame handler as
+       though it were the deployment's state -- and a page rendering from an object with none of
+       the fields blanks the traffic table, the failures panel and the strip, every ten minutes. */
+    if (name === "bye") { planned = true; return; }
+    if (name !== "status" || !payload) { return; }
     try { onFrame(JSON.parse(payload)); } catch (e) { /* a partial frame; the next one is whole */ }
+  }
+
+  /* A stream is closed on purpose once it reaches its maximum age, and the gateway says so before
+     it goes. That is not a fault: reporting it through the backoff path puts "down" on every open
+     page on a timer, and delays the reconnect for a second to no purpose. */
+  function reopen() {
+    /* The label says whether to report a fault; the clock says whether to believe it. A stream
+       that said goodbye within a second of opening is not one that reached its ten-minute age,
+       and reconnecting at once because it claimed to would be a hot loop for as long as the
+       deployment kept doing it. */
+    var kept = planned && (Date.now() - openedAt) > 1000;
+    planned = false;
+    if (kept) { backoff = 1000; open(); return; }
+    schedule();
   }
 
   function open() {
@@ -842,11 +869,12 @@ function liveStream(options) {
         if (!response.body) { return Promise.reject("nostream"); }
         onState("live");
         backoff = 1000;
+        openedAt = Date.now();
         var reader = response.body.getReader();
         var decoder = new TextDecoder();
         function pump() {
           return reader.read().then(function (chunk) {
-            if (chunk.done) { schedule(); return; }
+            if (chunk.done) { reopen(); return; }
             buffer += decoder.decode(chunk.value, { stream: true });
             var blocks = buffer.split("\n\n");
             buffer = blocks.pop();
@@ -2671,6 +2699,12 @@ function liveStream(options) {
   }
 
   var controller = null, backoff = 1000, buffer = "";
+  /* Set when the gateway says it is closing on purpose, cleared by the reopen it
+     causes. A planned recycle and a gateway that stopped answering look identical
+     from here without it, and only one of them is      one of them is worth telling anybody about. */
+  var planned = false;
+  /* When the current connection was established; see the floor in the reopen above. */
+  var openedAt = 0;
   /* Set the first time this deployment refuses an anonymous read. Until then there is
      no reason to assume a key is needed; afterwards there is no reason to ask again
      without one. */
@@ -2699,18 +2733,35 @@ function liveStream(options) {
       if (!r.ok || !r.body) { throw new Error("stream " + r.status); }
       dot.className = "live-dot";
       backoff = 1000;
+      openedAt = Date.now();
       var reader = r.body.getReader(), decoder = new TextDecoder();
       function pump() {
         return reader.read().then(function (chunk) {
-          if (chunk.done) { throw new Error("stream ended"); }
+          if (chunk.done) {
+            /* Closed on purpose once the stream reached its maximum age. Reconnect at once and
+               leave the dot alone: this is the gateway keeping its own rule, not one that stopped
+               answering, and marking it stale every ten minutes teaches people to ignore the
+               one signal the strip has. */
+            var kept = planned && (Date.now() - openedAt) > 1000;
+            planned = false;
+            if (kept) { controller = null; backoff = 1000; open(); return; }
+            throw new Error("stream ended");
+          }
           buffer += decoder.decode(chunk.value, { stream: true });
           var parts = buffer.split("\n\n");
           buffer = parts.pop();
           parts.forEach(function (block) {
+            /* Read the label. A goodbye carries a data line of its own, and rendering it as a
+               frame empties every segment of the strip -- on all five pages that read the stream
+               through here, every ten minutes. */
+            var name = "", payload = null;
             block.split("\n").forEach(function (line) {
-              if (line.indexOf("data:") !== 0) { return; }
-              try { render(JSON.parse(line.slice(5).trim())); } catch (err) { /* ignore */ }
+              if (line.indexOf("event:") === 0) { name = line.slice(6).trim(); }
+              else if (line.indexOf("data:") === 0) { payload = line.slice(5).trim(); }
             });
+            if (name === "bye") { planned = true; return; }
+            if (name !== "status" || !payload) { return; }
+            try { render(JSON.parse(payload)); } catch (err) { /* ignore */ }
           });
           return pump();
         });

--- a/tools/portal/stream_label_harness.js
+++ b/tools/portal/stream_label_harness.js
@@ -1,0 +1,231 @@
+/* Run both shipped stream readers against the bytes a gateway actually writes.
+ *
+ * The gateway labels what it sends: `event: status` for a frame, `event: bye` before it closes a
+ * stream that has reached its maximum age. Both readers looked for a `data:` line and nothing
+ * else -- and a goodbye carries one, so its reason was handed to the frame handler as though it
+ * were the deployment's state. None of that is provable from source: a reader that ignores the
+ * label reads exactly like one that honours it until something is put through it.
+ *
+ * A DOM stub rather than jsdom, matching the strip harness beside this one.
+ *
+ * Usage: node stream_label_harness.js <setup_portal.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+/* The exact shapes the gateway emits, copied from the stream handler: a retry directive, a status
+   frame, a comment keepalive, and the goodbye. */
+const STATUS = 'event: status\ndata: {"ts":1,"warnings":3,"imports":{"active":[]},'
+  + '"traffic":{"total_requests":7,"total_errors":0,"routes":{}},"settings_waiting":0}\n\n';
+const KEEPALIVE = ": keepalive\n\n";
+const GOODBYE = 'event: bye\ndata: {"reason": "stream_max_age"}\n\n';
+const UNKNOWN = 'event: something_new\ndata: {"warnings":99}\n\n';
+const RETRY = "retry: 3000\n\n";
+
+/* A clock the harness moves, so "the stream lasted ten minutes" and "the stream said goodbye
+   immediately" are two different runs rather than two different waits.
+ *
+ * One per run, not one shared. These runs are all in flight at once, and a shared clock lets the
+ * ten-minute run age the one that is meant to have lasted no time at all. */
+function makeClock() {
+  const clock = { t: 1000000 };
+  function FakeDate(value) { return value === undefined ? new Date() : new Date(value); }
+  FakeDate.now = () => clock.t;
+  clock.Date = FakeDate;
+  return clock;
+}
+
+function reader(clock, blocks, opts) {
+  const held = (opts || {}).lastFor || 0;
+  /* The connection after the one under test stays open. A second stream that also ends would
+     report its own close, and every assertion here is about the FIRST one. */
+  const hang = (opts || {}).thenHang;
+  let index = 0;
+  return {
+    read() {
+      if (index === 0 && held) { clock.t += held; }
+      if (index >= blocks.length) {
+        return hang ? new Promise(function () {}) : Promise.resolve({ done: true });
+      }
+      const value = Buffer.from(blocks[index++], "utf8");
+      return Promise.resolve({ done: false, value });
+    },
+  };
+}
+
+/* ---- reader one: liveStream(), used by the pages that run their own stream ------------------- */
+function extractLiveStream() {
+  const start = page.indexOf("function liveStream(options)");
+  if (start < 0) { return null; }
+  let depth = 0;
+  for (let i = page.indexOf("{", start); i < page.length; i++) {
+    if (page[i] === "{") { depth += 1; }
+    else if (page[i] === "}") { depth -= 1; if (depth === 0) { return page.slice(start, i + 1); } }
+  }
+  return null;
+}
+
+function driveLiveStream(connections) {
+  const source = extractLiveStream();
+  if (!source) { throw new Error("liveStream is not on this page"); }
+
+  const frames = [], states = [];
+  let opened = 0;
+  const clock = makeClock();
+  const Date_ = clock.Date;
+  const document_ = { hidden: false, addEventListener() {} };
+  const window_ = { addEventListener() {} };
+  const fetch_ = function () {
+    const plan = connections[Math.min(opened, connections.length - 1)];
+    opened += 1;
+    return Promise.resolve({
+      ok: true,
+      body: { getReader: () => reader(clock, plan.blocks,
+                                      { lastFor: plan.lastFor, thenHang: plan.thenHang }) },
+    });
+  };
+  const setTimeout_ = function () { return 0; };  /* a scheduled retry is recorded, not run */
+  const AbortController_ = function () { this.signal = {}; this.abort = function () {}; };
+
+  const build = new Function(
+    "document", "window", "fetch", "setTimeout", "AbortController", "TextDecoder", "Date",
+    source + "; return liveStream;");
+  const liveStream = build(document_, window_, fetch_, setTimeout_, AbortController_,
+                           TextDecoder, Date_);
+
+  liveStream({
+    onFrame: (frame) => frames.push(frame),
+    onState: (state, n) => states.push(n === undefined ? state : state + ":" + n),
+    headers: () => ({}),
+  });
+  return { frames, states, opened: () => opened };
+}
+
+/* ---- reader two: the strip's own, used by the five pages without one -------------------------- */
+function driveStrip(connections) {
+  const marker = page.indexOf("/* The shared live strip.");
+  if (marker < 0) { throw new Error("the strip script is not on this page"); }
+  const scriptStart = page.lastIndexOf("<script>", marker) + "<script>".length;
+  const source = page.slice(scriptStart, page.indexOf("</script>", scriptStart));
+
+  const els = {};
+  ["liveStrip", "liveEnc", "liveImp", "liveReq", "liveWarn", "liveDot", "liveNode",
+   "liveWaiting", "key"].forEach((id) => {
+    els[id] = { id, hidden: true, innerHTML: "", className: "", value: "",
+                addEventListener() {}, setAttribute() {}, removeAttribute() {} };
+  });
+
+  let opened = 0;
+  const clock = makeClock();
+  const win = {
+    document: { getElementById: (id) => els[id] || null, addEventListener() {}, hidden: false },
+    addEventListener() {},
+    setTimeout: () => 0,
+    sessionStorage: { getItem: () => "" },
+    Number, JSON, String, Math, Date: clock.Date,
+    TextDecoder,
+    AbortController: function () { this.signal = {}; this.abort = function () {}; },
+    fetch: function () {
+      const plan = connections[Math.min(opened, connections.length - 1)];
+      opened += 1;
+      return Promise.resolve({
+        ok: true, status: 200,
+        body: { getReader: () => reader(clock, plan.blocks,
+                                        { lastFor: plan.lastFor, thenHang: plan.thenHang }) },
+      });
+    },
+  };
+  win.window = win;
+
+  const run = new Function("window", "document", "setTimeout", "sessionStorage", "fetch",
+                           "AbortController", "TextDecoder", "Date", source);
+  run(win, win.document, win.setTimeout, win.sessionStorage, win.fetch,
+      win.AbortController, win.TextDecoder, clock.Date);
+  return { els, opened: () => opened };
+}
+
+/* ---- the checks ------------------------------------------------------------------------------ */
+function settle(times, fn) {
+  if (times <= 0) { return fn(); }
+  setImmediate(() => settle(times - 1, fn));
+}
+
+const longLived = { blocks: [RETRY, STATUS, KEEPALIVE, UNKNOWN, GOODBYE], lastFor: 600000 };
+const shortLived = { blocks: [RETRY, STATUS, GOODBYE], lastFor: 0 };
+const droppedWithoutAWord = { blocks: [RETRY, STATUS], lastFor: 600000 };
+/* Whatever comes after the connection under test just stays open. */
+const staysOpen = { blocks: [RETRY, STATUS], lastFor: 600000, thenHang: true };
+
+/* Only two pages run their own stream; the other five read through the strip. Skipped rather than
+   quietly passed, so a page that lost its reader cannot look like a page that never had one. */
+const hasLiveStream = extractLiveStream() !== null;
+const planned = hasLiveStream ? driveLiveStream([longLived, staysOpen]) : null;
+const tooSoon = hasLiveStream ? driveLiveStream([shortLived, staysOpen]) : null;
+const unannounced = hasLiveStream ? driveLiveStream([droppedWithoutAWord, staysOpen]) : null;
+const strip = driveStrip([longLived, staysOpen]);
+const stripUnannounced = driveStrip([droppedWithoutAWord, staysOpen]);
+const stripTooSoon = driveStrip([shortLived, staysOpen]);
+
+settle(12, () => {
+  if (!hasLiveStream) {
+    console.log("skip liveStream is not on this page; it reads through the strip");
+  } else {
+    /* Non-vacuous first: every check below is about what did NOT arrive, and all of them pass
+       against a reader that was never given anything. */
+    ok("the reader was given a frame to deliver", planned.frames.length >= 1,
+       JSON.stringify(planned.frames));
+
+    ok("a status frame reaches the frame handler",
+       planned.frames.some((f) => f && f.warnings === 3));
+    ok("a goodbye does not reach the frame handler",
+       !planned.frames.some((f) => f && f.reason === "stream_max_age"),
+       JSON.stringify(planned.frames));
+    ok("a keepalive does not reach the frame handler",
+       planned.frames.every((f) => f && f.warnings !== undefined));
+    ok("an event this page does not know does not reach the frame handler",
+       !planned.frames.some((f) => f && f.warnings === 99),
+       JSON.stringify(planned.frames));
+
+    ok("a planned close is not reported as a fault",
+       !planned.states.some((s) => s.indexOf("retrying") === 0),
+       JSON.stringify(planned.states));
+    ok("a planned close reconnects", planned.opened() > 1, "opened " + planned.opened());
+
+    ok("a close with no goodbye is still reported as a fault",
+       unannounced.states.some((s) => s.indexOf("retrying") === 0),
+       JSON.stringify(unannounced.states));
+
+    ok("a goodbye within a second of connecting does not reconnect at once",
+       tooSoon.opened() === 1, "opened " + tooSoon.opened());
+    ok("a goodbye within a second of connecting backs off instead",
+       tooSoon.states.some((s) => s.indexOf("retrying") === 0),
+       JSON.stringify(tooSoon.states));
+  }
+
+  /* The strip, which is the reader the other five pages use. */
+  ok("the strip drew the frame it was given", strip.els.liveWarn.innerHTML.indexOf("3") >= 0,
+     JSON.stringify(strip.els.liveWarn));
+  ok("the strip did not render the goodbye over it",
+     strip.els.liveWarn.innerHTML.indexOf("3") >= 0 && strip.els.liveWarn.hidden === false,
+     JSON.stringify(strip.els.liveWarn));
+  ok("a planned close leaves the strip's dot alone",
+     strip.els.liveDot.className.indexOf("stale") < 0,
+     JSON.stringify(strip.els.liveDot.className));
+  ok("a planned close reconnects the strip", strip.opened() > 1, "opened " + strip.opened());
+  ok("a close with no goodbye still marks the strip stale",
+     stripUnannounced.els.liveDot.className.indexOf("stale") >= 0,
+     JSON.stringify(stripUnannounced.els.liveDot.className));
+  ok("a strip goodbye within a second of connecting does not reconnect at once",
+     stripTooSoon.opened() === 1, "opened " + stripTooSoon.opened());
+
+  console.log(failures ? "\n" + failures + " failure(s)" : "\nall good");
+  process.exit(failures ? 1 : 0);
+});

--- a/tools/test_matrixark_the_stream_reader_reads_the_label.py
+++ b/tools/test_matrixark_the_stream_reader_reads_the_label.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The stream readers read the label the gateway writes.
+
+The gateway labels everything it puts on the stream: ``event: status`` for a frame, ``event: bye``
+before it closes one that has reached its maximum age -- ten minutes, so that an abandoned tab does
+not hold a connection for the life of the worker. Both page-side readers looked for a ``data:``
+line and nothing else.
+
+A goodbye carries a data line of its own. So ``{"reason": "stream_max_age"}`` was handed to the
+frame handler as though it were the deployment's state, and a page rendering from an object with
+none of the fields blanks what it draws: the traffic table, the failures panel, the imports, the
+counts, and every segment of the strip. The close was then reported through the backoff path, which
+the pages show as **down**. Both happen on every open page every ten minutes, on every deployment.
+
+The strip's reader is the worse of the two -- it did not look at the event line at all, so *any*
+event the gateway ever adds would be rendered as state on the five pages that read through it.
+Running it against an unknown event shows the strip drawing ``99 warnings`` from one.
+
+None of this is provable from source. A reader that ignores the label reads exactly like one that
+honours it until something is put through it, which is what ``stream_label_harness.js`` does.
+
+The floor on the reconnect is the other half. Reconnecting at once is right for a stream that ran
+its ten minutes; for one that says goodbye immediately it is a hot loop, so the label decides
+whether to report a fault and the clock decides whether to believe it.
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+PORTAL = os.path.join(os.path.dirname(os.path.abspath(__file__)), "portal")
+HARNESS = os.path.join(PORTAL, "stream_label_harness.js")
+GATEWAY = os.path.join(os.path.dirname(os.path.abspath(__file__)), "matrixark_v1_gateway.py")
+
+# The two pages that run their own stream; the other five read through the strip.
+OWN_STREAM = ("setup_portal.html", "overview_portal.html")
+
+
+def _pages():
+    return sorted(name for name in os.listdir(PORTAL) if name.endswith("_portal.html"))
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class EveryPageReadsTheLabelTest(unittest.TestCase):
+
+    def _run(self, page):
+        return subprocess.run(["node", HARNESS, os.path.join(PORTAL, page)],
+                              capture_output=True, text=True, timeout=300)
+
+    def test_there_are_pages_to_check(self) -> None:
+        """A sweep over an empty list would pass while checking nothing."""
+        self.assertGreaterEqual(len(_pages()), 7, _pages())
+
+    def test_every_page_passes(self) -> None:
+        for page in _pages():
+            with self.subTest(page=page):
+                proc = self._run(page)
+                self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_the_goodbye_is_not_rendered_as_state_anywhere(self) -> None:
+        for page in _pages():
+            with self.subTest(page=page):
+                self.assertIn("ok   the strip did not render the goodbye over it",
+                              self._run(page).stdout)
+
+    def test_a_planned_close_is_not_shown_as_trouble_anywhere(self) -> None:
+        for page in _pages():
+            with self.subTest(page=page):
+                self.assertIn("ok   a planned close leaves the strip's dot alone",
+                              self._run(page).stdout)
+
+    def test_a_real_disconnection_is_still_shown(self) -> None:
+        """The point of reading the label is to tell the two apart, not to stop reporting."""
+        for page in _pages():
+            with self.subTest(page=page):
+                self.assertIn("ok   a close with no goodbye still marks the strip stale",
+                              self._run(page).stdout)
+
+    def test_the_two_pages_with_their_own_reader_are_checked(self) -> None:
+        """The harness skips those checks where there is no such reader, and a skip that spread to
+        every page would empty this file without failing it."""
+        for page in _pages():
+            out = self._run(page).stdout
+            with self.subTest(page=page):
+                if page in OWN_STREAM:
+                    self.assertIn("ok   a goodbye does not reach the frame handler", out)
+                    self.assertIn("ok   a planned close reconnects", out)
+                else:
+                    self.assertIn("skip liveStream is not on this page", out)
+
+
+class TheGatewayAndTheReadersAgreeTest(unittest.TestCase):
+    """The two halves of one contract, asserted against each other.
+
+    The readers now act on the names `status` and `bye`. If the gateway ever emits a third, the
+    readers will ignore it -- which is the safe direction, and much better than rendering it -- but
+    this should be a decision somebody makes rather than one that happens quietly.
+    """
+
+    def _emitted_labels(self):
+        with open(GATEWAY, encoding="utf-8") as handle:
+            source = handle.read()
+        return set(re.findall(r'b"event: ([a-z_]+)', source))
+
+    def test_the_gateway_emits_labels_at_all(self) -> None:
+        """An empty set would make the comparison below vacuous."""
+        self.assertTrue(self._emitted_labels())
+
+    def test_the_readers_handle_every_label_the_gateway_emits(self) -> None:
+        emitted = self._emitted_labels()
+        with open(os.path.join(PORTAL, "setup_portal.html"), encoding="utf-8") as handle:
+            page = handle.read()
+        unhandled = sorted(name for name in emitted if '"%s"' % name not in page)
+        self.assertEqual([], unhandled,
+                         "the gateway labels these and no reader mentions them: %r" % unhandled)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The gateway labels everything it puts on the stream: `event: status` for a frame, and `event: bye`
before it closes one that has reached its maximum age — ten minutes, so an abandoned tab does not
hold a connection for the life of the worker. Both page-side readers looked for a `data:` line and
nothing else.

**A goodbye carries a data line of its own.** So `{"reason": "stream_max_age"}` was handed to the
frame handler as though it were the deployment's state, and a page rendering from an object with
none of the fields blanks what it draws — the traffic table, the failures panel, the imports, the
counts, and every segment of the strip. The close was then reported through the backoff path, which
the pages show as **down**.

Both happen on every open page every ten minutes, on every deployment.

```
run the shipped reader against the bytes the gateway writes, on main:

  FAIL a goodbye does not reach the frame handler
       [ …the real frame…, {"warnings":99}, {"reason":"stream_max_age"} ]
  FAIL a planned close is not reported as a fault      ["connecting","live","retrying:1"]
  FAIL a planned close reconnects                       opened 1
  FAIL the strip drew the frame it was given            liveWarn: "<b>99</b> warnings", hidden
```

That `99` is from an event named `something_new` that this build has never heard of. The strip's
reader did not look at the event line **at all**, so any event the gateway ever adds is rendered as
state on the five pages that read through it — and then the goodbye hid the segment entirely.

### The label decides whether to report a fault; the clock decides whether to believe it

Reconnecting at once is right for a stream that ran its ten minutes. For one that says goodbye
immediately it is a hot loop, for as long as the deployment keeps doing it — the harness found this
by hanging, which is a better argument than I would have made for it. So a planned reopen is
immediate only if the connection actually lasted more than a second; otherwise it takes the backoff
path like any other close.

A close with **no** goodbye is still reported exactly as before. Reading the label is for telling
the two apart, not for reporting less.

### Both readers, all seven pages

Two pages run their own stream; the other five read through the strip. Both readers had the defect
and both are fixed, and the harness runs against every page — skipping the `liveStream` checks where
there is no such reader, and the test asserts that the skip happens on exactly the five pages that
should skip, so it cannot spread and quietly empty the file.

```
liveStream: ignore the label again              -> FAIL x4
the strip:  ignore the label again              -> FAIL x21
liveStream: drop the reconnect floor            -> FAIL x2
the strip:  drop the reconnect floor            -> FAIL x7
liveStream: treat every close as a fault again  -> FAIL x2
the strip:  treat every close as a fault again  -> FAIL x14
```

A last test asserts the two halves against each other: every label the gateway emits is one the
reader mentions. Ignoring an unknown event is the safe direction — much better than rendering it —
but it should be a decision somebody makes rather than one that happens quietly.

8 tests, 16 harness assertions per page across 7 pages. Neighbours: v1_gateway 97, gateway_portal
60, live_strip 38, api_traffic 15, gateway_events 12, portal_pages 4, and all portal-named suites
together 141 — green.

Note: `ratchet` is currently failing on **main** itself
(`test_regenerating_produces_the_same_document`, four of main's last six commits). It reproduces on
neither of my branches locally, and this branch touches nothing it reads.
