### PR TITLE
Three switches whose variable was only supplying a field's default

### DIFF
--- a/tools/matrixark_mcp_direct_cache.py
+++ b/tools/matrixark_mcp_direct_cache.py
@@ -293,10 +293,7 @@ def placement_candidate_records_from_cache_or_load(
 def ensure_direct_context_pack_response_cache(target: Any) -> None:
     if hasattr(target, "_direct_context_pack_response_cache"):
         return
-    target._direct_context_pack_response_cache_enabled = (
-        os.environ.get("MATRIXARK_DIRECT_CONTEXT_PACK_RESPONSE_CACHE", "1").strip().lower()
-        not in {"0", "false", "no"}
-    )
+    target._direct_context_pack_response_cache_enabled = True
     target._direct_context_pack_response_cache_max_entries = max(
         1, int(os.environ.get("MATRIXARK_DIRECT_CONTEXT_PACK_RESPONSE_CACHE_MAX_ENTRIES", "256"))
     )

--- a/tools/matrixark_mcp_direct_write_queue.py
+++ b/tools/matrixark_mcp_direct_write_queue.py
@@ -90,7 +90,7 @@ def ensure_direct_write_queue_fields(target: Any) -> None:
     if not hasattr(target, "_direct_write_queue_allow_sync_context"):
         target._direct_write_queue_allow_sync_context = _env_bool("MATRIXARK_DIRECT_WRITE_QUEUE_ALLOW_SYNC_CONTEXT", False)
     if not hasattr(target, "_direct_write_queue_autostart"):
-        target._direct_write_queue_autostart = _env_bool("MATRIXARK_DIRECT_WRITE_QUEUE_AUTOSTART", True)
+        target._direct_write_queue_autostart = True
     if not hasattr(target, "_native_side_index_assume_fresh"):
         target._native_side_index_assume_fresh = _env_bool("MATRIXARK_NATIVE_SIDE_INDEX_ASSUME_FRESH", False)
     if not hasattr(target, "_direct_raw_ingestion_queue_enabled"):

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -111,7 +111,6 @@ RETRIEVAL_HOT_RECORD_TYPES = {
 }
 
 RESOURCE_IMPORT_IGNORE_DIRS = {".git", "node_modules", "target", "build", "dist", ".venv", "__pycache__"}
-LOCAL_READ_CACHE_COPY = os.environ.get("MATRIXARK_LOCAL_READ_CACHE_COPY", "1").strip().lower() not in {"0", "false", "no"}
 LOCAL_DURABLE_READ_CACHE_ENABLED = os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_CACHE_ENABLED", "1").strip().lower() not in {"0", "false", "no"}
 # Records the tail file may hold before the base is folded back in. Bounds both the
 # delta file and the work a load does stitching it onto the base.
@@ -6255,7 +6254,9 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         records = self.read_all()
         if len(records) <= limit:
             return records
-        return records[-limit:] if LOCAL_READ_CACHE_COPY else list(records[-limit:])
+        # Slicing a list copies it, so the caller cannot reach the cache through this. The
+        # branch that used to wrap this in `list(...)` copied a copy.
+        return records[-limit:]
 
     def read_all(self) -> list[Json]:
         """Live view: the compacted, tombstone-filtered log with expired / pre-cutoff records and

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -2876,7 +2876,7 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             raise MatrixArkError("MATRIXARK_DIRECT_WRITE_QUEUE_MODE must be memory or temporalstore")
         self._direct_write_queue_drain_max_batches = max(1, int(os.environ.get("MATRIXARK_DIRECT_WRITE_QUEUE_DRAIN_MAX_BATCHES", "64")))
         self._direct_write_queue_allow_sync_context = os.environ.get("MATRIXARK_DIRECT_WRITE_QUEUE_ALLOW_SYNC_CONTEXT", "0").strip().lower() in {"1", "true", "yes"}
-        self._direct_write_queue_autostart = os.environ.get("MATRIXARK_DIRECT_WRITE_QUEUE_AUTOSTART", "1").strip().lower() not in {"0", "false", "no"}
+        self._direct_write_queue_autostart = True
         self._native_side_index_assume_fresh = os.environ.get("MATRIXARK_NATIVE_SIDE_INDEX_ASSUME_FRESH", "0").strip().lower() in {"1", "true", "yes"}
         self._direct_raw_ingestion_queue_enabled = os.environ.get("MATRIXARK_DIRECT_RAW_INGESTION_QUEUE", "0").strip().lower() in {"1", "true", "yes"}
         self._direct_raw_ingestion_enabled = os.environ.get("MATRIXARK_DIRECT_RAW_INGESTION", "0").strip().lower() in {"1", "true", "yes"}

--- a/tools/matrixark_temporal_direct_backend.py
+++ b/tools/matrixark_temporal_direct_backend.py
@@ -92,7 +92,7 @@ class _TemporalDirectBackendMixin:
         if not hasattr(self, "_direct_write_queue_allow_sync_context"):
             self._direct_write_queue_allow_sync_context = os.environ.get("MATRIXARK_DIRECT_WRITE_QUEUE_ALLOW_SYNC_CONTEXT", "0").strip().lower() in {"1", "true", "yes"}
         if not hasattr(self, "_direct_write_queue_autostart"):
-            self._direct_write_queue_autostart = os.environ.get("MATRIXARK_DIRECT_WRITE_QUEUE_AUTOSTART", "1").strip().lower() not in {"0", "false", "no"}
+            self._direct_write_queue_autostart = True
         if not hasattr(self, "_native_side_index_assume_fresh"):
             self._native_side_index_assume_fresh = os.environ.get("MATRIXARK_NATIVE_SIDE_INDEX_ASSUME_FRESH", "0").strip().lower() in {"1", "true", "yes"}
         if not hasattr(self, "_direct_raw_ingestion_queue_enabled"):


### PR DESCRIPTION
Each of the three defaults on, and nothing anywhere selects the off position through the
environment. What should be left behind differs in all three cases.

### `MATRIXARK_LOCAL_READ_CACHE_COPY` — decided nothing

Its two arms were `records[-limit:]` and `list(records[-limit:])`. **Slicing a list already copies
it**, so one arm copied a copy.

The guarantee the name promises is real, but it is made two calls upstream, where the instance cache
is served as `list(self._read_cache_records)`. And the line directly above the switch returns
`records` whole when the limit does not bite — which no position of the switch affected either.

The constant is gone, and the slice now says why it is safe.

### `MATRIXARK_DIRECT_WRITE_QUEUE_AUTOSTART` — keeps its off position

Something *does* select it: `test_matrixark_mcp_backend_policy` sets
`adapter._direct_write_queue_autostart = False` **on the object**. The field is the switch; the
variable was only choosing its default.

Worth stating: that test cannot run in this repository — the module raises `SkipTest` at import
because `run_matrixark_rust_scale_report` is absent — so the selector is real but unexercised here.

That variable was read in **three** places, each initialising the same field, each with the same
default, each behind its own `hasattr`. Three copies of one decision is how two of them come to
disagree. There is now one value in three places rather than one parse in three places.

### `MATRIXARK_DIRECT_CONTEXT_PACK_RESPONSE_CACHE` — keeps its field

Nothing sets it today, but the field is already read twice and reported as a metric, so removing it
would take a metric with it for no gain. The environment stops supplying its default.

### Verification

96 tests across nine modules that exercise these adapters pass.

The direct-backend module still cannot be imported standalone — a circular import through the
temporal adapters. That fails identically on an unmodified tree and is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
