### PR TITLE
Hold the line on Python switches nothing can turn off

### DIFF
--- a/tools/test_python_flag_switches.py
+++ b/tools/test_python_flag_switches.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A default-ON switch that nothing can turn off is a branch, not a switch.
+
+The engine's flags are inventoried and guarded. The Python side was not, and it had accumulated
+eleven variables that defaulted on and that nothing anywhere selected the other position of: no
+test, no shell script, no config file, no tenant knob, no portal control, no command-line argument.
+Each kept a second code path alive that nothing could reach, and two of them were read in three
+places each, where the copies had already begun to disagree.
+
+They were retired by keeping the live path. This holds the line: a NEW one fails here.
+
+What counts as a selector is deliberately wide, because the ways to set one of these are not all
+code. A person setting a tenant knob or a portal control is a selector no search for an assignment
+finds, and this check would be wrong -- dangerously so, since it recommends deleting a customer's
+control -- if it looked only for assignments in this repository.
+
+Listing is the escape, not an exception. An entry has to say why the switch cannot be reached, and
+the last test fails if a listed switch becomes reachable, so a reason that stops being true does
+not quietly stand.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import unittest
+from typing import Dict, List, Set, Tuple
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(TOOLS)
+
+# A read whose value is turned into a bool, with a default that makes the switch default-ON.
+_READ = re.compile(
+    r'os\.(?:environ\.get|getenv)\(\s*["\']([A-Z][A-Z0-9_]{3,})["\']\s*,\s*["\']([^"\']*)["\']')
+_TRUTH_SET = re.compile(r'in\s*[\(\{\[][^)\}\]]*["\'](?:1|true|yes|on|0|false|no|off)["\']', re.I)
+_EQ = re.compile(r'[=!]=\s*["\'](?:1|true|yes|on|0|false|no|off)["\']', re.I)
+_NUMERIC = re.compile(r'\b(?:int|float)\s*\(')
+_ON_DEFAULT = re.compile(r'^(?:1|true|yes|on)$', re.I)
+
+# The two files that OFFER settings rather than set them. In these, naming the variable at all is
+# the offer: the value arrives from a customer, and the declaration spans lines, so no assignment
+# pattern finds it. MATRIXARK_LOCAL_DURABLE_READ_CACHE_ENABLED is declared here as the third
+# argument of a Setting(...) on a line of its own, and reading it as unreachable would have
+# recommended deleting a control the gateway offers.
+_REGISTRIES = ("matrixark_gateway_config.py", "matrixark_tenant_policy.py")
+
+# Each of these defaults ON and nothing selects the other position. The entry says why that is the
+# right answer rather than a defect.
+KNOWN_UNSELECTED: Dict[str, str] = {
+    # Gates schema DDL against a live database. Turning it off is what an operator running against
+    # a managed schema does, and that operator is outside this repository by construction.
+    "MATRIXARK_METADATA_AUTO_INIT": "operator safety switch for schema creation",
+    # A benchmark harness's own parameter: the person running the harness is the selector, exactly
+    # as with the engine's benchmark knobs.
+    "MATRIXARK_REQUIRE_SHARED_OSS_MODELS": "benchmark harness parameter, set by whoever runs it",
+    "TEMPORALSTORE_HF_READER_PRELOAD": "local model server parameter, set by whoever runs it",
+}
+
+# Seven remain after the eleven were retired. The floor is asserted so a scan that stops matching
+# fails rather than reporting that all is well.
+EXPECTED_SWITCH_FLOOR = 5
+
+
+def _production_sources() -> List[str]:
+    listed = subprocess.run(["git", "ls-files", "*.py"], cwd=REPO,
+                            capture_output=True, text=True).stdout.split()
+    return [path for path in listed if not os.path.basename(path).startswith("test_")]
+
+
+def _default_on_switches() -> Dict[str, str]:
+    """Variable -> "path:line" of the first read that makes it a default-ON boolean switch."""
+    found: Dict[str, str] = {}
+    for path in _production_sources():
+        try:
+            with open(os.path.join(REPO, path), encoding="utf-8") as handle:
+                lines = handle.read().splitlines()
+        except OSError:
+            continue
+        for number, line in enumerate(lines, 1):
+            for match in _READ.finditer(line):
+                name, default = match.group(1), match.group(2)
+                if name in found or not _ON_DEFAULT.match(default.strip()):
+                    continue
+                window = " ".join(lines[number - 1:number + 2])
+                if _NUMERIC.search(window):
+                    continue
+                if not (_TRUTH_SET.search(window) or _EQ.search(window)):
+                    continue
+                found[name] = "%s:%d" % (path, number)
+    return found
+
+
+def _selector_texts() -> List[Tuple[bool, str]]:
+    """(is_registry, text) for everywhere a switch could be selected."""
+    listed = subprocess.run(
+        ["git", "ls-files", "*.py", "*.sh", "*.json", "*.toml", "*.yml", "*.yaml", "*.rs", "*.js"],
+        cwd=REPO, capture_output=True, text=True).stdout.split()
+    texts: List[Tuple[bool, str]] = []
+    for path in listed:
+        try:
+            with open(os.path.join(REPO, path), encoding="utf-8") as handle:
+                texts.append((os.path.basename(path) in _REGISTRIES, handle.read()))
+        except OSError:
+            continue
+    return texts
+
+
+def _selected(names: Set[str]) -> Set[str]:
+    """Names something gives a value to, as opposed to reading."""
+    patterns = {}
+    for name in names:
+        escaped = re.escape(name)
+        patterns[name] = re.compile(
+            r"export\s+" + escaped + r"="
+            r"|environ\[\s*[\"']" + escaped + r"[\"']\s*\]\s*="
+            r"|setdefault\(\s*[\"']" + escaped + r"[\"']"
+            r"|set_var\(\s*\"" + escaped + r"\""
+            r"|[\"']" + escaped + r"[\"']\s*:")
+    selected: Set[str] = set()
+    for is_registry, text in _selector_texts():
+        for name, pattern in patterns.items():
+            if name in selected:
+                continue
+            if pattern.search(text):
+                selected.add(name)
+            elif is_registry and ('"' + name + '"') in text:
+                selected.add(name)
+    return selected
+
+
+class ADefaultOnSwitchIsReachableOrListedTest(unittest.TestCase):
+
+    def test_the_census_still_finds_switches(self) -> None:
+        switches = _default_on_switches()
+        self.assertGreaterEqual(
+            len(switches), EXPECTED_SWITCH_FLOOR,
+            "found %d default-ON boolean switches, expected at least %d -- if the read shape "
+            "changed, this file is looking for something that no longer exists and the assertion "
+            "below passes on an empty set" % (len(switches), EXPECTED_SWITCH_FLOOR))
+
+    def test_the_list_has_not_emptied(self) -> None:
+        self.assertTrue(
+            KNOWN_UNSELECTED,
+            "the list is empty, so the check below cannot tell a clean tree from a broken scan. "
+            "Delete this file rather than leave it passing on nothing.")
+
+    def test_no_new_switch_is_unreachable(self) -> None:
+        switches = _default_on_switches()
+        unreachable = set(switches) - _selected(set(switches)) - set(KNOWN_UNSELECTED)
+        new = sorted("%s (%s)" % (name, switches[name]) for name in unreachable)
+        self.assertEqual(
+            [], new,
+            "these default ON and nothing selects the other position -- not a test, a shell "
+            "script, a config file, a tenant knob, a portal control or a command-line argument. "
+            "The path behind them cannot be reached: %s. Make the live path unconditional, or "
+            "give the setting to the object it is about, or list it here with the reason." % new)
+
+    def test_a_listed_switch_that_became_reachable_is_struck_off(self) -> None:
+        switches = _default_on_switches()
+        listed = set(KNOWN_UNSELECTED) & set(switches)
+        reachable = sorted(listed & _selected(set(switches)))
+        self.assertEqual(
+            [], reachable,
+            "listed as unreachable, but something now selects them: %s. Strike them off -- a "
+            "reason that has stopped being true is worse than no reason." % reachable)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Eleven variables defaulted on with **nothing anywhere selecting the other position** — no test, no
shell script, no config file, no tenant knob, no portal control, no command-line argument. Each kept
a second path alive that nothing could reach.

