### PR TITLE
Have both encoder controls say the encoder server needs restarting

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -215,6 +215,17 @@ GROUPS: Dict[str, Json] = {
 # vectors already in the store stop being usable the moment the encoder changes. The engine's own
 # MIGRATION note calls the result "a quiet degradation rather than an error" -- which is exactly why
 # it belongs beside the control rather than in a comment somebody has to go and find.
+# The gateway re-reads both encoder fields on the next call, so `live` is true of it. A co-located
+# encoder server does not: `context_minilm_embed_server` binds MATRIXARK_EMBEDDING_MODEL and
+# MATRIXARK_EMBEDDING_MODEL_PATH at ITS import, and keeps whatever it started with. Said once and
+# shared by both controls, because saying it twice is how one of them came to say it and the other
+# not to.
+ENCODER_SERVER_NOTE = (
+    " The gateway picks this up on the next call, but a co-located encoder server reads it at ITS"
+    " startup — restart that too if you are running one."
+)
+
+
 ENCODER_CHANGE_NOTE = (
     " Changing this on a store that already holds documents leaves every vector in it made by the "
     "previous encoder: they are declined as a different model, so retrieval falls back to lexical "
@@ -310,13 +321,12 @@ SETTINGS: List[Setting] = [
             "Must end in /v1: the request is built as <base>/embeddings."),
     Setting("embedding.model", "embedding", "MATRIXARK_EMBEDDING_MODEL",
             "Embedding model", "str", "", "live",
-            "Encoder model name, e.g. paraphrase-multilingual-MiniLM-L12-v2. The gateway picks "
-            "this up on the next call, but a co-located encoder server reads it at ITS startup — "
-            "restart that too if you are running one." + ENCODER_CHANGE_NOTE),
+            "Encoder model name, e.g. paraphrase-multilingual-MiniLM-L12-v2."
+            + ENCODER_SERVER_NOTE + ENCODER_CHANGE_NOTE),
     Setting("embedding.model_path", "embedding", "MATRIXARK_EMBEDDING_MODEL_PATH",
             "Embedding model path", "str", "", "live",
             "Local path to a downloaded encoder; wins over the model name when set."
-            + ENCODER_CHANGE_NOTE),
+            + ENCODER_SERVER_NOTE + ENCODER_CHANGE_NOTE),
     Setting("embedding.api_key_env", "embedding", "MATRIXARK_EMBEDDING_API_KEY_ENV",
             "Embedding key variable", "str", "OPENAI_API_KEY", "live",
             "Name of the environment variable holding the encoder key."),

