### PR TITLE
Three copies of one setting, one of which had drifted

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -161,10 +161,11 @@ SECONDARY_INDEX_PRIORITY_PREFIXES = (
 # semantic dimension used to recall facts (entity_type, entity_name, segment_topic, event_type,
 # classification, status, source_role, source_type, keyword, and skill/resource/topology dims).
 #
-# Gated behind MATRIXARK_PRUNE_INTERNAL_INDEX_DIMENSIONS (default ON). Flag OFF reproduces today's
-# dimensions exactly. Recall is validated by test_prune_internal_index_dimensions (must stay 5/5); any
-# dimension whose removal drops recall must be taken OFF this list and kept.
-PRUNE_INTERNAL_INDEX_DIMENSIONS = os.environ.get("MATRIXARK_PRUNE_INTERNAL_INDEX_DIMENSIONS", "1").strip().lower() in {"1", "true", "yes", "on"}
+# On. `test_intern_record_metadata` sets this constant to False to isolate the other lever on a
+# metadata-heavy corpus, which is the only thing that ever selected the other position. Recall is
+# validated by test_prune_internal_index_dimensions (must stay 5/5); any dimension whose removal
+# drops recall must be taken OFF this list and kept.
+PRUNE_INTERNAL_INDEX_DIMENSIONS = True
 INTERNAL_INDEX_DIMENSIONS = frozenset({
     "memory_selection_policy",
     "memory_scope",

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -2912,14 +2912,8 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         self._append_engine_count = 0
         self._disk_fallback_adapter: MatrixArkLocalAdapter | None = None
         self._disk_fallback_path = os.environ.get("MATRIXARK_TEMPORALSTORE_LOCAL_STORE", "").strip()
-        self._disk_fallback_enabled = bool(self._disk_fallback_path) and os.environ.get(
-            "MATRIXARK_TEMPORALSTORE_SHADOW_LOCAL_STORE",
-            "1",
-        ).strip().lower() not in {"0", "false", "no", "off"}
-        self._disk_fallback_recovery_enabled = bool(self._disk_fallback_path) and os.environ.get(
-            "MATRIXARK_TEMPORALSTORE_RECOVER_LOCAL_STORE",
-            "1",
-        ).strip().lower() not in {"0", "false", "no", "off"}
+        self._disk_fallback_enabled = bool(self._disk_fallback_path)
+        self._disk_fallback_recovery_enabled = bool(self._disk_fallback_path)
         self._disk_fallback_recovery_attempted = False
         self._disk_fallback_recovery_in_progress = False
         self._disk_fallback_recovery_status: Json = {"status": "not_attempted"}
@@ -3061,15 +3055,9 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         if not hasattr(self, "_disk_fallback_path"):
             self._disk_fallback_path = os.environ.get("MATRIXARK_TEMPORALSTORE_LOCAL_STORE", "").strip()
         if not hasattr(self, "_disk_fallback_enabled"):
-            self._disk_fallback_enabled = bool(self._disk_fallback_path) and os.environ.get(
-                "MATRIXARK_TEMPORALSTORE_SHADOW_LOCAL_STORE",
-                "1",
-            ).strip().lower() not in {"0", "false", "no", "off"}
+            self._disk_fallback_enabled = bool(self._disk_fallback_path)
         if not hasattr(self, "_disk_fallback_recovery_enabled"):
-            self._disk_fallback_recovery_enabled = bool(self._disk_fallback_path) and os.environ.get(
-                "MATRIXARK_TEMPORALSTORE_RECOVER_LOCAL_STORE",
-                "1",
-            ).strip().lower() not in {"0", "false", "no", "off"}
+            self._disk_fallback_recovery_enabled = bool(self._disk_fallback_path)
         if not hasattr(self, "_disk_fallback_recovery_attempted"):
             self._disk_fallback_recovery_attempted = False
         if not hasattr(self, "_disk_fallback_recovery_in_progress"):
@@ -4544,12 +4532,7 @@ class MatrixArkTemporalStoreRustAdapter(MatrixArkTemporalStoreDirectAdapter):
         self._retrieval_candidate_cache_lock = threading.RLock()
         self._disk_fallback_adapter: MatrixArkLocalAdapter | None = None
         self._disk_fallback_path = os.environ.get("MATRIXARK_TEMPORALSTORE_LOCAL_STORE", "").strip()
-        self._disk_fallback_enabled = os.environ.get("MATRIXARK_TEMPORALSTORE_SHADOW_LOCAL_STORE", "1").strip().lower() in {
-            "1",
-            "true",
-            "yes",
-            "on",
-        }
+        self._disk_fallback_enabled = bool(self._disk_fallback_path)
         self._disk_fallback_write_failures = 0
         self._metaserver = metaserver
         self._namespace = namespace

--- a/tools/test_intern_record_metadata.py
+++ b/tools/test_intern_record_metadata.py
@@ -15,8 +15,8 @@ context_index postings for constant internal-metadata dimensions (memory_scope, 
 memory_layer, extraction_phase, ...), keeping the semantic dimensions that carry recall. Cuts posting
 COUNT ~65% with recall held at 5/5.
 
-Both are gated (MATRIXARK_INTERN_RECORD_METADATA / MATRIXARK_PRUNE_INTERNAL_INDEX_DIMENSIONS, default
-ON); flag-OFF reproduces today's behaviour exactly.
+Interning is gated by MATRIXARK_INTERN_RECORD_METADATA (default ON); pruning is simply on, and this
+file sets its module constant to False below to isolate one lever from the other.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
### Three copies of one setting, one of which had drifted

`MATRIXARK_TEMPORALSTORE_SHADOW_LOCAL_STORE` decides whether writes are shadowed to a local store. It
was read in **three** places, each initialising `_disk_fallback_enabled`, and the third did not agree
with the other two:

```
two of them:  bool(self._disk_fallback_path) and <var> not in {"0","false","no","off"}
the third:                                        <var>     in {"1","true","yes","on"}
```

Two differences:

1. the third **drops the requirement that a path be configured at all**, so that adapter reported
   shadowing as enabled with nowhere to shadow to
2. it decides the same variable by a **positive** spelling set where the others use a **negative**
   one — so they disagree on every value in neither list

**The write path is not affected.** `_append_disk_fallback_records` re-reads the path and returns
when it is empty, which is what masked this. What *was* affected is what the adapter **reports**:
`disk_fallback_enabled` appears in two state snapshots, and on that adapter it was true whatever the
configuration said. Correcting it is the only externally visible effect here.

Nothing sets the variable, or its sibling `MATRIXARK_TEMPORALSTORE_RECOVER_LOCAL_STORE`. What *does*
select these positions is the field — three backend-policy tests assign `_disk_fallback_enabled`
directly. So the field stays, the environment stops choosing its default, and with the parse gone all
three copies say the same short thing: `bool(self._disk_fallback_path)`.

> `MATRIXARK_TEMPORALSTORE_RECOVER_LOCAL_STORE_ANY_MODE` is a *different* variable that tests do set.
> Untouched.

### The same pattern once more

`MATRIXARK_PRUNE_INTERNAL_INDEX_DIMENSIONS`: the module constant is the switch —
`test_intern_record_metadata` sets `C.PRUNE_INTERNAL_INDEX_DIMENSIONS = False` to isolate one lever
from the other on a metadata-heavy corpus — and the variable only chose its default. The constant
stays, the parse goes, and the comment above it now names the test that selects the other position
rather than a variable nothing sets.

### Verification

50 tests across six modules pass, including the recall guard this pruning is conditional on:

```
[lever2] postings OFF=2505 ON=905 reduction=63.9% dropped_dims=[12 non-semantic dimensions]
[lever2] recall pruned=5/5 baseline=5/5
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
