### PR TITLE
Derive a frame's signature from that frame

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -2144,16 +2144,16 @@ def _reset_live_cache() -> None:
     _LIVE_DATANODE_INFLIGHT = None
     _LIVE_EMBEDDING.clear()
     _LIVE_EMBEDDING_INFLIGHT.clear()
-    _LIVE_SIGNATURE.clear()
 
 
 def _forget_idle_identities(now: float) -> None:
     """Drop live-cache entries that their own readers would already ignore.
 
-    Both caches are keyed on the identity triple, and nothing removed an entry. A worker's resident
+    The cache is keyed on the identity triple, and nothing removed an entry. A worker's resident
     memory therefore grew with the number of distinct keys that had EVER opened a status stream
-    rather than the number watching one -- measured at 2,433 bytes per identity, held for the life
-    of the process, of which every byte was already too stale to be served.
+    rather than the number watching one -- measured at 2,433 bytes per identity across the two
+    caches this once swept, held for the life of the process, of which every byte was already too
+    stale to be served.
 
     The tests below are the readers' own staleness checks, called with the same arguments. An entry
     is dropped exactly when it had stopped being an answer, so nothing that would have been served
@@ -2164,9 +2164,6 @@ def _forget_idle_identities(now: float) -> None:
     stay behind until somebody watches again -- bounded by the viewers of one tick, which is the
     thing that was unbounded before.
     """
-    for identity, entry in list(_LIVE_SIGNATURE.items()):
-        if (now - entry[0]) >= EVENT_TICK_S:
-            _LIVE_SIGNATURE.pop(identity, None)
     for identity, entry in list(_LIVE_EMBEDDING.items()):
         if (now - entry[0]) >= _embedding_refresh_interval(entry[1]):
             _LIVE_EMBEDDING.pop(identity, None)
@@ -2243,26 +2240,26 @@ def _shared_live_parts() -> Json:
     return _LIVE_SHARED
 
 
-# identity -> (built at, signature). The signature is what a frame SAYS, with the clock left out,
-# so two viewers on one key do not each serialise the same answer to find out it has not changed.
-_LIVE_SIGNATURE: dict = {}
-
-
-def _frame_signature(identity: tuple, frame: Json) -> bytes:
-    """What this frame says, ignoring when it said it.
+def _frame_signature(frame: Json) -> bytes:
+    """What THIS frame says, ignoring when it said it.
 
     The timestamp is excluded deliberately. It changes every tick by definition, so a comparison
     that included it would never find two frames equal -- the check would run, cost something, and
     never once skip a send.
