### PR TITLE
Four switches that default on and are turned off by nothing

### DIFF
--- a/crates/temporalstore-rust/src/context_workflow.rs
+++ b/crates/temporalstore-rust/src/context_workflow.rs
@@ -46,18 +46,6 @@ pub(crate) fn context_secondary_index_enabled() -> bool {
         .unwrap_or(false)
 }
 
-/// Hybrid lexical fallback for un-embedded nodes in `retrieve_context`
-/// (`MATRIXARK_CONTEXT_HYBRID_LEXICAL`, default ON). When enabled, a node with no
-/// stored summary embedding is scored by query/text lexical overlap instead of the
-/// flat 0 it used to get, so a freshly bulk-loaded store returns relevant results
-/// before the embed drainer catches up. Embedded-node scoring is unchanged.
-fn context_hybrid_lexical_enabled() -> bool {
-    std::env::var("MATRIXARK_CONTEXT_HYBRID_LEXICAL")
-        .ok()
-        .map(|v| !(v == "0" || v.eq_ignore_ascii_case("false")))
-        .unwrap_or(true)
-}
-
 /// Map a raw lexical-relevance score into the same micros scale cosine similarity
 /// uses (`context_embedding_similarity_micros`), so lexical and cosine node scores
 /// merge into one ranking. 0 stays 0 (no overlap => not surfaced by lexical).
