### PR TITLE
Have the configuration warnings name the control, not the variable

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1631,25 +1631,29 @@ def _model_config_snapshot() -> Json:
     deterministic = {"", "deterministic", "rules", "local"}
     if extraction_provider in deterministic:
         warnings.append(
-            "extraction_provider is deterministic: no LLM is called, so ingest stores only what the "
-            "local rules extract. Set MATRIXARK_EXTRACTION_PROVIDER=openai_compatible with "
-            "MATRIXARK_EXTRACTION_BASE_URL/_MODEL/_API_KEY_ENV to enable model extraction."
+            "Extraction provider is deterministic: no model is called, so ingest stores only "
+            "what the local rules extract. Set Extraction provider to openai_compatible, then fill "
+            "in Extraction base URL, Extraction model and Extraction API key below."
         )
     elif not extraction["api_key_configured"]:
         warnings.append(
-            "extraction_provider is " + repr(extraction_provider) + " but " + extraction_key_env
-            + " is empty: extraction calls will fail and fall back to the deterministic path."
+            "Extraction API key is empty and Extraction provider is "
+            + repr(extraction_provider) + ": extraction calls will fail and fall back to the "
+            "deterministic path. The key goes into " + extraction_key_env + ", which is what "
+            "Extraction key variable names."
         )
     if embedding_provider in deterministic:
         warnings.append(
-            "embedding_provider is deterministic: retrieval uses hash vectors, not semantic "
-            "embeddings. Set MATRIXARK_EMBEDDING_PROVIDER and MATRIXARK_REQUIRE_MODEL_EMBEDDINGS=1."
+            "Embedding provider is deterministic: retrieval uses hash vectors, not semantic "
+            "embeddings. Set Embedding provider to the encoder you run, and turn on Fail instead "
+            "of falling back so an unreachable one is not answered with hash vectors."
         )
     else:
         if not require_model_embeddings:
             warnings.append(
-                "MATRIXARK_REQUIRE_MODEL_EMBEDDINGS is not set: if the encoder becomes unreachable "
-                "the gateway falls back to hash vectors instead of failing the request."
+                "Fail instead of falling back is off: if the encoder becomes unreachable the "
+                "gateway answers with hash vectors instead of failing the request, and retrieval "
+                "looks healthy while it stops being semantic."
             )
         # Two configuration mistakes silently degrade an OpenAI-compatible encoder to hash vectors,
         # and neither is visible from the outside: the request 200s and retrieval still returns
@@ -1657,15 +1661,16 @@ def _model_config_snapshot() -> Json:
         api_base = embedding["api_base"]
         if api_base and not api_base.rstrip("/").endswith("/v1"):
             warnings.append(
-                "MATRIXARK_EMBEDDING_API_BASE (" + api_base + ") does not end in /v1: the endpoint "
-                "is built as <base>/embeddings, so an OpenAI-compatible encoder serving "
+                "Embedding base URL (" + api_base + ") does not end in /v1: the endpoint is "
+                "built as <base>/embeddings, so an OpenAI-compatible encoder serving "
                 "/v1/embeddings is never reached and every vector is a hash fallback."
             )
         if not embedding["api_key_configured"]:
             warnings.append(
-                "embedding key env " + embedding_key_env + " is empty: the embedding call is skipped "
-                "before it is attempted, even for a local encoder that needs no auth. Set it to any "
-                "non-empty placeholder for a local endpoint."
+                "Embedding API key is empty: the embedding call is skipped before it is "
+                "attempted, even for a local encoder that needs no auth, so set it to any "
+                "non-empty placeholder for a local endpoint. The key goes into "
+                + embedding_key_env + ", which is what Embedding key variable names."
             )
 
     # Both key controls can name the SAME variable -- they both default to OPENAI_API_KEY -- and the

--- a/tools/test_matrixark_gateway_admin_config.py
+++ b/tools/test_matrixark_gateway_admin_config.py
@@ -39,8 +39,10 @@ class ModelConfigSnapshotTest(unittest.TestCase):
         self.assertEqual(snapshot["extraction"]["provider"], "deterministic")
         self.assertEqual(snapshot["embedding"]["provider"], "deterministic")
         joined = " ".join(snapshot["warnings"])
