### PR TITLE
A guard that read its own list as the answer

### DIFF
--- a/tools/test_python_flag_switches.py
+++ b/tools/test_python_flag_switches.py
@@ -93,12 +93,23 @@ def _default_on_switches() -> Dict[str, str]:
 
 
 def _selector_texts() -> List[Tuple[bool, str]]:
-    """(is_registry, text) for everywhere a switch could be selected."""
+    """(is_registry, text) for everywhere a switch could be selected.
+
+    This file is excluded, and the reason is worth keeping. KNOWN_UNSELECTED writes each name as
+    a quoted key followed by a colon, which is one of the shapes that counts as selecting -- so
+    once this file was committed it read its own list as a set of selectors and reported every
+    listed switch as reachable. It could not do that before being committed, because the scan
+    walks  and an untracked file is not listed: the test was green when written and
+    red when merged. A file that LISTS switches must never count as selecting them.
+    """
     listed = subprocess.run(
         ["git", "ls-files", "*.py", "*.sh", "*.json", "*.toml", "*.yml", "*.yaml", "*.rs", "*.js"],
         cwd=REPO, capture_output=True, text=True).stdout.split()
+    myself = os.path.basename(__file__)
     texts: List[Tuple[bool, str]] = []
     for path in listed:
+        if os.path.basename(path) == myself:
+            continue
         try:
             with open(os.path.join(REPO, path), encoding="utf-8") as handle:
                 texts.append((os.path.basename(path) in _REGISTRIES, handle.read()))


### PR DESCRIPTION
`test_python_flag_switches` went red the moment it was merged — and **could not have gone red
before**.

It asks whether anything selects a switch, and one of the shapes that counts is the variable named
as a quoted key followed by a colon. That is exactly how `KNOWN_UNSELECTED` writes each entry, so
the file read its own list of unreachable switches as three selectors and reported all three as
reachable.

It could not do that while it was being written, because the scan walks `git ls-files` and **an
untracked file is not listed**. Green when written, red when committed, with nothing in between to
say so.

That is worth more than the fix: a source-scanning test can be a subject of its own scan, and the
moment it becomes one is the commit.

The file now excludes itself, and says why in the place someone would go looking.

### Verification

The check is still sharp — listing a switch that something *does* select still fails, naming it:

```
listed as unreachable, but something now selects them: ['MATRIXARK_PACK_DROP_REDUNDANT_ITEMS']
```

Four tests pass. The failure this fixes reproduces on a pristine checkout of main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
