### PR TITLE
Retire three resource-parser switches nothing selects, and test what they guarded

### DIFF
--- a/tools/matrixark_resource_parser.py
+++ b/tools/matrixark_resource_parser.py
@@ -39,7 +39,6 @@ DEFAULT_MAX_TOTAL_CHUNKS = int(os.environ.get("MATRIXARK_RESOURCE_MAX_TOTAL_CHUN
 DEFAULT_MAX_INLINE_TEXT_CHARS = int(os.environ.get("MATRIXARK_RESOURCE_MAX_INLINE_TEXT_CHARS", str(5 * 1024 * 1024)))
 DEFAULT_TABLE_ROWS_PER_CHUNK = int(os.environ.get("MATRIXARK_RESOURCE_TABLE_ROWS_PER_CHUNK", "20"))
 DEFAULT_JSON_RECORDS_PER_CHUNK = int(os.environ.get("MATRIXARK_RESOURCE_JSON_RECORDS_PER_CHUNK", "20"))
-DEFAULT_MD_PACK_SECTIONS = os.environ.get("MATRIXARK_RESOURCE_MD_PACK_SECTIONS", "1") not in {"0", "false", "False", ""}
 DEFAULT_SLIM_CHUNK_METADATA = os.environ.get("MATRIXARK_RESOURCE_SLIM_CHUNK_METADATA", "0") not in {"0", "false", "False", ""}
 # How many tokens each encoder actually reads. A window is a property of the MODEL, not a
 # constant: e5 and MiniLM stop at 512, BGE-M3 and jina-v3 at 8192. Anything beyond a model's
@@ -199,7 +198,6 @@ _CJK_CLASS = "぀-ヿ㐀-䶿一-鿿豈-﫿ｦ-ﾟ"
 _LATIN_RUN_RE = re.compile(r"[A-Za-z0-9_]+")
 _CJK_CHAR_RE = re.compile("[" + _CJK_CLASS + "]")
 _OTHER_SYMBOL_RE = re.compile("[^" + _CJK_CLASS + r"\sA-Za-z0-9_]")
-CJK_AWARE_TOKENS = os.environ.get("MATRIXARK_RESOURCE_CJK_TOKENS", "1") not in {"0", "false", "False", ""}
 _SPLIT_SPAN_RE = re.compile(
     "[" + _CJK_CLASS + r"]|[A-Za-z0-9_]+|[^" + _CJK_CLASS + r"\sA-Za-z0-9_]+"
 )
@@ -237,8 +235,6 @@ def token_estimate(text: str) -> int:
     a CJK corpus. Coefficients calibrated against the multilingual MiniLM
     tokenizer: median estimate/actual 1.00 over a mixed CN/EN sample.
     """
-    if not CJK_AWARE_TOKENS:
-        return max(1, len(_LATIN_RUN_RE.findall(text)))
     latin = len(_LATIN_RUN_RE.findall(text))
     cjk = len(_CJK_CHAR_RE.findall(text))
     other = len(_OTHER_SYMBOL_RE.findall(text))
@@ -298,7 +294,6 @@ def resource_content_version(raw_uri: str, units: list[Json]) -> str:
     return digest.hexdigest()[:16]
 
 
-CJK_KEYWORD_BIGRAMS = os.environ.get("MATRIXARK_RESOURCE_CJK_KEYWORDS", "1") not in {"0", "false", "False", ""}
 _CJK_RUN_RE = re.compile("[" + _CJK_CLASS + "]{2,}")
 
 
@@ -326,14 +321,13 @@ def keywords_for_text(text: str, limit: int = 12) -> list[str]:
         seen.add(token)
         latin.append(token)
     cjk: list[str] = []
-    if CJK_KEYWORD_BIGRAMS:
-        for run in _CJK_RUN_RE.findall(text):
-            for index in range(len(run) - 1):
-                bigram = run[index : index + 2]
-                if bigram in seen:
-                    continue
-                seen.add(bigram)
-                cjk.append(bigram)
+    for run in _CJK_RUN_RE.findall(text):
+        for index in range(len(run) - 1):
+            bigram = run[index : index + 2]
+            if bigram in seen:
+                continue
+            seen.add(bigram)
+            cjk.append(bigram)
     out: list[str] = []
     for index in range(max(len(latin), len(cjk))):
         if index < len(latin):
@@ -479,7 +473,7 @@ def parse_resource(
     max_directory_depth: int = DEFAULT_MAX_DIRECTORY_DEPTH,
     max_total_chunks: int = DEFAULT_MAX_TOTAL_CHUNKS,
     max_inline_text_chars: int | None = None,
-    pack_markdown_sections: bool | None = None,
+    pack_markdown_sections: bool = True,
     slim_chunk_metadata_fields: bool | None = None,
 ) -> list[ParsedResourceChunk]:
     """Parse supported resources into bounded serving chunks.
@@ -521,8 +515,6 @@ def parse_resource(
 
     if slim_chunk_metadata_fields is None:
         slim_chunk_metadata_fields = DEFAULT_SLIM_CHUNK_METADATA
-    if pack_markdown_sections is None:
-        pack_markdown_sections = DEFAULT_MD_PACK_SECTIONS
     if pack_markdown_sections and kind in {"md", "skill"}:
         units = _pack_markdown_units(units, max_chunk_tokens)
 

--- a/tools/test_resource_content.py
+++ b/tools/test_resource_content.py
@@ -154,5 +154,47 @@ class ResourceContentTest(unittest.TestCase):
         self.assertFalse(out["has_more"])
 
 
+class WhatTheParserOwesACjkCorpusTest(unittest.TestCase):
+    """Two behaviours that used to be switchable, and are now simply how the parser works.
+
+    Both switches defaulted on and nothing anywhere selected the off position, so retiring them
+    kept the live path -- but neither function had a test, which is the state that lets a live
+    path be edited away as easily as a dead one.
+    """
+
+    @staticmethod
+    def _parser():
+        try:
+            from tools import matrixark_resource_parser as parser  # noqa: PLC0415
+        except ImportError:  # run from tools/ dir
+            import matrixark_resource_parser as parser  # type: ignore[no-redef]  # noqa: PLC0415
+        return parser
+
+    def test_a_cjk_sentence_is_not_counted_as_one_token(self) -> None:
+        parser = self._parser()
+        chinese = "中文测试句子内容很长"
+        latin_runs = len(parser._LATIN_RUN_RE.findall(chinese))
+        self.assertEqual(0, latin_runs, "the control: this sample has no Latin runs at all")
+        self.assertGreater(
+            parser.token_estimate(chinese), 4,
+            "a Chinese sentence counted by Latin runs alone scores 1, which understates it by "
+            "about 37x and silently blows any max_context_tokens budget")
+
+    def test_a_mixed_passage_gives_both_halves_keywords(self) -> None:
+        parser = self._parser()
+        chinese = "向量检索系统"
+        keywords = parser.keywords_for_text("alpha beta gamma delta " + chinese, limit=6)
+        self.assertTrue(keywords, "the control: something must be indexed")
+        cjk = [k for k in keywords if parser._CJK_CHAR_RE.search(k)]
+        self.assertTrue(
+            cjk,
+            "Latin runs alone leave Chinese text with NO keywords, so on a CJK corpus the part "
+            "of the secondary index carrying any selectivity indexes nothing. Got: %r" % keywords)
+        self.assertTrue(
+            all(len(k) == 2 for k in cjk),
+            "Chinese has no spaces to split on, so runs contribute overlapping character "
+            "bigrams a lexical index can match without a segmenter. Got: %r" % cjk)
+
+
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
The engine's flags have been sorted; the Python side had never been asked the same question. Of **62
variables that become a bool, 42 are set by nothing** anywhere in this repository, and **15 of those
default ON** — so their off side is a branch, not a switch.

One of the 15 turns out to be offered by the gateway config — a setter no code search finds, because
the setter is a person. The three here are not.

All three decide what gets **written**, never what can be read, so retiring them strands nothing: a
chunk already stored keeps the keywords and the shape it was stored with, and no read path consults
any of them.

| flag | what its off position did |
|---|---|
| `MATRIXARK_RESOURCE_CJK_TOKENS` | returned the count of Latin runs — which the docstring directly above says understates Chinese by ~37x (a pure-CJK sentence scores **1**) and silently blows any `max_context_tokens` budget |
| `MATRIXARK_RESOURCE_CJK_KEYWORDS` | skipped the bigram loop, leaving Chinese text with **no keywords at all** — the part of the secondary index carrying any selectivity indexes nothing |
| `MATRIXARK_RESOURCE_MD_PACK_SECTIONS` | *keeps its choice* — see below |

`parse_resource` already takes `pack_markdown_sections`, so the per-call scope exists; the parameter
merely deferred to a process-wide variable when left unset. It states its own default now
(`pack_markdown_sections: bool = True`). No caller passes it either way, so nothing changes.

### The part worth more than the retirement

**Neither behaviour had a test.** That is the state that lets a live path be edited away as easily
as a dead one.

Two now exist: a CJK sentence must not be counted as one token, and a mixed passage must give both
halves keywords. Each carries its control *in the same test* — the sample provably has no Latin
runs; something provably got indexed — because both assertions are of a shape that passes loudest
when the input is empty.

Restoring both off arms:

```
AssertionError: 1 not greater than 4 : a Chinese sentence counted by Latin runs alone scores 1,
which understates it by about 37x and silently blows any max_context_tokens budget

AssertionError: [] is not true : Latin runs alone leave Chinese text with NO keywords, so on a
CJK corpus the part of the secondary index carrying any selectivity indexes nothing.
Got: ['alpha', 'beta', 'gamma', 'delta']
```

### Test baseline

The parser's importers run **154 tests** here, of which 152 also run on an unmodified tree. Both
report **12 failures and 1 error** — all in the codex-hook prompt-text cluster, unrelated to this
and intended to be red. The two extra tests are the ones added here, both passing, under both
import paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
