### PR TITLE
A permission that half-applied, and the check that finds the next one

### DIFF
--- a/tools/matrixark_codex_hook.py
+++ b/tools/matrixark_codex_hook.py
@@ -2446,7 +2446,20 @@ def production_profile_enabled() -> bool:
 
 
 def local_backend_allowed() -> bool:
-    return os.environ.get("MATRIXARK_ALLOW_LOCAL_BACKEND", "").strip().lower() in {"1", "true", "yes", "on"}
+    """Whether a local backend is permitted, spelled the way the guard that enforces it spells it.
+
+    `matrixark_mcp_backends` refuses a local backend under a production profile unless this is set,
+    and the refusal says to set it to 1. That guard accepts {1, true, yes}. This function also
+    accepted "on", so `MATRIXARK_ALLOW_LOCAL_BACKEND=on` permitted the backend here and was refused
+    there: a permission that half-applies, which is worse than one that does not apply, because
+    each half looks correct on its own.
+
+    The wider set in `matrixark_mcp_env.TRUE_VALUES` is deliberately NOT used here. A permission
+    should not gain accepting spellings by inheriting a general helper -- every spelling it gains
+    is another way to turn a production guard off, and the safe direction for a disagreement about
+    a guard is the narrower one.
+    """
+    return os.environ.get("MATRIXARK_ALLOW_LOCAL_BACKEND", "0").strip().lower() in {"1", "true", "yes"}
 
 
 def default_hook_backend() -> str:

