### PR TITLE
Say the log-in-record setting to the store it is already keyed by

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -5,6 +5,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
@@ -866,6 +867,10 @@ pub struct BlockStoreRollReport {
 #[derive(Debug, Clone)]
 pub struct LocalBlockStore {
     inner: Arc<Mutex<BlockStoreInner>>,
+    /// Whether a written page is staged into its log record. Shared by every clone of this
+    /// store, and read on the write and read paths, so it is an atomic beside the lock rather
+    /// than a field inside it.
+    block_in_wal: Arc<AtomicBool>,
 }
 
 impl LocalBlockStore {
@@ -877,6 +882,31 @@ impl LocalBlockStore {
     /// "user:1", so anything keyed per object has to include it.
     pub fn store_id(&self) -> usize {
         Arc::as_ptr(&self.inner) as *const u8 as usize
+    }
+
+    /// Whether a written page is staged into its log record and served back from it.
+    ///
+    /// On, and settable off only by a test. Off, an acked write reads back as MISSING once its
+    /// cache entry is dropped before a dump -- a correctness result, not a tuning one -- and the
+    /// cost that once justified it is gone: a staged page now costs about a third over its
+    /// contents rather than five times.
+    ///
+    /// This belongs to the store rather than to the process because the table that resolves a
+    /// staged page is already keyed by `store_id()`: an embedded process runs several engines,
+    /// and two of them serving shard 1 with a key called "user:1" are told apart by nothing else.
+    /// A setting that reached across all of them could not describe that arrangement.
+    pub fn block_in_wal(&self) -> bool {
+        self.block_in_wal.load(AtomicOrdering::Relaxed)
+    }
+
+    /// Serve pages only from the block store, as builds before the log-in-record path did.
+    ///
+    /// For the two tests whose subject IS that older behaviour: one asserting the resident-page
+    /// index does not grow for a store that puts nothing in the log, and one measuring which
+    /// served addresses only this process can resolve, under each setting that produces them.
+    #[cfg(test)]
+    pub(crate) fn stop_putting_pages_in_the_log_for_test(&self) {
+        self.block_in_wal.store(false, AtomicOrdering::Relaxed);
     }
 }
 
@@ -996,6 +1026,7 @@ impl LocalBlockStore {
                 shared_slab_source: None,
                 scratch: None,
             })),
+            block_in_wal: Arc::new(AtomicBool::new(true)),
         }
     }
 

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -695,7 +695,7 @@ impl TemporalEngine {
         }
         // Start this write with nothing staged, so a page put aside by a command that never
         // appended cannot ride along on the next command's record.
