### PR TITLE
Run the outcome sweep always, and let each binary know which binary it is

### DIFF
--- a/crates/temporalstore-rust/src/bin/matrixark_rust_direct_sdk.rs
+++ b/crates/temporalstore-rust/src/bin/matrixark_rust_direct_sdk.rs
@@ -6,4 +6,6 @@
 // This binary shares the long-lived JSON-lines implementation with
 // `matrixark_rust_proxy`, but reports `rust-direct-sdk-bridge` mode by default.
 #![recursion_limit = "256"]
+/// Which of the two bins sharing the implementation below this is: the direct SDK bridge.
+const DIRECT_SDK_BRIDGE: bool = true;
 include!("../matrixark_rust_proxy_impl.rs");

--- a/crates/temporalstore-rust/src/bin/matrixark_rust_proxy.rs
+++ b/crates/temporalstore-rust/src/bin/matrixark_rust_proxy.rs
@@ -6,4 +6,6 @@
 // Benchmarks and production wiring must invoke this binary name so retired
 // record-log artifacts are not mistaken for the Rust production path.
 #![recursion_limit = "256"]
+/// Which of the two bins sharing the implementation below this is: the proxy.
+const DIRECT_SDK_BRIDGE: bool = false;
 include!("../matrixark_rust_proxy_impl.rs");

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -860,12 +860,17 @@ impl TemporalEngine {
                 staged_outcomes.clear();
             }
             if write_command && !replaying_wal() {
-                // A write that changed the shard and recorded nothing cannot be replaced by its
-                // record. Off unless a sweep asks for it; when it is on, every existing test that
-                // writes anything becomes a probe for that property -- which covers far more of
-                // the mutating surface than a hand-listed fixture per command ever would.
+                // A write that changed the shard and recorded nothing cannot be replaced by
+                // its record. Every existing test that writes anything is a probe for that,
+                // which covers far more of the mutating surface than a hand-listed fixture per
+                // command would -- so this is checked in every debug build rather than behind
+                // `TS_WAL_OUTCOME_STRICT`, which nothing ever set. Measured before making it
+                // standing: 1628 lib tests, no violation. A release build pays nothing.
+                //
+                // Still conditional on records carrying results at all: with none there is
+                // nothing for the check to be about.
                 if crate::wal::wal_outcome_items_enabled()
-                    && crate::wal::wal_outcome_strict()
+                    && cfg!(debug_assertions)
                     && staged_outcomes.is_empty()
                 {
                     let rendered = format!("{command:?}");
@@ -874,7 +879,7 @@ impl TemporalEngine {
                         .map(|(head, _)| head.to_string())
                         .unwrap_or(rendered);
                     panic!(
-                        "TS_WAL_OUTCOME_STRICT: {label} changed shard {} and recorded nothing about what it did",
+                        "{label} changed shard {} and recorded nothing about what it did, so its record cannot replace it",
                         request.shard_id
                     );
                 }

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -688,14 +688,15 @@ fn run_request(request: RecordLogRequest) -> Result<(String, RecordLogOutput), (
     Ok((op, output))
 }
 
+/// Whether this binary is the direct SDK bridge.
+///
+/// Each bin that includes this file declares `DIRECT_SDK_BRIDGE`, so the answer is settled when
+/// the binary is built. It used to be asked of `MATRIXARK_RUST_SDK_MODE` and of a substring of
+/// argv[0]; the variable let a proxy process report itself as the bridge, and argv[0] is
+/// whatever the file was last renamed to. Neither can contradict the binary now, and a new bin
+/// that forgets to declare it does not compile.
 fn matrixark_rust_sdk_mode_is_direct() -> bool {
-    matches!(
-        env::var("MATRIXARK_RUST_SDK_MODE").ok().as_deref(),
-        Some("direct_sdk" | "direct-sdk" | "native-binding" | "rust-direct")
-    ) || env::args()
-        .next()
-        .map(|arg| arg.contains("matrixark_rust_direct_sdk"))
-        .unwrap_or(false)
+    DIRECT_SDK_BRIDGE
 }
 
 fn matrixark_rust_storage_mode() -> &'static str {

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -285,19 +285,6 @@ pub struct WriteAheadLogRecord {
     )]
     pub outcomes: Vec<WalOutcomeItem>,
 }
-/// Whether a write that changed the shard but recorded NOTHING should fail loudly.
-///
-/// Opt-in, and nothing sets it outside a deliberate sweep. The point is leverage: enumerating the
-/// mutating command surface by hand and writing a fixture per command tests what the author
-/// remembered to list, while this turns every test that already writes anything into a probe for
-/// the same property. A command that mutates without recording is exactly the one whose records
-/// cannot replace it.
-pub fn wal_outcome_strict() -> bool {
-    std::env::var("TS_WAL_OUTCOME_STRICT")
-        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
-        .unwrap_or(false)
-}
-
 /// TS_WAL_DATA_ONLY: stop writing the operation into a record that already states its results.
 ///
 /// Default ON. Carrying both is strictly bigger for no benefit -- the results are what replay

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -8,7 +8,7 @@ within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 304 of them, read by 102 functions.
+There are 302 of them, read by 100 functions.
 
 Deleting unreachable code is not the lever. An earlier version of this document argued that
 by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
@@ -46,11 +46,11 @@ Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 304 |
-| booleans whose default this could read off the source | 39 |
+| total | 302 |
+| booleans whose default this could read off the source | 37 |
 | **defaulting on, and set by nothing** | 5 |
 | offered on the portal | 23 |
