### PR TITLE
Let the function that receives an outcome decide whether to keep it

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -855,10 +855,9 @@ impl TemporalEngine {
             // a recovery inherited the recovery's items and recorded them as changes it had
             // made itself. A later replay then installs them, and if one cannot be applied it
             // aborts the whole shard load, taking unrelated keys down with it.
+            // Nothing can be staged while recording is off, because the staging function is
+            // where that is now decided -- so there is nothing left here to clear.
             let mut staged_outcomes = block_in_wal::take_outcomes();
-            if !crate::wal::wal_outcome_items_enabled() {
-                staged_outcomes.clear();
-            }
             if write_command && !replaying_wal() {
                 // A write that changed the shard and recorded nothing cannot be replaced by
                 // its record. Every existing test that writes anything is a probe for that,
@@ -3336,7 +3335,7 @@ fn mark_bucket_index_page_deleted(
     // Removing a member IS an outcome, and it is the one a command log states worst: replay has
     // to re-run the removal and hope the state it removes from matches. Saying "this component
     // is gone" needs no such hope. Recorded here because every typed removal comes through.
-    if crate::wal::wal_outcome_items_enabled() {
+    {
         block_in_wal::stage_outcome(crate::wal::WalOutcomeItem {
             kind: model_id.to_string(),
             object_key: key.to_string(),

--- a/crates/temporalstore-rust/src/engine/block_in_wal.rs
+++ b/crates/temporalstore-rust/src/engine/block_in_wal.rs
@@ -82,15 +82,25 @@ thread_local! {
 /// Staged for the same reason pages are -- the record does not exist yet, so there is nowhere
 /// to put it until the append.
 pub(super) fn stage_outcome(item: crate::wal::WalOutcomeItem) {
+    // Asked here rather than by each caller. Six of them asked it immediately before calling,
+    // which is six chances to write a seventh that does not -- and the answer belongs with the
+    // table that holds the result, not with the code that produced it.
+    //
+    // The cost of asking late is that a caller now builds the item before learning it is not
+    // wanted. That lands only on the opted-out path: recording results is the default, and the
+    // variable exists to write records an older build can still replay.
+    if !crate::wal::wal_outcome_items_enabled() {
+        return;
+    }
     OUTCOMES.with(|outcomes| outcomes.borrow_mut().push(item));
 }
 
-/// Take what this write recorded doing, leaving nothing behind.
 /// How many outcomes this write has staged so far, without consuming them.
 pub(super) fn staged_outcome_count() -> usize {
     OUTCOMES.with(|outcomes| outcomes.borrow().len())
 }
 
+/// Take what this write recorded doing, leaving nothing behind.
 pub(super) fn take_outcomes() -> Vec<crate::wal::WalOutcomeItem> {
     OUTCOMES.with(|outcomes| std::mem::take(&mut *outcomes.borrow_mut()))
 }

--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -25,9 +25,6 @@ fn stage_component_outcome(
     address: Option<crate::block_store::BlockAddress>,
     value: Option<Vec<u8>>,
 ) {
-    if !crate::wal::wal_outcome_items_enabled() {
-        return;
-    }
     super::block_in_wal::stage_outcome(crate::wal::WalOutcomeItem {
         kind: kind.to_string(),
         object_key: object_key.to_string(),
@@ -52,9 +49,6 @@ fn stage_meta_outcome(
     ttl: Option<u64>,
     deleted: bool,
 ) {
-    if !crate::wal::wal_outcome_items_enabled() {
-        return;
-    }
     super::block_in_wal::stage_outcome(crate::wal::WalOutcomeItem {
         kind: kind.to_string(),
         object_key: object_key.to_string(),

--- a/crates/temporalstore-rust/src/engine/packed_pages.rs
+++ b/crates/temporalstore-rust/src/engine/packed_pages.rs
@@ -80,7 +80,7 @@ fn stage_timestamped_outcomes(
     refs: &[(u64, BlockAddress)],
     identity: Option<u64>,
 ) {
-    if refs.is_empty() || !crate::wal::wal_outcome_items_enabled() {
+    if refs.is_empty() {
         return;
     }
     for (timestamp_ms, address) in refs {
@@ -111,9 +111,6 @@ fn stage_timestamped_removal(
     routing_bucket: u32,
     timestamp_ms: u64,
 ) {
-    if !crate::wal::wal_outcome_items_enabled() {
-        return;
-    }
     let component = timestamp_ms.to_string();
     super::block_in_wal::stage_outcome(crate::wal::WalOutcomeItem {
         kind: kind.to_string(),

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1377,7 +1377,7 @@ pub(super) fn upsert_bucket_index_page_with(
     // This IS the outcome: an object, its identity, and where its page ended up. Put it aside
     // for the record, so replay has the option of installing it instead of re-running the
     // command that produced it.
-    if stage && crate::wal::wal_outcome_items_enabled() {
+    if stage {
         super::block_in_wal::stage_outcome(crate::wal::WalOutcomeItem {
             kind: kind.to_string(),
             object_key: object_key.to_string(),


### PR DESCRIPTION
Nine places asked whether a write's result should be recorded. **Six of them asked it in the line
immediately before calling `stage_outcome`** — which is the only way a result is ever staged.

That is six chances to write a seventh that forgets, and the check sits with the code that *produced*
the result rather than with the table that holds it.

The question moves into `stage_outcome`. Six callers lose their gate, and a seventh line goes with
them: `execute_with_storage_override` cleared the staged list when recording was off, which can no
longer have anything to clear — nothing can stage while it is off.

### The eighth site stays, and is a different question

It asks whether results are expected *at all* before asserting, in debug builds, that a write which
changed the shard recorded something. That is about the mode, not about one item.

### What this costs

With the hatch taken, a caller now builds the item before learning it is not wanted. That lands only
on the opted-out path: recording is the default, and the variable exists so a node can write records
an older build is still able to replay — the one reason to turn it off.

The loop in `stage_timestamped_outcomes` keeps its `refs.is_empty()` early return, so the empty case
still costs nothing.

### The flag stays, and stays process-wide

The person who needs it is an operator rolling back, not a caller. What changes is that its answer is
given in one place, so scoping it to a store later is a one-line change instead of a nine-line one.

`cargo check --all-targets` clean · outcome, replay, staged-page and resident-page tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
