### PR TITLE
Offer the third model in the portal: the one that writes summaries

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -147,7 +147,9 @@ ESSENTIAL_KEYS = {
 GROUPS: Dict[str, Json] = {
     "extraction": {
         "title": "Extraction model", "order": 10, "advanced": False,
-        "note": "The LLM that turns ingested text into memories. DeepSeek, vLLM, Ollama and OpenAI "
+        "note": "The LLM that turns ingested text into memories, and the one that writes the node "
+                 "summaries retrieval walks -- both on the endpoint and key below. DeepSeek, "
+                 "vLLM, Ollama and OpenAI "
                 "all speak the same OpenAI-compatible shape.",
     },
     "embedding": {
@@ -234,6 +236,38 @@ SETTINGS: List[Setting] = [
     Setting("extraction.max_tokens", "extraction", "MATRIXARK_EXTRACTION_MAX_TOKENS",
             "Extraction max tokens", "int", "1200", "restart",
             "Completion cap per extraction call."),
+
+    # ---- the summary model ----------------------------------------------------------------------
+    # The third model a deployment runs, and the one called most: every context node gets a summary,
+    # where extraction runs once per ingest. It needs no endpoint or key of its own --
+    # openai_compatible_json_call sends a summary to EXTRACTION_LLM_BASE_URL with the key named by
+    # MATRIXARK_EXTRACTION_API_KEY_ENV, and takes only the model and the budget as arguments -- so
+    # these three sit in the extraction group beside the endpoint and key they use.
+    #
+    # `restart` on all three, and for the same reason audit.mode carries it: SUMMARY_LLM_MODEL and
+    # SUMMARY_LLM_MAX_TOKENS are module constants in two modules, bound at import. The provider is
+    # the mixed one -- summary_provider() re-reads the environment on every call, so the CHOICE
+    # moves at once, while the model those constants carry does not. `restart` is the only label
+    # true of all three, and the help says which half moves first.
+    Setting("summary.provider", "extraction", "MATRIXARK_SUMMARY_PROVIDER",
+            "Summary provider", "str", "", "restart",
+            "Which provider writes the node summaries retrieval walks. Blank follows the extraction "
+            "provider above, which is the default. openai_compatible is the only value that calls a "
+            "model: anthropic returns rule-written summaries and no error, so a deployment on "
+            "anthropic extraction gets deterministic summaries unless it names openai_compatible "
+            "here. The choice itself takes effect on the next summary; the model below waits for a "
+            "restart.",
+            ["", "deterministic", "openai_compatible"]),
+    Setting("summary.model", "extraction", "MATRIXARK_SUMMARY_MODEL",
+            "Summary model", "str", "", "restart",
+            "Model for node summaries, sent to the extraction endpoint above with the same key. "
+            "Blank uses the extraction model. Naming a smaller one here is the point of the "
+            "setting: every node gets a summary, so this call is made far more often than an "
+            "extraction."),
+    Setting("summary.max_tokens", "extraction", "MATRIXARK_SUMMARY_MAX_TOKENS",
+            "Summary max tokens", "int", "900", "restart",
+            "Completion cap per summary call, separate from the extraction cap because a summary is "
+            "the shorter of the two and is paid for on every node."),
 
     # ---- audit trail ---------------------------------------------------------------------------
     # Two readers, and they disagree about when a change lands. matrixark_access reads os.environ

--- a/tools/portal/summary_provider_select_harness.js
+++ b/tools/portal/summary_provider_select_harness.js
@@ -1,0 +1,51 @@
+/* Does the shipped controlHtml render a select a customer can set BACK to blank? */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const start = page.indexOf("function controlHtml(f)");
+if (start < 0) { console.log("controlHtml is not on this page"); process.exit(2); }
+let depth = 0, end = -1;
+for (let i = page.indexOf("{", start); i < page.length; i++) {
+  if (page[i] === "{") depth++;
+  else if (page[i] === "}") { depth--; if (depth === 0) { end = i + 1; break; } }
+}
+const esc = (s) => String(s).replace(/[&<>"]/g, (c) =>
+  ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+
+const fieldId = (key) => "f_" + key.replace(/[^a-z0-9]/gi, "_");
+const controlHtml = new Function("esc", "fieldId",
+  page.slice(start, end) + "; return controlHtml;")(esc, fieldId);
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+const field = {
+  key: "summary.provider",
+  kind: "str",
+  value: "",
+  choices: ["", "deterministic", "openai_compatible"],
+};
+const blank = controlHtml(field);
+ok("it renders a select", /^<select/.test(blank), blank.slice(0, 60));
+ok("the blank option is there", blank.indexOf('<option value=""') >= 0, blank);
+ok("and is the one selected when nothing is chosen",
+   /<option value=""[^>]* selected>/.test(blank), blank);
+
+const chosen = controlHtml(Object.assign({}, field, { value: "openai_compatible" }));
+ok("a chosen provider is the one selected",
+   /<option value="openai_compatible" selected>/.test(chosen), chosen);
+ok("and blank is still offered, so it is not a one-way door",
+   chosen.indexOf('<option value=""') >= 0, chosen);
+
+/* The comparison: a list WITHOUT the blank cannot express "same as extraction". */
+const withoutBlank = controlHtml(Object.assign({}, field,
+  { choices: ["deterministic", "openai_compatible"] }));
+ok("FLOOR: without the blank, nothing is selected and the browser shows the first",
+   withoutBlank.indexOf("selected") < 0, withoutBlank);
+
+console.log(failures ? "\n" + failures + " failure(s)" : "\nall good");
+process.exit(failures ? 1 : 0);

--- a/tools/test_matrixark_the_portal_offers_the_summary_model.py
+++ b/tools/test_matrixark_the_portal_offers_the_summary_model.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The portal offers the third model: the one that writes summaries.
+
+A deployment runs three models. The portal offered two -- extraction and embedding -- and the
+summary model was reachable only by setting ``MATRIXARK_SUMMARY_*`` by hand. It is the model called
+most: every context node gets a summary, where extraction runs once per ingest.
+
+It needs no endpoint or key of its own. ``openai_compatible_json_call`` sends a summary to
+``EXTRACTION_LLM_BASE_URL`` with the key named by ``MATRIXARK_EXTRACTION_API_KEY_ENV`` and takes only
+the model and the budget as arguments, so three controls complete the surface and they belong in the
+extraction group beside the endpoint and key they use.
+
+**Adding a control must not change what an untouched deployment does.** The two string defaults are
+blank, and a blank is not seeded into the environment, so the reader's chain
+(``SUMMARY -> UNDERSTANDING -> EXTRACTION -> deterministic``) is untouched. That is asserted here
+rather than assumed, in a process started the way a gateway starts.
+
+Every claim the help text makes is checked in a subprocess, because these are module-scope constants
+bound at import: a test that sets the variable afterwards would be testing something no deployment
+does.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+import matrixark_gateway_config as cfg  # noqa: E402
+
+SUMMARY_CONTROLS = ("summary.provider", "summary.model", "summary.max_tokens")
+
+PROBE = """
+import json, sys
+sys.path.insert(0, %r)
+import matrixark_mcp_core as core
+print(json.dumps({"provider": core.summary_provider(),
+                  "model": core.SUMMARY_LLM_MODEL,
+                  "max_tokens": core.SUMMARY_LLM_MAX_TOKENS}))
+""" % TOOLS
+
+CLEAR = ("MATRIXARK_SUMMARY_PROVIDER", "MATRIXARK_SUMMARY_MODEL", "MATRIXARK_SUMMARY_MAX_TOKENS",
+         "MATRIXARK_UNDERSTANDING_PROVIDER", "MATRIXARK_EXTRACTION_PROVIDER",
+         "MATRIXARK_EXTRACTION_MODEL", "OPENAI_MODEL")
+
+
+def started_with(**overrides):
+    """What a gateway resolves when it STARTS with this environment."""
+    env = dict(os.environ)
+    for name in CLEAR:
+        env.pop(name, None)
+    env.update({k: v for k, v in overrides.items() if v is not None})
+    proc = subprocess.run([sys.executable, "-c", PROBE], capture_output=True, text=True,
+                          timeout=600, env=env, cwd=TOOLS)
+    if proc.returncode != 0:
+        raise AssertionError("the probe did not run: %s" % proc.stderr[-400:])
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+class TheControlsExistTest(unittest.TestCase):
+
+    def test_all_three_are_offered(self) -> None:
+        for key in SUMMARY_CONTROLS:
+            with self.subTest(setting=key):
+                self.assertIn(key, cfg.SETTINGS_BY_KEY)
+
+    def test_they_sit_with_the_endpoint_and_key_they_use(self) -> None:
+        """A summary is sent to the extraction endpoint with the extraction key. Putting these in
+        their own group would separate them from the two fields they depend on."""
+        for key in SUMMARY_CONTROLS:
+            with self.subTest(setting=key):
+                self.assertEqual("extraction", cfg.SETTINGS_BY_KEY[key].group)
+
+    def test_they_wait_for_a_restart(self) -> None:
+        """SUMMARY_LLM_MODEL and SUMMARY_LLM_MAX_TOKENS are module constants in two modules, bound
+        at import. `restart` is the only label true of all three."""
+        for key in SUMMARY_CONTROLS:
+            with self.subTest(setting=key):
+                self.assertEqual("restart", cfg.SETTINGS_BY_KEY[key].applies)
+
+    def test_the_provider_can_be_set_back_to_following_extraction(self) -> None:
+        """The portal renders a `choices` setting as a select, so a list without the blank would be
+        a one-way door: a customer who picked a provider could never return to "same as
+        extraction"."""
+        self.assertIn("", cfg.SETTINGS_BY_KEY["summary.provider"].choices)
+
+    def test_the_provider_offers_only_what_writes_a_summary(self) -> None:
+        """anthropic is offered for extraction and would be accepted here, and produce rule-written
+        summaries with no error. It is left off the list on purpose."""
+        self.assertNotIn("anthropic", cfg.SETTINGS_BY_KEY["summary.provider"].choices)
+
+
+class AddingThemChangesNothingTest(unittest.TestCase):
+
+    def test_the_string_defaults_are_blank(self) -> None:
+        """A blank is not seeded into the environment, so the reader's fallback chain is untouched
+        for a deployment that never opens the page."""
+        self.assertEqual("", cfg.SETTINGS_BY_KEY["summary.provider"].default)
+        self.assertEqual("", cfg.SETTINGS_BY_KEY["summary.model"].default)
+
+    def test_the_budget_default_is_the_one_the_code_uses(self) -> None:
+        self.assertEqual(900, started_with()["max_tokens"])
+        self.assertEqual("900", cfg.SETTINGS_BY_KEY["summary.max_tokens"].default)
+
+    def test_storing_the_defaults_seeds_nothing(self) -> None:
+        """The actual no-op guarantee: a customer who saves the form untouched must not pin the
+        summary provider to whatever the blank resolves to."""
+        environment = dict(os.environ)
+
+        def restore() -> None:
+            os.environ.clear()
+            os.environ.update(environment)
+
+        self.addCleanup(restore)
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = os.path.join(tmp.name, "runtime.json")
+        for name in CLEAR:
+            os.environ.pop(name, None)
+
+        cfg.update({"summary.provider": "", "summary.model": ""}, actor="test")
+        cfg.apply_boot()
+        self.assertIsNone(os.environ.get("MATRIXARK_SUMMARY_PROVIDER"))
+        self.assertIsNone(os.environ.get("MATRIXARK_SUMMARY_MODEL"))
+
+
+class TheHelpTextIsTrueTest(unittest.TestCase):
+    """Each claim, in a process started the way a gateway starts."""
+
+    def test_blank_follows_the_extraction_provider_and_model(self) -> None:
+        got = started_with(MATRIXARK_UNDERSTANDING_PROVIDER="openai_compatible",
+                           MATRIXARK_EXTRACTION_MODEL="deepseek-chat")
+        self.assertEqual("openai_compatible", got["provider"])
+        self.assertEqual("deepseek-chat", got["model"])
+
+    def test_a_named_summary_model_wins(self) -> None:
+        """The reason to offer the control: a smaller model for the call made most often."""
+        got = started_with(MATRIXARK_UNDERSTANDING_PROVIDER="openai_compatible",
+                           MATRIXARK_EXTRACTION_MODEL="deepseek-chat",
+                           MATRIXARK_SUMMARY_MODEL="deepseek-chat-lite",
+                           MATRIXARK_SUMMARY_MAX_TOKENS="400")
+        self.assertEqual("deepseek-chat-lite", got["model"])
+        self.assertEqual(400, got["max_tokens"])
+
+    def test_anthropic_extraction_leaves_summaries_deterministic(self) -> None:
+        """What the help warns about. The provider passes through, and the generator calls a model
+        only for the openai-compatible names -- so the summary is rule-written and nothing errors."""
+        got = started_with(MATRIXARK_UNDERSTANDING_PROVIDER="anthropic")
+        self.assertEqual("anthropic", got["provider"])
+        with open(os.path.join(TOOLS, "matrixark_mcp_core.py"), encoding="utf-8") as handle:
+            source = handle.read()
+        marker = source.index("You generate MatrixArk ContextNode traversal summaries")
+        window = source[max(0, marker - 1200):marker]
+        self.assertIn('if provider in {"openai", "openai_compatible", "openai_compatible_llm"}',
+                      window)
+        self.assertNotIn("anthropic", window.rsplit("if provider in", 1)[-1])
+
+    def test_the_help_says_all_of_it(self) -> None:
+        provider_help = cfg.SETTINGS_BY_KEY["summary.provider"].help
+        self.assertIn("Blank follows the extraction provider", provider_help)
+        self.assertIn("anthropic", provider_help)
+        model_help = cfg.SETTINGS_BY_KEY["summary.model"].help
+        self.assertIn("extraction endpoint above with the same key", model_help)
+        self.assertIn("Blank uses the extraction model", model_help)
+
+
+@unittest.skipUnless(__import__("shutil").which("node"),
+                     "node is not installed; the page JS cannot be run")
+class TheSelectHonoursTheBlankTest(unittest.TestCase):
+    """Asserting that "" is in `choices` proves what the registry says, not what the page draws.
+
+    The page renders a `choices` setting as a `<select>`, and a list without the blank leaves NO
+    option selected -- the browser then shows the first, and saving pins it. This runs the shipped
+    `controlHtml` to check the blank is drawn, is selected when the value is blank, and is still
+    offered once a provider has been picked.
+    """
+
+    HARNESS = os.path.join(TOOLS, "portal", "summary_provider_select_harness.js")
+    PAGE = os.path.join(TOOLS, "portal", "setup_portal.html")
+
+    def _run(self):
+        return subprocess.run(["node", self.HARNESS, self.PAGE],
+                              capture_output=True, text=True, timeout=300)
+
+    def test_the_harness_passes(self) -> None:
+        proc = self._run()
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_the_blank_is_drawn_and_selected(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   the blank option is there", out)
+        self.assertIn("ok   and is the one selected when nothing is chosen", out)
+
+    def test_it_is_not_a_one_way_door(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   and blank is still offered, so it is not a one-way door", out)
+        self.assertIn("ok   FLOOR: without the blank, nothing is selected and the browser shows "
+                      "the first", out)
+
+
+class TheControlsAreNotDecorativeTest(unittest.TestCase):
+    """A control whose variable nothing reads is worse than no control."""
+
+    def test_each_variable_is_read_on_the_serving_path(self) -> None:
+        for key in SUMMARY_CONTROLS:
+            name = cfg._env_name(cfg.SETTINGS_BY_KEY[key], {})
+            readers = []
+            for entry in sorted(os.listdir(TOOLS)):
+                if not entry.endswith(".py") or entry.startswith("test_"):
+                    continue
+                if entry == "matrixark_gateway_config.py":
+                    continue
+                with open(os.path.join(TOOLS, entry), encoding="utf-8") as handle:
+                    if name in handle.read():
+                        readers.append(entry)
+            with self.subTest(setting=key, variable=name):
+                self.assertTrue(readers, "%s is offered and nothing reads %s" % (key, name))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A deployment runs **three** models. The portal offered two — extraction and embedding — and the
third, the one that writes the node summaries retrieval walks, was reachable only by setting
`MATRIXARK_SUMMARY_*` by hand. It is the model called *most*: every context node gets a summary,
where extraction runs once per ingest.

It needs no endpoint or key of its own. `openai_compatible_json_call` sends a summary to
`EXTRACTION_LLM_BASE_URL` with the key named by `MATRIXARK_EXTRACTION_API_KEY_ENV`, and takes only
the model and the budget as arguments — so three controls complete the surface, and they belong in
the extraction group beside the endpoint and key they use.

```
Summary provider    select: (blank) | deterministic | openai_compatible   needs restart
Summary model       text,  blank = the extraction model                   needs restart
Summary max tokens  900                                                   needs restart
```

Driven in a browser against a running gateway:

```
save     Saved. 2 settings (summary.model, summary.provider) are read once at startup
         — restart the gateway for them to take effect. Everything else is live now.
panel    2 settings are waiting for a restart. The gateway is still running the old
         value for them: summary.model, summary.provider
strip    2 settings awaiting restart
```

### Adding a control must not change what an untouched deployment does

Both string defaults are blank, and a blank is never seeded into the environment — asserted, not
assumed, by storing the defaults, running `apply_boot`, and checking the variables are still unset.
So the reader's chain (`SUMMARY → UNDERSTANDING → EXTRACTION → deterministic`) is untouched for
anyone who never opens the page.

### `restart`, for the reason `audit.mode` carries it

`SUMMARY_LLM_MODEL` and `SUMMARY_LLM_MAX_TOKENS` are module constants in two modules, bound at
import. The provider is the mixed one — `summary_provider()` re-reads the environment on every call,
so the *choice* moves at once while the model those constants carry does not. `restart` is the only
label true of all three, and the help says which half moves first.

### Two things the help had to say, both verified in a process started the way a gateway starts

- **Blank follows extraction.** Started with `openai_compatible` + `deepseek-chat`, summaries
  resolve to exactly that. Naming `deepseek-chat-lite` with a budget of 400 overrides it — which is
  the point of the control.
- **anthropic writes no summary.** The extraction control offers `anthropic`, `summary_provider()`
  passes it through, and the generator calls a model only for the openai-compatible names — so the
  summary is rule-written and nothing errors. It is left off this control's list, and the help warns
  the deployment that reaches it through extraction.

### The blank option is not decorative

The page renders a `choices` setting as a `<select>`, and a list without the blank leaves **no**
option selected — the browser shows the first, and saving pins it, so "same as extraction" would be
a one-way door. A harness runs the shipped `controlHtml` to check the blank is drawn, is selected
when the value is blank, and survives once a provider is picked; its floor asserts that dropping the
blank really does leave nothing selected.

```
drop the blank from the provider choices  -> FAIL it can be set back to following extraction
offer anthropic                           -> FAIL it offers only what writes a summary
default the provider to deterministic     -> FAIL the string defaults are blank
default the model to a literal            -> FAIL the string defaults are blank
claim the model is live                   -> FAIL they wait for a restart
get the budget default wrong              -> FAIL the budget default is the one the code uses
move them to a group of their own         -> FAIL they sit with the endpoint and key they use
point the model at an unread variable     -> FAIL each variable is read on the serving path
```

That last one is the guard against adding a control nothing honours.

16 tests. Neighbours: v1_gateway 97, gateway_portal 60, live_strip 38, gateway_config 28,
config_audit 14, admin_config 11, summary-model 4, portal_pages 4, and all portal-named suites
together 166 — green.
