### PR TITLE
An isolation five tests asked for, and four never got

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -133,6 +133,13 @@ pub struct TemporalEngine {
     /// baseline could otherwise observe a window its sibling had opened. Shared across clones,
     /// because a clone is the same engine.
     concurrent_commit: Arc<std::sync::atomic::AtomicBool>,
+    /// Whether eviction picks its victims by a sampled scan instead of enumerating and sorting
+    /// every bucket.
+    ///
+    /// FALSE. Sampling changes WHICH buckets are chosen, not only how fast they are found, so it
+    /// wants deliberate enabling and measurement per deployment. One test turns it on, of the
+    /// engine it built, to measure how the scan volume grows with the store either way.
+    evict_sampled_lru: Arc<std::sync::atomic::AtomicBool>,
     /// Whether a committed raft batch shares ONE durable engine-WAL barrier.
     ///
     /// True everywhere but a test measuring the per-entry loop. `TS_RAFT_APPLY_COALESCE` used to
@@ -2937,13 +2944,6 @@ fn env_flag_on(name: &str) -> bool {
 /// Default-ON gate read: the fix is LIVE unless explicitly disabled with
 /// `=0|false|no|off`. Shipped write-path/raft fixes use this so production gets the
 /// fixed behavior by default; the env var remains only as an escape hatch.
-/// Bound eviction victim selection to a sampled scan instead of enumerating and sorting every
-/// bucket. Off by default: this changes which buckets are chosen, not just how fast they are
-/// found, so it wants deliberate enabling and measurement per deployment.
-pub fn evict_sampled_lru_enabled() -> bool {
-    env_flag_on("TS_EVICT_SAMPLED_LRU")
-}
-
 /// Tuning for sampled eviction, read from the environment with defaults that mirror the
 /// established policy: sample several buckets per wanted victim, keep a bounded candidate pool
 /// across passes, and cap how far one pass may walk.

--- a/crates/temporalstore-rust/src/engine/hot_page_spill.rs
+++ b/crates/temporalstore-rust/src/engine/hot_page_spill.rs
@@ -35,21 +35,6 @@ use crate::types::ShardId;
 
 use super::constants::HOT_PAGE_SLAB_ID;
 
-/// TS_HOT_PAGE_SPILL: spill evicted hot pages to a real slab + serve the durable read-by-address
-/// fallback. Default ON -- it is strictly additive (adds a durable fallback + frees DRAM) and
-/// fixes an acked-write-reads-as-missing bug. Set to a falsey value to restore the prior
-/// memory-only behavior (evicted hot pages read as missing until reload).
-pub(super) fn spill_enabled() -> bool {
-    !matches!(
-        std::env::var("TS_HOT_PAGE_SPILL")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "0" | "false" | "no" | "off"
-    )
-}
-
 fn redirects() -> &'static Mutex<HashMap<(ShardId, u64), BlockAddress>> {
     static REDIRECTS: OnceLock<Mutex<HashMap<(ShardId, u64), BlockAddress>>> = OnceLock::new();
     REDIRECTS.get_or_init(|| Mutex::new(HashMap::new()))
@@ -85,10 +70,13 @@ fn parse_hot_selector(selector: &str) -> Option<(u64, Option<u32>)> {
 /// cache's callback, so a cache used 1:1 with an engine ends up with the correct store; the shared
 /// redirect map stays coherent because hot-page offsets are globally unique (one process-wide
 /// atomic), so an engine only ever looks up offsets it minted itself.
+///
+/// Always installed. `TS_HOT_PAGE_SPILL` used to be able to skip it -- strictly additive, so the
+/// off position only restored an acked-write-reads-as-missing bug -- and the only callers that
+/// ever set it were four tests that set it AFTER building their engine, by which time this had
+/// already run. `TemporalEngine::disable_hot_page_spill_for_test` is how an engine is told, and
+/// it works because `register_eviction_callback` replaces the callback rather than adding one.
 pub(super) fn install_spill_handler(cache: &MultiLayerCache, block_store: &LocalBlockStore) {
-    if !spill_enabled() {
-        return;
-    }
     let block_store = block_store.clone();
     let hot_record_key = hot_page_record_key();
     cache.register_eviction_callback(move |record: CacheEvictionRecord| {

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -74,13 +74,34 @@ impl TemporalEngine {
             maintenance_mirror: Arc::default(),
             quotas: Arc::new(RwLock::new(crate::engine::quota::QuotaTable::default())),
             concurrent_commit: Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            evict_sampled_lru: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             raft_apply_coalesce: Arc::new(std::sync::atomic::AtomicBool::new(true)),
         }
+    }
+
+    /// Stop this engine's cache spilling evicted hot pages to a real slab, so a read has to come
+    /// from the log-resident path.
+    ///
+    /// Five tests want this, and `TS_HOT_PAGE_SPILL=0` was how they asked. Four could not work:
+    /// `install_spill_handler` reads that variable during construction and every one of them set
+    /// it afterwards, so the handler was already installed and the isolation they described never
+    /// happened. `register_eviction_callback` REPLACES the callback, so a no-op takes the handler
+    /// off the engine this test built, at the moment it asks.
+    #[cfg(test)]
+    pub(crate) fn disable_hot_page_spill_for_test(&self) {
+        self.cache.register_eviction_callback(|_| {});
     }
 
     /// Take the durable WAL barrier UNDER the `shards` write lock, for a test measuring what
     /// the other side of the lock costs. Scoped to this engine.
     #[cfg(test)]
+    /// Pick eviction victims by a sampled scan, for the test that measures what that costs.
+    #[cfg(test)]
+    pub(crate) fn use_sampled_eviction_for_test(&self) {
+        self.evict_sampled_lru
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
     pub(crate) fn commit_under_lock_for_test(&self) {
         self.concurrent_commit
             .store(false, std::sync::atomic::Ordering::Relaxed);

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -274,7 +274,7 @@ pub(super) struct ShardState {
     pub(super) promote_scan_done: bool,
     /// Resume point and candidate pool for sampled eviction. In-memory and ephemeral like
     /// `bucket_recency`: on restart the scan simply restarts from the top, which costs one
-    /// pass, not correctness. Only consulted when `evict_sampled_lru_enabled()`.
+    /// pass, not correctness. Only consulted when the engine's `evict_sampled_lru` is on.
     #[serde(skip)]
     pub(super) evict_sampler: super::eviction_sampler::EvictionSamplerState,
 }

--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -1212,7 +1212,10 @@ impl TemporalEngine {
                 .map(|shard| shard.bucket_recency.clone())
                 .unwrap_or_default()
         };
-        let victims = if super::evict_sampled_lru_enabled() {
+        let victims = if self
+            .evict_sampled_lru
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
             self.sampled_eviction_victims(shard_id, batch_limit, &cache_by_bucket)
         } else {
             let mut victims = self

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -7113,15 +7113,12 @@ fn sampled_eviction_scan_volume_does_not_grow_with_the_store() {
         }
 
         if sampled {
-            std::env::set_var("TS_EVICT_SAMPLED_LRU", "1");
-        } else {
-            std::env::remove_var("TS_EVICT_SAMPLED_LRU");
+            engine.use_sampled_eviction_for_test();
         }
         crate::engine::reset_live_page_scan_entries();
         // Threshold 0 so the pressure gate always admits and the selection path actually runs.
         let report = engine.apply_storage_eviction(1, 0, 4, false, false);
         let scanned = crate::engine::live_page_scan_entries();
-        std::env::remove_var("TS_EVICT_SAMPLED_LRU");
         (scanned, report.selected_victims.len())
     }
 
@@ -7182,7 +7179,9 @@ fn an_evicted_async_write_is_served_from_its_wal_record() {
     std::env::set_var("TS_BLOCK_IN_WAL", "1");
     // The spill path would otherwise mask what is being tested by copying the value to a real
     // slab on eviction.
-    std::env::set_var("TS_HOT_PAGE_SPILL", "0");
+    // Said to THIS engine. `TS_HOT_PAGE_SPILL=0` was how this asked, and it could not
+    // work: the handler is installed during construction, which already happened above.
+    engine.disable_hot_page_spill_for_test();
 
     let key = "block-in-wal-key";
     let value = b"block-in-wal-value".to_vec();
@@ -7205,7 +7204,6 @@ fn an_evicted_async_write_is_served_from_its_wal_record() {
         },
     });
     std::env::remove_var("TS_BLOCK_IN_WAL");
-    std::env::remove_var("TS_HOT_PAGE_SPILL");
 
     assert_eq!(
         read.response,
@@ -7241,7 +7239,9 @@ fn an_evicted_derived_page_is_served_from_its_wal_record() {
     });
 
     std::env::set_var("TS_BLOCK_IN_WAL", "1");
-    std::env::set_var("TS_HOT_PAGE_SPILL", "0");
+    // Said to THIS engine. `TS_HOT_PAGE_SPILL=0` was how this asked, and it could not
+    // work: the handler is installed during construction, which already happened above.
+    engine.disable_hot_page_spill_for_test();
 
     let write = engine.execute(ExecuteRequest {
         shard_id: 1,
@@ -7264,7 +7264,6 @@ fn an_evicted_derived_page_is_served_from_its_wal_record() {
         },
     });
     std::env::remove_var("TS_BLOCK_IN_WAL");
-    std::env::remove_var("TS_HOT_PAGE_SPILL");
 
     assert_eq!(
         read.response,
@@ -7506,7 +7505,9 @@ fn a_block_in_wal_page_still_reads_back_after_a_shard_reload() {
     });
 
     std::env::set_var("TS_BLOCK_IN_WAL", "1");
-    std::env::set_var("TS_HOT_PAGE_SPILL", "0");
+    // Said to THIS engine. `TS_HOT_PAGE_SPILL=0` was how this asked, and it could not
+    // work: the handler is installed during construction, which already happened above.
+    engine.disable_hot_page_spill_for_test();
 
     let key = "reload-block-key";
     let value = b"reload-block-value".to_vec();
@@ -7532,7 +7533,6 @@ fn a_block_in_wal_page_still_reads_back_after_a_shard_reload() {
         },
     });
     std::env::remove_var("TS_BLOCK_IN_WAL");
-    std::env::remove_var("TS_HOT_PAGE_SPILL");
 
     assert_eq!(
         read.response,
@@ -7568,7 +7568,9 @@ fn a_wal_resident_page_records_where_it_lives_in_the_index() {
         },
     });
     std::env::set_var("TS_BLOCK_IN_WAL", "1");
-    std::env::set_var("TS_HOT_PAGE_SPILL", "0");
+    // Said to THIS engine. `TS_HOT_PAGE_SPILL=0` was how this asked, and it could not
+    // work: the handler is installed during construction, which already happened above.
+    engine.disable_hot_page_spill_for_test();
 
     assert_eq!(
         engine.wal_resident_page_count(1),
@@ -7612,7 +7614,6 @@ fn a_wal_resident_page_records_where_it_lives_in_the_index() {
         },
     });
     std::env::remove_var("TS_BLOCK_IN_WAL");
-    std::env::remove_var("TS_HOT_PAGE_SPILL");
     assert_eq!(
         read.response,
         CommandResponse::Bytes { value: Some(value) },
@@ -7790,11 +7791,14 @@ fn two_engines_in_one_process_do_not_read_each_others_pages() {
                 ..Config::default()
             },
         });
+        // Said to EACH engine this closure builds. The variable worked here -- it is set before
+        // construction, unlike the four above -- but it said it to the process, and this test
+        // builds two engines to prove they do not share a spill map.
+        engine.disable_hot_page_spill_for_test();
         engine
     };
 
     std::env::set_var("TS_BLOCK_IN_WAL", "1");