-        self.assertIn("extraction_provider is deterministic", joined)
-        self.assertIn("embedding_provider is deterministic", joined)
+        # Named as the customer sees them on the page: these are the labels of the two controls,
+        # not the provider fields underneath.
+        self.assertIn("Extraction provider is deterministic", joined)
+        self.assertIn("Embedding provider is deterministic", joined)
 
     def test_key_value_is_never_included_only_its_env_var_name(self) -> None:
         secret = "sk-this-value-must-never-appear"
@@ -100,12 +102,15 @@ class ModelConfigSnapshotTest(unittest.TestCase):
         os.environ["MATRIXARK_EXTRACTION_API_KEY_ENV"] = "DEEPSEEK_API_KEY"
         os.environ.pop("DEEPSEEK_API_KEY", None)
         joined = " ".join(gateway._model_config_snapshot()["warnings"])
-        self.assertIn("DEEPSEEK_API_KEY is empty", joined)
+        # The control, because two of them write this variable and the variable alone does not say
+        # which key is missing; and the variable too, because that is what an API reader sees.
+        self.assertIn("Extraction API key is empty", joined)
+        self.assertIn("DEEPSEEK_API_KEY", joined)
 
     def test_missing_require_model_embeddings_is_called_out(self) -> None:
         os.environ["MATRIXARK_EMBEDDING_PROVIDER"] = "openai_compatible"
         joined = " ".join(gateway._model_config_snapshot()["warnings"])
-        self.assertIn("MATRIXARK_REQUIRE_MODEL_EMBEDDINGS is not set", joined)
+        self.assertIn("Fail instead of falling back is off", joined)
 
 
 class SingleWriterGuardTest(unittest.TestCase):

