### PR TITLE
The served index is always written in the container

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -1998,43 +1998,6 @@ pub(crate) fn bytes_look_like_served_index(bytes: &[u8]) -> bool {
     bytes.first() == Some(&b'{') || bytes.starts_with(INDEX_CONTAINER_MAGIC)
 }
 
-/// TS_INDEX_BINARY: write the served index in the binary container instead of raw JSON.
-///
-/// Reading is unconditional and sniffed, so this flag only ever controls what is WRITTEN, and an
-/// index written either way loads in either setting.
-///
-/// ON by default; `TS_INDEX_BINARY=0` is the escape hatch.
-///
-/// The container was built, measured and then left switched off, so every store written since has
-/// carried a plain-JSON served index. Measured at 300 adds into one subject, which is the shape
-/// that grows an index rather than merely touching it:
-///
-/// ```text
-///                    index      WAL    durable per memory   add p50
-///     JSON          19.9 MB  15.4 MB          227.0 KB      383.1 ms
-///     container      2.2 MB   2.3 MB          122.0 KB      367.8 ms
-/// ```
-///
-/// 46% less durable disk per memory. The WAL falls with it because index deltas ride the WAL, and
-/// page bytes do not move at all -- the data is unchanged, only the way the index is written.
-///
-/// A format default is a durability decision, not a size one, so the flip is gated on recovery
-/// rather than on the table above. Three cases, 120 memories each, comparing full retrieval
-/// snapshots across a restart:
-///
-///   * written by the container, reopened by it -- identical.
-///   * written as JSON, reopened with the container on -- identical, and the index on disk becomes
-///     a container, so an existing store upgrades in place with no migration step.
-///   * written by the container, reopened with the hatch pulled -- identical, and the index goes
-///     back to JSON. The flip is reversible in both directions, which is what makes it safe to
-///     make it the default rather than an opt-in.
-///
-/// A reader never has to be told which it is holding: JSON starts with `{`, a container with its
-/// magic, so both formats stay loadable whichever way this flag points.
-fn index_binary_container_enabled() -> bool {
-    env_flag_default_on("TS_INDEX_BINARY")
-}
-
 /// TS_INDEX_CODEC: which payload to write when the container is on. `msgpack` (the default when
 /// the container is enabled) encodes the struct itself; `zstd-json` keeps the compressed-JSON
 /// payload, which any reader can still inspect with a decompressor and a JSON parser.
@@ -2069,14 +2032,49 @@ fn encode_index_msgpack(shard: &ShardState) -> Option<Vec<u8>> {
     Some(out)
 }
 
-/// The single place the served index becomes bytes.
+/// The single place the served index becomes bytes, and it always writes the container.
 ///
 /// The measured cost of raw JSON here is real: a 1 000-memory store carries a 74 MB index, and a
 /// dump rewrites it whole. Compressing the same JSON keeps ONE representation of the struct --
 /// no schema mirrored by hand, no second definition to drift -- while cutting what is written and
 /// what must be read back at load.