-    std::env::set_var("TS_HOT_PAGE_SPILL", "0");
 
     let first = make("first");
     let second = make("second");
@@ -7833,7 +7837,6 @@ fn two_engines_in_one_process_do_not_read_each_others_pages() {
     let first_read = read(&first);
     let second_read = read(&second);
     std::env::remove_var("TS_BLOCK_IN_WAL");
-    std::env::remove_var("TS_HOT_PAGE_SPILL");
 
     assert_eq!(
         first_read,

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -8,7 +8,7 @@ within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 314 of them, read by 111 functions.
+There are 312 of them, read by 109 functions.
 
 Deleting unreachable code is not the lever. An earlier version of this document argued that
 by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
@@ -46,8 +46,8 @@ Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 314 |
-| booleans whose default this could read off the source | 48 |
+| total | 312 |
+| booleans whose default this could read off the source | 47 |
 | **defaulting on, and set by nothing** | 9 |
 | offered on the portal | 23 |
 | **that nothing in this repository sets** | 184 |
@@ -371,7 +371,7 @@ Read only by the benchmark harnesses. Never consulted on a serving path.
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_SOURCE_ORDER_RANKING` | off | nothing | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_STORED_RECORD_SCORING` | on | nothing | 1 | — |
 
-## behaviour (68)
+## behaviour (66)
 
 Everything else that changes what the engine does.
 
@@ -403,10 +403,8 @@ Everything else that changes what the engine does.
 | `TS_CACHE_DISK_TIER` | — | test | 1 | — |
 | `TS_COLD_SCAN_NO_CACHE_FILL` | — | config, portal | 1 | — |
 | `TS_DATA_RAFT_READ_MODE` | — | config | 1 | — |
-| `TS_EVICT_SAMPLED_LRU` | — | test | 1 | — |
 | `TS_EVICT_SAMPLES` | — | nothing | 1 | — |
 | `TS_EVICT_SCAN_TURNS` | — | nothing | 1 | — |
-| `TS_HOT_PAGE_SPILL` | on | test | 1 | — |
 | `TS_MALLOC_TRIM` | on | test, portal | 1 | — |
 | `TS_MANIFEST_SHORT_FIELD_NAMES` | on | nothing | 1 | — |
 | `TS_MATRIXOBJECT_CHECKPOINT_ON_START` | — | nothing | 1 | — |


### PR DESCRIPTION
`TS_HOT_PAGE_SPILL` defaults on and is set by nothing but five tests, each setting it to `0` to
stop a spilled copy answering a read the log-resident path is meant to serve.

**Four of them could not work.** They set the variable AFTER constructing their engine, and
`install_spill_handler` reads it DURING construction, from the constructor. The handler was already
installed by the time any of those four wrote the variable — so the isolation each describes in its
own comment never happened, and they passed anyway. Whatever they assert, they were asserting it
with the spill path live.

`TemporalEngine::disable_hot_page_spill_for_test` re-registers a no-op eviction callback, which
replaces the handler on the engine the test built, at the moment the test asks. All five pass with
it, so what they assert holds with the spill path genuinely out of the way — which is what they
were written to say and could not.

The fifth is the one that did work: it sets the variable before building two engines through a
`make` closure, so the value reached both. It said it to the process in order to say it to two
engines, and now says it to each — inside the closure, where the engine exists. That test is about
two engines in one process not reading each other's pages, so a process-wide way of configuring
them was the wrong shape for it specifically.

The general rule, which is cheap to check and easy to miss: **a process-wide switch read at
construction cannot be set by a test that already holds the constructed thing.** Setting an
environment variable always succeeds, so nothing says otherwise.

`TS_EVICT_SAMPLED_LRU` travels with it — `TemporalEngine::evict_sampled_lru`, still off, set by one
test. Sampling changes WHICH buckets are chosen rather than only how fast they are found, so it
wants deliberate enabling and measurement per deployment, and a field makes that something other
than an export in a shell. Its test measures how scan volume grows with the store under each
strategy, so it doubles as a check that the field takes effect: with the sampled arm silently
falling back, the two volumes would match and the assertion would fail.

### Verification

`cargo check -p temporalstore-rust --all-targets` clean, no new warnings. The five spill tests, the
two-engine test and the sampled-eviction test pass. 32 inventory guards pass. Inventory 314 → 312.
Rebased on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