-| **that nothing in this repository sets** | 180 |
+| **that nothing in this repository sets** | 178 |
 | documented as keeping an older path alive | 5 |
 | reaching more than two files | 16 |
 | whose doc comment is really about another flag | 43 |
@@ -158,7 +158,7 @@ Secrets. Never a form field, never in a launch artifact.
 | `TS_API_AUTH_TOKEN` | — | nothing | 1 | — |
 | `TS_META_ADMIN_TOKEN` | — | nothing | 1 | — |
 
-## durability (25)
+## durability (24)
 
 What is written, when it is flushed, and what is reclaimed. The escape hatches here trade throughput for a more conservative barrier.
 
@@ -181,7 +181,6 @@ What is written, when it is flushed, and what is reclaimed. The escape hatches h
 | `TS_WAL_COMMIT_DELAY_US` | — | config | 1 | — |
 | `TS_WAL_DATA_ONLY` | on | launch, test | 1 | — |
 | `TS_WAL_OUTCOME_ITEMS` | on | launch, test | 1 | — |
-| `TS_WAL_OUTCOME_STRICT` | off | nothing | 1 | — |
 | `TS_WAL_PREALLOCATE` | on | launch, test | 1 | — |
 | `TS_WAL_PREALLOCATE_CHUNK` | — | nothing | 1 | — |
 | `TS_WAL_RECLAIM_MAX_SEGMENTS_PER_PASS` | — | test | 1 | yes |
@@ -365,7 +364,7 @@ Read only by the benchmark harnesses. Never consulted on a serving path.
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_SOURCE_ORDER_RANKING` | off | nothing | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_STORED_RECORD_SCORING` | on | nothing | 1 | — |
 
-## behaviour (64)
+## behaviour (63)
 
 Everything else that changes what the engine does.
 
@@ -386,7 +385,6 @@ Everything else that changes what the engine does.
 | `MATRIXARK_RUST_PROXY_ASYNC_STORAGE` | off | launch, test | 1 | — |
 | `MATRIXARK_RUST_PROXY_PAGE_COMPRESSION_ENABLED` | — | test | 1 | — |
 | `MATRIXARK_RUST_PROXY_PAGE_COMPRESSION_LEVEL` | — | test | 1 | — |
-| `MATRIXARK_RUST_SDK_MODE` | off | nothing | 1 | — |
 | `MATRIXARK_TEMPORALSTORE_RUST_ROOT` | — | launch, script, test | 1 | — |
 | `TEMPORALSTORE_RUST_CODEX_EVENT_LOG` | — | launch | 1 | — |
 | `TEMPORALSTORE_RUST_CODEX_EVENT_LOG_ENABLE` | — | nothing | 1 | — |
@@ -436,7 +434,7 @@ Everything else that changes what the engine does.
 | `TS_SHARD_WRITE_QPS` | — | nothing | 1 | — |
 | `TS_TABLE_NAME` | — | test | 1 | — |
 
-## outside this document (6)
+## outside this document (7)
 
 `sdk/rust/temporalstore` is a second Rust tree, carrying its own copy of the
 proxy implementation -- a different file, not a stale duplicate. The root
@@ -450,5 +448,6 @@ is computed, so one more cannot appear quietly.
 - `MATRIXARK_RUST_PROXY_DISABLE_LEGACY_PACK_FALLBACK`
 - `MATRIXARK_RUST_PROXY_DISABLE_SDK_NATIVE_PACK`
 - `MATRIXARK_RUST_SCAN_RECORD_CACHE_ENTRIES`
+- `MATRIXARK_RUST_SDK_MODE`
 - `TEMPORALSTORE_RUST_ALLOW_NATIVE_MATRIXARK_C_API`
 


### PR DESCRIPTION
Two switches, off and set by nothing, and neither is simply deleted.

### The sweep that had never been run

`TS_WAL_OUTCOME_STRICT` turned every existing write test into a probe for one property: **a write
that changed the shard must record something about what it did**, because a write that records
nothing cannot be replaced by its record. The leverage is real — it covers far more of the mutating
surface than a hand-listed fixture per command — and it had never been run, because running it
meant remembering a variable name.

So it was run: **1628 lib tests with it on, zero violations.**

A property that holds is worth more standing than optional, so it is a debug-build assertion now.
Every test run is the sweep; a release build pays nothing. The same suite after the change reports
the same 1628 passed and the same two pre-existing failures — making it standing changed nothing
except that it always runs.

It stays conditional on `wal_outcome_items_enabled`, which is live: when records carry no results
there is nothing for the check to be about.

### A binary that had to ask the environment which binary it was

`MATRIXARK_RUST_SDK_MODE` answered "which binary am I" — a question two bins differing in nothing
but their name were already answering twice, from this variable and from a substring of `argv[0]`.
Only two reported mode strings turn on it, so what the variable really offered was a way for a
proxy process to report itself as the direct SDK bridge: not a feature, a way to be wrong in
telemetry.

Each bin declares `DIRECT_SDK_BRIDGE` instead — settled when the binary is built, contradicted by
neither the environment nor a rename, and a new bin that forgets it does not compile.

`sdk/rust/temporalstore` keeps its own copy of that function unchanged: it is outside the
workspace, and a backend-policy test reads that copy by path.

### Verification

`cargo check -p temporalstore-rust --all-targets` clean, no new warnings. Full lib suite: 1628
passed, zero violations of the standing check, and the two failures are the pair that also fails on
unmodified main. The proxy bin's 52 tests pass. 32 inventory guards pass. Inventory 304 → 302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
