### PR TITLE
Say which scan gave up when the answer is to read the whole store

### DIFF
--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -486,6 +486,31 @@ def _shadow_log_path(operation: str) -> str:
     return _os.environ.get("MATRIXARK_SHADOW_LOG", "/tmp/matrixark_%s_shadow.log" % operation)
 
 
+def _note_full_read_fallback(where: str, reason: BaseException) -> None:
+    """Say which scoped scan gave up and why, when the answer is to read the whole store.
+
+    Each of these replaces a scan of the records a request needs with a read of every record
+    there is, on every turn it happens. Silent, that is invisible from outside: a scan path that
+    has stopped working looks exactly like one that was never taken, and the cost shows up only as
+    a store that got slower.
+
+    Written only when MATRIXARK_MCP_DEBUG_LOG names a file, so the normal path costs one lookup --
+    against a fallback that is about to read everything. Never raises: a channel that reports a
+    problem must not become one.
+    """
+    try:
+        import os as _os
+
+        debug_path = _os.environ.get("MATRIXARK_MCP_DEBUG_LOG")
+        if not debug_path:
+            return
+        with open(debug_path, "a", encoding="utf-8") as handle:
+            handle.write("%s fell back to the full read: %s: %s%s"
+                         % (where, reason.__class__.__name__, reason, chr(10)))
+    except OSError:
+        pass
+
+
 class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirectBackendMixin, _TemporalDirectWriteMixin, _TemporalDirectReadMixin, _TemporalDirectRetrieveMixin):
     # The base class precedes the mixins in the MRO, so without this the buffered audit
     # implementation the __init__ prepares for (MATRIXARK_DIRECT_AUDIT_MODE, buffer, flusher)
@@ -1303,7 +1328,8 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
                     return self._scan_records_of_types(
                         record_types, record_ids=record_ids, scope=scope, newest_by_type=None
                     )
-                except Exception:  # noqa: BLE001 - the full read is the fallback, not a guess.
+                except Exception as fallback_reason:  # noqa: BLE001 - the caller reads everything.
+                    _note_full_read_fallback("_scan_records_of_types", fallback_reason)
                     return None
             return None
         except Exception:  # noqa: BLE001 - an unanswered question means "do the full read".
@@ -1375,7 +1401,8 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
 
         try:
             tenant_hash, user_hash = self._resolve_subject_hashes(scope or {})
-        except Exception:  # noqa: BLE001
+        except Exception as fallback_reason:  # noqa: BLE001
+            _note_full_read_fallback("records_for_get_all", fallback_reason)
             return self.read_all()
         if not tenant_hash or not user_hash:
             return self.read_all()
@@ -1424,17 +1451,7 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         try:
             latest_state = self._load_latest_context_state_records()
         except Exception as fallback_reason:  # noqa: BLE001 - the full read is the fallback.
-            try:
-                _debug = _os.environ.get("MATRIXARK_MCP_DEBUG_LOG")
-                if _debug:
-                    with open(_debug, "a", encoding="utf-8") as _log:
-                        _log.write(
-                            "prior_context_records fell back to the full read: {}: {}".format(
-                                fallback_reason.__class__.__name__, fallback_reason
-                            ) + chr(10)
-                        )
-            except OSError:
-                pass
+            _note_full_read_fallback("records_for_get_all", fallback_reason)
             return self.read_all()
         folded = compact_latest_context_state_records(list(subset) + list(latest_state))
         live_subset = filter_live_memory_records(compact_and_apply_tombstones(folded))
@@ -1506,7 +1523,8 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
 
         try:
             tenant_hash, user_hash = self._resolve_subject_hashes(scope or {})
-        except Exception:  # noqa: BLE001
+        except Exception as fallback_reason:  # noqa: BLE001
+            _note_full_read_fallback("records_for_session_buffer", fallback_reason)
             return self.read_all()
         if not tenant_hash or not user_hash:
             return self.read_all()
@@ -1549,7 +1567,8 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             return self.read_all()
         try:
             latest_state = self._load_latest_context_state_records()
-        except Exception:  # noqa: BLE001 - the full read is the fallback, not a guess.
+        except Exception as fallback_reason:  # noqa: BLE001 - full read is the fallback.
+            _note_full_read_fallback("records_for_session_buffer", fallback_reason)
             return self.read_all()
         folded = compact_latest_context_state_records(list(subset) + list(latest_state))
         live_subset = filter_live_memory_records(compact_and_apply_tombstones(folded))
