### PR TITLE
Two switches that gated things nothing configures

### DIFF
--- a/crates/temporalstore-rust/src/shared_store.rs
+++ b/crates/temporalstore-rust/src/shared_store.rs
@@ -316,10 +316,14 @@ pub struct SharedStoreReplicator<O> {
     object_store: Arc<O>,
     retry_policy: SharedStoreRetryPolicy,
     wal_append_mode: SharedStoreWalAppendMode,
-    /// Durable single-writer fence. When set (and `TS_SHARED_STORE_FENCE` is on), every WAL
-    /// append and checkpoint publish first re-validates that this writer's `load_version`
-    /// still owns the shard lease in the object store, aborting a superseded stale owner
-    /// before it can double-append.
+    /// Durable single-writer fence, configured by `with_fence` and applying whenever it is.
+    /// Every WAL append and checkpoint publish then re-validates that this writer's
+    /// `load_version` still owns the shard lease in the object store, aborting a superseded
+    /// stale owner before it can double-append.
+    ///
+    /// `TS_SHARED_STORE_FENCE` used to gate this as well, so a caller could configure a fence
+    /// and have it silently not apply. Nothing outside the R2 test configures one, so nothing
+    /// production does changes by the gate going: with no fence there is nothing to enforce.
     fence: Option<ShardFenceConfig>,
 }
 
@@ -343,9 +347,6 @@ struct ShardLease {
     owner: String,
 }
 
-/// `TS_SHARED_STORE_FENCE`: gate for the durable single-writer fence (R2). Default OFF so the
-/// shared-store write path is byte-identical to the pre-fence behavior unless explicitly
-/// enabled.
 /// TS_SHARED_STORE_MAX_PENDING: how many entries the async queue may hold before a write
 /// stops being allowed to defer its own durability.
 ///
@@ -362,17 +363,6 @@ fn shared_store_max_pending() -> usize {
         .ok()
         .and_then(|value| value.trim().parse::<usize>().ok())
         .unwrap_or(50_000)
-}
-
-fn shared_store_fence_enabled() -> bool {
-    matches!(
-        std::env::var("TS_SHARED_STORE_FENCE")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "1" | "true" | "yes" | "on"
-    )
 }
 
 impl<O> Clone for SharedStoreReplicator<O> {
@@ -565,9 +555,12 @@ where
     }
 
     /// Attach a durable single-writer fence: this replicator (and every storage writer it