--- a/tools/test_matrixark_the_warnings_name_the_control.py
+++ b/tools/test_matrixark_the_warnings_name_the_control.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A warning names the control, not the environment variable behind it.
+
+Every one of these is rendered on the Setup page, inches from a control for the thing it names, and
+each told the reader to go and set an environment variable::
+
+    Set MATRIXARK_EXTRACTION_PROVIDER=openai_compatible with
+    MATRIXARK_EXTRACTION_BASE_URL/_MODEL/_API_KEY_ENV to enable model extraction.
+
+One of them could not be acted on at all. ``OPENAI_API_KEY is empty`` names a variable **two**
+controls write -- Extraction API key and Embedding API key -- so it does not say which one to fill
+in. All 103 labels are distinct, so naming the control always is.
+
+The rule below is the general one, because the specific wordings are what drifted: **a warning that
+mentions a variable the portal has a control for must name that control.** Where there is no control
+it may name the variable, and must -- ``MATRIXARK_REQUIRE_AUTH`` and ``MATRIXARK_ACCESS_MODE`` have
+none, so the anonymous-access warning names them and that is the only actionable thing it can say.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+import matrixark_gateway_config as cfg  # noqa: E402
+import matrixark_v1_gateway as gw  # noqa: E402
+
+VARIABLE = re.compile(r"\b(MATRIXARK_[A-Z0-9_]+|OPENAI_API_KEY|DEEPSEEK_API_KEY)\b")
+
+# Everything the portal offers a control for, and what that control is called.
+CONTROLS: dict = {}
+for _setting in cfg.SETTINGS:
+    _name = cfg._env_name(_setting, {})
+    if _name:
+        CONTROLS.setdefault(_name, []).append(_setting.label)
+
+KNOBS = ("MATRIXARK_UNDERSTANDING_PROVIDER", "MATRIXARK_EXTRACTION_PROVIDER",
+         "MATRIXARK_EXTRACTION_BASE_URL", "MATRIXARK_EXTRACTION_API_KEY_ENV",
+         "MATRIXARK_EMBEDDING_PROVIDER", "MATRIXARK_EMBEDDING_API_BASE",
+         "MATRIXARK_EMBEDDING_API_KEY_ENV", "MATRIXARK_REQUIRE_MODEL_EMBEDDINGS",
+         "OPENAI_API_KEY", "DEEPSEEK_API_KEY", "MATRIXARK_EMBED_BASE_URL")
+
+# Configurations chosen to raise as many different warnings as possible.
+SHAPES = (
+    {},
+    {"MATRIXARK_UNDERSTANDING_PROVIDER": "openai_compatible",
+     "MATRIXARK_EMBEDDING_PROVIDER": "openai_compatible",
+     "MATRIXARK_EMBEDDING_API_BASE": "https://api.openai.com"},
+    {"MATRIXARK_UNDERSTANDING_PROVIDER": "openai_compatible",
+     "MATRIXARK_EXTRACTION_BASE_URL": "https://api.deepseek.com/v1",
+     "MATRIXARK_EMBEDDING_PROVIDER": "openai_compatible",
+     "MATRIXARK_EMBEDDING_API_BASE": "https://api.openai.com/v1",
+     "MATRIXARK_REQUIRE_MODEL_EMBEDDINGS": "1",
+     "OPENAI_API_KEY": "sk-something"},
+)
+
+
+class _Configured(unittest.TestCase):
+
+    def setUp(self) -> None:
+        previous = {name: os.environ.get(name) for name in KNOBS}
+
+        def restore() -> None:
+            for name, value in previous.items():
+                if value is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = value
+
+        self.addCleanup(restore)
+
+    def every_warning(self):
+        seen = []
+        for shape in SHAPES:
+            for name in KNOBS:
+                os.environ.pop(name, None)
+            for name, value in shape.items():
+                os.environ[name] = value
+            for warning in gw._model_config_snapshot().get("warnings") or []:
+                if warning not in seen:
+                    seen.append(warning)
+        return seen
+
+
+class AWarningNamesTheControlTest(_Configured):
+
+    def test_there_are_warnings_to_check(self) -> None:
+        """The rule below is a loop; over an empty list it proves nothing."""
+        self.assertGreaterEqual(len(self.every_warning()), 5)
+
+    def test_the_rule_has_something_to_bite_on(self) -> None:
+        """At least one warning must mention a variable that HAS a control, or the check is inert."""
+        mentions = [w for w in self.every_warning()
+                    if any(v in CONTROLS for v in VARIABLE.findall(w))]
+        self.assertTrue(mentions, "no warning names a variable the portal controls")
+
+    def test_every_variable_with_a_control_is_named_by_its_control(self) -> None:
+        for warning in self.every_warning():
+            for variable in sorted(set(VARIABLE.findall(warning))):
+                labels = CONTROLS.get(variable)
+                if not labels:
+                    continue
+                with self.subTest(variable=variable):
+                    self.assertTrue(
+                        any(label in warning for label in labels),
+                        "this warning names %s and none of its controls (%s):\n  %s"
+                        % (variable, ", ".join(labels), warning))
+
+    def test_no_warning_tells_a_customer_to_set_a_variable_it_has_a_control_for(self) -> None:
+        """The specific phrasing that started this: an instruction to go to a shell."""
+        for warning in self.every_warning():
+            for variable in sorted(set(VARIABLE.findall(warning))):
+                if variable not in CONTROLS:
+                    continue
+                with self.subTest(variable=variable):
+                    self.assertNotRegex(
+                        warning, r"[Ss]et %s[= ]" % re.escape(variable),
+                        "this warning tells a customer to set %s, which is a control:\n  %s"
+                        % (variable, warning))
+
+
+class AVariableWithNoControlIsStillNamedTest(_Configured):
+    """The other half. Dropping the variable where there is nothing to point at would leave the
+    reader with no way to act at all."""
+
+    def test_the_anonymous_access_warning_still_names_its_variables(self) -> None:
+        self.assertNotIn("MATRIXARK_REQUIRE_AUTH", CONTROLS)
+        self.assertNotIn("MATRIXARK_ACCESS_MODE", CONTROLS)
+        previous = dict(gw._AUTH_POSTURE)
+
+        def restore() -> None:
+            gw._AUTH_POSTURE.clear()
+            gw._AUTH_POSTURE.update(previous)
+
+        self.addCleanup(restore)
+        gw._AUTH_POSTURE["require_auth"] = False
+        said = [w for w in gw._model_config_snapshot()["warnings"] if "anonymous" in w]
+        self.assertEqual(1, len(said), said)
+        self.assertIn("MATRIXARK_REQUIRE_AUTH=1", said[0])
+        self.assertIn("MATRIXARK_ACCESS_MODE=enforced", said[0])
+
+
+class TheLabelsAreWorthNamingTest(unittest.TestCase):
+
+    def test_every_label_is_distinct(self) -> None:
+        """Naming a control only works if the name picks one out. If two ever share a label, a
+        warning that names it becomes as ambiguous as the variable it replaced."""
+        labels = [s.label for s in cfg.SETTINGS]
+        self.assertEqual(len(labels), len(set(labels)),
+                         sorted({l for l in labels if labels.count(l) > 1}))
+
+    def test_the_ambiguous_variable_is_why_this_matters(self) -> None:
+        """OPENAI_API_KEY is written by two controls, so naming the variable cannot say which key
+        to fill in. This pins the reason rather than leaving it in a commit message."""
+        self.assertEqual(2, len(CONTROLS.get("OPENAI_API_KEY", [])), CONTROLS.get("OPENAI_API_KEY"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Every configuration warning is rendered on the Setup page, inches from a control for the thing it
names — and each told the reader to go and set an environment variable instead:

```
Set MATRIXARK_EXTRACTION_PROVIDER=openai_compatible with
MATRIXARK_EXTRACTION_BASE_URL/_MODEL/_API_KEY_ENV to enable model extraction.
```

One of them could not be acted on at all. `OPENAI_API_KEY is empty` names a variable that **two**
controls write — Extraction API key and Embedding API key — so it does not say which key to fill in.

All 103 labels are distinct, so naming the control always is:

```
Extraction provider is deterministic: no model is called, so ingest stores only what the local
rules extract. Set Extraction provider to openai_compatible, then fill in Extraction base URL,
Extraction model and Extraction API key below.

Extraction API key is empty and Extraction provider is 'openai_compatible': extraction calls will
fail and fall back to the deterministic path. The key goes into OPENAI_API_KEY, which is what
Extraction key variable names.

Fail instead of falling back is off: if the encoder becomes unreachable the gateway answers with
hash vectors instead of failing the request, and retrieval looks healthy while it stops being
semantic.
```

The variable is kept where it still tells the reader something — which variable holds the key —
because the same list is served over `/v1/admin/config` to readers with no page in front of them.

### The rule, not the wordings

The specific phrasings are what drifted, so the guard states the general form: **a warning that
mentions a variable the portal has a control for must name that control.** Where there is no
control it may name the variable, and must — `MATRIXARK_REQUIRE_AUTH` and `MATRIXARK_ACCESS_MODE`
have none, so the anonymous-access warning names them, and that is the only actionable thing it can
say.

```
extraction warning back to variable names   -> FAIL every variable with a control is named by it
embedding warning back to variable names    -> FAIL x3
key warning names the variable only         -> FAIL every variable with a control is named by it
fallback warning back to the variable name  -> FAIL every variable with a control is named by it
auth warning drops its variables            -> FAIL the anonymous-access warning still names them
```

That last mutation is the one that proves the rule does not over-apply: dropping a variable that has
nothing to point at would leave the reader with no way to act.

Two floors: there must be warnings to check, and at least one must mention a variable that *has* a
control, or the loop is inert. A third test pins why this matters — that `OPENAI_API_KEY` is written
by exactly two controls — so the reason lives beside the rule rather than in a commit message.

### Sequencing

#922 adds a seventh warning and was still open, so its wording is fixed **on that branch** rather
than left to redden `main` whichever order the two land in.

7 tests. Neighbours: v1_gateway 97, gateway_portal 60, live_strip 38, encoder_conflict 27,
dashboards 20, gateway_metrics 11, checklist 11, gateway-is-open 9, and all portal-named suites
together 166 — green.
