### PR TITLE
Guard the two defect classes this sortout kept finding by hand

### DIFF
--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -2796,14 +2796,6 @@ fn wal_env_flag_default_on(name: &str) -> bool {
     )
 }
 
-/// TS_WAL_PREALLOCATE (default ON): write records inside a file that has already been grown
-/// to size instead of growing it on every append. fdatasync on a growing file must persist the
-/// new length -- the bytes are unreadable without it -- so every barrier pays a metadata write.
-/// Growing the file in chunks moves that cost to once per chunk: measured 42-55% cheaper at a
-/// barrier per record (issue #188). Live by default now that the full suite runs green with it
-/// forced on; the env var remains the escape hatch (=0 restores growing appends, and a log
-/// written either way reads back under the other, since the tail scan treats a zeros run as
-/// room and a plain file simply ends at its records).
 /// TS_WAL_RECLAIM_MAX_SEGMENTS_PER_PASS: how many sealed pieces one reclaim pass may unlink.
 ///
 /// The unlinking happens while the log's lock is held, and every append takes that lock, so an
@@ -2820,6 +2812,14 @@ fn wal_reclaim_max_segments_per_pass() -> usize {
         .unwrap_or(64)
 }
 
+/// TS_WAL_PREALLOCATE (default ON): write records inside a file that has already been grown
+/// to size instead of growing it on every append. fdatasync on a growing file must persist the
+/// new length -- the bytes are unreadable without it -- so every barrier pays a metadata write.
+/// Growing the file in chunks moves that cost to once per chunk: measured 42-55% cheaper at a
+/// barrier per record (issue #188). Live by default now that the full suite runs green with it
+/// forced on; the env var remains the escape hatch (=0 restores growing appends, and a log
+/// written either way reads back under the other, since the tail scan treats a zeros run as
+/// room and a plain file simply ends at its records).
 fn wal_preallocate_enabled() -> bool {
     wal_env_flag_default_on("TS_WAL_PREALLOCATE")
 }

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -181,9 +181,9 @@ What is written, when it is flushed, and what is reclaimed. The escape hatches h
 | `TS_WAL_DATA_ONLY` | on | launch, test | 1 | — |
 | `TS_WAL_LEGACY_RECOVERY` | — | config, harness, script | 1 | yes |
 | `TS_WAL_OUTCOME_ITEMS` | on | launch, test | 1 | — |
-| `TS_WAL_PREALLOCATE` | on | launch, test | 1 | — |
+| `TS_WAL_PREALLOCATE` | on | launch, test | 1 | yes |
 | `TS_WAL_PREALLOCATE_CHUNK` | — | nothing | 1 | — |
-| `TS_WAL_RECLAIM_MAX_SEGMENTS_PER_PASS` | — | test | 1 | yes |
+| `TS_WAL_RECLAIM_MAX_SEGMENTS_PER_PASS` | — | test | 1 | — |
 | `TS_WAL_RECLAIM_MIN_COPY_BYTES` | — | nothing | 1 | — |
 | `TS_WAL_RECLAIM_MIN_FREED_PERCENT` | — | nothing | 1 | — |
 | `TS_WAL_RESIDENT_PAGES` | — | test | 1 | — |

--- a/tools/test_matrixark_engine_flag_inventory.py
+++ b/tools/test_matrixark_engine_flag_inventory.py
@@ -373,3 +373,126 @@ class TheInventoryKnowsWhatTheCustomerCanSeeTest(unittest.TestCase):
             len(offered & listed), 10,
             "only %d offered flags overlap the inventory; the comparison has stopped comparing"
             % len(offered & listed))