-        if block_in_wal::enabled() {
+        if self.page_store.block_in_wal() {
             block_in_wal::begin_write();
         }
         // What the touched keys held before this command, so the capture below can be
@@ -928,7 +928,7 @@ impl TemporalEngine {
                             command,
                             sync,
                             if carried_pages.is_empty() {
-                                if block_in_wal::enabled() {
+                                if self.page_store.block_in_wal() {
                                     block_in_wal::take_staged()
                                 } else {
                                     Vec::new()
@@ -937,7 +937,7 @@ impl TemporalEngine {
                                 // The caller handed us the pages the original write produced.
                                 // Drop whatever this execute re-derived rather than letting a
                                 // reconstruction win over the bytes that were acked.
-                                if block_in_wal::enabled() {
+                                if self.page_store.block_in_wal() {
                                     let _ = block_in_wal::take_staged();
                                 }
                                 std::mem::take(&mut carried_pages)
@@ -948,7 +948,7 @@ impl TemporalEngine {
                             // Point every page this record carries at the record, keyed on the
                             // object id the write derived -- which is what the stored address
                             // carries, so a read finds it by identity rather than by timing.
-                            if block_in_wal::enabled() {
+                            if self.page_store.block_in_wal() {
                                 block_in_wal::register_record(
                                     &self.page_store,
                                     request.shard_id,
@@ -3530,7 +3530,7 @@ fn append_value(
     let address = BlockAddress::from_parts(HOT_PAGE_SLAB_ID, HOT_PAGE_OFFSET.fetch_add(1, Ordering::Relaxed), bytes.len() as u64, None, object_id, routing_bucket, object_id, None);
     // Put the page aside for this write's record. It is often derived state rather than the
     // command's own bytes, so the record has to carry it for a read to serve it back.
-    if block_in_wal::enabled() {
+    if page_store.block_in_wal() {
         if let Some(object_id) = object_id {
             block_in_wal::stage(object_id, bytes);
         }
@@ -3716,7 +3716,7 @@ fn read_page_bytes(
         // been all along. Read it back by the log id the write registered. Tried after the
         // spill redirect because a spilled copy is a direct block-store read, while this one
         // parses a log record.
-        if block_in_wal::enabled() {
+        if page_store.block_in_wal() {
             if let Some(bytes) =
                 address
                     .object_id()

--- a/crates/temporalstore-rust/src/engine/block_in_wal.rs
+++ b/crates/temporalstore-rust/src/engine/block_in_wal.rs
@@ -46,25 +46,6 @@ use std::sync::{Mutex, OnceLock};
 use crate::types::ShardId;
 use crate::wal::{decode_wal_line, LocalWriteAheadLogStore, StagedPage};
 
-/// TS_BLOCK_IN_WAL: stage written pages into their log record and serve them back from it.
-///
-/// Default ON. Without it an acked write reads back as MISSING when its cache entry is dropped
-/// before a dump -- a correctness result, not a tuning one -- and the cost that kept it off is
-/// gone: a staged page now costs about a third over its contents rather than five times.
-///
-/// Set to a falsey value to restore the previous behaviour: records carry no pages, and an
-/// evicted write is served only if the spill path happened to catch it.
-pub(super) fn enabled() -> bool {
-    !matches!(
-        std::env::var("TS_BLOCK_IN_WAL")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "0" | "false" | "no" | "off"
-    )
-}
-
 thread_local! {
     /// Pages produced by the write currently executing on this thread.
     static STAGED: RefCell<Vec<StagedPage>> = const { RefCell::new(Vec::new()) };

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -1410,7 +1410,7 @@ impl TemporalEngine {
     /// reading the index. Both end up in the same table, which is why no read path had to
     /// change for this to work.
     pub(super) fn rehydrate_wal_resident_pages(&self, shard_id: ShardId) {
-        if !super::block_in_wal::enabled() {
+        if !self.page_store.block_in_wal() {
             return;
         }
         let shards = self.shards.read().expect("engine lock poisoned");
@@ -1562,7 +1562,7 @@ impl TemporalEngine {
             // an error, not an empty shard: a durably acknowledged write reported as absent,
             // which is the quietest way a store can lose data. Registering here, where the log
             // id is still in hand, makes a replayed record as addressable as a written one.
-            if super::block_in_wal::enabled() && !record.staged_pages.is_empty() {
+            if self.page_store.block_in_wal() && !record.staged_pages.is_empty() {
                 if let Some(&log_id) = log_id_by_sequence.get(&record.sequence) {
                     super::block_in_wal::register_record(
                         &self.page_store,

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -3389,7 +3389,7 @@ fn what_reading_one_summary_actually_costs() {
         println!(
             "         {wal_resident}/120 wal_resident addresses, {with_page_id} carry a page_id, {} distinct slabs, block_in_wal enabled={}",
             distinct_slabs.len(),
-            std::env::var("TS_BLOCK_IN_WAL").unwrap_or_else(|_| "unset(on)".to_string()),
+            engine.page_store.block_in_wal(),
         );
         let extent_total: u64 = addresses.iter().map(|a| a.length).sum();
 

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -7183,7 +7183,6 @@ fn an_evicted_async_write_is_served_from_its_wal_record() {
         },
     });
 
-    std::env::set_var("TS_BLOCK_IN_WAL", "1");
     // The spill path would otherwise mask what is being tested by copying the value to a real
     // slab on eviction.
     // Said to THIS engine. `TS_HOT_PAGE_SPILL=0` was how this asked, and it could not
@@ -7210,7 +7209,6 @@ fn an_evicted_async_write_is_served_from_its_wal_record() {
             key: key.to_string(),
         },
     });
-    std::env::remove_var("TS_BLOCK_IN_WAL");
 
     assert_eq!(
         read.response,
@@ -7245,7 +7243,6 @@ fn an_evicted_derived_page_is_served_from_its_wal_record() {
         },
     });
 
-    std::env::set_var("TS_BLOCK_IN_WAL", "1");
     // Said to THIS engine. `TS_HOT_PAGE_SPILL=0` was how this asked, and it could not
     // work: the handler is installed during construction, which already happened above.
     engine.disable_hot_page_spill_for_test();
@@ -7270,7 +7267,6 @@ fn an_evicted_derived_page_is_served_from_its_wal_record() {
             field: "f1".to_string(),
         },
     });
-    std::env::remove_var("TS_BLOCK_IN_WAL");
 
     assert_eq!(
         read.response,
@@ -7304,7 +7300,6 @@ fn a_carried_page_is_what_reaches_the_log_record() {
             ..Config::default()
         },
     });
-    std::env::set_var("TS_BLOCK_IN_WAL", "1");
 
     let carried = vec![crate::wal::StagedPage {
         object_id: 4242,
@@ -7321,7 +7316,6 @@ fn a_carried_page_is_what_reaches_the_log_record() {
         },
         carried.clone(),
     );
-    std::env::remove_var("TS_BLOCK_IN_WAL");
     assert!(write.status.ok, "the write must be acked: {write:?}");
 
     let records = engine
@@ -7511,7 +7505,6 @@ fn a_block_in_wal_page_still_reads_back_after_a_shard_reload() {
         },
     });
 
-    std::env::set_var("TS_BLOCK_IN_WAL", "1");
     // Said to THIS engine. `TS_HOT_PAGE_SPILL=0` was how this asked, and it could not
     // work: the handler is installed during construction, which already happened above.
     engine.disable_hot_page_spill_for_test();
@@ -7539,7 +7532,6 @@ fn a_block_in_wal_page_still_reads_back_after_a_shard_reload() {
             key: key.to_string(),
         },
     });
-    std::env::remove_var("TS_BLOCK_IN_WAL");
 
     assert_eq!(
         read.response,
@@ -7574,7 +7566,6 @@ fn a_wal_resident_page_records_where_it_lives_in_the_index() {
             ..Config::default()
         },
     });
-    std::env::set_var("TS_BLOCK_IN_WAL", "1");
     // Said to THIS engine. `TS_HOT_PAGE_SPILL=0` was how this asked, and it could not
     // work: the handler is installed during construction, which already happened above.
     engine.disable_hot_page_spill_for_test();
@@ -7620,7 +7611,6 @@ fn a_wal_resident_page_records_where_it_lives_in_the_index() {
             key: "logged".to_string(),
         },
     });
-    std::env::remove_var("TS_BLOCK_IN_WAL");
     assert_eq!(
         read.response,
         CommandResponse::Bytes { value: Some(value) },
@@ -7628,33 +7618,64 @@ fn a_wal_resident_page_records_where_it_lives_in_the_index() {
     );
 }
 
-/// With the feature off, nothing is recorded -- the index does not grow for stores that put no
+/// With the feature off, nothing is recorded -- the index does not grow for a store that puts no
 /// pages in the log.
+///
+/// Both halves are here because the assertion is `== 0`, and a zero is what this test would report
+/// if the write never staged a page for any other reason. It did exactly that until now: it wrote
+/// synchronously, and a synchronous write goes straight to the block store whatever this setting
+/// says, so the test passed with the feature ON as readily as OFF. The control below is the write
+/// that DOES stage, under the same configuration, differing only in the setting.
 #[test]
 fn a_store_that_puts_no_pages_in_the_log_carries_no_locations() {
-    let dir = tempfile::tempdir().unwrap();
-    let engine = TemporalEngine::with_local_dirs(
-        1024 * 1024,
-        dir.path().join("cache"),
-        dir.path().join("pages"),
-        dir.path().join("indexes"),
-    );
-    engine.load_shard(1);
-    std::env::set_var("TS_BLOCK_IN_WAL", "0");
+    fn resident_pages_after_a_staging_write(put_pages_in_the_log: bool) -> usize {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        // Asynchronous storage is what leaves a page somewhere other than the block store, and
+        // the spill handler is what would then catch it. Without both, nothing stages and the
+        // count is zero for reasons that have nothing to do with the setting.
+        engine.set_config(SetConfigRequest {
+            shard_id: 1,
+            config: Config {
+                version: 2,
+                async_storage: true,
+                ..Config::default()
+            },
+        });
+        engine.disable_hot_page_spill_for_test();
+        if !put_pages_in_the_log {
+            engine.block_store().stop_putting_pages_in_the_log_for_test();
+        }
+        assert!(
+            engine
+                .execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringSet {
+                        key: "plain".to_string(),
+                        value: b"v".to_vec(),
+                    },
+                })
+                .status
+                .ok
+        );
+        engine.wal_resident_page_count(1)
+    }
+
     assert!(
-        engine
-            .execute(ExecuteRequest {
-                shard_id: 1,
-                command: Command::StringSet {
-                    key: "plain".to_string(),
-                    value: b"v".to_vec(),
-                },
-            })
-            .status
-            .ok
+        resident_pages_after_a_staging_write(true) > 0,
+        "the control has to stage something, or the zero below means nothing"
     );
-    std::env::remove_var("TS_BLOCK_IN_WAL");
-    assert_eq!(engine.wal_resident_page_count(1), 0);
+    assert_eq!(
+        resident_pages_after_a_staging_write(false),
+        0,
+        "a store that puts no pages in the log records no locations"
+    );
 }
 
 /// A record can state what the write DID, and that statement has to match what the command
@@ -7805,7 +7826,6 @@ fn two_engines_in_one_process_do_not_read_each_others_pages() {
         engine
     };
 
-    std::env::set_var("TS_BLOCK_IN_WAL", "1");
 
     let first = make("first");
     let second = make("second");
@@ -7843,7 +7863,6 @@ fn two_engines_in_one_process_do_not_read_each_others_pages() {
     };
     let first_read = read(&first);
     let second_read = read(&second);
-    std::env::remove_var("TS_BLOCK_IN_WAL");
 
     assert_eq!(
         first_read,
@@ -7888,7 +7907,6 @@ fn one_engines_retention_floor_ignores_another_engines_registrations() {
         engine
     };
 
-    std::env::set_var("TS_BLOCK_IN_WAL", "1");
     let busy = make("busy");
     let quiet = make("quiet");
 
@@ -7906,7 +7924,6 @@ fn one_engines_retention_floor_ignores_another_engines_registrations() {
             .ok
         );
     }
-    std::env::remove_var("TS_BLOCK_IN_WAL");
 
     // The quiet engine's log has nothing registered against it, so nothing holds its floor.
     assert_eq!(
@@ -9482,7 +9499,6 @@ fn recording_results_still_coalesces_fsyncs() {
     let syncs = engine.write_ahead_log_store().stats(1).syncs - syncs_before;
     let writes = acked.load(Ordering::Relaxed);
     std::env::remove_var("TS_WAL_OUTCOME_ITEMS");
-    std::env::remove_var("TS_ENGINE_CONCURRENT_COMMIT");
 
     println!("[coalescing] writes={writes} fdatasyncs={syncs} while recording results");
     assert_eq!(writes, WRITERS * PER_WRITER, "every write must ack");
@@ -9534,7 +9550,6 @@ fn a_group_commit_write_keeps_the_block_it_staged() {
         },
     });
     assert!(response.status.ok);
-    std::env::remove_var("TS_ENGINE_CONCURRENT_COMMIT");
 
     let carried: usize = engine
         .write_ahead_log_store()
@@ -10398,7 +10413,6 @@ fn how_many_served_addresses_only_this_process_can_resolve() {
         ("async + group-commit OFF", "1", "0", true),
     ];
     for (label, block_in_wal, concurrent, async_storage) in cases {
-        std::env::set_var("TS_BLOCK_IN_WAL", block_in_wal);
         let dir = tempfile::tempdir().unwrap();
         let engine = TemporalEngine::with_local_dirs(
             1024 * 1024,
@@ -10408,6 +10422,9 @@ fn how_many_served_addresses_only_this_process_can_resolve() {
         );
         // Said to THIS engine. `TS_ENGINE_CONCURRENT_COMMIT` used to carry it, which meant the
         // case that wanted the barrier under the lock set it for every engine in the process.
+        if block_in_wal == "0" {
+            engine.block_store().stop_putting_pages_in_the_log_for_test();
+        }
         if concurrent == "0" {
             engine.commit_under_lock_for_test();
         }
@@ -10466,8 +10483,6 @@ fn how_many_served_addresses_only_this_process_can_resolve() {
                 }
             );
         }
-        std::env::remove_var("TS_BLOCK_IN_WAL");
-        std::env::remove_var("TS_ENGINE_CONCURRENT_COMMIT");
     }
 }
 
@@ -10484,7 +10499,6 @@ fn how_many_served_addresses_only_this_process_can_resolve() {
 /// slab that is not a file -- and every value still reads.
 #[test]
 fn a_checkpoint_index_names_no_place_only_this_process_can_reach() {
-    std::env::set_var("TS_BLOCK_IN_WAL", "1");
     let dir = tempfile::tempdir().unwrap();
     let engine = TemporalEngine::with_local_dirs(
         1024 * 1024,
@@ -10525,7 +10539,6 @@ fn a_checkpoint_index_names_no_place_only_this_process_can_reach() {
     let moved = engine.materialize_synthetic_pages(1);
     let after = engine.synthetic_address_count_for_test(1);
     println!("[portable] {before} in-process-only address(es), {moved} materialised, {after} left");
-    std::env::remove_var("TS_BLOCK_IN_WAL");
 
     assert_eq!(
         after, 0,
@@ -10683,7 +10696,6 @@ fn what_a_live_record_is_made_of() {
 /// Measured, not asserted, until the numbers say which.
 #[test]
 fn what_the_log_resident_registry_holds_after_a_dump() {
-    std::env::set_var("TS_BLOCK_IN_WAL", "1");
     let dir = tempfile::tempdir().unwrap();
     let engine = TemporalEngine::with_local_dirs(
         1024 * 1024,
@@ -10751,7 +10763,6 @@ fn what_the_log_resident_registry_holds_after_a_dump() {
     println!(
         "[registry] after materialising: {moved} page(s) moved, {after_materialise} registration(s) left, {synthetic_left} synthetic address(es) left"
     );
-    std::env::remove_var("TS_BLOCK_IN_WAL");
 
     // Whatever the counts, every value must still read -- a registry that shrank too far would
     // show up here rather than as a number.

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -8,7 +8,7 @@ within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 302 of them, read by 100 functions.
+There are 301 of them, read by 99 functions.
 
 Deleting unreachable code is not the lever. An earlier version of this document argued that
 by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
@@ -46,12 +46,12 @@ Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 302 |
-| booleans whose default this could read off the source | 36 |
+| total | 301 |
+| booleans whose default this could read off the source | 35 |
 | **defaulting on, and set by nothing** | 5 |
 | offered on the portal | 23 |
 | **that nothing in this repository sets** | 178 |
-| documented as keeping an older path alive | 6 |
+| documented as keeping an older path alive | 5 |
 | reaching more than two files | 15 |
 | whose doc comment is really about another flag | 43 |
 
@@ -158,7 +158,7 @@ Secrets. Never a form field, never in a launch artifact.
 | `TS_API_AUTH_TOKEN` | — | nothing | 1 | — |
 | `TS_META_ADMIN_TOKEN` | — | nothing | 1 | — |
 
-## durability (24)
+## durability (23)
 
 What is written, when it is flushed, and what is reclaimed. The escape hatches here trade throughput for a more conservative barrier.
 
@@ -168,7 +168,6 @@ What is written, when it is flushed, and what is reclaimed. The escape hatches h
 | `TS_RAFT_SNAPSHOT_CHECK_INTERVAL_MS` | — | nothing | 2 | — |
 | `MATRIXARK_RUST_PROXY_LOG_RECLAIM_INTERVAL_MS` | — | nothing | 1 | — |
 | `TS_BARRIER_PROFILE_WRITES` | — | nothing | 1 | — |
-| `TS_BLOCK_IN_WAL` | on | test | 1 | yes |
 | `TS_CROSS_SHARD_RECLAIM_GUARD` | on | config | 1 | yes |
 | `TS_DATA_NODE_LIFECYCLE_SNAPSHOT` | — | nothing | 1 | — |
 | `TS_INDEX_DUMP_WAL_GAP_BYTES` | — | portal | 1 | — |


### PR DESCRIPTION
Whether a written page is staged into its log record was a process-wide variable — and the table
that resolves such a page has never been process-wide. It is keyed by
`(block_store.store_id(), shard_id, object_id)`, and `store_id` exists precisely because an embedded
process runs several engines, two of which serving shard 1 with a key called `"user:1"` are told
apart by nothing else.

So the switch could not describe the arrangement its own registry was built for. It is a field on
`LocalBlockStore` now, next to the identity, and clones of a store share it exactly as they share
the registry entries.

### The threading cost that had this waiting is not there

Eight branches consult the setting, and **all eight already hold the store** — six in `engine.rs`,
two in `lifecycle.rs`, either through `self.page_store` or through the `page_store` parameter that
`append_value` and `read_page_bytes` already take. Nothing needed a new argument, so the 18 and 29
callers of those two functions are untouched.

### The off position is not a hatch for reading an older store

A record written before this path existed carries no staged pages, and the on path handles that:
`read_page` finds no registration and the read falls through as it always did.

What off does is reproduce the older behaviour on a store written by **this** build, where an acked
write reads back as MISSING once its cache entry is dropped before a dump. Off is not a rollback
position, it is the defect — and the only callers that want it are the two tests whose subject it is.

Of the fourteen places that set the variable, twelve set it to the value it already had.

### One test was inert, and had been before this change

`a_store_that_puts_no_pages_in_the_log_carries_no_locations` asserted that a store putting no pages
in the log records no locations — with a **synchronous** write, which goes straight to the block
store whatever the setting says. Its zero was unconditional; it passed just as readily with the
feature on.

It now runs the same write twice under asynchronous storage with the spill handler off — the
configuration that actually stages — and asserts the control staged something before asserting the
other did not. Verified by making the setter inert:

```
assertion `left == right` failed: a store that puts no pages in the log records no locations
test result: FAILED. 0 passed; 1 failed
```

and restored, the whole group passes 10/10.

### Also removed

- a `remove_var` for `TS_ENGINE_CONCURRENT_COMMIT`, left behind when that setting moved onto the engine
- a diagnostic in `part1.rs` that printed the setting by reading the environment — it would have
  printed `unset(on)` for a store that had been told otherwise

`cargo check --all-targets` clean · 34 flag guards pass · inventory 302 → 301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