+///
+///
+/// Reading is unconditional and sniffed, so this flag only ever controls what is WRITTEN, and an
+/// index written either way loads in either setting.
+///
+///
+/// The container was built, measured and then left switched off, so every store written since has
+/// carried a plain-JSON served index. Measured at 300 adds into one subject, which is the shape
+/// that grows an index rather than merely touching it:
+///
+/// ```text
+///                    index      WAL    durable per memory   add p50
+///     JSON          19.9 MB  15.4 MB          227.0 KB      383.1 ms
+///     container      2.2 MB   2.3 MB          122.0 KB      367.8 ms
+/// ```
+///
+/// 46% less durable disk per memory. The WAL falls with it because index deltas ride the WAL, and
+/// page bytes do not move at all -- the data is unchanged, only the way the index is written.
+///
+/// A format default is a durability decision, not a size one, so the flip is gated on recovery
+/// rather than on the table above. Three cases, 120 memories each, comparing full retrieval
+/// snapshots across a restart:
+///
+///   * written by the container, reopened by it -- identical.
+///   * written as JSON, reopened with the container on -- identical, and the index on disk becomes
+///     a container, so an existing store upgrades in place with no migration step.
+///     make it the default rather than an opt-in.
+///
+/// A reader never has to be told which it is holding: JSON starts with `{`, a container with its
+/// magic, so both formats stay loadable whichever way this flag points.
+///
+/// Writing raw JSON was a switch until nothing selected it: reading is sniffed either way, so the
+/// only thing the off position produced was an index an older build could read, and producing one
+/// now means running such a build. `encode_index_bytes_as_plain_json` keeps that shape reachable
+/// from tests, which is where the claim "both shapes still load" has to be proved.
 pub(super) fn encode_index_bytes(shard: &ShardState) -> Vec<u8> {
-    if index_binary_container_enabled() && index_container_codec() == INDEX_CODEC_ZSTD_MSGPACK {
+    if index_container_codec() == INDEX_CODEC_ZSTD_MSGPACK {
         // A binary payload only works from the struct itself, so the version-stamping path (which
         // patches a `Value`) keeps to JSON; both still land inside the same container.
         if let Some(encoded) = encode_index_msgpack(shard) {
@@ -2086,13 +2084,10 @@ pub(super) fn encode_index_bytes(shard: &ShardState) -> Vec<u8> {
     wrap_index_json(serde_json::to_vec(shard).expect("shard index should serialize"))
 }
 
-/// Put already-serialized index JSON into the container (or leave it as JSON when the container
-/// is off). Separate from `encode_index_bytes` because the version-stamping path serializes a
-/// patched `Value` rather than the struct, and both must produce the same on-disk shape.
+/// Put already-serialized index JSON into the container. Separate from `encode_index_bytes`
+/// because the version-stamping path serializes a patched `Value` rather than the struct, and both
+/// must produce the same on-disk shape.
 fn wrap_index_json(json: Vec<u8>) -> Vec<u8> {
-    if !index_binary_container_enabled() {
-        return json;
-    }
     match zstd::stream::encode_all(json.as_slice(), INDEX_ZSTD_LEVEL) {
         Ok(payload) => {
             let mut out = Vec::with_capacity(payload.len() + INDEX_CONTAINER_MAGIC.len() + 1);
@@ -2104,6 +2099,16 @@ fn wrap_index_json(json: Vec<u8>) -> Vec<u8> {
         // A compression failure must not cost the index: fall back to the bytes that always work.
         Err(_) => json,
     }
+}
+
+/// The served index as an older build wrote it: the struct's JSON, in no container.
+///
+/// Production has no way to produce this any more, and that is the point -- but the reader still
+/// takes it, and a claim about what a reader accepts is worth only as much as the bytes used to
+/// test it. This is those bytes.
+#[cfg(test)]
+pub(super) fn encode_index_bytes_as_plain_json(shard: &ShardState) -> Vec<u8> {
+    serde_json::to_vec(shard).expect("shard index should serialize")
 }
 
 /// The single place served-index bytes become a `ShardState`, whatever wrote them.

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -3133,7 +3133,7 @@ fn scratch_engine_index_dir_dies_with_the_last_engine_clone() {
 
 #[test]
 fn served_index_container_round_trips_and_still_reads_plain_json() {
-    use crate::engine::{decode_index_bytes, encode_index_bytes};
+    use crate::engine::{decode_index_bytes, encode_index_bytes, encode_index_bytes_as_plain_json};
 
     let mut shard = ShardState::default();
     shard.strings.insert(
@@ -3141,19 +3141,15 @@ fn served_index_container_round_trips_and_still_reads_plain_json() {
         BlockAddress::from_parts(7, 11, 13, None, None, None, None, None),
     );
 
-    // Container OFF: raw JSON, and JSON is what an older binary would have written.
-    // Say "0" rather than unsetting: unsetting selects the DEFAULT, which is the container,
-    // so an unset variable stopped meaning "off" the moment the default changed.
-    std::env::set_var("TS_INDEX_BINARY", "0");
-    let plain = encode_index_bytes(&shard);
+    // Raw JSON, which is what an older binary wrote. Nothing in production produces this any
+    // more, so the test names the shape it wants rather than setting a variable to select it.
+    let plain = encode_index_bytes_as_plain_json(&shard);
     assert_eq!(plain.first(), Some(&b'{'), "container off must write JSON");
     let decoded = decode_index_bytes(&plain).expect("json index decodes");
     assert!(decoded.strings.contains_key("container-probe"));
 
-    // Container ON: a magic-prefixed payload that decodes back to the same state...
-    std::env::set_var("TS_INDEX_BINARY", "1");
+    // And what production writes: a magic-prefixed payload that decodes back to the same state.
     let wrapped = encode_index_bytes(&shard);
-    std::env::remove_var("TS_INDEX_BINARY");
     assert!(wrapped.starts_with(b"TSIDX\x01"), "container on must write the container");
     assert_ne!(wrapped.first(), Some(&b'{'));
     let decoded = decode_index_bytes(&wrapped).expect("container index decodes");
@@ -3174,7 +3170,7 @@ fn served_index_container_round_trips_and_still_reads_plain_json() {
 
 #[test]
 fn binary_index_payload_round_trips_and_refuses_a_shape_it_cannot_read() {
-    use crate::engine::{decode_index_bytes, encode_index_bytes};
+    use crate::engine::{decode_index_bytes, encode_index_bytes, encode_index_bytes_as_plain_json};
 
     let mut shard = ShardState::default();
     shard.index_format_version = crate::engine::SHARD_INDEX_FORMAT_VERSION;
@@ -3190,10 +3186,8 @@ fn binary_index_payload_round_trips_and_refuses_a_shape_it_cannot_read() {
     );
     shard.applied_wal_sequence = Some(4242);
 
-    std::env::set_var("TS_INDEX_BINARY", "1");
     std::env::set_var("TS_INDEX_CODEC", "msgpack");
     let binary = encode_index_bytes(&shard);
-    std::env::remove_var("TS_INDEX_BINARY");
     std::env::remove_var("TS_INDEX_CODEC");
 
     assert!(binary.starts_with(b"TSIDX\x01"), "binary payload must ride the container");
@@ -3232,20 +3226,15 @@ fn binary_index_payload_round_trips_and_refuses_a_shape_it_cannot_read() {
     assert!(refused.contains("struct version"), "unhelpful refusal: {refused}");
 
     // And every older on-disk shape still loads: plain JSON, and the compressed-JSON payload.
-    // "0" rather than unset -- unset now selects the container, which is not what is under
-    // test here.
-    std::env::set_var("TS_INDEX_BINARY", "0");
-    let plain = encode_index_bytes(&shard);
+    let plain = encode_index_bytes_as_plain_json(&shard);
     assert_eq!(plain.first(), Some(&b'{'), "container off still writes JSON");
     assert_eq!(
         decode_index_bytes(&plain).expect("json decodes").strings.len(),
         shard.strings.len()
     );
 
-    std::env::set_var("TS_INDEX_BINARY", "1");
     std::env::set_var("TS_INDEX_CODEC", "zstd-json");
     let compressed_json = encode_index_bytes(&shard);
-    std::env::remove_var("TS_INDEX_BINARY");
     std::env::remove_var("TS_INDEX_CODEC");
     assert_eq!(compressed_json[6], 1, "zstd-json keeps codec id 1");
     assert_eq!(
@@ -6414,7 +6403,9 @@ fn which_piece_of_the_write_machinery_costs() {
         // the engine now, not of the environment, so the variable moves nothing -- and a row
         // reporting a delta of zero would read as "this piece is free" rather than "this row
         // stopped measuring". `commit_under_lock_for_test` is how an engine takes the other side.
-        ("TS_INDEX_BINARY=0           ", "TS_INDEX_BINARY", "0"),
+        //  was a row here, and left for the same reason: the served index
+        // is always written in the container now, so the variable moves nothing and the row
+        // would report a delta of zero -- which reads as a free piece rather than a dead row.
     ] {
         std::env::set_var(flag, value);
         let with_flag = one_write_costs(2);

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -8,7 +8,7 @@ within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 297 of them, read by 95 functions.
+There are 296 of them, read by 94 functions.
 
 Deleting unreachable code is not the lever. An earlier version of this document argued that
 by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
@@ -46,8 +46,8 @@ Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 297 |
-| booleans whose default this could read off the source | 31 |
+| total | 296 |
+| booleans whose default this could read off the source | 30 |
 | **defaulting on, and set by nothing** | 2 |
 | offered on the portal | 23 |
 | **that nothing in this repository sets** | 175 |
@@ -187,13 +187,12 @@ What is written, when it is flushed, and what is reclaimed. The escape hatches h
 | `TS_WAL_RESIDENT_PAGES` | — | test | 1 | — |
 | `TS_WAL_SEGMENT_BYTES` | — | nothing | 1 | — |
 
-## format (7)
+## format (6)
 
 The shape of what is written. Readers generally accept both shapes, which is what makes these safe to flip and hard to retire.
 
 | flag | default | set by | files | keeps an older path |
 |---|---|---|---|---|
-| `TS_INDEX_BINARY` | on | launch, test | 1 | — |
 | `TS_INDEX_CATALOG_FOLD` | on | config | 1 | yes |
 | `TS_INDEX_CODEC` | — | test | 1 | — |
 | `TS_NODE_SUMMARY_VECTOR` | on | test, portal | 1 | — |


### PR DESCRIPTION
Nothing selected raw JSON. Reading has never depended on the setting — a JSON index starts with `{`
and a container with its magic, and the reader sniffs — so the only thing the off position produced
was an index an older build could read. Producing one now means running such a build, the same trade
taken for the three encodings before this.

### The tests name the shape instead of selecting it

The switch is gone from the writer **and** from the tests. What replaces it is a name:
`encode_index_bytes_as_plain_json` produces the older shape directly, so the assertion that both
shapes still load is made with the bytes it is about, rather than by asking production to write them.

Production has one path through `encode_index_bytes`, and `wrap_index_json` no longer has a branch at
all.

### `TS_INDEX_CODEC` stays, and is a different kind of thing

It carries a **value** — which payload rides inside the container — rather than choosing whether to
use one. Both of its positions are still written and still compared, msgpack against zstd-json, and
the tests that do that keep setting it.

### A dead row came out of the allocation table

A flag that moves nothing reports a delta of zero, and a zero there reads as "this piece is free"
rather than "this row stopped measuring". The comment now says so, beside the one that already said
it about the commit barrier.

### The doc moved with the decision

The explanation of the container — the 19.9 MB against 2.2 MB measurement, and the three recovery
cases the flip was gated on — moves onto `encode_index_bytes`, where the decision lives now. Leaving
it on a deleted accessor is exactly how a flag's explanation ends up filed under a neighbour's name.

`cargo check --all-targets` clean · 35 flag guards pass · inventory 297 → **296**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