+
+
+class NoDocCommentIsGluedToTheWrongItemTest(unittest.TestCase):
+    """A `///` block documents the item below it -- and only one item is below any of them.
+
+    Two `///` runs with nothing between them are ONE block on whatever follows, and an
+    intervening `//` comment does not separate them either. So deleting a function between two
+    doc comments, or writing a second block without an item under the first, silently files one
+    subject's words under another's name. Rustdoc then renders them as that item's documentation
+    and nothing complains, because a comment cannot fail.
+
+    Four of these were found by hand while retiring flags -- `env_flag_on` had acquired two design
+    notes about the write path, `raft_durable_fingerprint` two more, and
+    `context_hybrid_lexical_enabled` and `wal_preallocate_enabled` had each lost their own to the
+    function above them. That is the whole reason this exists: the failure is invisible in review
+    and permanent once merged.
+
+    The signal is a line INSIDE a run that opens the way a block opens -- a flag name or an
+    `S2:`-style tag at the start -- where the line before it ended a sentence or was blank. The
+    "ended a sentence" part is what keeps a wrapped line from counting: a sentence continuing onto
+    a new line that happens to start with a flag name is ordinary prose, and two of the three
+    candidates this first reported were exactly that.
+    """
+
+    OPENER = re.compile(r"^///\s+((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]{3,}|[A-Z]\d)[:( ]")
+
+    def test_no_block_documents_an_item_that_is_not_below_it(self) -> None:
+        root = os.path.join(ROOT, "crates", "temporalstore-rust", "src")
+        glued, scanned = [], 0
+        for base, _dirs, names in os.walk(root):
+            for name in sorted(names):
+                if not name.endswith(".rs"):
+                    continue
+                scanned += 1
+                path = os.path.join(base, name)
+                with io.open(path, encoding="utf-8") as handle:
+                    lines = handle.read().splitlines()
+                run_start = None
+                for index, line in enumerate(lines):
+                    stripped = line.strip()
+                    if not stripped.startswith("///"):
+                        run_start = None
+                        continue
+                    if run_start is None:
+                        run_start = index
+                        continue
+                    if not self.OPENER.match(stripped):
+                        continue
+                    previous = lines[index - 1].strip()
+                    # A sentence that wraps onto a line starting with a flag name is prose, not a
+                    # new block. Only a line after a finished sentence, or after a blank `///`,
+                    # opens one.
+                    if previous != "///" and not previous.endswith((".", ")")):
+                        continue
+                    following = index + 1
+                    while following < len(lines) and (
+                        lines[following].strip().startswith(("///", "#["))
+                    ):
+                        following += 1
+                    item = lines[following].strip() if following < len(lines) else "(end of file)"
+                    glued.append(
+                        "%s:%d\n      %s\n      -> documents: %s"
+                        % (os.path.relpath(path, ROOT), index + 1, stripped[:88], item[:88])
+                    )
+        self.assertGreater(scanned, 100,
+                           "only %d .rs files scanned; the walk is broken" % scanned)
+        self.assertEqual(
+            [], glued,
+            "%d doc block(s) open inside another block, so they document an item they are not "
+            "about:\n  %s" % (len(glued), "\n  ".join(glued)))
+
+
+class NonTestCodeDoesNotWriteTheProcessEnvironmentTest(unittest.TestCase):
+    """A binary that sets a variable on itself is doing at a distance what an argument does.
+
+    It depends on the order the write and the read happen in, it is visible to every other reader
+    in the process, and it is almost never put back. Four were replaced while retiring flags: the
+    proxy and three binaries set `MATRIXARK_EAGER_CACHE_WARM_ON_LOAD` to configure an engine they
+    were about to build, and two set `TS_PHASE1_FLAT` to the value it already had.
+
+    What is allowed is a whole-PROCESS mode, where the binary genuinely is the thing the variable
+    describes -- a backfill setting `MATRIXARK_BULK_INGEST`. Anything else belongs on the object
+    it configures, so this list is meant to shrink and never to grow.
+    """
+
+    ALLOWED = {
+        # `context_batch_ingest` and `context_embed_backfill` ARE backfills; bulk ingest is a
+        # property of the process, not of one engine inside it.
+        ("bin/context_batch_ingest.rs", "MATRIXARK_BULK_INGEST"),
+        ("bin/context_embed_backfill.rs", "MATRIXARK_BULK_INGEST"),
+    }
+
+    WRITE = re.compile(r'env::set_var\(\s*"((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)"')
+
+    def test_only_a_whole_process_mode_is_written(self) -> None:
+        root = os.path.join(ROOT, "crates", "temporalstore-rust", "src")
+        found, scanned = set(), 0
+        for base, _dirs, names in os.walk(root):
+            if os.sep + "tests" in base:
+                continue
+            for name in sorted(names):
+                if not name.endswith(".rs") or name == "tests.rs":
+                    continue
+                scanned += 1
+                path = os.path.join(base, name)
+                with io.open(path, encoding="utf-8") as handle:
+                    lines = handle.read().splitlines()
+                cut = next((i for i, l in enumerate(lines) if re.match(r"\s*mod tests\b", l)),
+                           len(lines))
+                rel = os.path.relpath(path, root).replace(os.sep, "/")
+                for line in lines[:cut]:
+                    match = self.WRITE.search(line)
+                    if match:
+                        found.add((rel, match.group(1)))
+        self.assertGreater(scanned, 100,
+                           "only %d .rs files scanned; the walk is broken" % scanned)
+        self.assertTrue(self.ALLOWED, "the allowlist is empty; this test would assert nothing")
+        unexpected = sorted(found - self.ALLOWED)
+        self.assertEqual(
+            [], unexpected,
+            "non-test code writes these into the process environment. A setting that belongs to "
+            "one engine, store or cluster belongs on that object:\n  %s"
+            % "\n  ".join("%s sets %s" % pair for pair in unexpected))


