### PR TITLE
One reader each for two flags that four modules were parsing separately

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -1386,14 +1386,7 @@ fn slab_is_at_target(write_offset: u64, slab_target_bytes: u64) -> bool {
 /// resumable/WAL-backed chunk* for far fewer fsyncs. The live path (env unset)
 /// keeps full per-append durability.
 pub(crate) fn bulk_relaxed_durability() -> bool {
-    matches!(
-        std::env::var("MATRIXARK_BULK_INGEST")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "1" | "true" | "yes" | "on"
-    )
+    crate::engine::bulk_ingest_mode()
 }
 
 /// On the live path, defer the per-record extent-manifest persist to sync_durable()/slab-seal
@@ -1414,14 +1407,10 @@ pub(crate) fn page_wal_only_sync() -> bool {
 /// a synchronous per-write data-page fdatasync (with delta-fold recovery) only under the
 /// TS_WAL_LEGACY_RECOVERY escape hatch.
 pub(crate) fn page_wal_single_barrier() -> bool {
-    !matches!(
-        std::env::var("TS_WAL_LEGACY_RECOVERY")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "1" | "true" | "yes" | "on"
-    )
+    // One reader for the hatch, in `engine`. This parsed it itself, as did index_log, and the
+    // three barriers they gate have to move together -- a copy that drifted would leave one of
+    // them on the legacy path and the others on the default.
+    !crate::engine::wal_legacy_recovery()
 }
 
 /// Bands are neither preallocated nor recycled, and both are deliberate.

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -1861,7 +1861,13 @@ pub(crate) fn timestamp_range_bounds(
     }
 }
 
-fn bulk_ingest_mode() -> bool {
+/// Whether this process is running a bulk backfill, which defers per-append durability work
+/// to an explicit `sync_durable`.
+///
+/// The one reader of `MATRIXARK_BULK_INGEST`. block_store, index_log and wal each parsed it
+/// themselves and gate their own half of the same decision; a copy that drifted would leave one
+/// subsystem in bulk mode and the rest on the live path.
+pub(crate) fn bulk_ingest_mode() -> bool {
     matches!(
         std::env::var("MATRIXARK_BULK_INGEST")
             .unwrap_or_default()
@@ -2873,7 +2879,7 @@ fn sync_parent_dir(path: &Path) -> Result<(), std::io::Error> {
 /// path) AND delta-fold recovery. Default OFF -> the single write-path durability barrier
 /// (WAL-only fsync) + base-only recovery is the DEFAULT. This exists solely so an operator can
 /// revert the default in the field without a rebuild; steady state runs single-barrier.
-pub(super) fn wal_legacy_recovery() -> bool {
+pub(crate) fn wal_legacy_recovery() -> bool {
     env_flag_on("TS_WAL_LEGACY_RECOVERY")
 }
 

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -467,28 +467,16 @@ fn indexlog_enabled() -> bool {
 }
 
 fn bulk_ingest_mode() -> bool {
-    matches!(
-        std::env::var("MATRIXARK_BULK_INGEST")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "1" | "true" | "yes" | "on"
-    )
+    crate::engine::bulk_ingest_mode()
 }
 
 /// Defer the ack-path index-log fsync (WAL replay is the durable recovery source). This is the
 /// single-barrier default; restored to a synchronous fsync only under the TS_WAL_LEGACY_RECOVERY
 /// escape hatch (whose delta-fold recovery trusts the durable delta).
 fn indexlog_wal_only_sync() -> bool {
-    !matches!(
-        std::env::var("TS_WAL_LEGACY_RECOVERY")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "1" | "true" | "yes" | "on"
-    )
+    // See `block_store::page_wal_single_barrier`: one reader, in `engine`, so the three barriers
+    // this hatch controls cannot end up disagreeing about whether it is set.
+    !crate::engine::wal_legacy_recovery()
 }
 
 /// MANIFEST-CONFORMANCE FOLD gate (default ON, opt-out). When on, the band/zone

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -2675,14 +2675,7 @@ fn next_batch_id() -> u64 {
 }
 
 fn wal_bulk_relaxed_durability() -> bool {
-    matches!(
-        std::env::var("MATRIXARK_BULK_INGEST")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "1" | "true" | "yes" | "on"
-    )
+    crate::engine::bulk_ingest_mode()
 }
 
 /// TS_PHASE1_FLAT: make per-append WAL sequence resolution O(1) so phase-1 (the work under the

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -47,12 +47,12 @@ Anything else is blank, and a blank means go and look.
 | flags | count |
 |---|---|
 | total | 302 |
-| booleans whose default this could read off the source | 37 |
+| booleans whose default this could read off the source | 36 |
 | **defaulting on, and set by nothing** | 5 |
 | offered on the portal | 23 |
 | **that nothing in this repository sets** | 178 |
-| documented as keeping an older path alive | 5 |
-| reaching more than two files | 16 |
+| documented as keeping an older path alive | 6 |
+| reaching more than two files | 15 |
 | whose doc comment is really about another flag | 43 |
 
 ## topology (38)
@@ -164,7 +164,6 @@ What is written, when it is flushed, and what is reclaimed. The escape hatches h
 
 | flag | default | set by | files | keeps an older path |
 |---|---|---|---|---|
-| `TS_WAL_LEGACY_RECOVERY` | on | config, harness, script | 3 | — |
 | `MATRIXARK_BULK_INGEST_EXPECTED_WAL_COMMANDS` | — | test | 2 | — |
 | `TS_RAFT_SNAPSHOT_CHECK_INTERVAL_MS` | — | nothing | 2 | — |
 | `MATRIXARK_RUST_PROXY_LOG_RECLAIM_INTERVAL_MS` | — | nothing | 1 | — |
@@ -180,6 +179,7 @@ What is written, when it is flushed, and what is reclaimed. The escape hatches h
 | `TS_WAL_BINARY_RECORDS` | on | launch, test | 1 | — |
 | `TS_WAL_COMMIT_DELAY_US` | — | config | 1 | — |
 | `TS_WAL_DATA_ONLY` | on | launch, test | 1 | — |
+| `TS_WAL_LEGACY_RECOVERY` | — | config, harness, script | 1 | yes |
 | `TS_WAL_OUTCOME_ITEMS` | on | launch, test | 1 | — |
 | `TS_WAL_PREALLOCATE` | on | launch, test | 1 | — |
 | `TS_WAL_PREALLOCATE_CHUNK` | — | nothing | 1 | — |
@@ -370,9 +370,9 @@ Everything else that changes what the engine does.
 
 | flag | default | set by | files | keeps an older path |
 |---|---|---|---|---|
-| `MATRIXARK_BULK_INGEST` | off | config, test, portal | 6 | — |
 | `MATRIXARK_EAGER_CACHE_WARM_ON_LOAD` | on | config | 5 | — |
 | `TS_RAFT_ALLOW_PLAINTEXT` | — | harness, script | 4 | — |
+| `MATRIXARK_BULK_INGEST` | off | config, test, portal | 3 | — |
 | `TS_RAFT_ELECTION_TICK_MS` | — | harness, script | 3 | — |
 | `TS_RAFT_ENABLE_LOCAL_ADMIN` | — | harness, script | 3 | — |
 | `TS_RAFT_RPC_DEADLINE_MS` | — | harness, script | 3 | — |

--- a/tools/test_matrixark_engine_flag_legacy.py
+++ b/tools/test_matrixark_engine_flag_legacy.py
@@ -24,6 +24,7 @@ import re
 import unittest
 
 TOOLS = pathlib.Path(os.path.dirname(os.path.abspath(__file__)))
+ROOT_PATH = TOOLS.parent
 TOOL = TOOLS / "build_engine_flag_inventory.py"
 DOC = TOOLS.parent / "docs" / "ops" / "temporalstore-engine-flags.md"
 
@@ -252,14 +253,50 @@ class TheInventoryReportsWhatItMeasuredTest(unittest.TestCase):
     def _marked(self):
         return [r for r in self.rows if r.split("|")[self.legacy_column].strip() == "yes"]
 
-    def test_a_flag_is_not_marked_legacy_on_a_barrier_sentence(self) -> None:
-        """`TS_WAL_LEGACY_RECOVERY` is credited with block_store's doc, which says when pages are
-        fsynced and nothing else. That is a fact about ordering, not about a path kept alive."""
+    def test_the_legacy_mark_on_the_recovery_hatch_is_backed_by_its_own_doc(self) -> None:
+        """The mark has to come from a restore-claim, not from a sentence about fsync ordering.
+
+        This test used to assert the row was NOT marked, and that was right while the doc the
+        generator credited to `TS_WAL_LEGACY_RECOVERY` was block_store's -- which says when pages
+        are fsynced and nothing else, a fact about ordering rather than about a path kept alive.
+
+        Consolidating that flag's readers into one moved the credited doc to the engine's, which
+        says the non-default setting "falls back to the legacy multi-barrier write path" and
+        exists "so an operator can revert the default in the field". That is exactly the claim
+        this column is about, so the mark is now earned rather than inferred.
+
+        Pinning the answer would make this test fail for a correct change -- as it did. So it pins
+        the REASON: however the row reads, the flag's own doc must agree.
+        """
+        source = (ROOT_PATH / "crates" / "temporalstore-rust" / "src" / "engine.rs").read_text(
+            encoding="utf-8")
+        lines = source.splitlines()
+        index = next(
+            (i for i, line in enumerate(lines)
+             if line.lstrip().endswith("fn wal_legacy_recovery() -> bool {")), None)
+        self.assertIsNotNone(
+            index, "no reader for the hatch in engine.rs; this test lost its subject")
+        doc = []
+        for back in range(index - 1, -1, -1):
+            stripped = lines[back].lstrip()
+            if not stripped.startswith("///"):
+                break
+            doc.insert(0, stripped[3:].strip())
+        self.assertTrue(doc, "the hatch's reader carries no doc comment to judge")
+
+        # The flag's own NAME carries the word "legacy", so it comes out of the prose before the
+        # prose is asked whether it claims one. Leaving it in makes this check inert: `restores`
+        # could not be false for a flag called TS_WAL_LEGACY_RECOVERY whatever its doc said.
+        prose = " ".join(doc).lower().replace("ts_wal_legacy_recovery", "the hatch")
+        restores = any(word in prose for word in ("falls back", "revert", "restores"))
+
         row = [line for line in self.rows if line.startswith("| `TS_WAL_LEGACY_RECOVERY`")]
         self.assertTrue(row, "the flag is missing from the inventory entirely")
-        self.assertNotEqual("yes", row[0].split("|")[self.legacy_column].strip(),
-                            "marked as keeping an older path alive, on a doc comment that "
-                            "describes when pages are fsynced and nothing else")
+        marked = row[0].split("|")[self.legacy_column].strip() == "yes"
+        self.assertEqual(
+            restores, marked,
+            "the row says marked=%s while the flag's own doc says restores=%s: %s"
+            % (marked, restores, prose[:200]))
 
     def test_the_count_matches_the_rows(self) -> None:
         marked = self._marked()


### PR DESCRIPTION
`MATRIXARK_BULK_INGEST` was parsed in **four** places — `block_store::bulk_relaxed_durability`,
`engine::bulk_ingest_mode`, `index_log::bulk_ingest_mode` and `wal::wal_bulk_relaxed_durability` —
byte for byte identically. They gate one decision across four subsystems: WAL fsync, data-page
fsync, extent manifest, index-log persistence.

A copy that drifted would leave one of them in bulk mode and the rest on the live path. That is not
a durability posture anyone would choose on purpose, and the way you would find out is a crash
losing what the live path would have kept.

`TS_WAL_LEGACY_RECOVERY` had the same shape with three: `page_wal_single_barrier` in block_store,
`indexlog_wal_only_sync` in index_log, and `wal_legacy_recovery` in engine. The three barriers those
gate — WAL, data page, served index — are exactly the ones that must move together.

Each caller keeps its own name and its own doc, because each describes what its own subsystem
defers. Only the parse is shared.

**Neither flag is retired and no default moves.** Both remain the deployment knobs they are:
`MATRIXARK_BULK_INGEST` is set by the config, the portal and two binaries that are backfills;
`TS_WAL_LEGACY_RECOVERY` by the shipped config, a crash harness and the launch profile.

Found by a scan for flags parsed at more than one site, which reports eighteen — most of them
separate binaries reading their own deployment config, which is fine. These two were the ones where
several modules of one library each parsed the same variable for the same decision.

### One guard changed with it

`test_a_flag_is_not_marked_legacy_on_a_barrier_sentence` asserted `TS_WAL_LEGACY_RECOVERY` is never
marked as keeping an older path alive. That was right while the credited doc was block_store's — a
sentence about when pages are fsynced, which is ordering, not a path kept alive. With one reader the
credited doc is the engine's, which says the non-default setting "falls back to the legacy
multi-barrier write path" and exists "so an operator can revert the default". Under this file's own
rule — the evidence is a sentence saying the non-default setting *restores* something — the mark is
earned.

Pinning the answer made a correct change fail. The test pins the **reason** now: whichever way the
row reads, the flag's own doc must agree. It strips the flag's name from the prose first, because
the name contains "legacy" and leaving it in makes the check inert.

### Verification

`cargo check -p temporalstore-rust --all-targets` clean, no new warnings. Full lib suite: 1627
passed, zero violations of the standing outcome check. `bulk_install_index_durability` passes. 32
inventory guards pass, and the rewritten one was verified by removing the restore-claims from that
doc and watching it fail.

Three tests fail, all of which pass alone: the two that also fail on unmodified main, and
`the_dump_drain_looks_at_each_dirty_object_once`, a per-write cost assertion that failed under load
14 in the parallel run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
