### PR TITLE
Always try the native pack, and say that half this tree compiles for nobody

### DIFF
--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -432,7 +432,7 @@ Everything else that changes what the engine does.
 | `TS_SHARD_WRITE_QPS` | — | nothing | 1 | — |
 | `TS_TABLE_NAME` | — | test | 1 | — |
 
-## outside this document (7)
+## outside this document (6)
 
 `sdk/rust/temporalstore` is a second Rust tree, carrying its own copy of the
 proxy implementation -- a different file, not a stale duplicate. The root
@@ -444,7 +444,6 @@ is computed, so one more cannot appear quietly.
 - `MATRIXARK_RUST_FILTERED_SCAN_CACHE_ENTRIES`
 - `MATRIXARK_RUST_METRICS_PATH`
 - `MATRIXARK_RUST_PROXY_DISABLE_LEGACY_PACK_FALLBACK`
-- `MATRIXARK_RUST_PROXY_DISABLE_SDK_NATIVE_PACK`
 - `MATRIXARK_RUST_SCAN_RECORD_CACHE_ENTRIES`
 - `MATRIXARK_RUST_SDK_MODE`
 - `TEMPORALSTORE_RUST_ALLOW_NATIVE_MATRIXARK_C_API`

--- a/sdk/rust/temporalstore/src/bin/matrixark_rust_proxy/matrixark_rust_proxy_retrieve_result.rs
+++ b/sdk/rust/temporalstore/src/bin/matrixark_rust_proxy/matrixark_rust_proxy_retrieve_result.rs
@@ -38,17 +38,7 @@ pub(crate) fn try_sdk_native_pack(
     client: &Client,
     command: &Command,
 ) -> SdkNativePackAttempt {
-    let use_sdk_native = std::env::var("MATRIXARK_RUST_PROXY_DISABLE_SDK_NATIVE_PACK")
-        .map(|value| {
-            !matches!(
-                value.trim().to_ascii_lowercase().as_str(),
-                "1" | "true" | "yes"
-            )
-        })
-        .unwrap_or(true);
-    if !use_sdk_native {
-        return SdkNativePackAttempt::FallbackAllowed;
-    }
+    // The native pack is always attempted; the fallback below is for when it FAILS.
     match retrieve_context_pack_via_sdk_native(client, command) {
         Ok(response) => SdkNativePackAttempt::Response(response),
         Err(err) => {

--- a/sdk/rust/temporalstore/src/bin/matrixark_rust_proxy_impl.rs
+++ b/sdk/rust/temporalstore/src/bin/matrixark_rust_proxy_impl.rs
@@ -2335,29 +2335,21 @@ fn retrieve_context_pack_via_sdk_native(
 }
 
 fn retrieve_context_pack_native(client: &Client, command: &Command) -> Result<Value, String> {
-    let use_sdk_native = std::env::var("MATRIXARK_RUST_PROXY_DISABLE_SDK_NATIVE_PACK")
-        .map(|value| {
-            !matches!(
-                value.trim().to_ascii_lowercase().as_str(),
-                "1" | "true" | "yes"
-            )
-        })
-        .unwrap_or(true);
-    if use_sdk_native {
-        match retrieve_context_pack_via_sdk_native(client, command) {
-            Ok(response) => return Ok(response),
-            Err(err) => {
-                if std::env::var("MATRIXARK_RUST_PROXY_DISABLE_LEGACY_PACK_FALLBACK")
-                    .map(|value| {
-                        matches!(
-                            value.trim().to_ascii_lowercase().as_str(),
-                            "1" | "true" | "yes"
-                        )
-                    })
-                    .unwrap_or(false)
-                {
-                    return Err(err);
-                }
+    // The native pack is always attempted. What follows is the fallback for when it FAILS,
+    // which is a different question from whether to try it -- and the only one anything asks.
+    match retrieve_context_pack_via_sdk_native(client, command) {
+        Ok(response) => return Ok(response),
+        Err(err) => {
+            if std::env::var("MATRIXARK_RUST_PROXY_DISABLE_LEGACY_PACK_FALLBACK")
+                .map(|value| {
+                    matches!(
+                        value.trim().to_ascii_lowercase().as_str(),
+                        "1" | "true" | "yes"
+                    )
+                })
+                .unwrap_or(false)
+            {
+                return Err(err);
             }
         }
     }

--- a/tools/test_sdk_proxy_split_tree_is_uncompiled.py
+++ b/tools/test_sdk_proxy_split_tree_is_uncompiled.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The SDK proxy's split tree is not compiled by anything, and that has to be said out loud.
+
+`sdk/rust/temporalstore/src/bin/matrixark_rust_proxy/` holds a full second implementation of the
+proxy, split into files. Nothing declares those files as modules and nothing includes them, so no
+compiler reads them: `cargo` builds only the two binaries that sit directly in `src/bin/`, and
+`build.rs` is empty. The workspace excludes this tree as well, so `cargo check --all-targets` at
+the repository root never reaches even the parts that ARE compiled.
+
+That combination is the hazard. An edit here compiles for nobody, is checked by no gate, and looks
+exactly like an edit that works -- while a Python test elsewhere reads one of these files as TEXT
+and asserts on the identifiers in it, which passes whether or not the code around them is valid.
+
+This was found by retiring a flag. `MATRIXARK_RUST_PROXY_DISABLE_SDK_NATIVE_PACK` was read twice:
+once in the binary that runs, and once here. Keeping the two in step is right, but a reader has no
+way to know that only one of them is real.
+
+The test fails if any of these files becomes a declared module. That is not a complaint about
+fixing it -- it is the signal to come back here and narrow or delete this file, in the same way the
+policy-gate census fails when a listed gate is wired.
+"""
+from __future__ import annotations
+
+import os
+import re
+import unittest
+from typing import List
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(TOOLS)
+SDK = os.path.join(REPO, "sdk", "rust", "temporalstore")
+SPLIT_TREE = os.path.join(SDK, "src", "bin", "matrixark_rust_proxy")
+
+# Forty-seven when this was written. A floor rather than an equality, so deleting one of them is
+# not a failure -- shrinking this tree is the direction anyone should be free to go.
+EXPECTED_FILE_FLOOR = 40
+
+
+def _split_tree_modules() -> List[str]:
+    if not os.path.isdir(SPLIT_TREE):
+        return []
+    return sorted(name[:-3] for name in os.listdir(SPLIT_TREE) if name.endswith(".rs"))
+
+
+def _sdk_rust_sources() -> List[str]:
+    found: List[str] = []
+    for directory, _, names in os.walk(os.path.join(SDK, "src")):
+        for name in sorted(names):
+            if name.endswith(".rs"):
+                found.append(os.path.join(directory, name))
+    return found
+
+
+class TheSplitProxyTreeIsCompiledByNothingTest(unittest.TestCase):
+
+    def test_the_tree_is_still_there_to_check(self) -> None:
+        modules = _split_tree_modules()
+        self.assertGreaterEqual(
+            len(modules), EXPECTED_FILE_FLOOR,
+            "found %d .rs files under %s, expected at least %d -- if the tree moved or was "
+            "removed, every assertion below passes on an empty list"
+            % (len(modules), os.path.relpath(SPLIT_TREE, REPO), EXPECTED_FILE_FLOOR))
+
+    def test_nothing_declares_them_so_nothing_compiles_them(self) -> None:
+        modules = _split_tree_modules()
+        declared = []
+        for path in _sdk_rust_sources():
+            with open(path, encoding="utf-8") as handle:
+                text = handle.read()
+            for module in modules:
+                if re.search(r"^\s*(?:pub\s+)?mod\s+%s\s*;" % re.escape(module), text, re.M):
+                    declared.append("%s declares %s" % (os.path.relpath(path, REPO), module))
+                elif ('include!("matrixark_rust_proxy/%s.rs")' % module) in text:
+                    declared.append("%s includes %s" % (os.path.relpath(path, REPO), module))
+        self.assertEqual(
+            [], sorted(declared),
+            "one of these files is now compiled: %s. That is a good change -- come back here and "
+            "narrow or delete this test, which exists only to say that editing them affected "
+            "nothing." % sorted(declared))
+
+    def test_the_build_script_generates_nothing(self) -> None:
+        build_script = os.path.join(SDK, "build.rs")
+        self.assertTrue(os.path.exists(build_script), "the SDK build script has moved")
+        with open(build_script, encoding="utf-8") as handle:
+            body = handle.read()
+        self.assertNotIn(
+            "OUT_DIR", body,
+            "build.rs now writes generated source, so it may be declaring these modules after "
+            "all. The claim that nothing compiles them has to be re-established before this test "
+            "can go on making it.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`MATRIXARK_RUST_PROXY_DISABLE_SDK_NATIVE_PACK` decided whether the proxy attempts the native context
pack **at all**. It defaults to attempting it, and nothing anywhere selects the other position — no
test, no launcher, no config, no script.

Its off position is not the fallback anyone relies on, either. The legacy path is still reached when
the native pack **fails** — a different question, asked by a different variable
(`..._DISABLE_LEGACY_PACK_FALLBACK`, default off, an opt-in for callers that would rather see the
error). That one stays. What goes is only *"do not try"*.

### Where the second copy was

This variable was read twice, and one reader lives in
`sdk/rust/temporalstore/src/bin/matrixark_rust_proxy/` — a directory of **47 files holding a second,
split implementation of the whole proxy that nothing compiles.**

- no file declares them as modules
- nothing includes them
- `build.rs` is empty
- cargo builds only the two binaries sitting directly in `src/bin/`
- the workspace **excludes** this tree, so `cargo check --all-targets` at the root never reaches even
  the parts that are real

So an edit in there compiles for nobody and is checked by no gate, while looking exactly like an edit
that works — and a Python test elsewhere reads one of those files as **text** and asserts on the
identifiers in it, which passes whether or not the code around them is valid.

Both copies are edited here, because keeping them in step is right. The new test says which is which,
so the next reader does not find out the way I did. It fails if one of those files ever becomes a
declared module — the signal to come back and narrow it, the same shape as the policy-gate census
failing when a listed gate gets wired.

### The other four in that tree stay

| variable | why |
|---|---|
| `MATRIXARK_RUST_FILTERED_SCAN_CACHE_ENTRIES` | a cache size — an operator value, not a branch |
| `MATRIXARK_RUST_SCAN_RECORD_CACHE_ENTRIES` | same |
| `MATRIXARK_RUST_METRICS_PATH` | a path |
| `TEMPORALSTORE_RUST_ALLOW_NATIVE_MATRIXARK_C_API` | two Python launchers set it, so something selects it |

### Verification

`cargo check --all-targets` on the **SDK manifest** is clean — worth stating because no gate runs it.

35 flag guards pass; the three new ones pass and were each checked by making the change they exist to
catch (declaring one of the files → fails naming it; pointing the scan at a tree that is not there →
fails as `passes on an empty list`).

The inventory's list of variables read outside it loses one row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