@@ -1646,7 +1665,8 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             return self.read_all()
         try:
             latest_state = self._load_latest_context_state_records()
-        except Exception:  # noqa: BLE001 - the full read is the fallback, not a guess.
+        except Exception as fallback_reason:  # noqa: BLE001 - full read is the fallback.
+            _note_full_read_fallback("records_for_summary_refresh", fallback_reason)
             return self.read_all()
         folded = compact_latest_context_state_records(list(subset) + list(latest_state))
         live_subset = filter_live_memory_records(compact_and_apply_tombstones(folded))
@@ -1764,7 +1784,8 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             return self.read_all()
         try:
             latest_state = self._load_latest_context_state_records()
-        except Exception:  # noqa: BLE001 - the full read is the fallback, not a guess.
+        except Exception as fallback_reason:  # noqa: BLE001 - full read is the fallback.
+            _note_full_read_fallback("records_for_delete", fallback_reason)
             return self.read_all()
         folded = compact_latest_context_state_records(list(subset) + list(latest_state))
         live_subset = filter_live_memory_records(compact_and_apply_tombstones(folded))
@@ -1904,7 +1925,8 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             return self.read_all()
         try:
             latest_state = self._load_latest_context_state_records()
-        except Exception:  # noqa: BLE001 - the full read is the fallback, not a guess.
+        except Exception as fallback_reason:  # noqa: BLE001 - full read is the fallback.
+            _note_full_read_fallback("records_for_get_memory", fallback_reason)
             return self.read_all()
         folded = compact_latest_context_state_records(list(subset) + list(latest_state))
         live_subset = filter_live_memory_records(compact_and_apply_tombstones(folded))
@@ -2084,7 +2106,8 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         }
         try:
             latest_state = self._load_latest_context_state_records()
-        except Exception:  # noqa: BLE001 - the full read is the fallback, not a guess.
+        except Exception as fallback_reason:  # noqa: BLE001 - full read is the fallback.
+            _note_full_read_fallback("prior_context_records", fallback_reason)
             return self.read_all()
         try:
             from tools.matrixark_mcp_serving_records import compact_latest_context_state_records

