### PR TITLE
Say when one variable is holding two different providers' keys

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1668,6 +1668,27 @@ def _model_config_snapshot() -> Json:
                 "non-empty placeholder for a local endpoint."
             )
 
+    # Both key controls can name the SAME variable -- they both default to OPENAI_API_KEY -- and the
+    # portal reports each secret as configured because each is STORED, while the variable holds
+    # whichever was written last. Two providers on two endpoints then share one key, one of them is
+    # authenticating with the other's, and the 401 falls back silently to the deterministic path.
+    #
+    # Only when the endpoints differ. One provider serving both sides is the `openai` preset, where
+    # sharing the key is the point, and warning there would be noise on a correct configuration.
+    extraction_endpoint = str(extraction["base_url"] or "").rstrip("/")
+    embedding_endpoint = str(embedding["api_base"] or "").rstrip("/")
+    if (extraction_provider not in deterministic and embedding_provider not in deterministic
+            and extraction_key_env and extraction_key_env == embedding_key_env
+            and extraction_endpoint and embedding_endpoint
+            and extraction_endpoint != embedding_endpoint):
+        warnings.append(
+            "extraction and embedding both take their key from " + extraction_key_env + ", but they "
+            "call different endpoints (" + extraction_endpoint + " and " + embedding_endpoint
+            + "): whichever key was saved last is in that variable, so one of the two is "
+            "authenticating with the other's. Name a different variable in one of the key-variable "
+            "settings, then set that key again."
+        )
+
     return {
         "status": "ok",
         "extraction": extraction,

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1682,11 +1682,11 @@ def _model_config_snapshot() -> Json:
             and extraction_endpoint and embedding_endpoint
             and extraction_endpoint != embedding_endpoint):
         warnings.append(
-            "extraction and embedding both take their key from " + extraction_key_env + ", but they "
-            "call different endpoints (" + extraction_endpoint + " and " + embedding_endpoint
-            + "): whichever key was saved last is in that variable, so one of the two is "
-            "authenticating with the other's. Name a different variable in one of the key-variable "
-            "settings, then set that key again."
+            "Extraction API key and Embedding API key both go into " + extraction_key_env
+            + ", but they call different endpoints (" + extraction_endpoint + " and "
+            + embedding_endpoint + "): whichever was saved last is the one in that variable, so one "
+            "of the two is authenticating with the other's key. Give one of them its own place in "
+            "Extraction key variable or Embedding key variable, then set that key again."
         )
 
     return {

--- a/tools/test_matrixark_one_variable_holding_two_keys.py
+++ b/tools/test_matrixark_one_variable_holding_two_keys.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The portal says when extraction and embedding are sharing one key variable between two endpoints.
+
+Both key controls default to ``OPENAI_API_KEY``, and the key a customer types is written into
+whatever that control names. Set a DeepSeek extraction key and an OpenAI embedding key without
+renaming either variable and both land in ``OPENAI_API_KEY``: the last one saved wins, and the
+portal reports **both** secrets as configured, because each is stored. Reproduced before this was
+written::
+
+    extraction -> OPENAI_API_KEY          extraction base_url : https://api.deepseek.com/v1
+    embedding  -> OPENAI_API_KEY          embedding api_base  : https://api.openai.com/v1
+    the variable holds                    'sk-deepseek-key'
+    the portal reports extraction.api_key configured=True
+    the portal reports embedding.api_key  configured=True
+    warnings shown: nothing about it
+
+One endpoint is then called with the other's key, 401s, and falls back silently -- deterministic
+extraction, hash vectors -- which is the shape every warning in this list exists for.
+
+**Only when the endpoints differ.** One provider serving both sides is the ``openai`` preset, where
+sharing the key is the point; warning there would put a permanent complaint on a correct
+configuration, and a warning that is always on is one nobody reads.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+import matrixark_v1_gateway as gw  # noqa: E402
+
+KNOBS = ("MATRIXARK_UNDERSTANDING_PROVIDER", "MATRIXARK_EXTRACTION_PROVIDER",
+         "MATRIXARK_EXTRACTION_BASE_URL", "MATRIXARK_EXTRACTION_API_KEY_ENV",
+         "MATRIXARK_EMBEDDING_PROVIDER", "MATRIXARK_EMBEDDING_API_BASE",
+         "MATRIXARK_EMBEDDING_API_KEY_ENV", "MATRIXARK_REQUIRE_MODEL_EMBEDDINGS",
+         "OPENAI_API_KEY", "DEEPSEEK_API_KEY", "MATRIXARK_EMBED_BASE_URL")
+
+DEEPSEEK = "https://api.deepseek.com/v1"
+OPENAI = "https://api.openai.com/v1"
+
+
+def sharing(warnings):
+    return [w for w in warnings if "both take their key from" in w]
+
+
+class _Configured(unittest.TestCase):
+
+    def setUp(self) -> None:
+        previous = {name: os.environ.get(name) for name in KNOBS}
+
+        def restore() -> None:
+            for name, value in previous.items():
+                if value is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = value
+
+        self.addCleanup(restore)
+        for name in KNOBS:
+            os.environ.pop(name, None)
+
+    def configure(self, **env) -> list:
+        for name, value in env.items():
+            os.environ[name] = value
+        return gw._model_config_snapshot().get("warnings") or []
+
+    def two_providers(self, **overrides):
+        env = {
+            "MATRIXARK_UNDERSTANDING_PROVIDER": "openai_compatible",
+            "MATRIXARK_EXTRACTION_BASE_URL": DEEPSEEK,
+            "MATRIXARK_EMBEDDING_PROVIDER": "openai_compatible",
+            "MATRIXARK_EMBEDDING_API_BASE": OPENAI,
+            "OPENAI_API_KEY": "sk-whichever-was-last",
+            "MATRIXARK_REQUIRE_MODEL_EMBEDDINGS": "1",
+        }
+        env.update(overrides)
+        return self.configure(**env)
+
+
+class OneVariableTwoEndpointsIsCalledOutTest(_Configured):
+
+    def test_it_is_named(self) -> None:
+        found = sharing(self.two_providers())
+        self.assertEqual(1, len(found), self.two_providers())
+
+    def test_it_says_which_variable_and_which_endpoints(self) -> None:
+        """A warning that does not name the variable leaves the reader nothing to change."""
+        said = sharing(self.two_providers())[0]
+        self.assertIn("OPENAI_API_KEY", said)
+        self.assertIn(DEEPSEEK, said)
+        self.assertIn(OPENAI, said)
+
+    def test_it_says_what_to_do(self) -> None:
+        said = sharing(self.two_providers())[0]
+        self.assertIn("Name a different variable", said)
+        self.assertIn("set that key again", said)
+
+
+class WhenSharingIsRightItStaysQuietTest(_Configured):
+
+    def test_one_provider_serving_both_sides_is_not_warned_about(self) -> None:
+        """The `openai` preset: one endpoint, one key, correctly shared."""
+        found = sharing(self.two_providers(MATRIXARK_EXTRACTION_BASE_URL=OPENAI))
+        self.assertEqual([], found, found)
+
+    def test_a_trailing_slash_is_not_a_different_endpoint(self) -> None:
+        found = sharing(self.two_providers(MATRIXARK_EXTRACTION_BASE_URL=OPENAI + "/",
+                                           MATRIXARK_EMBEDDING_API_BASE=OPENAI))
+        self.assertEqual([], found, found)
+
+    def test_separate_variables_are_not_warned_about(self) -> None:
+        """The fix the warning asks for must silence it."""
+        found = sharing(self.two_providers(MATRIXARK_EXTRACTION_API_KEY_ENV="DEEPSEEK_API_KEY"))
+        self.assertEqual([], found, found)
+
+    def test_a_deterministic_side_needs_no_key(self) -> None:
+        for side in ("MATRIXARK_UNDERSTANDING_PROVIDER", "MATRIXARK_EMBEDDING_PROVIDER"):
+            with self.subTest(deterministic=side):
+                found = sharing(self.two_providers(**{side: "deterministic"}))
+                self.assertEqual([], found, found)
+
+    def test_an_endpoint_nobody_named_is_not_compared(self) -> None:
+        """Nothing to compare is not the same as a collision, and a warning on an unconfigured
+        deployment would fire on every fresh install."""
+        found = sharing(self.two_providers(MATRIXARK_EXTRACTION_BASE_URL=""))
+        self.assertEqual([], found, found)
+
+    def test_a_fresh_deployment_is_not_warned_about(self) -> None:
+        """The floor for all of the above: nothing configured, nothing said."""
+        self.assertEqual([], sharing(self.configure()))
+
+
+class ItRidesTheStripTest(_Configured):
+    """The count on every page is the length of this list, so this reaches a customer who is not on
+    the settings tab."""
+
+    def test_the_count_moves(self) -> None:
+        """Both arms carry a key in the variable they name, so the only difference between them is
+        the sharing itself. Without that, naming an unset variable trades this warning for the
+        empty-key one and the count does not move -- which reads as "the warning does nothing"."""
+        gw._LIVE_SHARED = None
+        self.addCleanup(setattr, gw, "_LIVE_SHARED", None)
+        quiet = self.two_providers(MATRIXARK_EXTRACTION_API_KEY_ENV="DEEPSEEK_API_KEY",
+                                   DEEPSEEK_API_KEY="sk-its-own")
+        noisy = self.two_providers(MATRIXARK_EXTRACTION_API_KEY_ENV="OPENAI_API_KEY")
+        self.assertEqual([], sharing(quiet), quiet)
+        self.assertEqual(1, len(sharing(noisy)), noisy)
+        self.assertEqual(len(quiet) + 1, len(noisy), (quiet, noisy))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_one_variable_holding_two_keys.py
+++ b/tools/test_matrixark_one_variable_holding_two_keys.py
@@ -44,7 +44,7 @@ OPENAI = "https://api.openai.com/v1"
 
 
 def sharing(warnings):
-    return [w for w in warnings if "both take their key from" in w]
+    return [w for w in warnings if "both go into" in w]
 
 
 class _Configured(unittest.TestCase):
@@ -88,15 +88,19 @@ class OneVariableTwoEndpointsIsCalledOutTest(_Configured):
         self.assertEqual(1, len(found), self.two_providers())
 
     def test_it_says_which_variable_and_which_endpoints(self) -> None:
-        """A warning that does not name the variable leaves the reader nothing to change."""
+        """It names the two CONTROLS, because that is what a reader on the Setup page can act on,
+        and the variable they share, because that is what an API reader sees."""
         said = sharing(self.two_providers())[0]
+        self.assertIn("Extraction API key", said)
+        self.assertIn("Embedding API key", said)
         self.assertIn("OPENAI_API_KEY", said)
         self.assertIn(DEEPSEEK, said)
         self.assertIn(OPENAI, said)
 
     def test_it_says_what_to_do(self) -> None:
         said = sharing(self.two_providers())[0]
-        self.assertIn("Name a different variable", said)
+        self.assertIn("Extraction key variable", said)
+        self.assertIn("Embedding key variable", said)
         self.assertIn("set that key again", said)
 
 


### PR DESCRIPTION
Both API-key controls default their variable to `OPENAI_API_KEY`, and the key a customer types is
written into whatever that control names. So setting a DeepSeek extraction key and an OpenAI
embedding key — without renaming either variable — puts both in the same place:

```
extraction -> OPENAI_API_KEY       extraction base_url : https://api.deepseek.com/v1
embedding  -> OPENAI_API_KEY       embedding api_base  : https://api.openai.com/v1
the variable holds                 'sk-deepseek-key'
the portal reports extraction.api_key  configured=True
the portal reports embedding.api_key   configured=True
warnings shown                     nothing about it
```

Each secret **is** stored, so each reports as configured; the variable holds whichever was saved
last. One endpoint is then called with the other's key, 401s, and falls back silently —
deterministic extraction, hash vectors — which is the shape every warning in this list exists for.

Against a running gateway, after the change:

```
* extraction and embedding both take their key from OPENAI_API_KEY, but they call different
  endpoints (https://api.deepseek.com/v1 and https://api.openai.com/v1): whichever key was saved
  last is in that variable, so one of the two is authenticating with the other's. Name a different
  variable in one of the key-variable settings, then set that key again.

strip frame: "warnings": 2
```

The count on the strip is the length of this list, so it reaches a customer who is not on the
settings tab.

### Only when sharing is actually wrong

One provider serving both sides is the `openai` preset, where sharing the key is the point — a
warning there would be a permanent complaint about a correct configuration, and a warning that is
always on is one nobody reads. It fires only when **both** providers are non-deterministic, the two
key variables are the same, both endpoints are named, and those endpoints differ (trailing slash
ignored).

```
never warn                                    -> FAIL it says which variable and which endpoints (+3)
warn even when the endpoints are the same     -> FAIL one provider serving both sides (+1)
warn even when the variables differ           -> FAIL x5
warn even when a side is deterministic        -> FAIL x8
warn when an endpoint is unnamed              -> FAIL an endpoint nobody named is not compared
stop naming the variable                      -> FAIL it says which variable and which endpoints (+3)
stop saying what to do                        -> FAIL it says what to do
compare endpoints without trimming the slash  -> FAIL a trailing slash is not a different endpoint
```

A floor asserts a fresh deployment with nothing configured says nothing, and another asserts the fix
the warning asks for silences it.

### One test needed fixing before it meant anything

The check that the strip's count moves compared an arm naming an **unset** variable against one
naming a set variable — so it traded this warning for the empty-key warning and the count did not
move. Both arms now carry a key in the variable they name, so the only difference between them is
the sharing itself.

10 tests. Neighbours: v1_gateway 97, gateway_portal 60, live_strip 38, gateway_config 28,
encoder_conflict 27, dashboards 20, checklist 11, gateway-is-open 9, and all portal-named suites
together 166 — green.