@@ -1732,14 +1720,10 @@ pub(crate) fn extract_context_gated(
     let (embedding_vectors, embedding_generation, embedding_deferred) = match embed_outcome {
         Ok((vectors, report)) => (vectors, report, false),
         Err(status) => {
-            if !context_embed_defer_on_failure() {
-                return empty_extract_report(
-                    status,
-                    provider,
-                    request.tenant_hash,
-                    request.timestamp_ms,
-                );
-            }
+            // `MATRIXARK_EMBED_DEFER_ON_FAILURE=0` used to abort the whole extract here and
+            // persist nothing. It defaulted on and nothing set it, so the extraction has always
+            // been kept: the node, event and summaries persist, the node is marked
+            // embedding-dirty for the drainer, and lexical scoring keeps it rankable meanwhile.
             (Vec::new(), ContextEmbeddingGenerationReport::default(), true)
         }
     };
@@ -2167,37 +2151,38 @@ pub fn retrieve_context(
     // embedded this pass does nothing and behavior is identical to before.
     let mut prefetched_nodes = BTreeMap::<u64, ContextNode>::new();
     let mut lexical_scores_by_node = BTreeMap::<u64, i64>::new();
-    if context_hybrid_lexical_enabled() {
-        let unembedded: Vec<u64> = node_hashes
-            .iter()
-            .copied()
-            .filter(|node_hash| {
-                summary_scores_by_node
-                    .get(node_hash)
-                    .map(|(_, found)| *found == 0)
-                    .unwrap_or(true)
-            })
-            .collect();
-        if !unembedded.is_empty() {
-            for chunk in unembedded.chunks(CONTEXT_EMBEDDING_QUERY_CHUNK) {
-                if chunk.is_empty() {
-                    continue;
-                }
-                let nodes_response = engine.execute(ExecuteRequest {
-                    shard_id: request.shard_id,
-                    command: Command::ContextGetNodes {
-                        tenant_hash: request.tenant_hash,
-                        node_hashes: chunk.to_vec(),
-                    },
-                });
-                if let CommandResponse::ContextNodes { nodes } = nodes_response.response {
-                    for node in nodes {
-                        let text = format!("{} {} {}", node.canonical_name, node.l0, node.l1_ref);
-                        let lexical = context_relevance_score_plan(&query_plan, &text);
-                        lexical_scores_by_node
-                            .insert(node.node_hash, lexical_score_to_micros(lexical));
-                        prefetched_nodes.insert(node.node_hash, node);
-                    }
+    // Every retrieve does this. `MATRIXARK_CONTEXT_HYBRID_LEXICAL` could skip it and
+    // defaulted on; nothing set it, so a node with no stored summary embedding has
+    // always been scored by lexical overlap rather than left at a flat 0.
+    let unembedded: Vec<u64> = node_hashes
+        .iter()
+        .copied()
+        .filter(|node_hash| {
+            summary_scores_by_node
+                .get(node_hash)
+                .map(|(_, found)| *found == 0)
+                .unwrap_or(true)
+        })
+        .collect();
+    if !unembedded.is_empty() {
+        for chunk in unembedded.chunks(CONTEXT_EMBEDDING_QUERY_CHUNK) {
+            if chunk.is_empty() {
+                continue;
+            }
+            let nodes_response = engine.execute(ExecuteRequest {
+                shard_id: request.shard_id,
+                command: Command::ContextGetNodes {
+                    tenant_hash: request.tenant_hash,
+                    node_hashes: chunk.to_vec(),
+                },
+            });
+            if let CommandResponse::ContextNodes { nodes } = nodes_response.response {
+                for node in nodes {
+                    let text = format!("{} {} {}", node.canonical_name, node.l0, node.l1_ref);
+                    let lexical = context_relevance_score_plan(&query_plan, &text);
+                    lexical_scores_by_node
+                        .insert(node.node_hash, lexical_score_to_micros(lexical));
+                    prefetched_nodes.insert(node.node_hash, node);
                 }
             }
         }

--- a/crates/temporalstore-rust/src/context_workflow/model_provider.rs
+++ b/crates/temporalstore-rust/src/context_workflow/model_provider.rs
@@ -52,20 +52,6 @@ pub(crate) fn context_require_model_embeddings() -> bool {
         .unwrap_or(false)
 }
 
-/// When true (the default), a live-path embedding failure (provider error/timeout,
-/// after any fallback provider is also exhausted) does NOT discard the extraction:
-/// the node/event/summaries are still persisted and the node is marked
-/// embedding-dirty so the async drainer attaches vectors on retry, and the hybrid
-/// retrieve path keeps it rankable via lexical scoring meanwhile. Set
-/// `MATRIXARK_EMBED_DEFER_ON_FAILURE=0` to restore the old fail-closed behavior
-/// (embed failure aborts the whole extract and persists nothing).
-pub(crate) fn context_embed_defer_on_failure() -> bool {
-    std::env::var("MATRIXARK_EMBED_DEFER_ON_FAILURE")
-        .ok()
-        .map(|v| !(v == "0" || v.eq_ignore_ascii_case("false")))
-        .unwrap_or(true)
-}
-
 pub(crate) fn context_summaries_for_extract(
     provider: &ContextModelProviderConfig,
     request: &ContextExtractRequest,

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -990,12 +990,6 @@ fn invalidate_record_count_cache(key: &str) {
     }
 }
 
-fn monotonic_record_count_enabled() -> bool {
-    env::var("MATRIXARK_MONOTONIC_RECORD_COUNT")
-        .map(|value| !matches!(value.trim(), "0" | "false" | "no" | "off"))
-        .unwrap_or(true)
-}
-
 // TemporalStore conformance with the native storage engine: the storage engine's
 // record/serving SEQUENCE is an engine-owned MONOTONIC log id, taken from the append
 // log's own iterator id and exposed read-only. It is advanced only by the append log /
@@ -1013,7 +1007,7 @@ fn monotonic_record_count_enabled() -> bool {
 // MATRIXARK_MONOTONIC_RECORD_COUNT=0 restores prior behavior). Inert for async, whose
 // counter already advances monotonically (the clamp only ever raises a low write).
 fn clamp_record_count_value(engine: &RecordStore, key: &str, value: Vec<u8>) -> Vec<u8> {
-    if !monotonic_record_count_enabled() || !is_record_count_key(key) {
+    if !is_record_count_key(key) {
         return value;
     }
     let Some(new_count) = std::str::from_utf8(&value)
@@ -4193,15 +4187,10 @@ fn open_engine(request: &RecordLogRequest) -> Result<RecordStore, String> {
             load.status.message
         ));
     }
-    let async_cache_warm = !matches!(
-        env::var("MATRIXARK_RUST_PROXY_ASYNC_CACHE_WARM_ON_LOAD")
-            .unwrap_or_else(|_| "1".to_string())
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "0" | "false" | "no" | "off"
-    );
-    if async_cache_warm {
+    // Warm the page cache on a background thread. `MATRIXARK_RUST_PROXY_ASYNC_CACHE_WARM_ON_LOAD`
+    // could stop this and defaulted on; nothing set it, so every proxy that loaded a record-log
+    // root warmed, and this is simply what loading one does.
+    {
         let warm_engine = engine.clone();
         let warm_root = root.clone();
         std::thread::spawn(move || {

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -8,7 +8,7 @@ within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 308 of them, read by 105 functions.
+There are 304 of them, read by 102 functions.
 
 Deleting unreachable code is not the lever. An earlier version of this document argued that
 by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
@@ -46,12 +46,12 @@ Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 308 |
-| booleans whose default this could read off the source | 43 |
-| **defaulting on, and set by nothing** | 9 |
+| total | 304 |
+| booleans whose default this could read off the source | 39 |
+| **defaulting on, and set by nothing** | 5 |
 | offered on the portal | 23 |
-| **that nothing in this repository sets** | 184 |
-| documented as keeping an older path alive | 6 |
+| **that nothing in this repository sets** | 180 |
+| documented as keeping an older path alive | 5 |
 | reaching more than two files | 16 |
 | whose doc comment is really about another flag | 43 |
 
@@ -292,7 +292,7 @@ Sizes, ceilings and intervals. The tuning a deployment actually reaches for.
 | `TS_STORAGE_ZONE_SIZE` | — | config, portal | 1 | — |
 | `TS_STREAM_MAX_BLOB_SIZE` | — | config, portal | 1 | — |
 
-## context (27)
+## context (25)
 
 The memory pipeline: what gets extracted, embedded, drained and packed. The surface a deployment tunes for recall rather than for throughput.
 
@@ -310,13 +310,11 @@ The memory pipeline: what gets extracted, embedded, drained and packed. The surf
 | `MATRIXARK_CONTEXT_COMPRESSION_WINDOW` | — | nothing | 1 | — |
 | `MATRIXARK_CONTEXT_EVENT_QUERY_OVERFETCH` | — | nothing | 1 | — |
 | `MATRIXARK_CONTEXT_EVENT_SCAN_CAP` | — | nothing | 1 | — |
-| `MATRIXARK_CONTEXT_HYBRID_LEXICAL` | on | nothing | 1 | — |
 | `MATRIXARK_CONTEXT_PACK_INCLUDE_SCORES` | off | nothing | 1 | — |
 | `MATRIXARK_CONTEXT_SECONDARY_INDEX` | off | test | 1 | — |
 | `MATRIXARK_EMBEDDING_MODEL` | — | config, script, portal | 1 | — |
 | `MATRIXARK_EMBED_API_KEY_ENV` | — | nothing | 1 | — |
 | `MATRIXARK_EMBED_BASE_URL` | — | config, script | 1 | — |
-| `MATRIXARK_EMBED_DEFER_ON_FAILURE` | on | nothing | 1 | yes |
 | `MATRIXARK_EMBED_DRAINER` | — | config, launch, portal | 1 | — |
 | `MATRIXARK_EMBED_DRAINER_BATCH` | — | config, portal | 1 | — |
 | `MATRIXARK_HOOK_ADDITIONAL_CONTEXT_CHAR_LIMIT` | — | launch | 1 | — |
@@ -367,7 +365,7 @@ Read only by the benchmark harnesses. Never consulted on a serving path.
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_SOURCE_ORDER_RANKING` | off | nothing | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_STORED_RECORD_SCORING` | on | nothing | 1 | — |
 
-## behaviour (66)
+## behaviour (64)
 
 Everything else that changes what the engine does.
 
@@ -385,8 +383,6 @@ Everything else that changes what the engine does.
 | `TS_PAGE_STORE_COMPRESSION_ENABLED` | — | config, launch, test | 2 | — |
 | `TS_PAGE_STORE_COMPRESSION_LEVEL` | — | config, test | 2 | — |
 | `TS_PHASE1_FLAT` | on | test | 2 | — |
-| `MATRIXARK_MONOTONIC_RECORD_COUNT` | on | nothing | 1 | — |
-| `MATRIXARK_RUST_PROXY_ASYNC_CACHE_WARM_ON_LOAD` | on | nothing | 1 | — |
 | `MATRIXARK_RUST_PROXY_ASYNC_STORAGE` | off | launch, test | 1 | — |
 | `MATRIXARK_RUST_PROXY_PAGE_COMPRESSION_ENABLED` | — | test | 1 | — |
 | `MATRIXARK_RUST_PROXY_PAGE_COMPRESSION_LEVEL` | — | test | 1 | — |


### PR DESCRIPTION
Each of these is read at exactly one place, defaults on, and **no** config file, launch profile,
script, portal or test selects the off position. The live side is what every deployment has always
run; the other side is code no one has taken.

| flag | what it gates |
|---|---|
| `MATRIXARK_CONTEXT_HYBRID_LEXICAL` | lexical fallback for un-embedded nodes |
| `MATRIXARK_EMBED_DEFER_ON_FAILURE` | persist-and-mark-dirty on an embed failure |
| `MATRIXARK_MONOTONIC_RECORD_COUNT` | a `record_count` write may only advance |
| `MATRIXARK_RUST_PROXY_ASYNC_CACHE_WARM_ON_LOAD` | background cache warm after a root load |

### The embed one removes an error path, not a fast path

`MATRIXARK_EMBED_DEFER_ON_FAILURE=0` aborted a whole extract when the provider failed and persisted
nothing. On — which is to say always — the node, event and summaries persist, the node is marked
embedding-dirty for the drainer, and lexical scoring keeps it rankable until vectors arrive.

Nothing ever selected the fail-closed arm, so no deployment has discarded an extraction for an
embedding failure. Now none can by accident.

### Two flags in the same class are deliberately not here

`TS_RAFT_WAL_BINARY_RECORDS` and `TS_INDEX_LOG_BINARY` also default on with nothing setting them.
Both select a **durable on-disk record encoding**, and their off position is the rollback hatch for
a reader older than the release that taught the decoder. That is a different thing from a scoring
pass or a warm-up thread.

It is also the distinction this work got wrong once in the other direction — flipping a format
default because nothing set it, when nothing setting it *was* the point. So format switches keep
their hatch.

### How these were found

The default column added in #871 reads a default off an inline statement as well as off a
dedicated accessor. The summary row that matters most — flags defaulting ON that nothing sets —
read **zero** before that change and **nine** after it. These are four of the nine.

### Verification

`cargo check -p temporalstore-rust --all-targets` clean, no new warnings. 61 context_workflow and
retrieve tests pass. The proxy bin's 52 tests pass. 32 inventory guards pass. Inventory 308 → 304.
Rebased on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
