### PR TITLE
Give one answer for which model writes a summary

### DIFF
--- a/tools/matrixark_mcp_summaries.py
+++ b/tools/matrixark_mcp_summaries.py
@@ -32,7 +32,13 @@ SUMMARY_LLM_PROVIDER = os.environ.get(
     "MATRIXARK_SUMMARY_PROVIDER",
     os.environ.get("MATRIXARK_UNDERSTANDING_PROVIDER", os.environ.get("MATRIXARK_EXTRACTION_PROVIDER", "deterministic")),
 ).strip().lower().replace("-", "_")
-SUMMARY_LLM_MODEL = os.environ.get("MATRIXARK_SUMMARY_MODEL", os.environ.get("MATRIXARK_EXTRACTION_MODEL", os.environ.get("OPENAI_MODEL", "gpt-4o-mini")))
+# The same chain matrixark_mcp_core resolves for EXTRACTION_LLM_MODEL, ending in the same
+# literal. This module imports nothing from the project on purpose, so the chain is written
+# out rather than shared -- and the last step used to say "gpt-4o-mini" here while mcp_core
+# said "qwen2.5:1.5b". Both modules send `model=SUMMARY_LLM_MODEL` to the endpoint, so a
+# deployment that chose a provider and named no model asked for a different model depending
+# on which of them did the summarising.
+SUMMARY_LLM_MODEL = os.environ.get("MATRIXARK_SUMMARY_MODEL", os.environ.get("MATRIXARK_EXTRACTION_MODEL", os.environ.get("OPENAI_MODEL", "qwen2.5:1.5b")))
 SUMMARY_LLM_MAX_TOKENS = int(os.environ.get("MATRIXARK_SUMMARY_MAX_TOKENS", "900"))
 
 

