### PR TITLE
Take the reader to what the strip says needs them

### DIFF
--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -176,7 +176,7 @@
       <a class="live-seg" href="/v1/admin/setup#encoding" id="liveEnc" hidden></a>
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
-      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup" id="liveWaiting" hidden></a>
+      <a class="live-seg warn" href="/v1/admin/setup#warnings" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup#awaitingRestart" id="liveWaiting" hidden></a>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -428,7 +428,7 @@
       <a class="live-seg" href="/v1/admin/setup#encoding" id="liveEnc" hidden></a>
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
-      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup" id="liveWaiting" hidden></a>
+      <a class="live-seg warn" href="/v1/admin/setup#warnings" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup#awaitingRestart" id="liveWaiting" hidden></a>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>

--- a/tools/portal/awaiting_restart_harness.js
+++ b/tools/portal/awaiting_restart_harness.js
@@ -1,0 +1,224 @@
+/* Run the "awaiting restart" panel: what it names, and where clicking a name goes.
+ *
+ * The strip counts the settings waiting for a restart from every page. Naming them is this panel's
+ * whole job, and taking somebody to one is harder than scrolling: four of the nine groups render
+ * shut, and 26 of the 47 restart-scoped settings live in one of them. A name that scrolls to a
+ * folded row lands on a closed triangle, which looks exactly like a working link.
+ *
+ * Extracted and run rather than read, in the manner of the byte-hint harness beside this one: a
+ * renderer that never opens the group reads the same in a diff as one that does.
+ *
+ * Usage: node awaiting_restart_harness.js <setup_portal.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+function extract(marker) {
+  const start = page.indexOf(marker);
+  if (start < 0) { throw new Error("not on this page: " + marker); }
+  let depth = 0;
+  for (let i = page.indexOf("{", start); i < page.length; i++) {
+    if (page[i] === "{") { depth += 1; }
+    else if (page[i] === "}") { depth -= 1; if (depth === 0) { return page.slice(start, i + 1); } }
+  }
+  throw new Error("unbalanced: " + marker);
+}
+
+/* ---------- a DOM with real containment ---------- */
+/* Flat stubs agree with whatever they are told, and everything here is a question about what is
+   inside what, so the nodes below carry a parent and answer `closest` by walking it. */
+function node(tag, attrs) {
+  const el = {
+    tagName: tag.toUpperCase(),
+    parent: null,
+    children: [],
+    attrs: attrs || {},
+    hidden: false,
+    open: false,
+    innerHTML: "",
+    scrolled: false,
+    focused: false,
+    classes: new Set(),
+    getAttribute(name) { return Object.prototype.hasOwnProperty.call(this.attrs, name)
+      ? this.attrs[name] : null; },
+    scrollIntoView() { this.scrolled = true; },
+    focus() { this.focused = true; },
+    append(child) { child.parent = this; this.children.push(child); return child; },
+    closest(selector) {
+      let cursor = this;
+      while (cursor) {
+        if (selector === "details" && cursor.tagName === "DETAILS") { return cursor; }
+        if (selector === ".field" && cursor.classes.has("field")) { return cursor; }
+        cursor = cursor.parent;
+      }
+      return null;
+    },
+    querySelector(selector) {
+      const key = /\[data-key="([^"]+)"\]/.exec(selector);
+      const walk = (n) => {
+        if (key && n.attrs["data-key"] === key[1]) { return n; }
+        for (const child of n.children) {
+          const found = walk(child);
+          if (found) { return found; }
+        }
+        return null;
+      };
+      return walk(this);
+    },
+  };
+  el.classList = {
+    add: (c) => el.classes.add(c),
+    remove: (c) => el.classes.delete(c),
+    contains: (c) => el.classes.has(c),
+  };
+  return el;
+}
+
+/* The shape the settings pane really has: a shut advanced group, holding a field row, holding the
+   control. */
+const groups = node("div");
+const group = groups.append(node("details"));
+group.open = false;
+const field = group.append(node("div"));
+field.classes.add("field");
+field.classes.add("hidden");
+const control = field.append(node("select", { "data-key": "ingestion.bulk_ingest" }));
+
+const box = node("div");
+box.hidden = true;
+const saveMsg = node("div");
+
+const byId = { groups, awaitingRestart: box, saveMsg };
+const shown = [];
+const said = [];
+
+const $ = (id) => byId[id] || null;
+const esc = (s) => String(s).replace(/[&<>"]/g, (c) =>
+  ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+const say = (el, text) => said.push(text);
+const window_ = { showTab: (pane) => shown.push(pane) };
+
+const build = new Function("$", "esc", "say", "window",
+  extract("function showSetting(key)") + "\n" +
+  extract("function renderAwaiting(keys)") + "\n" +
+  "return { showSetting: showSetting, renderAwaiting: renderAwaiting };");
+const panel = build($, esc, say, window_);
+
+/* ---------- what it names ---------- */
+panel.renderAwaiting([]);
+ok("nothing waiting: the panel is not shown", box.hidden === true);
+ok("nothing waiting: it says nothing", box.innerHTML === "", JSON.stringify(box.innerHTML));
+
+panel.renderAwaiting(["ingestion.bulk_ingest", "extraction.provider"]);
+ok("the panel appears when something is waiting", box.hidden === false);
+ok("it says how many", box.innerHTML.indexOf("2 settings are waiting") >= 0, box.innerHTML);
+ok("it names the first", box.innerHTML.indexOf("ingestion.bulk_ingest") >= 0);
+ok("it names the second", box.innerHTML.indexOf("extraction.provider") >= 0);
+ok("each name is something you can click",
+   (box.innerHTML.match(/data-goto="/g) || []).length === 2, box.innerHTML);
+
+panel.renderAwaiting(["extraction.provider"]);
+ok("one waiting reads as one", box.innerHTML.indexOf("1 setting is waiting") >= 0, box.innerHTML);
+
+/* ---------- where a name takes you ---------- */
+ok("FLOOR: the group starts shut", group.open === false);
+ok("FLOOR: the row starts hidden", field.classes.has("hidden") === true);
+
+const went = panel.showSetting("ingestion.bulk_ingest");
+ok("it reports having gone somewhere", went === true);
+ok("the group it was folded into is opened", group.open === true);
+ok("the group is not left hidden", group.hidden === false);
+ok("a filtered-out row is uncovered", field.classes.has("hidden") === false);
+ok("the settings tab is opened", shown.indexOf("settings") >= 0, JSON.stringify(shown));
+ok("the control is scrolled to", control.scrolled === true);
+ok("and focused, so it is obvious which one", control.focused === true);
+
+/* ---------- a name for a setting that is not loaded ---------- */
+const missing = panel.showSetting("not.a.setting");
+ok("an unloaded setting is refused rather than silently doing nothing", missing === false);
+ok("and says why", said.some((t) => /admin key/.test(t)), JSON.stringify(said));
+
+/* ---------- the wiring, run rather than read ---------- */
+const listenerSource = (() => {
+  const start = page.indexOf('$("awaitingRestart").addEventListener("click"');
+  if (start < 0) { return null; }
+  /* Match from addEventListener's OWN parenthesis. Starting at the first "(" after `start` closes
+     on `$("awaitingRestart")` and yields a statement that registers nothing -- which then reads as
+     "the page has no handler" rather than "the harness looked in the wrong place". */
+  let depth = 0;
+  for (let i = page.indexOf("(", page.indexOf("addEventListener", start)); i < page.length; i++) {
+    if (page[i] === "(") { depth += 1; }
+    else if (page[i] === ")") { depth -= 1; if (depth === 0) { return page.slice(start, i + 1); } }
+  }
+  return null;
+})();
+ok("the panel has a click handler at all", listenerSource !== null);
+if (listenerSource) {
+  let handler = null;
+  const capturing = (id) => ({ addEventListener: (_name, fn) => { handler = fn; } });
+  new Function("$", "showSetting", listenerSource + ";")(capturing, () => {});
+  ok("the handler is registered on click", typeof handler === "function");
+
+  const visited = [];
+  new Function("$", "showSetting", listenerSource + ";")(
+    capturing, (key) => visited.push(key));
+  handler({ target: { getAttribute: (n) => (n === "data-goto" ? "extraction.provider" : null) } });
+  ok("clicking a name goes to that setting",
+     visited.indexOf("extraction.provider") >= 0, JSON.stringify(visited));
+
+  visited.length = 0;
+  handler({ target: { getAttribute: () => null } });
+  ok("clicking the surrounding text goes nowhere", visited.length === 0);
+}
+
+/* ---------- and that something actually calls it ---------- */
+/* Everything above proves the panel works when run. None of it proves the page ever runs it, which
+   is the failure this whole change is about -- a thing built and then delivered to nobody. So the
+   renderer that draws the settings is extracted and called too, with the panel stubbed, and asked
+   whether it passed the pending list along. */
+{
+  const groupsBox = node("div");
+  const cfgTime = node("div");
+  cfgTime.textContent = "";
+  const ids = { groups: groupsBox, cfgTime: cfgTime };
+  const handed = [];
+
+  const renderGroups = new Function(
+    "$", "esc", "fieldHtml", "renderAwaiting", "applyFilter", "markDirty",
+    "var fields;" + extract("function renderGroups(settings)") + "; return renderGroups;")(
+    (id) => ids[id] || node("div"),
+    esc,
+    (f) => '<div class="field" data-field="' + f.key + '"></div>',
+    (keys) => handed.push(keys),
+    () => {},
+    () => {});
+
+  renderGroups({
+    groups: { ingestion: [{ key: "ingestion.bulk_ingest" }] },
+    group_meta: { ingestion: { advanced: true, title: "Ingestion" } },
+    pending_restart: ["ingestion.bulk_ingest"],
+  });
+
+  ok("FLOOR: the settings renderer drew its groups",
+     groupsBox.innerHTML.indexOf("ingestion.bulk_ingest") >= 0, groupsBox.innerHTML.slice(0, 120));
+  ok("drawing the settings also draws the waiting panel", handed.length === 1,
+     "renderAwaiting was called " + handed.length + " times");
+  ok("and hands it what the deployment says is waiting",
+     JSON.stringify(handed[0]) === JSON.stringify(["ingestion.bulk_ingest"]),
+     JSON.stringify(handed[0]));
+
+  /* The group this setting is in renders SHUT, which is the reason the panel has to exist. */
+  ok("FLOOR: an advanced group really does render shut",
+     / open>/.test(groupsBox.innerHTML) === false, groupsBox.innerHTML.slice(0, 160));
+}
+
+console.log(failures ? "\n" + failures + " failure(s)" : "\nall good");
+process.exit(failures ? 1 : 0);

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -673,7 +673,7 @@ LIVE_STRIP = """
       <a class="live-seg" href="/v1/admin/setup#encoding" id="liveEnc" hidden></a>
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
-      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup" id="liveWaiting" hidden></a>
+      <a class="live-seg warn" href="/v1/admin/setup#warnings" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup#awaitingRestart" id="liveWaiting" hidden></a>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>"""
 
@@ -988,6 +988,10 @@ SETUP_BODY = """
   <section class="pane" role="tabpanel" aria-labelledby="tab-settings" id="pane-settings" hidden>
 
   <form id="settingsForm">
+    <!-- Where the strip's "awaiting restart" segment lands. The count rides every page; the names
+         lived only on a badge inside a group that is shut by default, so the number had nowhere to
+         take anybody. -->
+    <div id="awaitingRestart" class="note" hidden></div>
     <div class="toolbar">
       <label for="filter" class="visually-hidden">Filter settings</label>
       <input id="filter" type="search" placeholder="Filter settings — name, help text, or variable" spellcheck="false" autocomplete="off">
@@ -1380,6 +1384,43 @@ SETUP_JS = r"""
       .sort();
   }
 
+  /* Take somebody to a setting, uncovering whatever is folded over it.
+
+     A name on its own is not enough here. Four of the nine groups render shut -- 26 of the 47
+     restart-scoped settings are in one of them -- and a filter may have hidden the row outright, so
+     scrolling to it would scroll to something that is not on screen. */
+  function showSetting(key) {
+    var el = $("groups").querySelector('[data-key="' + key + '"]');
+    if (!el) {
+      say($("saveMsg"), "That setting is not loaded \u2014 enter an admin key first.", "warn");
+      return false;
+    }
+    var group = el.closest("details");
+    if (group) { group.hidden = false; group.open = true; }
+    var row = el.closest(".field");
+    if (row) { row.classList.remove("hidden"); }
+    window.showTab("settings");
+    el.scrollIntoView({ block: "center" });
+    if (el.focus) { el.focus(); }
+    return true;
+  }
+
+  /* The strip counts these from every page. This is the only place that can say WHICH, and until
+     now nothing did: the badge that names one sits on the field itself, behind a closed group. */
+  function renderAwaiting(keys) {
+    var box = $("awaitingRestart"), list = keys || [];
+    box.hidden = list.length === 0;
+    if (!list.length) { box.innerHTML = ""; return; }
+    box.innerHTML = "<b>" + list.length +
+      (list.length === 1 ? " setting is" : " settings are") + " waiting for a restart.</b> " +
+      "The gateway is still running the old value for " +
+      (list.length === 1 ? "it" : "them") + ": " +
+      list.map(function (k) {
+        return '<button type="button" class="link" data-goto="' + esc(k) + '">' + esc(k) +
+          "</button>";
+      }).join(", ");
+  }
+
   function renderGroups(settings) {
     var groups = (settings || {}).groups || {};
     var meta = (settings || {}).group_meta || {};
@@ -1401,6 +1442,7 @@ SETUP_JS = r"""
         (m.note ? '<p class="group-note">' + esc(m.note) + "</p>" : "") +
         '<div class="grid2">' + groups[g].map(fieldHtml).join("") + "</div></div></details>";
     }).join("");
+    renderAwaiting((settings || {}).pending_restart);
     $("cfgTime").textContent = settings && settings.updated_at
       ? "Stored in " + (settings.config_file || "the runtime config") + " · last saved " +
         new Date(settings.updated_at * 1000).toLocaleString()
@@ -2596,6 +2638,12 @@ SETUP_JS = r"""
     applyFilter();
   });
   $("onlyChanged").addEventListener("change", applyFilter);
+  /* Delegated: the names are rebuilt on every load, and a listener per name would be rebound each
+     time or leak the old ones. */
+  $("awaitingRestart").addEventListener("click", function (ev) {
+    var key = ev.target && ev.target.getAttribute && ev.target.getAttribute("data-goto");
+    if (key) { showSetting(key); }
+  });
   $("onlyEssential").addEventListener("change", function () {
     /* The required settings live in the two model groups, both of which are open by default; but
        ingestion.root is in an advanced one, so narrowing to "must set" has to reveal it. */

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -428,7 +428,7 @@
       <a class="live-seg" href="/v1/admin/setup#encoding" id="liveEnc" hidden></a>
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
-      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup" id="liveWaiting" hidden></a>
+      <a class="live-seg warn" href="/v1/admin/setup#warnings" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup#awaitingRestart" id="liveWaiting" hidden></a>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -428,7 +428,7 @@
       <a class="live-seg" href="/v1/admin/setup#encoding" id="liveEnc" hidden></a>
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
-      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup" id="liveWaiting" hidden></a>
+      <a class="live-seg warn" href="/v1/admin/setup#warnings" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup#awaitingRestart" id="liveWaiting" hidden></a>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -207,7 +207,7 @@
       <a class="live-seg" href="/v1/admin/setup#encoding" id="liveEnc" hidden></a>
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
-      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup" id="liveWaiting" hidden></a>
+      <a class="live-seg warn" href="/v1/admin/setup#warnings" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup#awaitingRestart" id="liveWaiting" hidden></a>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -428,7 +428,7 @@
       <a class="live-seg" href="/v1/admin/setup#encoding" id="liveEnc" hidden></a>
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
-      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup" id="liveWaiting" hidden></a>
+      <a class="live-seg warn" href="/v1/admin/setup#warnings" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup#awaitingRestart" id="liveWaiting" hidden></a>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -428,7 +428,7 @@
       <a class="live-seg" href="/v1/admin/setup#encoding" id="liveEnc" hidden></a>
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
-      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup" id="liveWaiting" hidden></a>
+      <a class="live-seg warn" href="/v1/admin/setup#warnings" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup#awaitingRestart" id="liveWaiting" hidden></a>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>
@@ -485,6 +485,10 @@
   <section class="pane" role="tabpanel" aria-labelledby="tab-settings" id="pane-settings" hidden>
 
   <form id="settingsForm">
+    <!-- Where the strip's "awaiting restart" segment lands. The count rides every page; the names
+         lived only on a badge inside a group that is shut by default, so the number had nowhere to
+         take anybody. -->
+    <div id="awaitingRestart" class="note" hidden></div>
     <div class="toolbar">
       <label for="filter" class="visually-hidden">Filter settings</label>
       <input id="filter" type="search" placeholder="Filter settings — name, help text, or variable" spellcheck="false" autocomplete="off">
@@ -1095,6 +1099,43 @@ function liveStream(options) {
       .sort();
   }
 
+  /* Take somebody to a setting, uncovering whatever is folded over it.
+
+     A name on its own is not enough here. Four of the nine groups render shut -- 26 of the 47
+     restart-scoped settings are in one of them -- and a filter may have hidden the row outright, so
+     scrolling to it would scroll to something that is not on screen. */
+  function showSetting(key) {
+    var el = $("groups").querySelector('[data-key="' + key + '"]');
+    if (!el) {
+      say($("saveMsg"), "That setting is not loaded \u2014 enter an admin key first.", "warn");
+      return false;
+    }
+    var group = el.closest("details");
+    if (group) { group.hidden = false; group.open = true; }
+    var row = el.closest(".field");
+    if (row) { row.classList.remove("hidden"); }
+    window.showTab("settings");
+    el.scrollIntoView({ block: "center" });
+    if (el.focus) { el.focus(); }
+    return true;
+  }
+
+  /* The strip counts these from every page. This is the only place that can say WHICH, and until
+     now nothing did: the badge that names one sits on the field itself, behind a closed group. */
+  function renderAwaiting(keys) {
+    var box = $("awaitingRestart"), list = keys || [];
+    box.hidden = list.length === 0;
+    if (!list.length) { box.innerHTML = ""; return; }
+    box.innerHTML = "<b>" + list.length +
+      (list.length === 1 ? " setting is" : " settings are") + " waiting for a restart.</b> " +
+      "The gateway is still running the old value for " +
+      (list.length === 1 ? "it" : "them") + ": " +
+      list.map(function (k) {
+        return '<button type="button" class="link" data-goto="' + esc(k) + '">' + esc(k) +
+          "</button>";
+      }).join(", ");
+  }
+
   function renderGroups(settings) {
     var groups = (settings || {}).groups || {};
     var meta = (settings || {}).group_meta || {};
@@ -1116,6 +1157,7 @@ function liveStream(options) {
         (m.note ? '<p class="group-note">' + esc(m.note) + "</p>" : "") +
         '<div class="grid2">' + groups[g].map(fieldHtml).join("") + "</div></div></details>";
     }).join("");
+    renderAwaiting((settings || {}).pending_restart);
     $("cfgTime").textContent = settings && settings.updated_at
       ? "Stored in " + (settings.config_file || "the runtime config") + " · last saved " +
         new Date(settings.updated_at * 1000).toLocaleString()
@@ -2311,6 +2353,12 @@ function liveStream(options) {
     applyFilter();
   });
   $("onlyChanged").addEventListener("change", applyFilter);
+  /* Delegated: the names are rebuilt on every load, and a listener per name would be rebound each
+     time or leak the old ones. */
+  $("awaitingRestart").addEventListener("click", function (ev) {
+    var key = ev.target && ev.target.getAttribute && ev.target.getAttribute("data-goto");
+    if (key) { showSetting(key); }
+  });
   $("onlyEssential").addEventListener("change", function () {
     /* The required settings live in the two model groups, both of which are open by default; but
        ingestion.root is in an advanced one, so narrowing to "must set" has to reveal it. */

--- a/tools/test_matrixark_the_strip_takes_you_to_what_it_reports.py
+++ b/tools/test_matrixark_the_strip_takes_you_to_what_it_reports.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A segment that reports something needing attention takes you to it.
+
+The status strip runs across all seven pages and five of its segments are links. Three named a
+place: ``#encoding`` and ``#traffic`` inside the setup page's panes, and the ingestion page, which
+has no tabs and so needs no fragment. **The two that mean something needs you** -- the warning count
+and the count of settings waiting for a restart -- pointed at a bare ``/v1/admin/setup``.
+
+A bare link opens the FIRST tab, which is Access. So the strip said work was waiting and the click
+put the reader in front of the key input instead. The link cannot report that it failed; it went to
+the page it named.
+
+Getting to the right pane is only half of it for a pending setting. The page never said WHICH
+settings were waiting: the name existed only as a badge on the field itself, and four of the nine
+groups render shut -- **26 of the 47 restart-scoped settings live in one of them**. So the count on
+every page had nowhere to go, and following it landed on a closed triangle.
+
+This adds the panel that names them, with each name taking the reader to that control: opening the
+group it is folded into, uncovering the row if a filter has hidden it, switching to the pane, and
+focusing it.
+
+The rule the guard below states is the general one, because the specific hrefs are what drifted:
+**a segment pointing at a page that has tabs must name a fragment.** The existing fragment sweep in
+``test_matrixark_a_badge_that_names_a_tab_opens_it`` checks that a named fragment resolves; it
+cannot catch a link that names nothing at all, and that is exactly what these two were.
+"""
+from __future__ import annotations
+
+import io
+import os
+import re
+import shutil
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+HARNESS = os.path.join(PORTAL, "awaiting_restart_harness.js")
+SETUP = os.path.join(PORTAL, "setup_portal.html")
+
+SEGMENT = re.compile(r'<a class="live-seg[^"]*" href="([^"]+)"[^>]*id="(\w+)"')
+
+# Which file each portal route serves. Taken from the gateway in the neighbouring suite; here only
+# the two the strip points at are needed, and both are unambiguous.
+SERVES = {"/v1/admin/setup": "setup_portal.html", "/v1/admin/ingestion": "ingestion_portal.html"}
+
+
+def read(path: str) -> str:
+    with io.open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def pages() -> list:
+    return sorted(n for n in os.listdir(PORTAL) if n.endswith("_portal.html"))
+
+
+def segments(page_text: str) -> list:
+    return SEGMENT.findall(page_text)
+
+
+def has_tabs(filename: str) -> bool:
+    return 'role="tab"' in read(os.path.join(PORTAL, filename))
+
+
+class ASegmentNamesWhereToLookTest(unittest.TestCase):
+
+    def test_there_are_segments_to_check(self) -> None:
+        """The rule below is a loop; over an empty list it proves nothing."""
+        found = segments(read(SETUP))
+        self.assertGreaterEqual(len(found), 5, found)
+
+    def test_the_rule_has_something_to_bite_on(self) -> None:
+        """If no destination had tabs, every bare link would be fine and the guard would be inert."""
+        destinations = {href.split("#")[0] for href, _id in segments(read(SETUP))}
+        tabbed = [d for d in destinations if d in SERVES and has_tabs(SERVES[d])]
+        self.assertTrue(tabbed, "no strip destination has tabs, so this guard checks nothing")
+
+    def test_every_segment_pointing_into_a_tabbed_page_names_a_place(self) -> None:
+        for page in pages():
+            for href, ident in segments(read(os.path.join(PORTAL, page))):
+                route = href.split("#")[0]
+                if route not in SERVES or not has_tabs(SERVES[route]):
+                    continue
+                with self.subTest(page=page, segment=ident):
+                    self.assertIn("#", href,
+                                  "%s links to a page with tabs and names no place in it, so it "
+                                  "opens whichever tab is first" % ident)
+
+    def test_the_two_that_report_trouble_are_the_ones_this_was_about(self) -> None:
+        """Named, because they are the two that were wrong and the sweep above would keep passing
+        if a later edit dropped them from the strip entirely."""
+        for page in pages():
+            found = dict((ident, href) for href, ident in
+                         segments(read(os.path.join(PORTAL, page))))
+            with self.subTest(page=page):
+                self.assertIn("liveWarn", found)
+                self.assertIn("liveWaiting", found)
+                self.assertIn("#", found["liveWarn"])
+                self.assertIn("#", found["liveWaiting"])
+
+
+class TheNamedPlaceExistsTest(unittest.TestCase):
+
+    def test_the_panel_is_on_the_page(self) -> None:
+        self.assertIn('id="awaitingRestart"', read(SETUP))
+
+    def test_it_is_inside_the_settings_pane(self) -> None:
+        """A fragment resolves to whichever pane contains it; in the wrong one it would open the
+        wrong tab, which is the fault this change is about."""
+        page = read(SETUP)
+        start = page.index('id="pane-settings"')
+        depth, end = 0, len(page)
+        for match in re.finditer(r"<section\b|</section>", page[start:]):
+            depth += -1 if match.group(0) == "</section>" else 1
+            if depth == 0:
+                end = start + match.end()
+                break
+        self.assertIn('id="awaitingRestart"', page[start:end])
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class ThePanelWorksTest(unittest.TestCase):
+    """Run, not read: a renderer that never opens the folded group reads the same in a diff."""
+
+    def _run(self):
+        return subprocess.run(["node", HARNESS, SETUP], capture_output=True, text=True, timeout=300)
+
+    def test_the_harness_passes(self) -> None:
+        proc = self._run()
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_it_ran_all_of_its_checks(self) -> None:
+        """A harness that throws part way through still prints the checks it reached. Counting them
+        is what tells a stopped run from a passing one."""
+        out = self._run().stdout
+        self.assertIn("all good", out)
+        self.assertGreaterEqual(out.count("ok   "), 20, out)
+
+    def test_it_names_the_settings_that_are_waiting(self) -> None:
+        out = self._run().stdout
+        for line in ("ok   it says how many",
+                     "ok   it names the first",
+                     "ok   it names the second",
+                     "ok   one waiting reads as one"):
+            with self.subTest(line=line):
+                self.assertIn(line, out)
+
+    def test_a_name_uncovers_the_control_it_points_at(self) -> None:
+        out = self._run().stdout
+        for line in ("ok   FLOOR: the group starts shut",
+                     "ok   the group it was folded into is opened",
+                     "ok   a filtered-out row is uncovered",
+                     "ok   the settings tab is opened",
+                     "ok   the control is scrolled to"):
+            with self.subTest(line=line):
+                self.assertIn(line, out)
+
+    def test_clicking_a_name_is_wired_to_going_there(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   clicking a name goes to that setting", out)
+        self.assertIn("ok   clicking the surrounding text goes nowhere", out)
+
+    def test_something_actually_draws_the_panel(self) -> None:
+        """The one the rest of this file could not catch.
+
+        Every check above proves the panel works when it is run. None of them proved the page ever
+        runs it -- deleting the call from the settings renderer left all of them green, which is the
+        same shape as the defect this change exists to fix. So the renderer is extracted and called
+        too, with the panel stubbed, and asked whether it passed the pending list along.
+        """
+        out = self._run().stdout
+        for line in ("ok   FLOOR: the settings renderer drew its groups",
+                     "ok   drawing the settings also draws the waiting panel",
+                     "ok   and hands it what the deployment says is waiting",
+                     "ok   FLOOR: an advanced group really does render shut"):
+            with self.subTest(line=line):
+                self.assertIn(line, out)
+
+    def test_it_says_nothing_when_nothing_is_waiting(self) -> None:
+        """The common case. A panel that always shows is one people stop reading."""
+        out = self._run().stdout
+        self.assertIn("ok   nothing waiting: the panel is not shown", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The status strip runs across all seven pages, and five of its segments are links. Three name a
place: `#encoding` and `#traffic` inside the setup page's panes, and the ingestion page, which has
no tabs and needs no fragment.

**The two that mean something needs you** — the warning count, and the count of settings waiting for
a restart — pointed at a bare `/v1/admin/setup`.

A bare link opens the *first* tab, which is Access. So the strip said work was waiting and the click
put the reader in front of the key input instead. A link cannot report that it failed; it went to
the page it named.

For a pending setting there was a second half. The page never said **which** settings were waiting:
the name existed only as a badge on the field itself, and four of the nine groups render shut —
**26 of the 47 restart-scoped settings live in one of them**. So the count on every page had nowhere
to go, and arriving at the right pane still left the setting folded away.

### What it does now

```
strip        "1 setting awaiting restart"  ->  /v1/admin/setup#awaitingRestart
settings     1 setting is waiting for a restart. The gateway is still running the old
             value for it: [ingestion.bulk_ingest]
clicking it  opens the group it was folded into, uncovers the row if a filter hid it,
             switches pane, scrolls, and focuses the control
```

Driven against a running gateway with a pending setting in an *advanced* group:

```
arriving at a bare page      activeTab: tab-access          <- the fault
following #awaitingRestart   activeTab: tab-settings,  group still shut  <- the second half
clicking the name            group open, row shown, control focused
```

### The guard is the general rule

The specific hrefs are what drifted, so the test states the rule instead: **a segment pointing at a
page that has tabs must name a fragment.** The existing sweep in
`test_matrixark_a_badge_that_names_a_tab_opens_it` checks that a named fragment *resolves* — it
cannot catch a link that names nothing at all, which is exactly what these two were. Two floors keep
it honest: that there are segments to check, and that at least one destination really has tabs.

```
the waiting segment goes back to a bare link  -> FAIL every segment ... names a place
the warning segment goes back to a bare link  -> FAIL every segment ... names a place
the panel never opens the folded group        -> FAIL a name uncovers the control
the panel does not switch pane                -> FAIL a name uncovers the control
the panel leaves a filtered-out row hidden    -> FAIL a name uncovers the control
the panel shows when nothing is waiting       -> FAIL it says nothing when nothing is waiting
the names are not clickable                   -> FAIL the harness passes
the panel is never rendered                   -> FAIL something actually draws the panel
```

### The last one caught me

Every check proved the panel works when run; none proved the page ever *runs* it. Deleting the call
from the settings renderer left the whole file green — the same "built and delivered to nobody"
shape this change exists to fix. So the harness extracts the settings renderer and calls it too,
with the panel stubbed, and asks whether it passed the pending list along.

12 tests, 28 harness assertions. Neighbours: v1_gateway 97, gateway_portal 60, live_strip 38,
gateway_events 12, badge-names-a-tab 9, stream-reader 8, portal_pages 4, and all portal-named suites
together 141 — green.