They were retired by keeping the live path over the last several changes. Nothing stopped a twelfth
appearing tomorrow. This does.

The census looks for the shape that produced all eleven: a variable read with a default that makes it
on, whose value is then compared against truthy or falsey literals, in production Python.

### What counts as a selector is where the care is

Most of them are not assignments. A tenant knob and a gateway setting **name** the variable and never
assign it — the value arrives from a customer — so for those two registries, being named at all is
the offer.

That is not theoretical. `MATRIXARK_LOCAL_DURABLE_READ_CACHE_ENABLED` is declared as the third
argument of a `Setting(...)` on a line of its own, and the first version of this check — which looked
for assignments — reported it **unreachable**. Acting on that would have deleted a control the
gateway offers, complete with a customer-facing description of what turning it off costs.

A check that recommends deleting things has to be wrong in the safe direction.

### Listed, with reasons

Three switches are listed rather than reachable:

| switch | why |
|---|---|
| `MATRIXARK_METADATA_AUTO_INIT` | schema-DDL safety switch; its operator is outside this repository by construction |
| `MATRIXARK_REQUIRE_SHARED_OSS_MODELS` | benchmark harness parameter — the selector is whoever runs it |
| `TEMPORALSTORE_HF_READER_PRELOAD` | local model server parameter, same |

The last two are the answer already given to the engine's benchmark knobs.

### Both directions

A new unreachable switch fails. A **listed** switch that acquires a selector also fails, so a reason
that stops being true does not stand.

### Verification

Four mutations, each producing its own message:

- adding an unreachable switch → names it and its line
- breaking the census → `found 0 ... passes on an empty set`, rather than passing
- listing a switch that *is* selected → fails as a stale entry
- emptying the list → fails rather than leaving the check unable to tell a clean tree from a broken scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
