### PR TITLE
Say beside the encoder controls what changing one costs

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -207,6 +207,19 @@ GROUPS: Dict[str, Json] = {
 # persisted but only effective after a restart. The extraction API KEY is different -- the request
 # path does `os.environ.get(EXTRACTION_LLM_API_KEY_ENV)` per call, so a key written here is live on
 # the very next extraction. Every embedding setting is read per call in matrixark_mcp_embeddings.
+# What changing an encoder costs a store that already holds documents, said once and shared by the
+# three controls that change one. Embeddings are keyed by a model-specific ref and
+# `embedding_conflicts` declines a stored vector whose model differs from the active one, so the
+# vectors already in the store stop being usable the moment the encoder changes. The engine's own
+# MIGRATION note calls the result "a quiet degradation rather than an error" -- which is exactly why
+# it belongs beside the control rather than in a comment somebody has to go and find.
+ENCODER_CHANGE_NOTE = (
+    " Changing this on a store that already holds documents leaves every vector in it made by the "
+    "previous encoder: they are declined as a different model, so retrieval falls back to lexical "
+    "and recency until context_embed_backfill re-encodes them."
+)
+
+
 SETTINGS: List[Setting] = [
     # ---- extraction (the LLM that turns raw text into memories) --------------------------------
     Setting("extraction.provider", "extraction", "MATRIXARK_UNDERSTANDING_PROVIDER",
@@ -256,7 +269,7 @@ SETTINGS: List[Setting] = [
     Setting("embedding.provider", "embedding", "MATRIXARK_EMBEDDING_PROVIDER",
             "Embedding provider", "str", "deterministic", "live",
             "deterministic produces hash vectors — retrieval still answers 200, but it is not "
-            "semantic. openai_compatible calls the encoder below.",
+            "semantic. openai_compatible calls the encoder below." + ENCODER_CHANGE_NOTE,
             ["deterministic", "openai_compatible", "voyage", "local"]),
     Setting("embedding.api_base", "embedding", "MATRIXARK_EMBEDDING_API_BASE",
             "Embedding base URL", "str", "", "live",
@@ -265,10 +278,11 @@ SETTINGS: List[Setting] = [
             "Embedding model", "str", "", "live",
             "Encoder model name, e.g. paraphrase-multilingual-MiniLM-L12-v2. The gateway picks "
             "this up on the next call, but a co-located encoder server reads it at ITS startup — "
-            "restart that too if you are running one."),
+            "restart that too if you are running one." + ENCODER_CHANGE_NOTE),
     Setting("embedding.model_path", "embedding", "MATRIXARK_EMBEDDING_MODEL_PATH",
             "Embedding model path", "str", "", "live",
-            "Local path to a downloaded encoder; wins over the model name when set."),
+            "Local path to a downloaded encoder; wins over the model name when set."
+            + ENCODER_CHANGE_NOTE),
     Setting("embedding.api_key_env", "embedding", "MATRIXARK_EMBEDDING_API_KEY_ENV",
             "Embedding key variable", "str", "OPENAI_API_KEY", "live",
             "Name of the environment variable holding the encoder key."),

--- a/tools/test_matrixark_the_encoder_controls_say_what_they_cost.py
+++ b/tools/test_matrixark_the_encoder_controls_say_what_they_cost.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The three encoder controls say what changing them does to what is already stored.
+
+Embeddings are keyed by a model-specific ref, and ``embedding_model_conflicts`` declines a stored
+vector whose model differs from the active one. So changing the provider, the model name or the
+model path on a populated store leaves every vector in it declined, and retrieval falls back to
+lexical and recency. The engine's own MIGRATION note calls that *"a quiet degradation rather than an
+error"* -- which is the whole reason it has to be said next to the control: nothing fails, nothing
+is logged, and the portal reports the save as applied.
+
+``embedding_model_conflicts`` is explicit that **width is not the signal**: two models truncated to
+a common width look identical, so a swap raises no length mismatch anywhere. The recorded model name
+is the only thing separating them, which is why the note promises what it promises.
+
+The portal offers all three as **live** controls, and no help text in the registry mentioned any of
+it. Searching every setting for "backfill", "existing vector", "re-embed" or "lexical" found none.
+
+The tests below do not check prose against prose. They assert the *behaviour the note describes*:
+that two encoder names produce different refs, and that a stored vector under one is declined under
+the other. If that ever stops being true, these fail and the note gets revisited rather than
+quietly becoming false -- which is the failure mode of every warning written once and left.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+import matrixark_gateway_config as cfg  # noqa: E402
+import matrixark_mcp_core as core  # noqa: E402
+
+# The controls that change which encoder makes a vector.
+ENCODER_CONTROLS = ("embedding.provider", "embedding.model", "embedding.model_path")
+
+
+class TheControlsCarryTheNoteTest(unittest.TestCase):
+
+    def test_the_controls_exist_and_are_live(self) -> None:
+        """A live control is one a customer changes without an operator, which is exactly why the
+        cost has to be written where they are looking."""
+        for key in ENCODER_CONTROLS:
+            with self.subTest(setting=key):
+                self.assertIn(key, cfg.SETTINGS_BY_KEY)
+                self.assertEqual("live", cfg.SETTINGS_BY_KEY[key].applies)
+
+    def test_each_one_says_what_happens_to_what_is_already_stored(self) -> None:
+        for key in ENCODER_CONTROLS:
+            with self.subTest(setting=key):
+                help_text = cfg.SETTINGS_BY_KEY[key].help
+                self.assertIn("already holds documents", help_text)
+                self.assertIn("declined as a different model", help_text)
+
+    def test_each_one_names_the_remedy(self) -> None:
+        """A warning a reader cannot act on is one they learn to scroll past."""
+        for key in ENCODER_CONTROLS:
+            with self.subTest(setting=key):
+                self.assertIn("context_embed_backfill", cfg.SETTINGS_BY_KEY[key].help)
+
+    def test_the_note_is_one_sentence_not_three(self) -> None:
+        """Three copies is how two of them end up saying different things."""
+        notes = {cfg.SETTINGS_BY_KEY[key].help[-len(cfg.ENCODER_CHANGE_NOTE):]
+                 for key in ENCODER_CONTROLS}
+        self.assertEqual(1, len(notes), notes)
+        self.assertEqual({cfg.ENCODER_CHANGE_NOTE}, notes)
+
+    def test_it_keeps_what_each_control_already_said(self) -> None:
+        """The note is added to the help, not instead of it."""
+        self.assertIn("hash vectors", cfg.SETTINGS_BY_KEY["embedding.provider"].help)
+        self.assertIn("co-located encoder server",
+                      cfg.SETTINGS_BY_KEY["embedding.model"].help)
+        self.assertIn("wins over the model name",
+                      cfg.SETTINGS_BY_KEY["embedding.model_path"].help)
+
+    def test_settings_that_do_not_change_the_encoder_are_left_alone(self) -> None:
+        """A note on every control is a note nobody reads."""
+        for key, setting in cfg.SETTINGS_BY_KEY.items():
+            if key in ENCODER_CONTROLS:
+                continue
+            with self.subTest(setting=key):
+                self.assertNotIn("context_embed_backfill", setting.help or "")
+
+
+class TheNoteDescribesWhatTheCodeDoesTest(unittest.TestCase):
+    """Prose against behaviour, so the warning cannot quietly become false."""
+
+    def test_two_encoders_key_their_vectors_differently(self) -> None:
+        one = core.embedding_model_ref_for_name("sentence-transformers/all-MiniLM-L6-v2")
+        other = core.embedding_model_ref_for_name("intfloat/multilingual-e5-large")
+        self.assertNotEqual(one, other,
+                            "the note says a changed encoder leaves the old vectors behind, and "
+                            "they would be found under the same ref")
+
+    def test_a_vector_from_another_encoder_is_declined(self) -> None:
+        self.assertTrue(core.embedding_model_conflicts("sentence-transformers/all-MiniLM-L6-v2",
+                                                 "intfloat/multilingual-e5-large"))
+
+    def test_the_deterministic_provider_is_an_encoder_too(self) -> None:
+        """Switching the PROVIDER changes the name as surely as switching the model, which is why
+        that control carries the note as well."""
+        self.assertTrue(core.embedding_model_conflicts("matrixark-local-token-hash-v1",
+                                                 "intfloat/multilingual-e5-large"))
+
+    def test_the_same_encoder_is_not_declined(self) -> None:
+        """The floor. A guard that declined everything would make the note true and the product
+        useless, and every test above would still pass."""
+        self.assertFalse(core.embedding_model_conflicts("intfloat/multilingual-e5-large",
+                                                  "intfloat/multilingual-e5-large"))
+        self.assertFalse(core.embedding_model_conflicts("sentence-transformers/all-MiniLM-L6-v2",
+                                                  "all-MiniLM-L6-v2"),
+                         "a repository prefix is not an encoder change")
+
+    def test_an_unknown_model_is_not_declined(self) -> None:
+        """An older store wrote no model name. Declining those would take retrieval dark, which is
+        the outcome the guard exists to prevent -- so the note must not promise it."""
+        self.assertFalse(core.embedding_model_conflicts("", "intfloat/multilingual-e5-large"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The portal offers three **live** controls that change which encoder makes a vector — provider, model
name, model path. Changing any of them on a store that already holds documents leaves every vector
in it unusable: embeddings are keyed by a model-specific ref, and `embedding_model_conflicts`
declines a stored vector whose model differs from the active one. Retrieval falls back to lexical
and recency. The engine's own MIGRATION note calls that

> a quiet degradation rather than an error

Nothing fails, nothing is logged, and the portal reports the save as applied. **No help text in the
registry said any of it** — searching all 100 settings for "backfill", "existing vector", "re-embed"
or "lexical" found nothing.

```
embedding.provider   [live]  deterministic produces hash vectors … + the note
embedding.model      [live]  Encoder model name … restart that too … + the note
embedding.model_path [live]  Local path to a downloaded encoder … + the note
```

The note is written **once** and shared, because three copies of a sentence is how two of them end
up saying different things — and a test asserts all three carry the same one.

### Width is not the safety net

I nearly reasoned that a mixed store is protected by a length mismatch. `embedding_model_conflicts`
says otherwise, in its own words:

> Width is not the signal. Any two models truncated to a common width look identical, so a swap
> produces no length mismatch and no error; the recorded model name is the only thing separating
> them.

With `MATRIXARK_EMBEDDING_DIMS` at 384 or below, both encoders produce the same width under one
label. So the recorded name is the whole of the protection, which is why the control has to say what
changing it costs.

### The tests assert behaviour, not prose

A warning checked only against itself rots silently. These check what the note *claims*:

```
drop the note from the model control       -> FAIL x3
drop the note from the provider control    -> FAIL x3
stop naming the remedy                     -> FAIL x3
put the note on a setting that does not
  change the encoder                       -> FAIL settings that do not change it are left alone
make a changed encoder stop conflicting    -> FAIL a vector from another encoder is declined (+1)
make every encoder conflict, incl. itself  -> FAIL the same encoder is not declined
give two encoders the same ref             -> FAIL two encoders key their vectors differently
```

The last three mutate `matrixark_mcp_core`, not the note: if a future change makes an encoder swap
harmless, these fail and the note gets revisited instead of quietly becoming false. Two floors keep
it honest — the same encoder must *not* conflict (a guard that declined everything would make the
note true and the product useless), and an unknown model must not conflict either, since declining
those would take retrieval dark for every older store.

11 tests. Neighbours: v1_gateway 97, gateway_portal 60, live_strip 38, gateway_config 28,
encoder_conflict 27, config_audit 14, admin_config 11, portal_pages 4, and all portal-named suites
together 150 — green.
