### PR TITLE
Do not let a flag's doc state a default its code contradicts

### DIFF
--- a/crates/temporalstore-rust/src/raft/wal_proto.rs
+++ b/crates/temporalstore-rust/src/raft/wal_proto.rs
@@ -341,12 +341,17 @@ fn entry_from_proto(entry: v1::WalLogEntry) -> io::Result<RaftLogEntry> {
 /// envelope starts with `#`.
 pub(super) const BINARY_RECORD_MAGIC: u8 = 0xA7;
 
-/// Whether new records are written in the binary encoding. Off unless asked for: reading it is
-/// safe from the moment the code lands, but writing it is a one-way step for any reader that
-/// predates this, so the switch is deliberate.
+/// Whether new records are written in the binary encoding. On, and the variable opts out.
+///
+/// Reading either shape has been safe since the code landed -- a read dispatches on the first
+/// byte, and the magic was chosen so it cannot be confused with either text form. WRITING binary
+/// is the one-way half: a reader that predates this cannot take it. So the default stayed off
+/// until the encoding had proved out on real hardware, and this sentence said so long after it
+/// stopped being true, which is the failure worth naming -- the default was read as fact while
+/// deciding whether a neighbouring switch could be turned on.
+///
+/// A node that must produce records an older reader accepts sets the variable to 0.
 pub(super) fn binary_records_enabled() -> bool {
-    // Default ON since the encoding proved out on real hardware; the env var now
-    // opts OUT. Old records read back fine: reads dispatch on the first byte.
     std::env::var("TS_RAFT_WAL_BINARY_RECORDS")
         .map(|value| !(value == "0" || value.eq_ignore_ascii_case("false")))
         .unwrap_or(true)

--- a/tools/test_matrixark_engine_flag_inventory.py
+++ b/tools/test_matrixark_engine_flag_inventory.py
@@ -496,3 +496,71 @@ class NonTestCodeDoesNotWriteTheProcessEnvironmentTest(unittest.TestCase):
             "non-test code writes these into the process environment. A setting that belongs to "
             "one engine, store or cluster belongs on that object:\n  %s"
             % "\n  ".join("%s sets %s" % pair for pair in unexpected))
+
+
+class ADocDoesNotStateADefaultTheCodeContradictsTest(unittest.TestCase):
+    """A flag's doc must not claim a default its own code disagrees with.
+
+    A stale default in a comment is worse than no comment: it is read as fact by whoever is
+    deciding whether a neighbouring switch can be turned on, and nothing about reading it feels
+    like guessing. `TS_RAFT_WAL_BINARY_RECORDS` carried "Off unless asked for" while its code
+    defaulted ON, and a `//` line two lines below said "Default ON" -- so the file disagreed with
+    itself, and the half a reader trusts is the one rustdoc renders.
+
+    Only the accessor shape is checked, because that is the shape whose default can be read off
+    the source without guessing: one function, one flag, returning a bool. A doc that states BOTH
+    positions is skipped rather than judged -- describing a flip needs both words, and which one
+    is the claim cannot be settled by matching.
+    """
+
+    # Every way these docs state a default, including the ones that avoid the word.
+    SAYS_ON = re.compile(
+        r"default(?:s|ed)?\s*(?:\*\*)?on\b|\bon\s+by\s+default|\bon\s+unless\b|"
+        r"\bopt(?:s|ed)?[- ]out\b", re.I)
+    SAYS_OFF = re.compile(
+        r"default(?:s|ed)?\s*(?:\*\*)?off\b|\boff\s+by\s+default|\boff\s+unless\b|"
+        r"\bopt(?:s|ed)?[- ]in\b|\bunless\s+asked\s+for\b", re.I)
+    ACCESSOR = re.compile(
+        r"\s*(?:pub(?:\([a-z():]+\))?\s+)?fn\s+\w+\s*\([^)]*\)\s*->\s*bool\s*\{")
+
+    def test_no_doc_contradicts_its_own_default(self) -> None:
+        prelude = _builder_prelude()
+        function_end, default_of = prelude["function_end"], prelude["default_of"]
+        checked, wrong = [], []
+        for path, source in _engine_sources():
+            lines = source.split("\n")
+            for index, line in enumerate(lines):
+                if not self.ACCESSOR.match(line):
+                    continue
+                body = "\n".join(lines[index:function_end(lines, index)])
+                names = set(FLAG_LITERAL.findall(body))
+                if len(names) != 1:
+                    continue
+                actual = default_of(body, 1)
+                if actual not in ("on", "off"):
+                    continue
+                doc, cursor = [], index - 1
+                while cursor >= 0 and lines[cursor].strip().startswith("///"):
+                    doc.insert(0, lines[cursor].strip()[3:].strip())
+                    cursor -= 1
+                if not doc:
+                    continue
+                prose = " ".join(doc)
+                says_on = bool(self.SAYS_ON.search(prose))
+                says_off = bool(self.SAYS_OFF.search(prose))
+                checked.append(next(iter(names)))
+                if says_on and says_off:
+                    continue
+                if (actual == "on" and says_off) or (actual == "off" and says_on):
+                    wrong.append("%s (%s:%d) defaults %s, its doc says %s"
+                                 % (next(iter(names)), os.path.basename(path), index + 1,
+                                    actual, "off" if says_off else "on"))
+        self.assertGreater(
+            len(checked), 15,
+            "only %d documented flags had a readable default; the scan found nothing to check "
+            "and would pass however wrong the docs were" % len(checked))
+        self.assertEqual(
+            [], sorted(wrong),
+            "a flag's documentation states a default its code contradicts. Correct the prose, "
+            "not the code -- and say it once, so the two halves cannot drift:\n  %s"
+            % "\n  ".join(sorted(wrong)))


### PR DESCRIPTION
`TS_RAFT_WAL_BINARY_RECORDS` was documented **"Off unless asked for"**. It defaults **on**, and has
since the encoding proved out on real hardware. Two lines below that sentence, inside the same
function, a `//` line said `Default ON` — so the file disagreed with itself, and the half a reader
trusts is the half rustdoc renders.

This is the failure the phase-1 doc named in as many words: *a stale default in a comment is worse
than no comment*, because it is read as fact while deciding whether a neighbouring switch can be
turned on.

It is not hypothetical here. This flag decides whether raft WAL records are written in a binary
encoding, and its off position is a **real hatch** — writing binary is the one-way half, since a
reader that predates the change cannot take it. Someone reading "off unless asked for" would
conclude no node had taken that step yet, when every node had.

The sentence is corrected and now says it once; the `//` note is folded into it, because two places
stating the same default is how they came to disagree.

### The guard

It checks the shape whose default can be read off the source without guessing: one function, one
flag, returning a bool. **21 flags qualify and carry a doc; one contradicted its code** — the one
above.

A doc that states *both* positions is skipped rather than judged: to describe a flip you need both
words, and which one is the claim cannot be settled by matching.

The phrase list is deliberately wider than `default on` / `default off`. This doc said neither — it
said "off unless asked for", which is exactly why nothing noticed. It also reads "on/off by
default", "on/off unless", and opt-in / opt-out.

### Verification

Putting the stale sentence back:

```
TS_RAFT_WAL_BINARY_RECORDS (wal_proto.rs:354) defaults on, its doc says off
FAILED (failures=1)
```

Breaking its own walk:

```
only 0 documented flags had a readable default; the scan found nothing to check
and would pass however wrong the docs were
FAILED (failures=1)
```

35 guards pass. The generated inventory is unchanged, which the regenerate-and-compare test
confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