--- a/tools/test_full_read_fallbacks_name_themselves.py
+++ b/tools/test_full_read_fallbacks_name_themselves.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A fallback that reads the whole store has to say which scan gave up.
+
+Seven places replace a scoped scan with a read of every record there is. Six of them said nothing,
+so a scan path that stopped working looked exactly like one that was never taken -- and the cost,
+which lands on every turn it happens, showed up only as a store that had got slower.
+
+The seventh did say something, and named the wrong method: it sat in `records_for_get_all` and
+reported itself as `prior_context_records`, which is a real method elsewhere in the same class. A
+label that points at the wrong function is worse than no label, because it is acted on.
+
+So the interesting assertion is not that the calls exist. It is that each one names the method it
+is actually inside -- the only part a copied line gets wrong, and the part no reader checks.
+"""
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+import unittest
+import unittest.mock
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+MODULE = os.path.join(TOOLS, "matrixark_mcp_temporal_adapters.py")
+
+# Seven sites when this was written. Asserted so a scan that stops matching fails rather than
+# reporting that every call is correctly named.
+EXPECTED_CALL_FLOOR = 7
+
+_CALL = re.compile(r'_note_full_read_fallback\(\s*"(\w+)"')
+_DEF = re.compile(r"^\s*def (\w+)\(")
+
+
+def _calls_with_enclosing_method():
+    """(label, enclosing def, line number) for every call site."""
+    with open(MODULE, encoding="utf-8") as handle:
+        lines = handle.read().splitlines()
+    found = []
+    for number, line in enumerate(lines):
+        match = _CALL.search(line)
+        if not match:
+            continue
+        enclosing = ""
+        for back in range(number, -1, -1):
+            outer = _DEF.match(lines[back])
+            if outer and not lines[back].startswith("    def _note_full_read_fallback"):
+                enclosing = outer.group(1)
+                break
+        found.append((match.group(1), enclosing, number + 1))
+    return found
+
+
+class EveryFullReadFallbackNamesItselfTest(unittest.TestCase):
+
+    def test_the_scan_still_finds_the_call_sites(self) -> None:
+        calls = _calls_with_enclosing_method()
+        self.assertGreaterEqual(
+            len(calls), EXPECTED_CALL_FLOOR,
+            "found %d calls, expected at least %d -- if they moved or were renamed this file is "
+            "looking for something that no longer exists, and the assertion below passes on an "
+            "empty list" % (len(calls), EXPECTED_CALL_FLOOR))
+
+    def test_each_call_names_the_method_it_is_in(self) -> None:
+        wrong = ["%s:%d says %r but is inside %r" % (os.path.basename(MODULE), line, label, method)
+                 for label, method, line in _calls_with_enclosing_method() if label != method]
+        self.assertEqual(
+            [], wrong,
+            "a fallback reports a method other than the one it is in, which sends whoever reads "
+            "the log to the wrong function: %s" % wrong)
+
+    def test_no_full_read_fallback_is_left_silent(self) -> None:
+        with open(MODULE, encoding="utf-8") as handle:
+            lines = handle.read().splitlines()
+        silent = []
+        for number, line in enumerate(lines):
+            if not line.strip().startswith("except Exception:"):
+                continue
+            following = " ".join(lines[number + 1:number + 3])
+            if "return self.read_all()" in following:
+                silent.append(number + 1)
+        self.assertEqual(
+            [], silent,
+            "these fall back to reading the whole store without saying why, at lines %s. Bind the "
+            "exception and call _note_full_read_fallback with this method's name." % silent)
+
+
+class TheChannelItselfTest(unittest.TestCase):
+    """The helper has to be safe in the place it is called: inside an except, on a hot path."""
+
+    @staticmethod
+    def _helper():
+        try:
+            from tools import matrixark_mcp_temporal_adapters as adapters  # noqa: PLC0415
+        except ImportError:  # run from tools/ dir
+            import matrixark_mcp_temporal_adapters as adapters  # type: ignore  # noqa: PLC0415
+        return adapters._note_full_read_fallback
+
+    def test_it_writes_the_method_and_the_reason(self) -> None:
+        note = self._helper()
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "debug.log")
+            with unittest.mock.patch.dict(os.environ, {"MATRIXARK_MCP_DEBUG_LOG": path}):
+                note("records_for_delete", ValueError("scan unavailable"))
+            with open(path, encoding="utf-8") as handle:
+                written = handle.read()
+        self.assertIn("records_for_delete", written)
+        self.assertIn("ValueError", written)
+        self.assertIn("scan unavailable", written)
+
+    def test_it_writes_nothing_when_no_file_is_named(self) -> None:
+        note = self._helper()
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "debug.log")
+            environment = dict(os.environ)
+            environment.pop("MATRIXARK_MCP_DEBUG_LOG", None)
+            with unittest.mock.patch.dict(os.environ, environment, clear=True):
+                note("records_for_delete", ValueError("scan unavailable"))
+            self.assertFalse(
+                os.path.exists(path),
+                "the default path must not open a file it was never given")
+
+    def test_an_unwritable_destination_does_not_raise(self) -> None:
+        note = self._helper()
+        with unittest.mock.patch.dict(
+                os.environ, {"MATRIXARK_MCP_DEBUG_LOG": "/nonexistent-dir/debug.log"}):
+            note("records_for_delete", ValueError("scan unavailable"))  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Nine places replace a scan of the records a request needs with **a read of every record there is**.
Eight of them said nothing.

A scan path that has stopped working therefore looks exactly like one that was never taken, and the
cost — a whole-store read, on every turn it happens — shows up only as a store that has got slower.

The ninth *did* say something, and **named the wrong method**: it sits in `records_for_get_all` and
reported itself as `prior_context_records`, a real method elsewhere in the same class. A label that
points at the wrong function is worse than no label, because it is acted on.

All nine now go through one helper — one place deciding the format, one lookup of the file to write
to, and one guarantee that a channel reporting a problem cannot become one. It writes only when
`MATRIXARK_MCP_DEBUG_LOG` names a file, which costs one lookup against a fallback that is about to
read everything.

### Two of the nine came from the test, not from reading

Six matched the comment I was looking for. The other two fall back for a different reason — subject
hashes that would not resolve — and carry no such comment.

Asking about the **consequence** rather than the comment found them, which is why the guard checks
for `except` followed by `return self.read_all()`.

### The assertion that matters

Not that the calls exist — that each one **names the method it is inside**. That is the only part a
copied line gets wrong, and the part no reader checks.

| mutation | result |
|---|---|
| mislabel one call | fails, printing both names |
| leave one fallback silent | fails, printing its line number |
| break the scan itself | `found 0 calls ... passes on an empty list`, rather than passing |

63 tests across nine modules pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
