### PR TITLE
Write only the binary shape, in the three places nothing asked for the other one

### DIFF
--- a/crates/temporalstore-rust/src/engine/reports.rs
+++ b/crates/temporalstore-rust/src/engine/reports.rs
@@ -442,12 +442,14 @@ pub struct StorageSlabIntegrityReport {
 /// Measured on a 4,000-bucket manifest: the field names are 592,046 bytes of a 1,367,875-byte
 /// document -- 43% of it, once the whitespace came out.
 ///
-/// The second step has been taken: the writer emits the short names by default, which is worth
-/// 43% of the document. `TS_MANIFEST_SHORT_FIELD_NAMES=0` restores the long spelling for a fleet
-/// that still holds a reader older than the release which taught them.
+/// The second step has been taken and the switch that guarded it is gone: the writer emits the
+/// short names, which is worth 43% of the document.
 ///
-/// Reading never depends on the switch. Both spellings deserialize, so a directory holding
-/// manifests written either way -- which is what flipping it leaves behind -- loads end to end.
+/// Reading never depended on that switch and still does not. Both spellings deserialize, so a
+/// directory holding manifests written either way -- which every fleet that has run both has --
+/// loads end to end. What no longer exists is a way to ASK for the long spelling: producing a
+/// manifest for a reader older than the release that taught the aliases now means running such a
+/// build, not setting a variable on this one.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize)]
 pub struct BucketStorageSummary {
     #[serde(rename = "routing_slot", alias = "rs")]
@@ -486,19 +488,6 @@ pub struct BucketStorageSummary {
 /// Python tool reads this document -- the `logical_bytes`/`physical_bytes` names in `tools/`
 /// belong to the band extent manifest, which is a different file with different fields.
 ///
-/// `TS_MANIFEST_SHORT_FIELD_NAMES=0` restores the long spelling. Reading never depends on the
-/// switch either way, so a directory holding manifests written both ways loads end to end.
-pub(crate) fn manifest_short_field_names_enabled() -> bool {
-    !matches!(
-        std::env::var("TS_MANIFEST_SHORT_FIELD_NAMES")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "0" | "false" | "no" | "off"
-    )
-}
-
 impl BucketStorageSummary {
     /// Write the summary under one spelling or the other.
     ///
@@ -565,7 +554,7 @@ impl serde::Serialize for BucketStorageSummary {
     where
         S: serde::Serializer,
     {
-        self.serialize_named(serializer, manifest_short_field_names_enabled())
+        self.serialize_named(serializer, true)
     }
 }
 
@@ -3696,18 +3685,14 @@ mod manifest_field_name_tests {
         }
     }
 
-    /// The DEFAULT is now the short spelling.
+    /// The writer emits the short spelling, and nothing can ask it not to.
     ///
-    /// Reads the switch and sets nothing: the variable is process-global, and several hundred
-    /// sites in this crate already race over environment. Nothing in the suite sets this one.
-    /// Without this test the flip would be invisible -- every other test here names the spelling
-    /// explicitly, so all of them would pass with the default either way.
+    /// Every other test here names the spelling explicitly through `serialize_named`, so all of
+    /// them would pass whichever one `Serialize` chose. This is the only test that exercises the
+    /// choice `Serialize` actually makes, which is why it asserts the BYTES rather than a
+    /// setting -- there is no longer a setting to read.
     #[test]
     fn the_default_is_now_the_short_spelling() {
-        assert!(
-            super::manifest_short_field_names_enabled(),
-            "the switch should default on"
-        );
         let written = serde_json::to_vec(&BucketStorageSummary::default()).expect("serialize");
         let text = String::from_utf8_lossy(&written);
         assert!(

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -43,41 +43,26 @@ pub(crate) const INDEX_LOG_CONTAINER_MAGIC: &[u8] = b"TSILOG\x01";
 /// Payload codec: msgpack, struct-as-map.
 pub(crate) const INDEX_LOG_CODEC_MSGPACK: u8 = 1;
 
-/// `TS_INDEX_LOG_BINARY` writes records as JSON when it is off. Default **on**.
-///
-/// The decoder shipped first and separately: every build that can be rolled back to reads a
-/// binary container already, which is the condition this flip was waiting on. Set it to 0 to
-/// write JSON again -- readers keep taking both, so a log may hold either shape and a node may
-/// be moved between them without a rewrite.
-fn index_log_binary_enabled() -> bool {
-    std::env::var("TS_INDEX_LOG_BINARY")
-        .ok()
-        .map(|value| !matches!(value.trim(), "0" | "false" | "FALSE" | "no" | "NO" | "off"))
-        .unwrap_or(true)
-}
-
 /// The single place an index-log record becomes payload bytes.
 ///
 /// Both append paths go through here so the whole-index record and the delta record cannot
 /// drift into different shapes -- the reader tells them apart by their fields, which only
 /// works while both are encoded the same way.
 fn encode_index_payload<T: serde::Serialize>(record: &T) -> Result<Vec<u8>, IndexLogError> {
-    if index_log_binary_enabled() {
-        // struct-as-MAP, not struct-as-array. The array form is positional, which mis-reads a
-        // struct that skipped an absent optional -- and GC's anchor probe pulls two fields out
-        // of an arbitrary record BY NAME, which positional makes impossible.
-        let mut packed = Vec::new();
-        let mut serializer = rmp_serde::Serializer::new(&mut packed).with_struct_map();
-        if serde::Serialize::serialize(record, &mut serializer).is_ok() {
-            let mut out =
-                Vec::with_capacity(packed.len() + INDEX_LOG_CONTAINER_MAGIC.len() + 1);
-            out.extend_from_slice(INDEX_LOG_CONTAINER_MAGIC);
-            out.push(INDEX_LOG_CODEC_MSGPACK);
-            out.extend_from_slice(&packed);
-            return Ok(out);
-        }
-        // An encode failure must not cost the record: fall through to the bytes that always work.
+    // struct-as-MAP, not struct-as-array. The array form is positional, which mis-reads a
+    // struct that skipped an absent optional -- and GC's anchor probe pulls two fields out
+    // of an arbitrary record BY NAME, which positional makes impossible.
+    let mut packed = Vec::new();
+    let mut serializer = rmp_serde::Serializer::new(&mut packed).with_struct_map();
+    if serde::Serialize::serialize(record, &mut serializer).is_ok() {
+        let mut out = Vec::with_capacity(packed.len() + INDEX_LOG_CONTAINER_MAGIC.len() + 1);
+        out.extend_from_slice(INDEX_LOG_CONTAINER_MAGIC);
+        out.push(INDEX_LOG_CODEC_MSGPACK);
+        out.extend_from_slice(&packed);
+        return Ok(out);
     }
+    // An encode failure must not cost the record: fall through to the bytes that always work,
+    // which the reader still takes. This is the only path that now produces JSON.
     Ok(serde_json::to_vec(record)?)
 }
 
@@ -2493,12 +2478,13 @@ mod tests {
         assert!(whole > 0, "the probe must encode something");
     }
 
-    /// The writer is on, and every reader has been able to decode a container since the step
-    /// before this one. What this pins is that the two never move in the wrong order: a
-    /// container is only written where one can be read.
+    /// A container is only written where one can be read, and both halves are asserted here.
+    ///
+    /// The writer has no switch any more, so what pins it is the bytes it produces rather than
+    /// the setting it consulted -- and the reader half matters more than before, because a log
+    /// written by an older build is now the only way JSON gets into one.
     #[test]
     fn the_binary_writer_is_on_and_its_reader_shipped_first() {
-        assert!(index_log_binary_enabled(), "TS_INDEX_LOG_BINARY defaults on");
         // The reader takes a container whatever the writer is set to -- that is the property
         // that made the flip safe, so it is worth holding rather than assuming.
         let json = serde_json::to_vec(&IndexDeltaRecord {

--- a/crates/temporalstore-rust/src/raft/local_wal.rs
+++ b/crates/temporalstore-rust/src/raft/local_wal.rs
@@ -61,10 +61,7 @@ impl LocalRaftWal {
             delta: None,
         };
         let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
-        file.write_all(&wal_proto::encode_record_line(
-            &envelope,
-            wal_proto::binary_records_enabled(),
-        )?)?;
+        file.write_all(&wal_proto::encode_record_line(&envelope, true)?)?;
         crate::durability_metrics::record_barrier("raft_wal_append_unsegmented");
         file.sync_data()?;
         Ok(())
@@ -394,7 +391,7 @@ impl LocalRaftWal {
                     delta: None,
                 }
             };
-            wal_proto::encode_record_line(&envelope, wal_proto::binary_records_enabled())
+            wal_proto::encode_record_line(&envelope, true)
         };
 
         let mut wrote_base = !delta_safe;
@@ -833,11 +830,10 @@ impl LocalRaftWal {
             .write(true)
             .truncate(true)
             .open(&path)?;
-        // Rewriting the retained records adopts whichever encoding is current; a reader
-        // handles either, but a file written whole in one encoding is easier to reason about.
-        let binary = wal_proto::binary_records_enabled();
+        // Rewriting the retained records writes them binary, as every append does. A reader
+        // handles either, so a file that still holds text records loads until it is rewritten.
         for envelope in retained {
-            file.write_all(&wal_proto::encode_record_line(&envelope, binary)?)?;
+            file.write_all(&wal_proto::encode_record_line(&envelope, true)?)?;
         }
         crate::durability_metrics::record_barrier("raft_wal_compact");
         file.sync_data()?;

--- a/crates/temporalstore-rust/src/raft/wal_proto.rs
+++ b/crates/temporalstore-rust/src/raft/wal_proto.rs
@@ -341,22 +341,6 @@ fn entry_from_proto(entry: v1::WalLogEntry) -> io::Result<RaftLogEntry> {
 /// envelope starts with `#`.
 pub(super) const BINARY_RECORD_MAGIC: u8 = 0xA7;
 
-/// Whether new records are written in the binary encoding. On, and the variable opts out.
-///
-/// Reading either shape has been safe since the code landed -- a read dispatches on the first
-/// byte, and the magic was chosen so it cannot be confused with either text form. WRITING binary
-/// is the one-way half: a reader that predates this cannot take it. So the default stayed off
-/// until the encoding had proved out on real hardware, and this sentence said so long after it
-/// stopped being true, which is the failure worth naming -- the default was read as fact while
-/// deciding whether a neighbouring switch could be turned on.
-///
-/// A node that must produce records an older reader accepts sets the variable to 0.
-pub(super) fn binary_records_enabled() -> bool {
-    std::env::var("TS_RAFT_WAL_BINARY_RECORDS")
-        .map(|value| !(value == "0" || value.eq_ignore_ascii_case("false")))
-        .unwrap_or(true)
-}
-
 /// Encode one record as it should appear in a segment file.
 pub(super) fn encode_record_line(
     envelope: &RaftWalEnvelope,

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -8,7 +8,7 @@ within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 300 of them, read by 98 functions.
+There are 297 of them, read by 95 functions.
 
 Deleting unreachable code is not the lever. An earlier version of this document argued that
 by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
@@ -46,11 +46,11 @@ Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 300 |
-| booleans whose default this could read off the source | 34 |
-| **defaulting on, and set by nothing** | 5 |
+| total | 297 |
+| booleans whose default this could read off the source | 31 |
+| **defaulting on, and set by nothing** | 2 |
 | offered on the portal | 23 |
-| **that nothing in this repository sets** | 178 |
+| **that nothing in this repository sets** | 175 |
 | documented as keeping an older path alive | 5 |
 | reaching more than two files | 15 |
 | whose doc comment is really about another flag | 43 |
@@ -158,7 +158,7 @@ Secrets. Never a form field, never in a launch artifact.
 | `TS_API_AUTH_TOKEN` | — | nothing | 1 | — |
 | `TS_META_ADMIN_TOKEN` | — | nothing | 1 | — |
 
-## durability (23)
+## durability (22)
 
 What is written, when it is flushed, and what is reclaimed. The escape hatches here trade throughput for a more conservative barrier.
 
@@ -173,7 +173,6 @@ What is written, when it is flushed, and what is reclaimed. The escape hatches h
 | `TS_INDEX_DUMP_WAL_GAP_BYTES` | — | portal | 1 | — |
 | `TS_META_RAFT_SNAPSHOT_CHECK_INTERVAL_MS` | — | nothing | 1 | — |
 | `TS_META_SCHEDULER_SNAPSHOT` | — | nothing | 1 | — |
-| `TS_RAFT_WAL_BINARY_RECORDS` | on | nothing | 1 | — |
 | `TS_WAL_BINARY_FRAME` | on | launch, test | 1 | — |
 | `TS_WAL_BINARY_RECORDS` | on | launch, test | 1 | — |
 | `TS_WAL_COMMIT_DELAY_US` | — | config | 1 | — |
@@ -188,7 +187,7 @@ What is written, when it is flushed, and what is reclaimed. The escape hatches h
 | `TS_WAL_RESIDENT_PAGES` | — | test | 1 | — |
 | `TS_WAL_SEGMENT_BYTES` | — | nothing | 1 | — |
 
-## format (8)
+## format (7)
 
 The shape of what is written. Readers generally accept both shapes, which is what makes these safe to flip and hard to retire.
 
@@ -197,7 +196,6 @@ The shape of what is written. Readers generally accept both shapes, which is wha
 | `TS_INDEX_BINARY` | on | launch, test | 1 | — |
 | `TS_INDEX_CATALOG_FOLD` | on | config | 1 | yes |
 | `TS_INDEX_CODEC` | — | test | 1 | — |
-| `TS_INDEX_LOG_BINARY` | on | nothing | 1 | — |
 | `TS_NODE_SUMMARY_VECTOR` | on | test, portal | 1 | — |
 | `TS_PROXY_BINARY_VERSION` | — | nothing | 1 | — |
 | `TS_VECTOR_INT8` | off | test, portal | 1 | — |
@@ -363,7 +361,7 @@ Read only by the benchmark harnesses. Never consulted on a serving path.
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_SOURCE_ORDER_RANKING` | off | nothing | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_STORED_RECORD_SCORING` | on | nothing | 1 | — |
 
-## behaviour (62)
+## behaviour (61)
 
 Everything else that changes what the engine does.
 
@@ -394,7 +392,6 @@ Everything else that changes what the engine does.
 | `TS_EVICT_SAMPLES` | — | nothing | 1 | — |
 | `TS_EVICT_SCAN_TURNS` | — | nothing | 1 | — |
 | `TS_MALLOC_TRIM` | on | test, portal | 1 | — |
-| `TS_MANIFEST_SHORT_FIELD_NAMES` | on | nothing | 1 | — |
 | `TS_MATRIXOBJECT_CHECKPOINT_ON_START` | — | nothing | 1 | — |
 | `TS_MATRIXOBJECT_FLUSH_BATCH` | — | nothing | 1 | — |
 | `TS_MATRIXOBJECT_NETWORKED_CHECKPOINT_ON_START` | — | nothing | 1 | — |


### PR DESCRIPTION
Three encodings each had a switch choosing between a binary form and a text one. All three defaulted
to binary, and **nothing anywhere selected the text side** — not a test, not the shipped config, not a
launch profile, not the portal.

| | binary (kept) | text (removed from the writer) |
|---|---|---|
| served-index log | msgpack container | JSON |
| raft log | length-prefixed record | JSON line |
| bucket manifest | short field names | long names |

### Why removing the text writer is safe

**No reader was ever told which shape it holds.**

- the index log distinguishes a container from a record starting with `{`
- the raft log dispatches on a first byte chosen so it cannot be confused with either text form
- the manifest carries a serde `alias` on every field, so both spellings deserialize

So a log or directory written by any earlier build still loads, and a file that still holds text
records keeps loading until something rewrites it.

### What is lost, deliberately

The ability to **ask** for the old shape. Producing a manifest for a reader older than the release
that taught it the aliases now means running such a build, not setting a variable on this one. That
is the rollback position these switches held, and it is the cost of collapsing to the live path.

### One JSON path remains, and it is not a switch

If the msgpack encoder fails, an index-log record falls through to the bytes that always work rather
than being lost. That is now the only way JSON enters a log this build writes.

### Two tests now assert bytes instead of a setting

`the_default_is_now_the_short_spelling` read the switch and then checked the output. The switch is
gone and the output check is the whole test — which is the stronger half, since every other test in
that file names the spelling explicitly through `serialize_named` and would pass whichever one
`Serialize` chose.

The index-log test keeps both halves: a container is written, and a JSON record still reads.

`cargo check --all-targets` clean · 35 flag guards pass · inventory 300 → **297**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