### PR DESCRIPTION
Two defect classes this work kept finding by hand. Both are invisible in review and permanent once
merged, and neither had anything watching for it.

### A doc comment can end up on an item it is not about

A `///` block documents the item below it — and only one item is below any of them. Two `///` runs
with nothing between become **one** block on whatever follows, and an intervening `//` comment does
not separate them either. So deleting a function between two doc comments — which is exactly what
retiring a flag does — silently files one subject's words under another's name, and rustdoc renders
them as that item's documentation.

Found by hand during this work:

- `env_flag_on`, a general-purpose **default-OFF** reader, had acquired design notes about the
  concurrent-commit barrier and raft apply coalescing
- `raft_durable_fingerprint` had picked up the S2 and P1 notes
- `context_hybrid_lexical_enabled` and `wal_preallocate_enabled` had each lost their own doc to the
  function above them

The last is fixed here: eight lines describing `TS_WAL_PREALLOCATE` sat above
`wal_reclaim_max_segments_per_pass`, two functions from the reader they belong to, which carried
nothing.

The guard looks for a line **inside** a run that opens the way a block opens — a flag name or an
`S2:`-style tag at the start — where the line before it ended a sentence or was blank. That last
condition is what keeps a wrapped line from counting: a sentence continuing onto a line that starts
with a flag name is ordinary prose, and two of the first three candidates were exactly that.

### Non-test code should not write the process environment

A binary that sets a variable on itself is doing at a distance what an argument does directly: it
depends on the order the write and the read happen in, it is visible to every other reader in the
process, and it is almost never put back. Four such writes were replaced while retiring flags — the
proxy and three binaries configuring an engine they were about to build, and two writing a default
over the default.

What stays allowed is a whole-**process** mode, where the binary genuinely is the thing the variable
describes: a backfill setting `MATRIXARK_BULK_INGEST`. The allowlist has two entries and is meant to
shrink, never to grow.

### Verification

Both guards assert their own extent — a walk that stopped finding files, or an allowlist that
emptied, would otherwise pass loudest.

Both were verified by making the change they exist to catch: gluing the preallocate block back onto
the wrong function, and adding a `set_var` to `engine.rs`. Each named exactly what was wrong, and
each passed again once reverted.

34 guards pass. `cargo check -p temporalstore-rust --all-targets` clean.

Regenerating the inventory after the doc move marks `TS_WAL_PREALLOCATE` as keeping an older path
alive — correct, and not visible before: its doc says `=0` restores growing appends, and until now
that doc was credited to a different flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