-    /// spawns) claims `load_version` for its shard leases. Combine with
-    /// [`acquire_shard_lease`](Self::acquire_shard_lease) to install the lease and with
-    /// `TS_SHARED_STORE_FENCE=1` to enforce re-validation on every append/checkpoint.
+    /// spawns) claims `load_version` for its shard leases, and re-validates that claim on every
+    /// append and checkpoint. Combine with
+    /// [`acquire_shard_lease`](Self::acquire_shard_lease) to install the lease.
+    ///
+    /// Attaching one IS enabling it. `TS_SHARED_STORE_FENCE` used to be a second condition, so a
+    /// caller could ask for a fence and not get one.
     pub fn with_fence(mut self, load_version: u64, owner: impl Into<String>) -> Self {
         self.fence = Some(ShardFenceConfig {
             load_version,
@@ -657,7 +650,7 @@ where
     }
 
     /// Fence check invoked on every WAL append + checkpoint publish. A no-op unless a fence is
-    /// configured AND `TS_SHARED_STORE_FENCE` is enabled, so the default write path is
+    /// configured, which is a decision the caller makes by name, so the default write path is
     /// unchanged. When active it re-validates the durable lease, aborting a superseded writer.
     async fn enforce_fence(
         &self,
@@ -666,9 +659,6 @@ where
         let Some(fence) = &self.fence else {
             return Ok(());
         };
-        if !shared_store_fence_enabled() {
-            return Ok(());
-        }
         self.validate_shard_lease(shard_id, fence.load_version).await
     }
 
@@ -5436,7 +5426,6 @@ mod tests {
     /// an in-memory load_version check.
     #[tokio::test]
     async fn r2_stale_load_version_writer_is_rejected_at_store_layer() {
-        std::env::set_var("TS_SHARED_STORE_FENCE", "1");
         let dir = tempfile::tempdir().unwrap();
         let store = Arc::new(FileObjectStore::new(dir.path().join("objects")));
         let shard: ShardId = 7;
@@ -5511,8 +5500,6 @@ mod tests {
             .await
             .expect_err("CAS with a mismatched expected value must fail");
         assert!(matches!(cas_err, ObjectStoreError::ConditionFailed { .. }));
-
-        std::env::remove_var("TS_SHARED_STORE_FENCE");
     }
 
     #[derive(Debug)]

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -580,14 +580,31 @@ pub struct WriteAheadLogRecordMetadata {
 }
 
 impl WriteAheadLogRecordMetadata {
+    /// Metadata for a record carrying one command, without the per-item description.
+    ///
+    /// That description is derived entirely from the command this record already carries, and
+    /// read by nothing, so writing it costs 147 fsynced bytes per record to say what the record
+    /// says twice. `WriteAheadLogItemMetadata::from_command` reconstructs it for any caller that
+    /// wants it, and `single_command_with_items` writes it for one that cannot.
     pub fn single_command(command: &Command) -> Self {
+        Self::for_command(command, false)
+    }
+
+    /// The same, carrying the per-item description, for a consumer that reads records directly
+    /// and has not moved to deriving it.
+    ///
+    /// `TS_WAL_ITEM_METADATA` used to select this for every writer in the process. Nothing set
+    /// it, and the cost it added was per write, so restoring the description is a call rather
+    /// than an export -- made by whoever knows the consumer that needs it.
+    pub fn single_command_with_items(command: &Command) -> Self {
+        Self::for_command(command, true)
+    }
+
+    fn for_command(command: &Command, with_items: bool) -> Self {
         Self {
             version: WRITE_AHEAD_LOG_FORMAT_VERSION,
             timestamp_ms: current_time_ms(),
-            // Derived from the command this record already carries, and read by nothing, so
-            // writing it costs 147 fsynced bytes per record to say what the record says twice.
-            // `from_command` reconstructs it for any caller that wants it.
-            items: if wal_item_metadata_enabled() {
+            items: if with_items {
                 vec![WriteAheadLogItemMetadata::from_command(command)]
             } else {
                 Vec::new()
@@ -620,22 +637,6 @@ pub struct WriteAheadLogItemMetadata {
     pub meta_log: bool,
     #[serde(default)]
     pub block_log: bool,
-}
-
-/// TS_WAL_ITEM_METADATA: write the per-item description into each record.
-///
-/// Default OFF. Every field is derived from the command in the same record and nothing reads it
-/// back, so writing it is 147 bytes of amplification per write. Set to a truthy value to restore
-/// it for a consumer that reads records directly and has not moved to deriving it.
-fn wal_item_metadata_enabled() -> bool {
-    matches!(
-        std::env::var("TS_WAL_ITEM_METADATA")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "1" | "true" | "yes" | "on"
-    )
 }
 
 impl WriteAheadLogItemMetadata {
@@ -6085,9 +6086,8 @@ mod tests {
         assert!(!item.meta_log);
         assert!(!item.block_log);
 
-        // By default the record does not carry it -- 147 fsynced bytes per write saying what
-        // the record already says.
-        std::env::remove_var("TS_WAL_ITEM_METADATA");
+        // The record does not carry it -- 147 fsynced bytes per write saying what the record
+        // already says.
         let lean = WriteAheadLogRecordMetadata::single_command(&command);
         assert!(
             lean.items.is_empty(),
@@ -6099,10 +6099,9 @@ mod tests {
             "an empty description must be skipped entirely, got {encoded}"
         );
 
-        // The escape hatch restores it for a consumer reading records directly.
-        std::env::set_var("TS_WAL_ITEM_METADATA", "1");
-        let full = WriteAheadLogRecordMetadata::single_command(&command);
-        std::env::remove_var("TS_WAL_ITEM_METADATA");
+        // The other constructor restores it for a consumer reading records directly. It is
+        // named rather than selected, so no environment can point the live path at it.
+        let full = WriteAheadLogRecordMetadata::single_command_with_items(&command);
         assert_eq!(full.items.len(), 1);
         assert_eq!(full.items[0].object_key.as_deref(), Some("k"));
     }

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -8,7 +8,7 @@ within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 312 of them, read by 109 functions.
+There are 310 of them, read by 107 functions.
 
 Deleting unreachable code is not the lever. An earlier version of this document argued that
 by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
@@ -46,8 +46,8 @@ Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 312 |
-| booleans whose default this could read off the source | 47 |
+| total | 310 |
+| booleans whose default this could read off the source | 45 |
 | **defaulting on, and set by nothing** | 9 |
 | offered on the portal | 23 |
 | **that nothing in this repository sets** | 184 |
@@ -158,7 +158,7 @@ Secrets. Never a form field, never in a launch artifact.
 | `TS_API_AUTH_TOKEN` | — | nothing | 1 | — |
 | `TS_META_ADMIN_TOKEN` | — | nothing | 1 | — |
 
-## durability (27)
+## durability (25)
 
 What is written, when it is flushed, and what is reclaimed. The escape hatches here trade throughput for a more conservative barrier.
 
@@ -176,12 +176,10 @@ What is written, when it is flushed, and what is reclaimed. The escape hatches h
 | `TS_META_RAFT_SNAPSHOT_CHECK_INTERVAL_MS` | — | nothing | 1 | — |
 | `TS_META_SCHEDULER_SNAPSHOT` | — | nothing | 1 | — |
 | `TS_RAFT_WAL_BINARY_RECORDS` | on | nothing | 1 | — |
-| `TS_SHARED_STORE_FENCE` | off | test | 1 | — |
 | `TS_WAL_BINARY_FRAME` | on | launch, test | 1 | — |
 | `TS_WAL_BINARY_RECORDS` | on | launch, test | 1 | — |
 | `TS_WAL_COMMIT_DELAY_US` | — | config | 1 | — |
 | `TS_WAL_DATA_ONLY` | on | launch, test | 1 | — |
-| `TS_WAL_ITEM_METADATA` | off | test | 1 | — |
 | `TS_WAL_OUTCOME_ITEMS` | on | launch, test | 1 | — |
 | `TS_WAL_OUTCOME_STRICT` | off | nothing | 1 | — |
 | `TS_WAL_PREALLOCATE` | on | launch, test | 1 | — |


### PR DESCRIPTION
Both are off, both set by exactly one test, and both turn out to be a second way of asking a
question the caller already answers directly.

### The shared-store fence gated something nothing configures

`enforce_fence` was a no-op unless **both** a fence was configured **and** the variable was on. A
fence is configured only by `with_fence`, an explicit builder call — and its three callers are all
in the R2 test. So in a deployment the variable gated something that was `None` regardless, and the
only behaviour it could ever have had was to let a caller ask for a fence and quietly not get one.

That is a bad thing for a single-writer fence to be able to do. The failure it prevents is a
superseded stale owner double-appending to the shared WAL, and the way you find out the gate was
off is the corruption.

Attaching a fence is enabling it now. Nothing production does changes, because production attaches
none.

### The WAL item description becomes a named constructor

`TS_WAL_ITEM_METADATA` restores a per-item description in every record — item kind, model, object
key, bucket, TTL. Every field is derived from the command in the same record, nothing reads it
back, and writing it costs 147 fsynced bytes per write to say what the record already says. It was
kept for "a consumer that reads records directly and has not moved to deriving it" — a real
scenario, and a hypothetical consumer.

So the capability stays and the switch goes.
`WriteAheadLogRecordMetadata::single_command_with_items` names it, `single_command` is the live
path, and no environment can point the live path at the expensive one. Both delegate to one shared
constructor, so they cannot drift apart.

### A doc comment that was on the wrong item

Three lines about the fence sat above the `TS_SHARED_STORE_MAX_PENDING` block, so
`shared_store_max_pending` — a queue-depth cap — carried the fence's documentation while the
fence's own reader carried none. That predates this work; it is the same failure pattern as a
`///` block whose item is deleted, and it is what made it recognisable.

### Verification

`cargo check -p temporalstore-rust --all-targets` clean, no new warnings. 37 tests across the R2
fence test, the WAL record-metadata test and the shared-store module pass. 32 inventory guards
pass. Inventory 312 → 310. Rebased on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
