### PR TITLE
Say the flat-append setting to the log it is about

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -155,7 +155,7 @@ pub struct TemporalEngine {
     raft_apply_coalesce: Arc<std::sync::atomic::AtomicBool>,
     /// Diagnostics: number of per-execute `promote_model_maps_to_bucket_index_authority` full
     /// O(store) reconcile scans this engine has run at the hot-path call site. Without
-    /// TS_PHASE1_FLAT this fires once per command (O(writes)); with the gate on the
+    /// `flat_append()` this fires once per command (O(writes)); with it on the
     /// `promote_scan_done` fast-skip holds it to a small constant once warm. Read by the phase-1
     /// aging test to prove the per-write O(n) reconcile scan is gone.
     promote_scans: Arc<std::sync::atomic::AtomicU64>,
@@ -626,7 +626,7 @@ impl TemporalEngine {
         // flag is `#[serde(skip)]` (false on any fresh load), so the first live command after a
         // reload still pays one full reconcile. Gate OFF -> the scan runs every command as before.
         if !defer_bucket_index_reconstruct()
-            && !(phase1_flat_enabled() && shard.promote_scan_done)
+            && !(self.wal_store.flat_append() && shard.promote_scan_done)
         {
             self.promote_scans
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -641,7 +641,7 @@ impl TemporalEngine {
             // Mark the reconcile confirmed only once the shard actually holds model-map state:
             // `promote` returns false (without establishing anything) on an empty shard, so
             // guarding on non-emptiness avoids latching the flag before the first real write.
-            if phase1_flat_enabled() && shard_has_model_entries(shard) {
+            if self.wal_store.flat_append() && shard_has_model_entries(shard) {
                 shard.promote_scan_done = true;
             }
         }
@@ -1029,9 +1029,9 @@ impl TemporalEngine {
                 // dumped-log-id anchor read back on load). Reading the sequence via `stats()`
                 // triggers a full-file `last_wal_sequence_at` rescan -- an O(records)-per-write cost
                 // under this lock (stack-sampling shows it dominates a warm ingest). Under
-                // TS_PHASE1_FLAT anchor off the O(1) cached last sequence (authoritative right after
-                // this write's append) instead; gate OFF keeps the exact `stats()` value.
-                shard.applied_wal_sequence = Some(if phase1_flat_enabled() || raft_apply_batch_active() {
+                // flat append anchor off the O(1) cached last sequence (authoritative right after
+                // this write's append) instead; without it the exact `stats()` value is kept.
+                shard.applied_wal_sequence = Some(if self.wal_store.flat_append() || raft_apply_batch_active() {
                     self.wal_store.cached_last_sequence(request.shard_id)
                 } else {
                     self.wal_store.stats(request.shard_id).last_sequence
@@ -2925,20 +2925,6 @@ pub(super) fn wal_single_barrier() -> bool {
 // barrier. The ack is always returned
 // strictly AFTER the covering barrier succeeds, so durability is never weakened.
 
-/// TS_PHASE1_FLAT: make phase-1 (the work under the global `shards` write lock in
-/// `execute_with_storage_override`) O(1) per write so it stops aging O(n) with data size. Two
-/// per-write O(store) costs otherwise run under the lock on the live path: (1) the WAL append's
-/// full-file `last_wal_sequence_at` rescan (handled in `wal.rs` by the same gate), and (2) the
-/// per-execute `promote_model_maps_to_bucket_index_authority` reconciliation scan at the top of
-/// `execute_with_storage_override`, which walks + clones every live model-map entry only to
-/// re-confirm that `bucket_index` (which every write already keeps authoritative) is in sync. With
-/// the gate on, once a promote scan has confirmed sync (`ShardState.promote_scan_done`) the hot
-/// path skips the repeat scan. Default ON; set the variable to 0 for byte-identical behaviour
-/// (the scan then runs every command exactly as before). Sharing one gate with the WAL
-/// fast-append so a single switch flattens phase-1.
-fn phase1_flat_enabled() -> bool {
-    env_flag_default_on("TS_PHASE1_FLAT")
-}
 
 // TS_RAFT_APPLY_COALESCE: on the raft state-machine apply path, coalesce the per-committed-entry
 // engine-WAL fdatasync across a whole committed batch (one fsync per AppendEntries batch / recovery

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -262,14 +262,14 @@ pub(super) struct ShardState {
     pub(super) bucket_recency: HashMap<u32, u64>,
     #[serde(skip)]
     pub(super) dirty_objects: BTreeSet<String>,
-    /// Phase-1 flat-append (TS_PHASE1_FLAT) fast-skip flag for the per-execute
+    /// Phase-1 flat-append fast-skip flag for the per-execute
     /// `promote_model_maps_to_bucket_index_authority` reconciliation. The live write path already
     /// keeps `bucket_index` authoritative in step with the model maps (each mutating command
     /// upserts its page into `bucket_index` before returning), so once a full promote scan has
     /// confirmed the two are in sync a repeat per-command O(store) scan can only re-confirm it.
     /// Set true after a confirmed/rebuilt reconcile at the hot-path call site; `#[serde(skip)]`
     /// so it is false on every fresh load -> the first live command after any reload pays one
-    /// full reconcile and re-establishes it. Only consulted when `phase1_flat_enabled()`.
+    /// full reconcile and re-establishes it. Only consulted when the log's `flat_append()`.
     #[serde(skip)]
     pub(super) promote_scan_done: bool,
     /// Resume point and candidate pool for sampled eviction. In-memory and ephemeral like

--- a/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
+++ b/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
@@ -235,7 +235,7 @@ impl TemporalEngine {
         // `promote_scan_done` is `#[serde(skip)]`, so a freshly loaded shard still pays exactly
         // one full reconcile before the skip engages, and with the gate off the scan runs on
         // every batch precisely as before.
-        if !(phase1_flat_enabled() && shard.promote_scan_done) {
+        if !(self.wal_store.flat_append() && shard.promote_scan_done) {
             self.promote_scans
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             if promote_model_maps_to_bucket_index_authority(
@@ -249,7 +249,7 @@ impl TemporalEngine {
             // Latch only once the shard actually holds model-map state: `promote` returns false
             // without establishing anything on an empty shard, so guarding on non-emptiness
             // avoids latching before the first real write.
-            if phase1_flat_enabled() && shard_has_model_entries(shard) {
+            if self.wal_store.flat_append() && shard_has_model_entries(shard) {
                 shard.promote_scan_done = true;
             }
         }
@@ -506,9 +506,9 @@ impl TemporalEngine {
             if !config.async_storage && !bulk_ingest_mode() {
                 // Anchor the served index to the WAL sequence it reflects (see the
                 // single-command path) so shard load replays only records after it. Under
-                // TS_PHASE1_FLAT read the O(1) cached last sequence instead of `stats()` (which
-                // rescans the whole WAL file); gate OFF keeps the exact `stats()` value.
-                shard.applied_wal_sequence = Some(if phase1_flat_enabled() {
+                // flat append read the O(1) cached last sequence instead of `stats()` (which
+                // rescans the whole WAL file); without it the exact `stats()` value is kept.
+                shard.applied_wal_sequence = Some(if self.wal_store.flat_append() {
                     self.wal_store.cached_last_sequence(request.shard_id)
                 } else {
                     self.wal_store.stats(request.shard_id).last_sequence

--- a/crates/temporalstore-rust/src/engine/tests/phase1_flat.rs
+++ b/crates/temporalstore-rust/src/engine/tests/phase1_flat.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 MatrixArkAI
 
-//! Tests for the phase-1 flat-append gate (`TS_PHASE1_FLAT`): the two per-write O(store) costs that
+//! Tests for phase-1 flat append (`LocalWriteAheadLogStore::flat_append`): the two per-write
+//! O(store) costs that
 //! run under the engine `shards` write lock -- the WAL append's full-file `last_wal_sequence_at`
 //! rescan and the per-execute `promote_model_maps_to_bucket_index_authority` reconcile scan -- are
 //! made O(1) so phase-1 stops aging O(n) with data size. These tests prove:
@@ -16,13 +17,12 @@
 #![allow(clippy::all)]
 use super::*;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Barrier, Mutex};
+use std::sync::{Arc, Barrier};
 
 // The gates are process-global env vars; serialize the sub-tests that toggle them so an OFF-baseline
 // measurement never observes a sibling's ON window (and vice versa). Other tests are unaffected: the
 // gate only alters an internal fast path and the per-engine/per-store counters read here are
 // isolated to the engine under test.
-static PHASE1_ENV_LOCK: Mutex<()> = Mutex::new(());
 
 fn new_engine(dir: &std::path::Path) -> Arc<TemporalEngine> {
     let engine = Arc::new(TemporalEngine::with_local_dirs(
@@ -70,8 +70,6 @@ fn assert_present_sampled(engine: &TemporalEngine, n: usize, step: usize) {
 #[test]
 #[ignore]
 fn phase1_flat_diag_timing() {
-    let _serial = PHASE1_ENV_LOCK.lock().unwrap();
-    std::env::set_var("TS_PHASE1_FLAT", "1");
     let dir = tempfile::tempdir().unwrap();
     let engine = new_engine(dir.path());
     let batch = 500usize;
@@ -98,18 +96,15 @@ fn phase1_flat_diag_timing() {
             raw.stats_full_scans
         );
     }
-    std::env::remove_var("TS_PHASE1_FLAT");
 }
 
-/// AGING: with TS_PHASE1_FLAT ON, the WAL append rescan count and the promote reconcile scan count
+/// AGING: with flat append ON, the WAL append rescan count and the promote reconcile scan count
 /// both stay a SMALL CONSTANT over 5k writes -- phase-1 is O(1) per write, not O(n). The OFF
 /// baseline fires each scan once per command, so the counts track the write volume (O(writes)).
 #[test]
 fn phase1_flat_keeps_per_write_scans_flat_over_5k_writes() {
-    let _serial = PHASE1_ENV_LOCK.lock().unwrap();
 
     // --- Gate ON: 5k writes, scans must stay flat (a small constant, not ~5000). ---
-    std::env::set_var("TS_PHASE1_FLAT", "1");
     let on_dir = tempfile::tempdir().unwrap();
     let on = new_engine(on_dir.path());
     const N: usize = 5000;
@@ -125,7 +120,6 @@ fn phase1_flat_keeps_per_write_scans_flat_over_5k_writes() {
     // Read back a sample WHILE the gate is still on (so the reads also skip the O(store) promote
     // scan -- reading all N with the gate off would itself be O(N^2) and is not what we measure).
     assert_present_sampled(&on, N, 137);
-    std::env::remove_var("TS_PHASE1_FLAT");
     // A tiny constant covers the first warm-up append + the first reconcile (+ any load-time
     // reconcile). The point is NONE of the three per-write scans scale with N.
     assert!(
@@ -142,9 +136,9 @@ fn phase1_flat_keeps_per_write_scans_flat_over_5k_writes() {
     );
 
     // --- Gate OFF baseline: each scan fires once per command -> counts track the write volume. ---
-    std::env::set_var("TS_PHASE1_FLAT", "0");
     let off_dir = tempfile::tempdir().unwrap();
     let off = new_engine(off_dir.path());
+    off.write_ahead_log_store().rescan_on_every_append_for_test();
     // Smaller than N: with the gate off each of these writes pays the O(store) promote scan AND a
     // full-file WAL rescan, so the run is intentionally O(M^2) -- kept modest so the baseline is
     // quick while still proving the per-command scans track the write volume.
@@ -193,8 +187,6 @@ fn phase1_flat_keeps_per_write_scans_flat_over_5k_writes() {
 /// cold reload's first append correctly reconciles against the on-disk WAL via the full scan.
 #[test]
 fn phase1_flat_writes_survive_wal_replay_reload() {
-    let _serial = PHASE1_ENV_LOCK.lock().unwrap();
-    std::env::set_var("TS_PHASE1_FLAT", "1");
 
     let dir = tempfile::tempdir().unwrap();
     const N: usize = 400;
@@ -226,7 +218,6 @@ fn phase1_flat_writes_survive_wal_replay_reload() {
         "post-reload readback failed: {:?}",
         get.response
     );
-    std::env::remove_var("TS_PHASE1_FLAT");
 }
 
 /// COALESCING: with the gate ON plus the concurrent-commit path, group commit still engages
@@ -236,9 +227,6 @@ fn phase1_flat_writes_survive_wal_replay_reload() {
 /// re-test on the standalone shared backend.
 #[test]
 fn phase1_flat_composes_with_concurrent_commit_coalescing() {
-    let _serial = PHASE1_ENV_LOCK.lock().unwrap();
-    std::env::set_var("TS_PHASE1_FLAT", "1");
-    std::env::set_var("TS_ENGINE_CONCURRENT_COMMIT", "1");
 
     const WRITERS: usize = 8;
     const PER_WRITER: usize = 25;
@@ -272,8 +260,6 @@ fn phase1_flat_composes_with_concurrent_commit_coalescing() {
         handle.join().expect("writer thread must not panic");
     }
     let fsyncs = engine.write_ahead_log_store().stats(1).syncs - syncs_before;
-    std::env::remove_var("TS_PHASE1_FLAT");
-    std::env::remove_var("TS_ENGINE_CONCURRENT_COMMIT");
     eprintln!(
         "[phase1_flat] concurrent writers={WRITERS} writes={total} fdatasyncs={fsyncs} ratio={:.3} fsync/write",
         fsyncs as f64 / total as f64

--- a/crates/temporalstore-rust/src/log_framing.rs
+++ b/crates/temporalstore-rust/src/log_framing.rs
@@ -74,7 +74,7 @@ pub(crate) const FRAME_MAGIC_V3: u8 = 0xB3;
 /// The one thing length framing takes away is the ability to find a log's tail by scanning
 /// BACKWARD: a length prefix is only readable from in front of the record it describes, so the
 /// tail has to be walked to. That walk reads the file, which would be ruinous if it ran per
-/// append -- and it does not: TS_PHASE1_FLAT resolves the sequence from the warm cache plus a
+/// append -- and it does not: flat append resolves the sequence from the warm cache plus a
 /// length stat, leaving the walk for a cold open. (A log format that frames by length usually
 /// records where its last record is as it writes, which bounds even that; the descriptors for
 /// it exist in `storage_descriptor` and are not yet wired.)

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -46,6 +46,7 @@ use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -695,13 +696,13 @@ pub struct WriteAheadLogStats {
     pub last_flushed_sequence: u64,
     pub persistent_bytes: u64,
     /// Diagnostics: full-file `last_wal_sequence_at` rescans taken on the client append path for
-    /// this shard. Without TS_PHASE1_FLAT this increments once per append (O(writes)); with the
-    /// gate on it stays O(1) once the shard's length cache is warm. Read by the phase-1 aging test.
+    /// this shard. Without the log's `flat_append()` this increments once per append (O(writes));
+    /// with it on the count stays O(1) once the shard's length cache is warm. Read by the phase-1 aging test.
     #[serde(default)]
     pub append_full_scans: u64,
     /// Diagnostics: full-file `last_wal_sequence_at` rescans taken inside `stats()`. The per-write
-    /// index-anchor step reads `stats().last_sequence`; without TS_PHASE1_FLAT that rescans on every
-    /// write (O(writes)); with the gate on the engine anchors off `cached_last_sequence` so this
+    /// index-anchor step reads `stats().last_sequence`; without `flat_append()` that rescans on
+    /// every write (O(writes)); with it on the engine anchors off `cached_last_sequence` so this
     /// stays flat. Read (via `raw_stats`, which does NOT itself scan) by the phase-1 aging test.
     #[serde(default)]
     pub stats_full_scans: u64,
@@ -850,6 +851,10 @@ pub struct LocalWriteAheadLogStore {
     // Writers append their bytes under the `inner` lock, RELEASE it, then coalesce
     // their fsync here -- so a burst of concurrent writes amortizes onto ~1 fsync.
     sync_coord: Arc<Mutex<HashMap<ShardId, GroupCommitState>>>,
+    /// Whether an append resolves its sequence from the warm cache. Read on the append path and
+    /// on every execute, so it is an atomic beside the lock rather than a field inside it -- the
+    /// engine asks without taking the log's lock.
+    flat_append: Arc<AtomicBool>,
 }
 
 #[derive(Debug, Default)]
@@ -918,14 +923,14 @@ struct WriteAheadLogInner {
     /// appends to it and never revisited, because the answer is a property of the bytes already
     /// on disk rather than of the current configuration.
     block_mode_by_shard: HashMap<ShardId, bool>,
-    // MANIFEST-CONFORMANCE / phase-1 flat-append cache (TS_PHASE1_FLAT). The WAL file byte length as
+    // MANIFEST-CONFORMANCE / phase-1 flat-append cache (`flat_append()`). The WAL file byte length as
     // this process last left it after its own append (or after a full reconcile scan), per shard.
     // On the next append the fast path stats the file: if the on-disk length still equals this,
     // no other writer touched the file since we wrote it (the append lock is cross-process) and --
     // because we only ever append complete framed lines -- there is no torn tail, so the warm
     // `last_sequence_by_shard` is authoritative and the O(records) `last_wal_sequence_at` scan is
     // skipped. Any mismatch (external append, or first touch this process lifetime) falls back to
-    // the full scan. Only consulted when `wal_fast_append_seq()`; harmless to maintain when off.
+    // the full scan. Only consulted when `flat_append()`; harmless to maintain when off.
     verified_len_by_shard: HashMap<ShardId, u64>,
     // Lowest sequence whose record may still hold the only copy of a block's bytes -- the dump
     // watermark. A block written into the WAL is addressed by the byte offset of its record and
@@ -974,7 +979,41 @@ impl LocalWriteAheadLogStore {
                 dir_sync_owed_by_shard: HashSet::new(),
             })),
             sync_coord: Arc::new(Mutex::new(HashMap::new())),
+            flat_append: Arc::new(AtomicBool::new(true)),
         }
+    }
+
+    /// Whether an append resolves its sequence from the warm in-process cache.
+    ///
+    /// On, and settable off only by a test. Off, the live client-write append path calls
+    /// `last_wal_sequence_at()` on EVERY append -- a full read of this shard's log from offset 0
+    /// that decodes every record to find the max sequence, so an ingest costs O(records) per
+    /// append and O(n^2) overall. That scan is the dominant cost of the work done under the
+    /// engine's shards write lock: longer than the ~3.3 ms fsync and serialized under the same
+    /// lock, so concurrent writers never overlap at the fsync barrier and group commit cannot
+    /// coalesce.
+    ///
+    /// On, the cache is trusted whenever the file's on-disk length is still exactly what this
+    /// process last left it -- an O(1) `metadata()` stat instead of the O(n) scan. That is safe
+    /// because the append lock is cross-process, so any external appender changes the length and
+    /// forces the full scan; and because only complete framed records are ever appended, so a
+    /// matching length rules out a torn tail. The result is byte-identical to the scanning path.
+    ///
+    /// The same setting decides whether the engine repeats its promote reconcile scan, which is
+    /// the other per-write cost that ages with the store. One switch flattens both, which is why
+    /// it lives here rather than in each place that consults it.
+    pub fn flat_append(&self) -> bool {
+        self.flat_append.load(AtomicOrdering::Relaxed)
+    }
+
+    /// Rescan the whole log on every append, as builds before the warm cache did.
+    ///
+    /// For the test that measures both: it writes to one log with the cache trusted and to
+    /// another without, and asserts the scan counts of the second track its write volume while
+    /// the first stay flat.
+    #[cfg(test)]
+    pub(crate) fn rescan_on_every_append_for_test(&self) {
+        self.flat_append.store(false, AtomicOrdering::Relaxed);
     }
 
     pub fn append(
@@ -1063,7 +1102,7 @@ impl LocalWriteAheadLogStore {
             let _append_lock = WalAppendLock::acquire(&mut inner, shard_id)?;
             ensure_active_wal_segment(&mut inner, shard_id)?;
             let (last_sequence, on_disk_len) =
-                resolve_last_sequence_for_append(&mut inner, shard_id)?;
+                resolve_last_sequence_for_append(&mut inner, shard_id, self.flat_append())?;
             inner.last_sequence_by_shard.insert(shard_id, last_sequence);
             let seq = last_sequence.saturating_add(1);
             let rec = WriteAheadLogRecord {
@@ -1150,7 +1189,7 @@ impl LocalWriteAheadLogStore {
         // the record creates the file with no base header, so it reads as starting at log id zero
         // -- an address the sealed pieces already own.
         ensure_active_wal_segment(&mut inner, shard_id)?;
-        let (last_sequence, _on_disk_len) = resolve_last_sequence_for_append(&mut inner, shard_id)?;
+        let (last_sequence, _on_disk_len) = resolve_last_sequence_for_append(&mut inner, shard_id, self.flat_append())?;
         inner.last_sequence_by_shard.insert(shard_id, last_sequence);
         let seq = last_sequence.saturating_add(1);
         let rec = WriteAheadLogRecord {
@@ -1235,7 +1274,7 @@ impl LocalWriteAheadLogStore {
     ) -> Result<WriteAheadLogRecord, WriteAheadLogError> {
         let mut inner = self.inner.lock().expect("write-ahead log lock poisoned");
         let _append_lock = WalAppendLock::acquire(&mut inner, shard_id)?;
-        let (last_sequence, _on_disk_len) = resolve_last_sequence_for_append(&mut inner, shard_id)?;
+        let (last_sequence, _on_disk_len) = resolve_last_sequence_for_append(&mut inner, shard_id, self.flat_append())?;
         let seq = last_sequence.saturating_add(1);
         let record = WriteAheadLogRecord {
             shard_id,
@@ -2069,7 +2108,7 @@ impl LocalWriteAheadLogStore {
     /// `stats()` runs. The per-write index-anchor step (`shard.applied_wal_sequence = last
     /// sequence`) otherwise calls `stats()` on EVERY write, so its embedded rescan is a second
     /// O(records)-per-write cost under the engine `shards` lock (equal in weight to the append-path
-    /// rescan, and confirmed dominant by stack sampling). Under TS_PHASE1_FLAT the engine anchors
+    /// rescan, and confirmed dominant by stack sampling). Under flat append the engine anchors
     /// off this cached value instead. Returns 0 if this store has not yet observed the shard (no
     /// append and no scan); the write path always has, so the value equals the on-disk maximum.
     pub fn cached_last_sequence(&self, shard_id: ShardId) -> u64 {
@@ -2678,25 +2717,6 @@ fn wal_bulk_relaxed_durability() -> bool {
     crate::engine::bulk_ingest_mode()
 }
 
-/// TS_PHASE1_FLAT: make per-append WAL sequence resolution O(1) so phase-1 (the work under the
-/// engine `shards` write lock) stops aging O(n) with data size. The live client-write append path
-/// (`append_with_sync` / `append_for_group_commit`) otherwise calls `last_wal_sequence_at()` on
-/// EVERY append -- a full read of the per-shard WAL file from offset 0 that decodes every record to
-/// find the max sequence (O(records) per append -> O(n^2) ingest). That per-write scan is the
-/// dominant WAL-side phase-1 cost, longer than the ~3.3 ms fsync and serialized under the global
-/// lock, so concurrent writers never overlap at the fsync barrier and group commit cannot coalesce.
-/// With the gate on we trust the warm in-process `last_sequence_by_shard` cache whenever the file's
-/// on-disk length is still exactly what we last left it (`verified_len_by_shard`) -- an O(1)
-/// `metadata()` stat instead of the O(n) scan. Safe because (a) the append lock is cross-process, so
-/// any external appender changes the length and forces the full scan, and (b) we only ever append
-/// complete framed records, so a length match rules out a torn tail. DEFAULT ON (the comment here
-/// said OFF long after the code said otherwise, and a stale default in a comment is worse than no
-/// comment: it was read as fact while deciding whether another gate could be turned on).
-/// Byte-identical to the unconditional-scan path when off. Mirrors the warm-cache fast path already used by
-/// `index_log::append_delta` and `append_replayed_record`.
-fn wal_fast_append_seq() -> bool {
-    wal_env_flag_default_on("TS_PHASE1_FLAT")
-}
 
 /// Resolve the last WAL sequence for `shard_id` immediately before an append, under the `inner`
 /// lock. Fast path (gate on): if a cached sequence AND a verified file length are both present and
@@ -2711,13 +2731,14 @@ fn wal_fast_append_seq() -> bool {
 fn resolve_last_sequence_for_append(
     inner: &mut WriteAheadLogInner,
     shard_id: ShardId,
+    flat_append: bool,
 ) -> Result<(u64, u64), WriteAheadLogError> {
     let cached_last_sequence = inner
         .last_sequence_by_shard
         .get(&shard_id)
         .copied()
         .unwrap_or_default();
-    if wal_fast_append_seq() {
+    if flat_append {
         if let (true, Some(&verified_len)) = (
             inner.last_sequence_by_shard.contains_key(&shard_id),
             inner.verified_len_by_shard.get(&shard_id),

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -8,7 +8,7 @@ within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 301 of them, read by 99 functions.
+There are 300 of them, read by 98 functions.
 
 Deleting unreachable code is not the lever. An earlier version of this document argued that
 by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
@@ -46,8 +46,8 @@ Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 301 |
-| booleans whose default this could read off the source | 35 |
+| total | 300 |
+| booleans whose default this could read off the source | 34 |
 | **defaulting on, and set by nothing** | 5 |
 | offered on the portal | 23 |
 | **that nothing in this repository sets** | 178 |
@@ -363,7 +363,7 @@ Read only by the benchmark harnesses. Never consulted on a serving path.
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_SOURCE_ORDER_RANKING` | off | nothing | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_STORED_RECORD_SCORING` | on | nothing | 1 | — |
 
-## behaviour (63)
+## behaviour (62)
 
 Everything else that changes what the engine does.
 
@@ -380,7 +380,6 @@ Everything else that changes what the engine does.
 | `TEMPORALSTORE_RUST_CODEX_HOOK_ROOT` | — | launch | 2 | — |
 | `TS_PAGE_STORE_COMPRESSION_ENABLED` | — | config, launch, test | 2 | — |
 | `TS_PAGE_STORE_COMPRESSION_LEVEL` | — | config, test | 2 | — |
-| `TS_PHASE1_FLAT` | on | test | 2 | — |
 | `MATRIXARK_RUST_PROXY_ASYNC_STORAGE` | off | launch, test | 1 | — |
 | `MATRIXARK_RUST_PROXY_PAGE_COMPRESSION_ENABLED` | — | test | 1 | — |
 | `MATRIXARK_RUST_PROXY_PAGE_COMPRESSION_LEVEL` | — | test | 1 | — |


### PR DESCRIPTION
Whether an append resolves its sequence from the warm in-process cache — and, by the same switch,
whether the engine repeats its promote reconcile scan — was a process-wide variable read by two
separate functions, one in the WAL and one in the engine.

Both are about **one log**. The cache it validates is `last_sequence_by_shard` inside a particular
`WriteAheadLogInner`; the length it compares against is that log's file. A second store in the same
process has its own cache and its own file, and was never described by the setting at all.

It is a field on `LocalWriteAheadLogStore` now. The engine asks the log it owns
(`self.wal_store.flat_append()`) at its six sites, and the log's own resolver is *told* rather than
asking — `resolve_last_sequence_for_append` takes a `bool`, because it is a free function over the
locked inner and cannot see the outer store. Three callers pass it, all methods on the store.

### One home, deliberately

The two costs share a switch by design: flattening one and not the other leaves phase-1 aging with
the store either way. Two independently settable fields would have made a state that means nothing
reachable.

### The off position stays, because a test compares the two

The aging test writes to one engine with the cache trusted and to another without, then asserts the
second's scan counts track its write volume while the first's stay flat. That comparison *is* the
test — and it now describes two logs rather than one process at two moments.

Its `PHASE1_ENV_LOCK` goes with it: four tests were serialized against each other only because they
took turns writing one variable.

Sixteen process-wide lines went, of which four set the value that was already there, and two set
`TS_ENGINE_CONCURRENT_COMMIT` — a field on the engine since it moved, so those had been setting
nothing.

### Verification

Making the setter inert collapses the baseline onto the fast path, and the test says so:

```
[phase1_flat] gate OFF writes=800 wal_append_full_scans=1 stats_full_scans=0 promote_scans=2
gate OFF: WAL append should rescan once per append (>= 800), got 1
test result: FAILED. 0 passed; 1 failed
```

Restored: aging, replay-reload and coalescing all pass, 3/3.

Eleven comments named the variable, including two a reader would have gone looking for it by. They
name the setting now.

`cargo check --all-targets` clean, no new warnings · 34 flag guards pass · inventory 301 → 300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
