### PR TITLE
Stop writing the process environment to configure an engine you hold

### DIFF
--- a/crates/temporalstore-rust/src/bin/cb_retrieve.rs
+++ b/crates/temporalstore-rust/src/bin/cb_retrieve.rs
@@ -64,9 +64,10 @@ fn main() {
     // Retrieval probes should measure serving-read latency, not block startup on
     // full page-cache warmup. The decoded serving maps are still rebuilt during
     // load; cold pages can then warm through read-through or a separate warmer.
-    if std::env::var("MATRIXARK_EAGER_CACHE_WARM_ON_LOAD").is_err() {
-        std::env::set_var("MATRIXARK_EAGER_CACHE_WARM_ON_LOAD", "0");
-    }
+    // Only the default moves: an operator who set the variable keeps what they asked for. This
+    // used to be a write into the process environment, aimed at an engine built further down.
+    let warm_cache_in_background =
+        std::env::var("MATRIXARK_EAGER_CACHE_WARM_ON_LOAD").is_err();
     let root = PathBuf::from(arg("--root", "/tmp/ts-cb/store"));
     let agent = arg("--agent-name", "claude");
     let session = arg("--session-id", "s000");
@@ -116,6 +117,9 @@ fn main() {
         eprintln!("stage=engine_open root={}", root.display());
     }
     let load_started = Instant::now();
+    if warm_cache_in_background {
+        engine.warm_cache_in_background_on_load();
+    }
     engine.load_shard(1);
     let shard_load_seconds = load_started.elapsed().as_secs_f64();
     if trace_stages {

--- a/crates/temporalstore-rust/src/bin/context_batch_ingest.rs
+++ b/crates/temporalstore-rust/src/bin/context_batch_ingest.rs
@@ -64,12 +64,10 @@ fn main() {
     // Bulk backfill writes many WAL records into an already-large live hook store.
     // Trust the WAL's verified in-process sequence cache so each append does not
     // rescan the full WAL file to find the tail.
-    if std::env::var("TS_PHASE1_FLAT").is_err() {
-        std::env::set_var("TS_PHASE1_FLAT", "1");
-    }
-    if std::env::var("MATRIXARK_EAGER_CACHE_WARM_ON_LOAD").is_err() {
-        std::env::set_var("MATRIXARK_EAGER_CACHE_WARM_ON_LOAD", "0");
-    }
+    // Only the default moves: an operator who set the variable keeps what they asked for. This
+    // used to be a write into the process environment, aimed at an engine built further down.
+    let warm_cache_in_background =
+        std::env::var("MATRIXARK_EAGER_CACHE_WARM_ON_LOAD").is_err();
     let raw_first = env_bool("MATRIXARK_BACKFILL_RAW_FIRST");
     let checkpoint_only = env_bool("MATRIXARK_BACKFILL_CHECKPOINT_ONLY")
         || std::env::args().any(|arg| arg == "--checkpoint-only");
@@ -132,6 +130,9 @@ fn main() {
         root.join("pages"),
         root.join("indexes"),
     );
+    if warm_cache_in_background {
+        engine.warm_cache_in_background_on_load();
+    }
     engine.load_shard(1);
     let load_seconds = load_started.elapsed().as_secs_f64();
     let replay_from_sequence = engine.write_ahead_log_store().stats(1).last_sequence;

--- a/crates/temporalstore-rust/src/bin/context_embed_backfill.rs
+++ b/crates/temporalstore-rust/src/bin/context_embed_backfill.rs
@@ -207,12 +207,10 @@ fn main() {
     // Embedding backfill is an additive bulk maintenance task. Coalesce per-node
     // persistence and persist the served index once at the end.
     std::env::set_var("MATRIXARK_BULK_INGEST", "1");
-    if std::env::var("TS_PHASE1_FLAT").is_err() {
-        std::env::set_var("TS_PHASE1_FLAT", "1");
-    }
-    if std::env::var("MATRIXARK_EAGER_CACHE_WARM_ON_LOAD").is_err() {
-        std::env::set_var("MATRIXARK_EAGER_CACHE_WARM_ON_LOAD", "0");
-    }
+    // Only the default moves: an operator who set the variable keeps what they asked for. This
+    // used to be a write into the process environment, aimed at an engine built further down.
+    let warm_cache_in_background =
+        std::env::var("MATRIXARK_EAGER_CACHE_WARM_ON_LOAD").is_err();
 
     let root = PathBuf::from(arg("--root", "/tmp/ts-cb/store"));
     let agent = arg("--agent-name", "claude");
@@ -242,6 +240,9 @@ fn main() {
         root.join("indexes"),
     );
     let load_started = Instant::now();
+    if warm_cache_in_background {
+        engine.warm_cache_in_background_on_load();
+    }
     engine.load_shard(1);
     let shard_load_seconds = load_started.elapsed().as_secs_f64();
 

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -133,6 +133,13 @@ pub struct TemporalEngine {
     /// baseline could otherwise observe a window its sibling had opened. Shared across clones,
     /// because a clone is the same engine.
     concurrent_commit: Arc<std::sync::atomic::AtomicBool>,
+    /// Whether loading a shard warms the in-memory cache tier from the page store as part of
+    /// the load, rather than leaving it to be warmed in the background.
+    ///
+    /// Starts from `MATRIXARK_EAGER_CACHE_WARM_ON_LOAD`, which the shipped config and several
+    /// binaries set, so this is a deployment knob and not a retired switch. The proxy turns it
+    /// off for its own engine, and used to do that by writing the variable into the process.
+    eager_cache_warm: Arc<std::sync::atomic::AtomicBool>,
     /// Whether eviction picks its victims by a sampled scan instead of enumerating and sorting
     /// every bucket.
     ///
@@ -1876,7 +1883,7 @@ fn defer_bucket_index_reconstruct() -> bool {
 /// Whether load_shard should eagerly warm the in-memory cache tier from the page
 /// store after reconstructing the index (disk->memory promotion on restart).
 /// Defaults ON; set MATRIXARK_EAGER_CACHE_WARM_ON_LOAD to 0/false/off/no to disable.
-fn eager_cache_warm_on_load() -> bool {
+pub(crate) fn eager_cache_warm_on_load() -> bool {
     !matches!(
         std::env::var("MATRIXARK_EAGER_CACHE_WARM_ON_LOAD")
             .unwrap_or_default()

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -75,6 +75,9 @@ impl TemporalEngine {
             quotas: Arc::new(RwLock::new(crate::engine::quota::QuotaTable::default())),
             concurrent_commit: Arc::new(std::sync::atomic::AtomicBool::new(true)),
             evict_sampled_lru: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            eager_cache_warm: Arc::new(std::sync::atomic::AtomicBool::new(
+                crate::engine::eager_cache_warm_on_load(),
+            )),
             raft_apply_coalesce: Arc::new(std::sync::atomic::AtomicBool::new(true)),
         }
     }
@@ -90,6 +93,22 @@ impl TemporalEngine {
     #[cfg(test)]
     pub(crate) fn disable_hot_page_spill_for_test(&self) {
         self.cache.register_eviction_callback(|_| {});
+    }
+
+    /// Warm this engine's page cache in the BACKGROUND rather than during `load_shard`, so a
+    /// restart publishes serving state before the promotion pass finishes.
+    ///
+    /// A caller that holds the engine says this to the engine. The proxy used to say it to the
+    /// process, by setting `MATRIXARK_EAGER_CACHE_WARM_ON_LOAD` and never putting it back.
+    pub fn warm_cache_in_background_on_load(&self) {
+        self.eager_cache_warm
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Whether `load_shard` warms the cache as part of the load.
+    pub(crate) fn eager_cache_warm(&self) -> bool {
+        self.eager_cache_warm
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Take the durable WAL barrier UNDER the `shards` write lock, for a test measuring what
@@ -271,7 +290,7 @@ impl TemporalEngine {
             // deliberately NOT folded (load_index_base_only), so each tail record is applied
             // EXACTLY ONCE -- no double-apply of non-idempotent commands (counters, appends).
             let base_only =
-                self.load_index_base_only(request.shard_id, eager_cache_warm_on_load());
+                self.load_index_base_only(request.shard_id, self.eager_cache_warm());
             let base_watermark = base_only
                 .as_ref()
                 .and_then(|state| state.applied_wal_sequence)
@@ -315,7 +334,7 @@ impl TemporalEngine {
             // Fold-aware load: a corrupt served-index delta log is fatal here. Silently
             // folding a holed delta prefix would advance the anchor past a removal/eviction
             // recorded only in the delta -> silent loss. Refuse the load instead.
-            let loaded = match self.load_index_checked(request.shard_id, eager_cache_warm_on_load()) {
+            let loaded = match self.load_index_checked(request.shard_id, self.eager_cache_warm()) {
                 Ok(loaded) => loaded,
                 Err(status) => return LoadShardResponse { status },
             };
@@ -460,7 +479,7 @@ impl TemporalEngine {
             info.recovering = false;
         }
         // Disk->memory promotion on a normal restart is folded directly into
-        // load_index()/reconcile above (gated by eager_cache_warm_on_load()): the pages
+        // load_index()/reconcile above (gated by this engine's `eager_cache_warm`): the pages
         // reconcile reads to rebuild the secondary views are promoted into the cache
         // tier in the same pass, so we avoid a second warm pass re-reading every page
         // under the mutex-serialized block store. No-op on a fresh/empty shard.
@@ -1802,7 +1821,7 @@ impl TemporalEngine {
         let installed_manifest_watermark = self
             .install_latest_manifest_if_newer_on_load(shard_id)
             .expect("manifest install should succeed in test");
-        let loaded = self.load_index(shard_id, eager_cache_warm_on_load());
+        let loaded = self.load_index(shard_id, self.eager_cache_warm());
         let replay_watermark = match installed_manifest_watermark {
             Some(manifest_watermark) => manifest_watermark,
             None => match &loaded {

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -4164,9 +4164,9 @@ fn open_engine(request: &RecordLogRequest) -> Result<RecordStore, String> {
     // restart. Rebuild decoded serving maps during load, then warm the page cache
     // in the background so first requests can read through storage instead of
     // waiting for a full synchronous cache promotion pass.
-    let defaulted_nonblocking_warm = env::var("MATRIXARK_EAGER_CACHE_WARM_ON_LOAD").is_err();
-    if defaulted_nonblocking_warm {
-        env::set_var("MATRIXARK_EAGER_CACHE_WARM_ON_LOAD", "0");
+    if env::var("MATRIXARK_EAGER_CACHE_WARM_ON_LOAD").is_err() {
+        // Only the DEFAULT moves: an operator who set the variable keeps what they asked for.
+        engine.warm_cache_in_background_on_load();
     }
     // A shard load can be REFUSED (corrupt delta stream, WAL hole, replay failure) or can
     // genuinely fail partway. `load_shard` discards that answer, and the engine below is

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -52,7 +52,7 @@ Anything else is blank, and a blank means go and look.
 | offered on the portal | 23 |
 | **that nothing in this repository sets** | 184 |
 | documented as keeping an older path alive | 6 |
-| reaching more than two files | 17 |
+| reaching more than two files | 16 |
 | whose doc comment is really about another flag | 43 |
 
 ## topology (38)
@@ -374,8 +374,7 @@ Everything else that changes what the engine does.
 | flag | default | set by | files | keeps an older path |
 |---|---|---|---|---|
 | `MATRIXARK_BULK_INGEST` | off | config, test, portal | 6 | — |
-| `MATRIXARK_EAGER_CACHE_WARM_ON_LOAD` | on | config, test | 5 | — |
-| `TS_PHASE1_FLAT` | on | test | 4 | — |
+| `MATRIXARK_EAGER_CACHE_WARM_ON_LOAD` | on | config | 5 | — |
 | `TS_RAFT_ALLOW_PLAINTEXT` | — | harness, script | 4 | — |
 | `TS_RAFT_ELECTION_TICK_MS` | — | harness, script | 3 | — |
 | `TS_RAFT_ENABLE_LOCAL_ADMIN` | — | harness, script | 3 | — |
@@ -385,6 +384,7 @@ Everything else that changes what the engine does.
 | `TEMPORALSTORE_RUST_CODEX_HOOK_ROOT` | — | launch | 2 | — |
 | `TS_PAGE_STORE_COMPRESSION_ENABLED` | — | config, launch, test | 2 | — |
 | `TS_PAGE_STORE_COMPRESSION_LEVEL` | — | config, test | 2 | — |
+| `TS_PHASE1_FLAT` | on | test | 2 | — |
 | `MATRIXARK_MONOTONIC_RECORD_COUNT` | on | nothing | 1 | — |
 | `MATRIXARK_RUST_PROXY_ASYNC_CACHE_WARM_ON_LOAD` | on | nothing | 1 | — |
 | `MATRIXARK_RUST_PROXY_ASYNC_STORAGE` | off | launch, test | 1 | — |


### PR DESCRIPTION
Six places outside tests wrote a `TS_*`/`MATRIXARK_*` variable into the process. Four are gone.

### Two wrote the default over the default

`context_batch_ingest` and `context_embed_backfill` each set `TS_PHASE1_FLAT=1` when it was unset.
`wal_fast_append_seq` reads it through `wal_env_flag_default_on`, so absent already means on. It
read as configuration and did nothing.

### Three configured an engine by writing the environment

`cb_retrieve`, `context_batch_ingest` and `context_embed_backfill` each set
`MATRIXARK_EAGER_CACHE_WARM_ON_LOAD=0` to configure an engine they were about to build — a
process-global write aimed at a free function the engine reads later inside `load_shard`. It works
only because of the order those two happen in, it applies to every engine and every other reader in
the process, and it is never put back. The proxy had the same pattern.

`TemporalEngine::eager_cache_warm` holds the choice now, initialised from the variable so the
shipped config and anything else that sets it are unaffected.
`warm_cache_in_background_on_load` is how a caller holding an engine says this to that engine.

All three still **read** the variable, to leave an operator's explicit setting alone — only the
default moves — but none of them writes it.

The field's doc deliberately does not open with `TRUE` or `FALSE`: that wording is what the
field-default guard keys on, and this default is not a literal — it comes from the environment, so
claiming one would make the guard assert something untrue.

### What remains, and why

Two writes of `MATRIXARK_BULK_INGEST`. Those are a different thing: bulk ingest is a whole-process
mode — the binary *is* a backfill — so a process-wide variable is the right shape for it, unlike a
setting that belongs to one engine.

### Verification

`cargo check -p temporalstore-rust --all-targets` clean, no new warnings. 32 inventory guards pass.

`engine::tests::part4` at two threads: 145 passed, 2 failed — and **unmodified main reports the
same two, with the same counts**: `the_index_wire_keys_are_what_they_were`, and
`an_async_write_is_never_lost_across_a_restart`, which passes alone on both. Checked by restoring
`crates/temporalstore-rust/src` and `tests` to `origin/main` and re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