--- a/tools/test_flag_readers_agree.py
+++ b/tools/test_flag_readers_agree.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Two readers of one variable must agree about it.
+
+A flag read in two places can disagree in three ways, and each produces a setting that half-applies:
+
+  - the DEFAULT differs, so the answer depends on which module was imported
+  - the accepted SPELLINGS differ, so the two agree on "1" and part company on "on"
+  - the SENSE differs, one asking `in {...}` and the other `not in {...}`
+
+Half-applied is worse than not applied, because each half looks correct where it is written and
+nothing reports the disagreement. `MATRIXARK_ALLOW_LOCAL_BACKEND` was in exactly that state: the
+hook accepted "on" and the production guard that refuses a local backend did not, so
+`MATRIXARK_ALLOW_LOCAL_BACKEND=on` permitted the backend in one place and was refused in the other.
+
+The statement is the unit, not a window of lines. A first version of this scan read three lines
+from each match and reported four disagreements, of which three were its own: it took the spellings
+of the NEXT line's different variable, and it truncated a set that continued past the window. A
+statement carries its own set and nothing else's, which is why the scan below follows brackets.
+"""
+from __future__ import annotations
+
+import collections
+import os
+import re
+import subprocess
+import unittest
+from typing import Dict, List, Tuple
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(TOOLS)
+
+_READ = re.compile(
+    r'os\.(?:environ\.get|getenv)\(\s*["\']([A-Z][A-Z0-9_]{3,})["\']\s*,\s*["\']([^"\']*)["\']')
+_SPELLING = re.compile(r'["\'](1|0|true|false|yes|no|on|off)["\']', re.I)
+_NUMERIC = re.compile(r"\b(?:int|float)\s*\(")
+_OTHER_FLAG = re.compile(r'["\']([A-Z][A-Z0-9_]{3,})["\']')
+
+# Twenty-one when this was written. Asserted so a scan that stops matching fails rather than
+# reporting that every reader agrees.
+EXPECTED_SHARED_FLOOR = 15
+
+
+def _production_sources() -> List[str]:
+    listed = subprocess.run(["git", "ls-files", "*.py"], cwd=REPO,
+                            capture_output=True, text=True).stdout.split()
+    return [path for path in listed if not os.path.basename(path).startswith("test_")]
+
+
+def _statement_at(lines: List[str], start: int) -> str:
+    """The whole statement beginning at `start`, followed by bracket balance."""
+    depth, collected = 0, []
+    for number in range(start, min(start + 40, len(lines))):
+        line = lines[number]
+        collected.append(line)
+        depth += line.count("(") + line.count("{") + line.count("[")
+        depth -= line.count(")") + line.count("}") + line.count("]")
+        if depth <= 0:
+            break
+    return "\n".join(collected)
+
+
+def _readers() -> Dict[str, List[Tuple[str, int, str, Tuple[str, ...], bool]]]:
+    found: Dict[str, List[Tuple[str, int, str, Tuple[str, ...], bool]]] = collections.defaultdict(list)
+    for path in _production_sources():
+        try:
+            with open(os.path.join(REPO, path), encoding="utf-8") as handle:
+                lines = handle.read().splitlines()
+        except OSError:
+            continue
+        for number, line in enumerate(lines):
+            for match in _READ.finditer(line):
+                name, default = match.group(1), match.group(2).strip()
+                statement = _statement_at(lines, number)
+                if _NUMERIC.search(statement):
+                    continue
+                # A statement naming a second flag is not a clean read of either.
+                if set(_OTHER_FLAG.findall(statement)) - {name}:
+                    continue
+                accepted = tuple(sorted({s.lower() for s in _SPELLING.findall(statement)}
+                                        - {default.lower()}))
+                if not accepted:
+                    continue
+                found[name].append((path, number + 1, default.lower(), accepted,
+                                    "not in" in statement))
+    return found
+
+
+class TwoReadersOfOneFlagAgreeTest(unittest.TestCase):
+
+    @staticmethod
+    def _shared():
+        return {name: entries for name, entries in _readers().items()
+                if len({(entry[0], entry[1]) for entry in entries}) > 1}
+
+    def test_the_scan_still_finds_shared_flags(self) -> None:
+        shared = self._shared()
+        self.assertGreaterEqual(
+            len(shared), EXPECTED_SHARED_FLOOR,
+            "found %d flags read from more than one production site, expected at least %d -- if "
+            "the read shape changed, this file is looking for something that no longer exists and "
+            "the assertion below passes on an empty set" % (len(shared), EXPECTED_SHARED_FLOOR))
+
+    def test_no_two_readers_disagree(self) -> None:
+        disagreeing = []
+        for name, entries in sorted(self._shared().items()):
+            ways = []
+            if len({entry[2] for entry in entries}) > 1:
+                ways.append("default")
+            if len({entry[3] for entry in entries}) > 1:
+                ways.append("spellings")
+            if len({entry[4] for entry in entries}) > 1:
+                ways.append("sense")
+            if not ways:
+                continue
+            sites = "; ".join(
+                "%s:%d default=%r %s{%s}"
+                % (os.path.basename(entry[0]), entry[1], entry[2],
+                   "not in " if entry[4] else "in ", ",".join(entry[3]))
+                for entry in sorted(entries))
+            disagreeing.append("%s disagrees on %s -- %s" % (name, "+".join(ways), sites))
+        self.assertEqual(
+            [], disagreeing,
+            "a flag means different things to different readers, so setting it applies in some "
+            "places and not others:\n  %s\nGive it one answer. Where the readers guard something, "
+            "take the narrower spelling: a permission should not gain accepting spellings."
+            % "\n  ".join(disagreeing))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`MATRIXARK_ALLOW_LOCAL_BACKEND` is read in three places. The hook accepted `on`; the other two did
not.

So `MATRIXARK_ALLOW_LOCAL_BACKEND=on` **permitted a local backend in the hook and was refused** by
the guard in `matrixark_mcp_backends` that exists to refuse exactly that under a production profile.

Half-applied is worse than not applied: each half looks correct where it is written, nothing reports
the disagreement, and the two only part company on a value neither author thought about.

### Narrowed, not widened — and the direction is the point

Widening the guard to accept `on` would have made a spelling that previously did nothing **turn a
production check off**. The refusal's own message says to set the variable to `1`.

The hook now spells the permission the way the thing enforcing it spells it, and the docstring says
why the wider set in `matrixark_mcp_env.TRUE_VALUES` is deliberately not inherited: every spelling a
permission gains is another way to turn a guard off.

No test asserted the spelling that goes — the tests that set this variable set it to `1`.

### The check

It asks the question of every flag read in more than one place, which can disagree three ways:

- the **default** differs, so the answer depends on which module was imported
- the accepted **spellings** differ, so the two agree on `1` and part company on `on`
- the **sense** differs, one asking `in {...}` where the other asks `not in {...}`

### The unit is the statement, not a window

That is not a detail. A first version read three lines from each match and reported **four**
disagreements, of which three were its own doing: it took the spellings from the *next* line's
different variable, and it truncated a set that continued past the window. Following brackets
instead leaves one finding — the one above. I nearly wrote up all four.

### Verification

Putting the wider spelling back:

```
MATRIXARK_ALLOW_LOCAL_BACKEND disagrees on spellings -- matrixark_codex_hook.py:2462 default='0'
in {1,on,true,yes}; matrixark_mcp_core.py:96 default='0' in {1,true,yes};
matrixark_mcp_runtime_config.py:44 default='0' in {1,true,yes}
```

Breaking its own scan reports finding nothing rather than passing. Twenty-one flags are read from
more than one place today, and that floor is asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