+
+    Derived from the frame every time, and it takes no identity, because there is no answer here
+    that depends on who is asking. It used to be cached per identity for a tick so that two viewers
+    on one key did not each serialise the same answer. On a hit that returned the signature of a
+    frame built EARLIER and ignored the one passed in -- and the caller sends only when the
+    signature differs from the last it sent, so a viewer could be told nothing had changed while
+    holding a frame that had, and waited another tick for state it already had.
+
+    The cache saved 54 microseconds a call: 0.27 ms of CPU per second at ten viewers on one
+    identity, 2.7 ms at a hundred. A status stream arriving a tick late is the thing it exists not
+    to be.
     """
-    cached = _LIVE_SIGNATURE.get(identity)
-    now = time.time()
-    if cached is not None and (now - cached[0]) < EVENT_TICK_S:
-        return cached[1]
-    signature = json.dumps({field: value for field, value in frame.items() if field != "ts"},
-                           default=str, sort_keys=True).encode("utf-8")
-    _LIVE_SIGNATURE[identity] = (now, signature)
-    return signature
+    return json.dumps({field: value for field, value in frame.items() if field != "ts"},
+                      default=str, sort_keys=True).encode("utf-8")
 
 
 async def _datanode_for_frame(cfg: GatewayConfig) -> Optional[str]:
@@ -2456,7 +2453,7 @@ async def _event_stream(server: Any, cfg: GatewayConfig, scope: Json, receive: C
             datanode = await _datanode_for_frame(cfg)
             frame = await _event_frame(server, cfg, key, tenant, account, embedding,
                                        datanode=datanode)
-            signature = _frame_signature((key, tenant, account), frame)
+            signature = _frame_signature(frame)
             if signature == last_signature:
                 # Nothing has changed since the last frame, so there is nothing to say. The comment
                 # keeps the connection alive through an idle proxy; the browser's parser drops

--- a/tools/test_matrixark_a_signature_describes_its_own_frame.py
+++ b/tools/test_matrixark_a_signature_describes_its_own_frame.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A frame's signature describes THAT frame.
+
+The status stream sends a frame only when what it says differs from what this connection was last
+sent. That comparison is made on a signature: the frame serialised with the timestamp left out,
+because a timestamp changes every tick by definition and a comparison including it would never find
+two frames equal.
+
+The signature was cached per identity for one tick, so that two viewers on the same key did not each
+serialise the same answer. **On a cache hit it returned the signature of a frame built earlier and
+ignored the frame it was handed.** Two plainly different frames therefore got the same signature,
+and a viewer could be told nothing had changed while holding a frame that had -- waiting a further
+tick for state it already possessed.
+
+That is the shape below: two viewers on one key, ticking at an offset, and a change that lands
+between them. The second is the one that misses it.
+
+The cache saved 54 microseconds a call, measured on a frame from a busy deployment (4,301 bytes,
+fourteen routes and a full failure ring). That is 0.27 ms of CPU per second at ten viewers on one
+identity and 2.7 ms at a hundred. A status stream arriving a tick late is the thing it exists not to
+be, so the cache is gone and the signature is derived from the frame every time.
+
+Removing it also takes a process-wide dict with it -- one that had to be swept, and is now not
+there to sweep. The eviction suite next door covers the one cache that remains.
+"""
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import sys
+import time
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_v1_gateway as gw  # noqa: E402
+
+
+def frame(warnings: int, at: float = None) -> dict:
+    """A frame's content as the emit loop would have built it at this instant."""
+    return {"ts": time.time() if at is None else at,
+            "warnings": warnings, "traffic": {}, "imports": {}, "settings_waiting": 0}
+
+
+class ASignatureIsAboutItsOwnFrameTest(unittest.TestCase):
+
+    def test_two_different_frames_do_not_agree(self) -> None:
+        """The defect at its smallest. These differ in every field but the clock."""
+        first = gw._frame_signature(frame(0))
+        second = gw._frame_signature(frame(9))
+        self.assertNotEqual(first, second)
+
+    def test_the_signature_says_what_the_frame_says(self) -> None:
+        """Not merely different -- the right one. Two frames could differ consistently and still
+        both be described wrongly."""
+        signature = json.loads(gw._frame_signature(frame(7)).decode("utf-8"))
+        self.assertEqual(7, signature["warnings"])
+
+    def test_the_clock_is_still_left_out(self) -> None:
+        """The reason the signature exists rather than comparing frames directly. Including the
+        timestamp would make every tick look like a change, and the check would never once skip a
+        send."""
+        early, late = frame(3, at=1000.0), frame(3, at=9999.0)
+        self.assertNotEqual(early["ts"], late["ts"])
+        self.assertEqual(gw._frame_signature(early), gw._frame_signature(late))
+
+    def test_it_does_not_ask_who_wants_to_know(self) -> None:
+        """There is no answer here that depends on the viewer, and taking an identity is what let
+        one viewer be handed another's answer."""
+        parameters = list(inspect.signature(gw._frame_signature).parameters)
+        self.assertEqual(["frame"], parameters,
+                         "the signature takes something other than the frame: %r" % parameters)
+
+
+class TheViewerThatUsedToMissAChangeTest(unittest.TestCase):
+    """The emit loop's decision, run: it sends when the signature differs from the one it last
+    sent, and keeps quiet otherwise."""
+
+    class Viewer:
+        def __init__(self) -> None:
+            self.last = None
+            self.sent = []
+
+        def tick(self, content) -> str:
+            signature = gw._frame_signature(content)
+            if signature == self.last:
+                return "keepalive"
+            self.last = signature
+            self.sent.append(content["warnings"])
+            return "sent"
+
+    def setUp(self) -> None:
+        gw._reset_live_cache()
+        self.addCleanup(gw._reset_live_cache)
+
+    def test_a_second_viewer_on_one_key_sees_a_change_that_lands_between_ticks(self) -> None:
+        """Two tabs on the same key, ticking half a tick apart. A warning appears just after the
+        first has ticked, so only the second is holding a frame that shows it.
+
+        This is what a cached signature got wrong: the second was handed the answer computed for
+        the first, before the change, and stayed quiet.
+        """
+        first, second = self.Viewer(), self.Viewer()
+        self.assertEqual("sent", first.tick(frame(2)))
+        self.assertEqual("sent", second.tick(frame(2)))
+
+        # Nothing has changed for the first viewer, so it says nothing. That entry is what the
+        # second used to be given.
+        self.assertEqual("keepalive", first.tick(frame(2)))
+
+        self.assertEqual("sent", second.tick(frame(3)),
+                         "a viewer holding a changed frame was told nothing had changed")
+        self.assertIn(3, second.sent)
+
+    def test_a_viewer_still_keeps_quiet_when_nothing_changed(self) -> None:
+        """The floor. A signature that never matched would make every tick a send, which is the
+        cost the comparison exists to avoid -- and every test above would still pass."""
+        viewer = self.Viewer()
+        self.assertEqual("sent", viewer.tick(frame(2)))
+        self.assertEqual("keepalive", viewer.tick(frame(2)))
+        self.assertEqual("keepalive", viewer.tick(frame(2)))
+        self.assertEqual([2], viewer.sent)
+
+    def test_the_two_viewers_are_independent(self) -> None:
+        """A viewer that has just arrived has nothing on screen, so its first frame must be sent
+        however long the deployment has been quiet."""
+        first = self.Viewer()
+        first.tick(frame(2))
+        first.tick(frame(2))
+        arriving = self.Viewer()
+        self.assertEqual("sent", arriving.tick(frame(2)))
+
+
+class NothingCachesTheSignatureAnyMoreTest(unittest.TestCase):
+
+    def test_the_module_has_no_signature_cache(self) -> None:
+        """A dict left behind would be swept for nothing, and would invite the same mistake back."""
+        self.assertFalse(hasattr(gw, "_LIVE_SIGNATURE"),
+                         "the per-identity signature cache is back")
+
+    def test_the_cache_that_remains_is_still_swept(self) -> None:
+        """Removing one cache must not take the eviction of the other with it."""
+        self.assertTrue(hasattr(gw, "_forget_idle_identities"))
+        body = inspect.getsource(gw._forget_idle_identities)
+        self.assertIn("_LIVE_EMBEDDING", body)
+        self.assertNotIn("_LIVE_SIGNATURE", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_the_live_caches_forget.py
+++ b/tools/test_matrixark_the_live_caches_forget.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-"""The per-identity live caches forget the identities that stopped watching.
+"""The per-identity live cache forgets the identities that stopped watching.
 
-Two caches behind the status stream are keyed on the identity triple ``(key, tenant, account)``:
-``_LIVE_SIGNATURE``, which holds what a viewer was last told so an unchanged frame can be skipped,
-and ``_LIVE_EMBEDDING``, which holds one identity's encoding backlog so its other tabs reuse the
-read. Nothing removed an entry. ``_reset_live_cache`` exists but is for tests.
+``_LIVE_EMBEDDING`` is keyed on the identity triple ``(key, tenant, account)`` and holds one
+identity's encoding backlog so its other tabs reuse the read. Nothing removed an entry.
+``_reset_live_cache`` exists but is for tests.
+
+There were two such caches when this was written. The other held a frame's signature, and it is
+gone: caching that answer per identity meant returning one computed from a DIFFERENT frame, which
+is a correctness question rather than a memory one -- see
+``test_matrixark_a_signature_describes_its_own_frame``.
 
 So a worker's resident memory grew with the number of distinct keys that had **ever** opened a
 status stream, not the number watching one. Measured at **2,433 bytes per identity**, kept for the
@@ -53,9 +57,7 @@ class _LiveCacheTest(unittest.TestCase):
             for n in range(count):
                 key, tenant, account = _identity(n + offset)
                 embedding = await gw._embedding_for(self.server, self.cfg, key, tenant, account)
-                frame = await gw._event_frame(self.server, self.cfg, key, tenant, account,
-                                              embedding, "ok")
-                gw._frame_signature((key, tenant, account), frame)
+                await gw._event_frame(self.server, self.cfg, key, tenant, account, embedding, "ok")
         asyncio.run(run())
 
     def tick(self) -> None:
@@ -66,8 +68,6 @@ class _LiveCacheTest(unittest.TestCase):
     def age_everything(self) -> None:
         """Put every entry past its own reader's staleness test, without waiting for a clock."""
         now = time.time()
-        for identity, (_at, signature) in list(gw._LIVE_SIGNATURE.items()):
-            gw._LIVE_SIGNATURE[identity] = (now - gw.EVENT_TICK_S - 1.0, signature)
         for identity, (_at, value) in list(gw._LIVE_EMBEDDING.items()):
             gw._LIVE_EMBEDDING[identity] = (now - gw._embedding_refresh_interval(value) - 1.0,
                                             value)
@@ -76,17 +76,9 @@ class _LiveCacheTest(unittest.TestCase):
 class TheCachesForgetWhoLeftTest(_LiveCacheTest):
 
     def test_the_sweep_has_something_to_sweep(self) -> None:
-        """A leak test over empty caches would pass while nothing was ever cached."""
+        """A leak test over an empty cache would pass while nothing was ever cached."""
         self.watch(20)
-        self.assertEqual(20, len(gw._LIVE_SIGNATURE))
         self.assertEqual(20, len(gw._LIVE_EMBEDDING))
-
-    def test_a_signature_does_not_outlive_its_own_staleness(self) -> None:
-        self.watch(20)
-        self.age_everything()
-        self.tick()
-        left = [i for i in gw._LIVE_SIGNATURE if i[0].startswith("k-0000")]
-        self.assertEqual([], left, "signatures too stale to be served were kept anyway")
 
     def test_an_embedding_does_not_outlive_its_own_interval(self) -> None:
         self.watch(20)
@@ -102,24 +94,16 @@ class TheCachesForgetWhoLeftTest(_LiveCacheTest):
         describe who is watching now, not everyone who ever did.
         """
         self.watch(2000)
-        self.assertEqual(2000, len(gw._LIVE_SIGNATURE))
+        self.assertEqual(2000, len(gw._LIVE_EMBEDDING))
         self.age_everything()
         self.tick()
-        self.assertLess(len(gw._LIVE_SIGNATURE), 10,
-                        "the worker still holds an entry for every key that ever watched")
         self.assertLess(len(gw._LIVE_EMBEDDING), 10,
                         "the worker still holds a backlog read for every key that ever watched")
 
 
 class NothingStillWorthServingIsDroppedTest(_LiveCacheTest):
-    """The floor. Clearing both dicts on every tick would pass every test above and destroy the
-    only reason either cache exists."""
-
-    def test_a_fresh_signature_survives_a_tick(self) -> None:
-        self.watch(3)
-        self.tick()
-        kept = [i for i in gw._LIVE_SIGNATURE if i[0].startswith("k-0000")]
-        self.assertEqual(3, len(kept), "a signature the reader would still have served was dropped")
+    """The floor. Clearing the dict on every tick would pass every test above and destroy the only
+    reason the cache exists."""
 
     def test_a_fresh_embedding_survives_a_tick(self) -> None:
         self.watch(3)


### PR DESCRIPTION
The status stream sends a frame only when what it says differs from what this connection was last
sent. That comparison runs on a *signature*: the frame serialised with the timestamp left out,
because a timestamp changes every tick by definition and including it would mean never finding two
frames equal.

The signature was cached per identity for one tick, so two viewers on the same key would not each
serialise the same answer. **On a cache hit it returned the signature of a frame built earlier and
ignored the frame it was handed.**

```
two plainly different frames, same identity, within one tick:

  frame 1 -> {"settings_waiting": 0, "warnings": 0}
  frame 2 -> {"settings_waiting": 0, "warnings": 0}     <- frame 2 says warnings: 9
```

So a viewer could be told nothing had changed while holding a frame that had. Running the emit
loop's own decision shows who pays:

```
t=0.0  A ticks, nothing changed yet   -> sent
t=0.5  B ticks, its first frame       -> sent
t=2.1  A ticks, still nothing changed -> keepalive     (this is the entry B is about to be given)
       ...a warning appears...
t=2.3  B ticks, holding a frame that says 3 warnings
                                      -> keepalive     <- B says nothing
```

B delivers the change on its *next* tick — a full tick late, on a stream whose entire purpose is
not being late.

### What the cache was worth

Measured on a frame from a busy deployment (4,278 bytes, fourteen routes and a full failure ring):

| | |
|---|---|
| deriving the signature every time | **57.3 µs** |
| ten viewers on one identity | 0.29 ms of CPU per second |
| a hundred viewers on one identity | 2.87 ms of CPU per second |

It only ever helped viewers *sharing* an identity — a single connection's ticks are already further
apart than the TTL, so it always missed there. Correctness is worth more than that, so the cache is
gone and the signature is derived from the frame every time.

The function no longer takes an identity, because there is no answer here that depends on who is
asking, and taking one is what let a viewer be handed somebody else's.

### It also removes a cache that had to be swept

`_LIVE_SIGNATURE` was one of the two process-wide dicts `_forget_idle_identities` evicts from. It is
not there to sweep now; the eviction suite is trimmed to the one cache that remains, and a test
asserts that removing one did not take the eviction of the other with it.

```
cache the signature again, as it was          -> FAIL x5, incl. the second viewer missing a change
put the timestamp back into the signature     -> FAIL x3
return a constant, so nothing looks changed   -> FAIL x3
return something unique every time            -> FAIL x3
```

The floors matter here: a signature that never matched would make every tick a send, which is the
cost the comparison exists to avoid — and would pass every other test in the file.

9 tests. Neighbours: v1_gateway 97, gateway_portal 60, live_strip 38, api_traffic 15,
gateway_events 12, stream-reader 8, live-caches 7, frame-delivers 7 — green.
