### PR TITLE
Two flag docs that had fused onto the item beside them

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -178,10 +178,15 @@ pub struct TemporalEngine {
 }
 
 
+/// How many times a sweep has moved pages out, for tests that need to know the bound fired
+/// rather than that the count merely happened to stay low.
+pub(crate) static RESIDENT_SWEEPS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
 /// TS_WAL_RESIDENT_PAGES: how many log-resident pages one shard may hold before the oldest are
 /// written out to the block store. Zero disables the bound entirely.
 ///
-/// resident pages are bounded because an unbounded set costs twice. Each one is a registration,
+/// Resident pages are bounded because an unbounded set costs twice. Each one is a registration,
 /// which is memory; each one also pins `min_registered_sequence`, and reclaim may not truncate
 /// below the lowest registration — so a set that only grows is a log that can never be reclaimed
 /// whatever the retention policy says. Measured on an ingest of distinct keys, registrations
@@ -190,11 +195,6 @@ pub struct TemporalEngine {
 /// The default is deliberately generous. The recent ones are worth keeping where they are: a page
 /// written moments ago is the one a read is most likely to want, and its bytes are already in the
 /// record just written. This is a ceiling on how far behind the dump can fall, not a cache policy.
-/// How many times a sweep has moved pages out, for tests that need to know the bound fired
-/// rather than that the count merely happened to stay low.
-pub(crate) static RESIDENT_SWEEPS: std::sync::atomic::AtomicU64 =
-    std::sync::atomic::AtomicU64::new(0);
-
 fn wal_resident_page_limit() -> usize {
     std::env::var("TS_WAL_RESIDENT_PAGES")
         .ok()
@@ -1990,9 +1990,6 @@ const INDEX_BINARY_VERSION_BYTES: usize = 4;
 /// path for a large cut in bytes written and bytes read at load.
 const INDEX_ZSTD_LEVEL: i32 = 3;
 
-/// TS_INDEX_BINARY: write the served index in the binary container instead of raw JSON.
-/// Reading is unconditional and sniffed, so this flag only ever controls what is WRITTEN, and an
-/// index written either way loads in either setting.
 /// Does this look like a served index, in either of the two formats a reader may be handed?
 ///
 /// A JSON index starts with `{`; a container starts with its magic. Callers that only need to
@@ -2001,6 +1998,11 @@ pub(crate) fn bytes_look_like_served_index(bytes: &[u8]) -> bool {
     bytes.first() == Some(&b'{') || bytes.starts_with(INDEX_CONTAINER_MAGIC)
 }
 
+/// TS_INDEX_BINARY: write the served index in the binary container instead of raw JSON.
+///
+/// Reading is unconditional and sniffed, so this flag only ever controls what is WRITTEN, and an
+/// index written either way loads in either setting.
+///
 /// ON by default; `TS_INDEX_BINARY=0` is the escape hatch.
 ///
 /// The container was built, measured and then left switched off, so every store written since has


### PR DESCRIPTION
A `///` block documents the item below it, and only one item is below any of them. Two blocks with
nothing between become **one** block on whatever follows — so a flag's own explanation ends up filed
under a neighbour's name, and the function that reads the flag is left with nothing, or with a
sentence that starts mid-thought.

| flag | its doc was attached to | its reader was left with |
|---|---|---|
| `TS_INDEX_BINARY` | `bytes_look_like_served_index`, which does not read it | `index_binary_container_enabled`, opening "ON by default" — a sentence with no subject |
| `TS_WAL_RESIDENT_PAGES` | `RESIDENT_SWEEPS`, a counter whose own two-line doc was the tail of that same block | `wal_resident_page_limit` — nothing at all |

Both move onto the function that reads the flag. `RESIDENT_SWEEPS` keeps the two lines that were
always about it.

### Why the existing guard misses these, and why I did not widen it

The guard added for this class looks for a line **inside** a doc run that opens the way a block opens
— a flag name or a tag. Here the flag name is the **first** line and the second subject opens in
ordinary prose, which is the half a matcher cannot tell from a wrapped sentence.

I tried the obvious inversion — *a block that opens by naming a flag must sit on something that reads
that flag* — and did not ship it. Across 19 such blocks it reported two, and **both were wrong**:

- one function is *named* for its flag and reads it through a helper
- the other block is long enough that the item detection landed on the wrong line

It also **missed the `TS_INDEX_BINARY` case it was written for**, because `Some(&b'{')` puts a brace
inside a byte literal and the brace counter walked past the end of the function.

A check with a false-positive rate of two-in-two and a known blind spot is not a guard. These two
were found by reading.

`cargo check --all-targets` clean · 35 flag guards pass · generated inventory unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