--- a/tools/test_matrixark_one_answer_for_the_summary_model.py
+++ b/tools/test_matrixark_one_answer_for_the_summary_model.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Two modules answer "which model writes a summary", and they must not disagree.
+
+``matrixark_mcp_summaries`` imports nothing from this project on purpose -- five modules pull it in,
+and a cycle would be worse than a duplicated line -- so it re-derives what ``matrixark_mcp_core``
+defines. Its chain for the summary model open-codes what mcp_core calls ``EXTRACTION_LLM_MODEL``,
+and it used to end in a different literal::
+
+    core       MATRIXARK_SUMMARY_MODEL -> MATRIXARK_EXTRACTION_MODEL -> OPENAI_MODEL -> qwen2.5:1.5b
+    summaries  MATRIXARK_SUMMARY_MODEL -> MATRIXARK_EXTRACTION_MODEL -> OPENAI_MODEL -> gpt-4o-mini
+
+Both modules **use** it: each sends ``model=SUMMARY_LLM_MODEL`` to the configured endpoint. So a
+deployment that chose a summary provider and named no model asked for a different model depending on
+which of them happened to summarise, and nothing anywhere said so. On an OpenAI endpoint one of
+those two silently names a paid model the customer never chose.
+
+The values are bound at import, so each case below is measured in its own process with the
+environment set before either module is imported. Reading the expressions and re-implementing them
+here would test this file's copy of the logic rather than the modules'.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+
+PROBE = """
+import json, sys
+sys.path.insert(0, %r)
+import matrixark_mcp_core as core
+import matrixark_mcp_summaries as summaries
+print(json.dumps({
+    "core": core.SUMMARY_LLM_MODEL,
+    "summaries": summaries.SUMMARY_LLM_MODEL,
+    "core_provider": core.SUMMARY_LLM_PROVIDER,
+    "summaries_provider": summaries.SUMMARY_LLM_PROVIDER,
+    "core_tokens": core.SUMMARY_LLM_MAX_TOKENS,
+    "summaries_tokens": summaries.SUMMARY_LLM_MAX_TOKENS,
+}))
+""" % TOOLS
+
+# What a deployment can plausibly have set when a summary is written.
+CASES = {
+    "nothing set": {},
+    "a provider chosen, no model named": {"MATRIXARK_SUMMARY_PROVIDER": "openai_compatible"},
+    "only OPENAI_MODEL": {"OPENAI_MODEL": "gpt-4o"},
+    "an extraction model named": {"MATRIXARK_EXTRACTION_MODEL": "deepseek-chat"},
+    "a summary model named": {"MATRIXARK_SUMMARY_MODEL": "something-cheap"},
+    "extraction named and OPENAI_MODEL set": {"MATRIXARK_EXTRACTION_MODEL": "deepseek-chat",
+                                              "OPENAI_MODEL": "gpt-4o"},
+}
+
+CLEAR = ("MATRIXARK_SUMMARY_MODEL", "MATRIXARK_SUMMARY_PROVIDER", "MATRIXARK_EXTRACTION_MODEL",
+         "MATRIXARK_UNDERSTANDING_PROVIDER", "MATRIXARK_EXTRACTION_PROVIDER", "OPENAI_MODEL")
+
+
+def _resolve(overrides):
+    """Both modules' constants, from a process that started with this environment."""
+    env = dict(os.environ)
+    for name in CLEAR:
+        env.pop(name, None)
+    env.update(overrides)
+    proc = subprocess.run([sys.executable, "-c", PROBE], capture_output=True, text=True,
+                          timeout=600, env=env, cwd=TOOLS)
+    if proc.returncode != 0:
+        raise AssertionError("the probe did not run: %s" % (proc.stderr[-500:]))
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+class BothModulesNameTheSameModelTest(unittest.TestCase):
+
+    def test_the_cases_actually_differ_from_each_other(self) -> None:
+        """A floor. If every case resolved to one value, the comparisons below would hold for a
+        pair of constants that never move, and the guard would be worth nothing."""
+        seen = {_resolve(env)["core"] for env in CASES.values()}
+        self.assertGreaterEqual(len(seen), 3, sorted(seen))
+
+    def test_they_agree_on_the_model(self) -> None:
+        for label, env in CASES.items():
+            with self.subTest(case=label):
+                got = _resolve(env)
+                self.assertEqual(got["core"], got["summaries"],
+                                 "%s: mcp_core would ask for %r and mcp_summaries for %r"
+                                 % (label, got["core"], got["summaries"]))
+
+    def test_they_agree_on_the_provider_and_the_token_budget(self) -> None:
+        """These two already matched. Asserted so that fixing one drift does not leave the others
+        unwatched -- all three constants are duplicated in the same way."""
+        for label, env in CASES.items():
+            with self.subTest(case=label):
+                got = _resolve(env)
+                self.assertEqual(got["core_provider"], got["summaries_provider"], label)
+                self.assertEqual(got["core_tokens"], got["summaries_tokens"], label)
+
+
+class TheValueIsActuallySentTest(unittest.TestCase):
+    """A guard over two constants nobody reads would be tidy and pointless."""
+
+    def _source(self, name):
+        with open(os.path.join(TOOLS, name), encoding="utf-8") as handle:
+            return handle.read()
+
+    def test_each_module_sends_the_model_it_resolved(self) -> None:
+        for name in ("matrixark_mcp_core.py", "matrixark_mcp_summaries.py"):
+            with self.subTest(module=name):
+                self.assertIn("model=SUMMARY_LLM_MODEL", self._source(name),
+                              "%s resolves a summary model and never sends it" % name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two modules answer "which model writes a summary", and they answered differently.

`matrixark_mcp_summaries` imports nothing from this project on purpose — five modules pull it in and
a cycle would be worse than a duplicated line — so it re-derives what `matrixark_mcp_core` defines.
Its chain for the summary model open-codes what mcp_core calls `EXTRACTION_LLM_MODEL`, and ended in
a different literal:

```
core       MATRIXARK_SUMMARY_MODEL -> MATRIXARK_EXTRACTION_MODEL -> OPENAI_MODEL -> qwen2.5:1.5b
summaries  MATRIXARK_SUMMARY_MODEL -> MATRIXARK_EXTRACTION_MODEL -> OPENAI_MODEL -> gpt-4o-mini
```

Both modules **use** it — each sends `model=SUMMARY_LLM_MODEL` to the configured endpoint. So a
deployment that chose a summary provider and named no model asked for a different model depending on
which of them happened to summarise, and nothing anywhere said so:

```
nothing set                        core=qwen2.5:1.5b   summaries=gpt-4o-mini   <- DIFFERENT
a provider chosen, no model named  core=qwen2.5:1.5b   summaries=gpt-4o-mini   <- DIFFERENT
only OPENAI_MODEL                  core=gpt-4o         summaries=gpt-4o
an extraction model named          core=deepseek-chat  summaries=deepseek-chat
a summary model named              core=cheap-model    summaries=cheap-model
```

That last shape is the reachable one: the portal's `extraction.model` defaults to empty and an empty
value is not seeded into the environment, so a deployment configured entirely through the portal can
have a provider and no model name.

### Not a new default

mcp_core's expression says *"the extraction model, unless a summary model is named"*, and mcp_core
has one definition of what the extraction model is. This makes the copy match the original it
reproduces rather than picking a new answer. One side had to move; the side that moved is the one
that had drifted from the intent it was written to express.

It is still a behaviour change where the two used to differ, and worth stating plainly: against an
OpenAI endpoint, a deployment in that state previously named `gpt-4o-mini` — a paid model nobody
chose — and now names the same model mcp_core would, which that endpoint will reject. An error
naming a model you did not configure is easier to act on than a bill.

### The guard

Each case is measured in **its own process**, with the environment set before either module is
imported: these are module-scope constants, and reading the expressions and re-implementing them in
the test would check the test's copy of the logic rather than the modules'.

```
put the old literal back in mcp_summaries   -> FAIL they agree on the model
drop a step from the chain                  -> FAIL they agree on the model
diverge the token budget instead            -> FAIL they agree on the provider and token budget
change mcp_core's literal instead           -> FAIL they agree on the model
either module stops sending what it resolved-> FAIL each module sends the model it resolved
```

The provider and the token budget already agreed; they are asserted too, because all three constants
are duplicated the same way and fixing one drift should not leave the others unwatched. A floor
asserts the cases resolve to at least three distinct models, so the comparison cannot pass over a
pair of constants that never move.

4 tests. Neighbours: v1_gateway 97, summary_worker 6 — green.
