### PR TITLE
Deleting one string costs the size of its routing bucket

### DIFF
--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -15741,3 +15741,103 @@ fn what_a_bigger_read_cache_buys() {
     let _ = (first, last);
 }
 
+
+/// What does the String family cost as the store grows?
+///
+/// `StringSet` declares its index component; `StringGet`, `StringDelete` and `StringSetEx` do
+/// not. On every other family, a write that declares nothing restated every page of its object
+/// and cost megabytes -- so `StringDelete` sits on the shape that was worth 16x elsewhere.
+///
+/// The prediction is that it does NOT matter here, because a string is one page per key
+/// (`component: None`), so "every page of the object" is one page. This checks that, because the
+/// same reasoning applied to sets and lists would have been wrong.
+///
+/// Two-sided control, both asserted.
+#[test]
+#[cfg(feature = "alloc-probe")]
+fn what_the_string_family_costs_against_the_store() {
+    const REPS: usize = 20;
+    let cost = |kind: &str, fill: usize| -> (u64, u64) {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            8 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        let seed = |i: usize| -> Command {
+            match kind {
+                "FeatureAppend" => Command::FeatureAppend {
+                    key: "f".to_string(),
+                    points: vec![FeaturePoint { timestamp_ms: 1_000 + i as u64, value: vec![b'v'; 8] }],
+                },
+                "SetAdd" => Command::SetAdd {
+                    key: "s".to_string(),
+                    member: format!("m{i:07}").into_bytes(),
+                },
+                _ => Command::StringSet {
+                    key: format!("k{i:07}"),
+                    value: vec![b'v'; 128],
+                },
+            }
+        };
+        for i in 0..fill {
+            let out = engine.execute(ExecuteRequest { shard_id: 1, command: seed(i) });
+            assert!(out.status.ok, "{kind} fill refused: {:?}", out.status);
+        }
+        let make = |i: usize| -> Command {
+            match kind {
+                "StringSet" => Command::StringSet {
+                    key: format!("k{:07}", fill + i),
+                    value: vec![b'v'; 128],
+                },
+                "StringGet" => Command::StringGet { key: format!("k{:07}", i % fill.max(1)) },
+                "StringDelete" => Command::StringDelete { key: format!("k{:07}", i) },
+                "SetAdd" => Command::SetAdd {
+                    key: "s".to_string(),
+                    member: format!("m{:07}", fill + i).into_bytes(),
+                },
+                "FeatureAppend" => Command::FeatureAppend {
+                    key: "f".to_string(),
+                    points: vec![FeaturePoint { timestamp_ms: 1_000 + (fill + i) as u64, value: vec![b'v'; 8] }],
+                },
+                other => panic!("unknown {other}"),
+            }
+        };
+        let probe = crate::alloc_probe::Probe::start();
+        let mut ok = 0u64;
+        for i in 0..REPS {
+            let out = engine.execute(ExecuteRequest { shard_id: 1, command: make(i) });
+            assert!(out.status.ok, "{kind} refused: {:?}", out.status);
+            ok += 1;
+        }
+        (probe.stop().alloc_bytes / REPS as u64, ok)
+    };
+
+    println!("  command          declares?   bytes @200   bytes @3200    ratio");
+    let mut flat = 0.0f64;
+    let mut scaling = 0.0f64;
+    for (kind, declares) in [
+        ("SetAdd", "yes"),
+        ("FeatureAppend", "no"),
+        ("StringSet", "yes"),
+        ("StringGet", "n/a"),
+        ("StringDelete", "no"),
+    ] {
+        let (small, sa) = cost(kind, 200);
+        let (large, la) = cost(kind, 3200);
+        assert!(small > 0, "{kind}: measured zero bytes");
+        assert!(sa == REPS as u64 && la == REPS as u64, "{kind}: not every op answered");
+        let ratio = large as f64 / small as f64;
+        match kind {
+            "SetAdd" => flat = ratio,
+            "FeatureAppend" => scaling = ratio,
+            _ => {}
+        }
+        println!("  {kind:14}  {declares:9}   {small:10}  {large:12}   {ratio:6.2}x");
+    }
+    assert!(flat < 1.5, "the flat control reported {flat:.2}x");
+    assert!(scaling > 3.0, "the scaling control reported {scaling:.2}x -- probe cannot see growth");
+    println!("  A string is one page per key, so declaring or not should not matter here.");
+}


### PR DESCRIPTION
| command | declares a component? | bytes @200 | bytes @3 200 | ratio |
|---|---|---|---|---|
| `SetAdd` *(flat control)* | yes | 3 346 | 3 533 | 1.06x |
| `FeatureAppend` *(scaling control)* | no | 145 940 | 2 249 378 | 15.41x |
| `StringSet` | yes | 5 389 | 5 531 | 1.03x |
| `StringGet` | n/a | 40 502 | 40 502 | 1.00x |
| **`StringDelete`** | **no** | **6 388** | **46 428** | **7.27x** |

## The prediction this test was written to check was wrong

A string is one page per key (`component: None`), so "restate every page of the object" should
mean restating **one** page, and `StringDelete` should have been flat. It is not.

That is what makes it useful. Because a string object really is a single page, item construction
is already minimal — so the 7.27x is **purely the bucket walk**.
`collect_command_index_items` iterates the routing bucket's whole `page_index` and filters by
key, so with 3 200 string objects in the bucket it walks 3 200 entries to emit one item.

`StringDelete` is therefore the cleanest available demonstration of that walk: it has nothing
else to pay for.

## It isolates a residual that was already named

The removal change that cut `SetRemove` and `HashDelete` from ~2.5 MB to ~156 KB said in its own
description: *"the bucket walk is still O(pages of the object). This removes the per-page item
construction, not the walk."*

This measures that leftover on its own, with the construction term reduced to a single item.

## What is not a problem

`StringSet` is flat because it declares its component. `StringGet` is flat and identical to the
byte at both sizes. Its 40 502 bytes per read is a fixed cost rather than a scaling one — large
against a 128-byte value, and worth its own look, but not a function of store size.

## Controls

Two-sided and both asserted, so the flat rows are read off an instrument shown to move at both
ends in the same run. Every operation is asserted answered, so a refused command cannot look
cheap.

## Verification

* Built and run **with the `alloc-probe` feature enabled**; `cargo check --all-targets` does not
  compile feature-gated code.
* Test-only; no engine code is touched.
