### PR TITLE
The context node operations do not cost the store

### DIFF
--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -15740,3 +15740,4 @@ fn what_a_bigger_read_cache_buys() {
     // Not asserted as a win or a loss -- this is a sweep, and either answer is informative.
     let _ = (first, last);
 }
+


### PR DESCRIPTION
The mem0 node path — upsert a node, fetch one, attach an embedding — is **flat against store
size**, which is what a hash-addressed operation should be and had never been checked.

| command | bytes @200 | bytes @3 200 | ratio |
|---|---|---|---|
| `SetAdd` *(flat control)* | 3 262 | 3 231 | 0.99x |
| `FeatureAppend` *(scaling control)* | 152 385 | 2 326 337 | 15.27x |
| **`ContextUpsertNode`** | 7 441 | 7 643 | **1.03x** |
| **`ContextGetNode`** | 5 257 | 5 257 | **1.00x** |
| **`ContextSetNodeEmbedding`** | 17 574 | 17 588 | **1.00x** |

`ContextGetNode` returning the identical figure at both sizes is as clean an O(1) signature as
this instrument can produce.

## Why measure something expected to be flat

Four commands in this sweep looked like keyed operations and were quietly restating whole
objects: a set add, a list push, a removal, a feature append. Each was flat in allocation
*count* and moved megabytes in *bytes*. "Addressed by hash, so it must be O(1)" is exactly the
reasoning that missed them, so the node path gets the same treatment rather than the assumption.

The result is a guard: if a later change makes a node operation depend on store size, this
fails.

## Controls

Two-sided and both asserted — `SetAdd` must stay under 1.5x, `FeatureAppend` must exceed 3x —
so a flat row is read off an instrument shown to move at both ends in the same run. Every
operation is also asserted to have been answered, so a refused command cannot look cheap.

## An unplanned check

`FeatureAppend` reads 2 326 337 bytes at 3 200 here, against 4 070 106 before the additive-publish
change merged. That is an independent reproduction of that 43 % win by a probe written for a
different purpose.

## Verification

* Built and run **with the `alloc-probe` feature enabled**; `cargo check --all-targets` does not
  compile feature-gated code.
* Test-only; no engine code is touched.
