### PR TITLE
A flag that asked for an op the proxy already has a name for

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -1074,12 +1074,6 @@ fn storage_prefix_from_request(request: &RecordLogRequest) -> String {
         .unwrap_or_default()
 }
 
-fn matrixark_compact_snapshot_retrieve_enabled() -> bool {
-    env::var("MATRIXARK_RUST_PROXY_FULL_RETRIEVE_SCAN")
-        .map(|value| !matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
-        .unwrap_or(true)
-}
-
 fn invalidate_retrieve_candidate_cache(storage_prefix: &str) {
     if storage_prefix.trim().is_empty() {
         return;
@@ -3758,13 +3752,7 @@ fn execute_record_log_request(
             );
             output
         }
-        "matrixark_retrieve_context_pack" => {
-            if matrixark_compact_snapshot_retrieve_enabled() {
-                retrieve_context_pack_output(engine, &request, root)?
-            } else {
-                json_output(retrieve_context_pack_native(engine, &request)?, root)?
-            }
-        }
+        "matrixark_retrieve_context_pack" => retrieve_context_pack_output(engine, &request, root)?,
         "matrixark_retrieve_context_pack_full_scan" => {
             json_output(retrieve_context_pack_native(engine, &request)?, root)?
         }
@@ -6876,7 +6864,6 @@ mod tests {
         let _guard = env_guard();
         let dir = tempdir().expect("tempdir");
         env::set_var("MATRIXARK_TEMPORALSTORE_RUST_ROOT", dir.path());
-        env::remove_var("MATRIXARK_RUST_PROXY_FULL_RETRIEVE_SCAN");
 
         let storage_prefix = "matrixark:test:native-pack";
         let mut append = request("matrixark_batch_append_records");
@@ -7156,7 +7143,6 @@ mod tests {
         let _guard = env_guard();
         let dir = tempdir().expect("tempdir");
         env::set_var("MATRIXARK_TEMPORALSTORE_RUST_ROOT", dir.path());
-        env::remove_var("MATRIXARK_RUST_PROXY_FULL_RETRIEVE_SCAN");
 
         let storage_prefix = "matrixark:test:native-source-role-budget";
         let mut append = request("matrixark_batch_append_records");
@@ -7423,7 +7409,6 @@ mod tests {
         let _guard = env_guard();
         let dir = tempdir().expect("tempdir");
         env::set_var("MATRIXARK_TEMPORALSTORE_RUST_ROOT", dir.path());
-        env::remove_var("MATRIXARK_RUST_PROXY_FULL_RETRIEVE_SCAN");
 
         let storage_prefix = "matrixark:test:native-selection-phase-budget";
         let mut append = request("matrixark_batch_append_records");
@@ -7520,7 +7505,6 @@ mod tests {
         let _guard = env_guard();
         let dir = tempdir().expect("tempdir");
         env::set_var("MATRIXARK_TEMPORALSTORE_RUST_ROOT", dir.path());
-        env::remove_var("MATRIXARK_RUST_PROXY_FULL_RETRIEVE_SCAN");
 
         let storage_prefix = "matrixark:test:native-compact-profile-shadow";
         let mut append = request("matrixark_batch_append_records");
@@ -7625,7 +7609,6 @@ mod tests {
         let _guard = env_guard();
         let dir = tempdir().expect("tempdir");
         env::set_var("MATRIXARK_TEMPORALSTORE_RUST_ROOT", dir.path());
-        env::set_var("MATRIXARK_RUST_PROXY_FULL_RETRIEVE_SCAN", "1");
 
         let storage_prefix = "matrixark:test:native-profile-shadow";
         let mut append = request("matrixark_batch_append_records");
@@ -7641,7 +7624,9 @@ mod tests {
         let engine = open_engine(&append).expect("engine");
         execute_record_log_request(&engine, append, root.clone()).expect("append compact bundle");
 
-        let mut retrieve = request("matrixark_retrieve_context_pack");
+        // The op that does this has a name. The variable made a DIFFERENT op behave
+        // this way, for every caller in the process.
+        let mut retrieve = request("matrixark_retrieve_context_pack_full_scan");
         retrieve.storage_prefix = storage_prefix.to_string();
         retrieve.count_key = Some(format!("{storage_prefix}:record_count"));
         retrieve.record_hash_key = Some(format!("{storage_prefix}:records"));
@@ -7724,7 +7709,6 @@ mod tests {
             Some(1)
         );
 
-        env::remove_var("MATRIXARK_RUST_PROXY_FULL_RETRIEVE_SCAN");
         env::remove_var("MATRIXARK_TEMPORALSTORE_RUST_ROOT");
     }
 

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -8,7 +8,7 @@ within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 309 of them, read by 106 functions.
+There are 308 of them, read by 105 functions.
 
 Deleting unreachable code is not the lever. An earlier version of this document argued that
 by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
@@ -46,8 +46,8 @@ Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 309 |
-| booleans whose default this could read off the source | 44 |
+| total | 308 |
+| booleans whose default this could read off the source | 43 |
 | **defaulting on, and set by nothing** | 9 |
 | offered on the portal | 23 |
 | **that nothing in this repository sets** | 184 |
@@ -292,7 +292,7 @@ Sizes, ceilings and intervals. The tuning a deployment actually reaches for.
 | `TS_STORAGE_ZONE_SIZE` | — | config, portal | 1 | — |
 | `TS_STREAM_MAX_BLOB_SIZE` | — | config, portal | 1 | — |
 
-## context (28)
+## context (27)
 
 The memory pipeline: what gets extracted, embedded, drained and packed. The surface a deployment tunes for recall rather than for throughput.
 
@@ -323,7 +323,6 @@ The memory pipeline: what gets extracted, embedded, drained and packed. The surf
 | `MATRIXARK_REQUIRE_MODEL_EMBEDDINGS` | off | config, portal | 1 | — |
 | `MATRIXARK_REQUIRE_MODEL_SUMMARIES` | off | config, portal | 1 | — |
 | `MATRIXARK_RETRIEVAL_TRAVERSAL_TOP_K` | — | nothing | 1 | — |
-| `MATRIXARK_RUST_PROXY_FULL_RETRIEVE_SCAN` | on | test | 1 | — |
 | `TS_PROXY_CONTEXT_FIRST_SHARD` | — | nothing | 1 | — |
 | `TS_PROXY_CONTEXT_SHARD_COUNT` | — | nothing | 1 | — |
 


### PR DESCRIPTION
`MATRIXARK_RUST_PROXY_FULL_RETRIEVE_SCAN` made `matrixark_retrieve_context_pack` take the full-scan
path:

```rust
"matrixark_retrieve_context_pack" => {
    if matrixark_compact_snapshot_retrieve_enabled() {
        retrieve_context_pack_output(engine, &request, root)?
    } else {
        json_output(retrieve_context_pack_native(engine, &request)?, root)?
    }
}
"matrixark_retrieve_context_pack_full_scan" => {
    json_output(retrieve_context_pack_native(engine, &request)?, root)?
}
```

The op directly below it does the same thing, by name. So the variable asked for something already
askable — and asked the worse way, because it changed what a **different** op meant, for every
caller in the process, for as long as it was set.

One test used it. It names the op it wants now, which also says what the test is about: a reader of
the old version saw a request for the compact-snapshot op and had to know the process environment
to know it would not get one.

That leaves nothing reading the flag, so its reader goes, along with the five defensive
`remove_var` calls that had accumulated around it, and the dispatch arm collapses to one expression.

### Verification

`cargo check -p temporalstore-rust --all-targets` clean, no new warnings. The proxy bin's 52 tests
pass — which is where these tests live, and is not covered by `--lib`. 32 inventory guards pass.
Inventory 309 → 308. Rebased on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
