### PR TITLE
Two more walkers still read a block footer as a record

### DIFF
--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -1932,6 +1932,23 @@ impl LocalWriteAheadLogStore {
             if cursor >= walk_until {
                 break;
             }
+            // Step over a block footer this lands on, before reading. The branch below only
+            // catches a boundary with PADDING in front of its footer; a block whose records end
+            // flush against the footer has none, and the footer is then read as a record -- its
+            // first byte is not a frame marker, so the reader falls to newline-delimited mode and
+            // returns a fragment.
+            //
+            // That matters more here than in a scan that only counts: `cursor` becomes `split`
+            // below, the byte offset this reclaim keeps from. A fragment read at a boundary moves
+            // the line between what is copied and what is dropped, so the pass can retain or
+            // discard the wrong records rather than merely report the wrong number of them.
+            let stepped = skip_block_footer_if_due(&mut reader, cursor, header_len)?;
+            if stepped != cursor {
+                cursor = stepped;
+                if cursor >= walk_until {
+                    break;
+                }
+            }
             let Some(line) = read_raw_record(&mut reader)? else {
                 // Padding before a closed block's footer, or the end. The footer decides.
                 match block_is_closed(&mut reader, cursor, header_len, walk_until)? {
@@ -2151,6 +2168,10 @@ impl LocalWriteAheadLogStore {
         let info_len = path.metadata().map(|meta| meta.len()).unwrap_or(0);
         let mut info_at = info_header_len;
         loop {
+            // The same first step the other walkers take. Without it a footer landed on flush
+            // against a block's last record is read as a record, and the counts and sequences
+            // reported here describe a log that stops at the first such boundary.
+            info_at = skip_block_footer_if_due(&mut reader, info_at, info_header_len)?;
             let Some(mut line) = read_raw_record(&mut reader)? else {
                 match block_is_closed(&mut reader, info_at, info_header_len, info_len)? {
                     Some(next) => {


### PR DESCRIPTION
Two of the five walkers over this log still read a block footer as a record.

## The defect

A WAL block is 128 KiB: records, then zero padding, then a 128-byte footer at the block's end. Five
loops walk the log with `read_raw_record` + `block_is_closed`, and the zero-run branch only notices a
boundary that has PADDING in front of its footer. A block whose records end flush against the footer
has none, so the footer is read as a record — its first byte is not a frame marker, the reader falls
to newline-delimited mode, and hands back a fragment.

#878 fixed the recovery scan, named two siblings with the same shape, and left them:

| walker | steps over a footer |
|---|---|
| recovery scan | yes, since #878 |
| **`gc_before_sequence_unchecked`** | **no** |
| **`info`** | **no** |
| append | yes |
| tail repair | yes |

## Why the reclaim one matters more than a miscount

`gc_before_sequence_unchecked` is the reclaim walker. Its `cursor` becomes `split`, the byte offset
the pass keeps from, and `removed_bytes` / `retained_bytes` are measured from it. A fragment read at
a boundary therefore moves the line between what is copied and what is dropped: the pass can retain
or discard the wrong records, not merely report the wrong number of them.

`info` is the milder half — the counts and sequences it reports would describe a log that stops at
the first such boundary.

## The change

Both track physical offsets already, so each takes the helper's return value directly, rather than
translating log ids the way the recovery scan has to. No new mechanism: it is the same
`skip_block_footer_if_due` call the other three walkers make, at the same point in the loop.

The reclaim walker was already prepared for it. Its reader carries the comment "Bounded by the cursor
below rather than by `take`, because a Take is not seekable and stepping over a block's footer is a
seek" — the seekability was arranged for this step, which was then never added.

## Why it is worth doing now

The one-box runs with `TS_WAL_BINARY_RECORDS=0` and `TS_WAL_BINARY_FRAME=0`, and its store is
**71% text**: a 549 MB `shard-1.wal.jsonl` and a 372 MB single-line `shard-1.index.json` against
379 MB of binary pages. Both encodings default ON in this crate; they are off on that box because
binary framing is what exposed the footer defect. Every walker taking the same first step is a
prerequisite for turning them back on.

## What is NOT verified here

I did not compile this locally: the box was at load 25 and building degrades the live one-box, which
serves this repo's own agent hooks. CI compiles it. **The crash-recovery suite still needs a local
run before this merges** — `cargo test -p temporalstore-rust --lib -- --test-threads=1` — and there
are five crash-recovery tests already red on main's default path that this does not claim to fix.