--- a/tools/test_matrixark_both_encoder_controls_name_the_server.py
+++ b/tools/test_matrixark_both_encoder_controls_name_the_server.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Every control the co-located encoder server reads says the server needs restarting too.
+
+``applies: live`` is true of the gateway, which re-reads both encoder fields on the next call. A
+co-located encoder server does not: ``context_minilm_embed_server`` binds
+``MATRIXARK_EMBEDDING_MODEL`` and ``MATRIXARK_EMBEDDING_MODEL_PATH`` at **its** import and keeps
+whatever it started with. Only the first control said so.
+
+The path is the one that matters more, because it *wins over* the model name: a customer who sets it
+and restarts nothing is running an encoder chosen by a field the portal no longer shows as the
+effective one, and nothing anywhere says why.
+
+**The rule is derived, not listed.** The set of variables comes from parsing the server's own
+module-scope reads, so a third one starts failing this the day it is added rather than the day
+somebody notices. Listing the two by hand would have passed on the same day this was written and
+told nobody anything afterwards.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+import matrixark_gateway_config as cfg  # noqa: E402
+
+SERVER = "context_minilm_embed_server.py"
+
+
+def bound_at_import(filename: str) -> set:
+    """Variables the module reads in a top-level assignment: bound once, when it starts."""
+    with open(os.path.join(TOOLS, filename), encoding="utf-8") as handle:
+        tree = ast.parse(handle.read(), filename=filename)
+    found = set()
+    for node in tree.body:                        # top level only
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        for sub in ast.walk(node):
+            if not isinstance(sub, ast.Call) or not sub.args:
+                continue
+            target = sub.func
+            reads_env = ((isinstance(target, ast.Attribute) and target.attr in {"get", "getenv"})
+                         or (isinstance(target, ast.Name) and target.id == "getenv"))
+            first = sub.args[0]
+            if reads_env and isinstance(first, ast.Constant) and isinstance(first.value, str):
+                found.add(first.value)
+    return found
+
+
+def controls_by_variable() -> dict:
+    out: dict = {}
+    for setting in cfg.SETTINGS:
+        name = cfg._env_name(setting, {})
+        if name:
+            out.setdefault(name, []).append(setting)
+    return out
+
+
+class TheServerIsStillReadThisWayTest(unittest.TestCase):
+    """Floors. The rule below is a loop over what this finds."""
+
+    def test_the_server_is_there(self) -> None:
+        self.assertTrue(os.path.exists(os.path.join(TOOLS, SERVER)), SERVER)
+
+    def test_it_binds_something_at_import(self) -> None:
+        self.assertTrue(bound_at_import(SERVER))
+
+    def test_at_least_one_of_them_is_a_portal_control(self) -> None:
+        """If none were, the rule would be inert and would pass forever."""
+        shared = bound_at_import(SERVER) & set(controls_by_variable())
+        self.assertTrue(shared, "the encoder server reads nothing the portal offers")
+
+
+class EveryControlItReadsSaysSoTest(unittest.TestCase):
+
+    def test_each_one_names_the_server(self) -> None:
+        controls = controls_by_variable()
+        for variable in sorted(bound_at_import(SERVER) & set(controls)):
+            for setting in controls[variable]:
+                with self.subTest(setting=setting.key, variable=variable):
+                    self.assertIn("co-located encoder server", setting.help or "",
+                                  "%s is read by %s at its import and does not say so"
+                                  % (setting.key, SERVER))
+
+    def test_they_say_it_the_same_way(self) -> None:
+        """One sentence, shared. Two copies is how one of them came to carry it and the other not."""
+        controls = controls_by_variable()
+        carrying = [s for v in bound_at_import(SERVER) & set(controls) for s in controls[v]]
+        self.assertGreaterEqual(len(carrying), 2)
+        for setting in carrying:
+            with self.subTest(setting=setting.key):
+                self.assertIn(cfg.ENCODER_SERVER_NOTE, setting.help or "")
+
+    def test_a_control_it_does_not_read_is_left_alone(self) -> None:
+        """A note on every control is a note nobody reads."""
+        controls = controls_by_variable()
+        read = bound_at_import(SERVER)
+        for setting in cfg.SETTINGS:
+            if cfg._env_name(setting, {}) in read:
+                continue
+            with self.subTest(setting=setting.key):
+                self.assertNotIn("co-located encoder server", setting.help or "")
+
+    def test_the_gateway_half_is_still_true(self) -> None:
+        """`live` is not wrong -- it is true of the gateway, which is what the note explains. If
+        these ever became `restart`, the note would be saying something the label already says."""
+        controls = controls_by_variable()
+        for variable in sorted(bound_at_import(SERVER) & set(controls)):
+            for setting in controls[variable]:
+                with self.subTest(setting=setting.key):
+                    self.assertEqual("live", setting.applies)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`context_minilm_embed_server` binds exactly two variables at **its** import —
`MATRIXARK_EMBEDDING_MODEL` and `MATRIXARK_EMBEDDING_MODEL_PATH` — and keeps whatever it started
with. Both are `live` controls, which is true of the *gateway*: it re-reads them on the next call.
Only one of them said the encoder server does not.

```
embedding.model       live   "…a co-located encoder server reads it at ITS startup — restart
                              that too if you are running one."
embedding.model_path  live   (nothing)
```

The path is the one that matters more, because it **wins over the model name**. A customer who sets
it and restarts nothing is running an encoder chosen by a field the portal no longer shows as the
effective one, and nothing anywhere says why.

The sentence is now written once and shared by both, because two copies is exactly how one came to
carry it and the other not to. `embedding.model`'s text is unchanged — it just moved into the
constant.

### The rule is derived, not listed

The set of variables comes from **parsing the server's own module-scope reads**, so a third one
starts failing this the day it is added rather than the day somebody notices. A hand-written list of
the two would have passed on the day it was written and told nobody anything afterwards.

```
the path control loses the note (the state before this)  -> FAIL each one names the server (+1)
the model control loses the note                         -> FAIL each one names the server (+1)
the two say it in their own words again                  -> FAIL they say it the same way
the note lands on a control the server never reads       -> FAIL one it does not read is left alone
the controls are relabelled restart                      -> FAIL the gateway half is still true
the server stops reading the path (both occurrences)     -> FAIL x2, the rule follows the source
```

That last one is the point of deriving it: change what the server reads and the rule moves with it.

Three floors keep the loop honest — the server exists, it binds something at import, and at least
one of those is a portal control. Without the third, a rename in the server would leave the rule
iterating over an empty set and passing forever.

7 tests. Neighbours: v1_gateway 97, gateway_portal 60, live_strip 38, gateway_config 28,
encoder_conflict 27, config_audit 14, admin_config 11, encoder-controls 11, and all portal-named
suites together 166 — green.
