### PR TITLE
The meta restates a path nothing reads

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -1714,7 +1714,7 @@ INLINE_VECTOR_OWNER_BY_REF_TYPE = {
 # Fields the owner record carries in its own right. They are stripped from `embedding_meta` when
 # they match the owner's, which they do for every writer today -- an embedding is addressed by the
 # owner's hash, so it inherits the owner's node and timestamp. Kept when they differ.
-_EMBEDDING_META_SAME_AS_OWNER = ("node_path", "updated_at_ms", "node_hash")
+_EMBEDDING_META_SAME_AS_OWNER = ("updated_at_ms", "node_hash")
 
 # `embedding_type` repeats the owner's record_type whenever the fold's owner map is identity, which
 # it is for chunks: skill_section -> skill_section, resource_chunk -> resource_chunk. It is NOT
@@ -1743,6 +1743,21 @@ _EMBEDDING_META_SKIP = (
     # -- 99,280 of 100,122 records -- inherits the RETIRED row's identity, and
     # `latest_value_record_key` prefers a stamped key over deriving one.
     "row_key",
+    # The owning record's own path, restated. It sat in _EMBEDDING_META_SAME_AS_OWNER, which drops a
+    # field only when the OWNER carries the same value -- and the two types that are 99.1% of a
+    # skill corpus carry `node_hash` and no `node_path`, so the comparison never ran and the path
+    # was written on every record. 54.9 B a row, one distinct value across the whole corpus,
+    # ~129 MB of durable bytes at 1,000 x 1 MB.
+    #
+    # Checked both ways, as the rest of this tuple was. A recording dict over every embedding_meta,
+    # driven through read_all and a retrieve, was asked for `node_path` 0 times across 4,326
+    # records while the positive control `model` was read 4,324 times; and no Python reader exists
+    # outside a comment, with the Rust `node_path` matches belonging to an unrelated Raft
+    # file-path helper.
+    #
+    # Only the copy INSIDE embedding_meta goes. The top-level `node_path` other record types carry
+    # is read in 614 places and is untouched -- the same split as `row_key` above.
+    "node_path",
     "storage_route",
     "storage_options",
     # The placement/storage half of the same routing blob, inherited the same way and read by

--- a/tools/test_matrixark_the_meta_does_not_restate_the_path.py
+++ b/tools/test_matrixark_the_meta_does_not_restate_the_path.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""`embedding_meta` must not restate the owning record's path.
+
+`node_path` sat in `_EMBEDDING_META_SAME_AS_OWNER`, which drops a field only when the OWNER carries
+the same value. The two record types that are 99.1% of a skill corpus carry `node_hash` and no
+`node_path`, so that comparison never ran and the path was written on every record -- 54.9 B a row,
+one distinct value across the whole corpus, about 129 MB of durable bytes at 1,000 x 1 MB.
+
+Nothing reads it. A recording dict over every `embedding_meta`, driven through `read_all` and a
+retrieve, was asked for `node_path` zero times across 4,326 records while `model` was read 4,324
+times; no Python reader exists outside a comment; and the `node_path` matches in the Rust crates
+belong to an unrelated Raft file-path helper.
+
+Every assertion here is paired with one that would fail if the meta were simply empty -- a test that
+"the field is absent" passes loudest when there is nothing to be absent from.
+"""
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools.matrixark_mcp_local_adapter import (
+    _EMBEDDING_META_SAME_AS_OWNER,
+    _EMBEDDING_META_SKIP,
+    MatrixArkLocalAdapter,
+    _LOCAL_READ_CACHE,
+    _LOCAL_READ_CACHE_LOCK,
+)
+
+SCOPE = {"tenant_id": "acme", "user_id": "dana", "session_id": "skills"}
+DOMINANT = ("skill_section", "resource_chunk")
+
+
+def _clear_process_read_cache() -> None:
+    with _LOCAL_READ_CACHE_LOCK:
+        _LOCAL_READ_CACHE.clear()
+
+
+def _skill_text(index: int, sections: int = 40) -> str:
+    out = ["# Runbook %d" % index, ""]
+    for section in range(sections):
+        out += ["## Step %d" % section, "",
+                "Check the queue depth for case %d step %d, then drain the backlog." % (index, section),
+                ""]
+    return "\n".join(out)
+
+
+class MetaDoesNotRestateThePathTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._dir.cleanup)
+        self.log = Path(self._dir.name) / "events.jsonl"
+        _clear_process_read_cache()
+        self.addCleanup(_clear_process_read_cache)
+
+    def _records(self, documents: int = 2):
+        for index in range(documents):
+            adapter = MatrixArkLocalAdapter(self.log)
+            adapter.ingest({
+                "kind": "skill", "scope": SCOPE, "text": _skill_text(index),
+                "metadata": {"raw_uri": "file:///s/doc-%d.md" % index, "title": "doc-%d" % index},
+            })
+            adapter.close(timeout_s=3600)
+        _clear_process_read_cache()
+        return MatrixArkLocalAdapter(self.log).read_all()
+
+    def test_the_meta_carries_no_node_path(self):
+        records = self._records()
+        metas = [r["embedding_meta"] for r in records if isinstance(r.get("embedding_meta"), dict)]
+
+        # Non-vacuity: there must BE metas, and they must still carry the field that is read.
+        self.assertTrue(metas, "no embedding_meta was written, so absence proves nothing")
+        self.assertTrue(all("model" in meta for meta in metas),
+                        "embedding_meta lost `model`, which the retrieve path reads")
+
+        carrying = [meta for meta in metas if "node_path" in meta]
+        self.assertEqual([], carrying,
+                         "%d embedding_meta dict(s) still restate the owner's node_path"
+                         % len(carrying))
+
+    def test_the_owner_still_has_no_node_path_to_compare_against(self):
+        """The reason the old rule could not drop it, pinned.
+
+        If a future change gives these record types their own `node_path`, the
+        `_EMBEDDING_META_SAME_AS_OWNER` rule would start firing and this removal would become
+        redundant rather than wrong -- but the premise should be stated, not assumed.
+        """
+        records = self._records()
+        dominant = [r for r in records if str(r.get("record_type") or "") in DOMINANT]
+        self.assertTrue(dominant, "no dominant records were written")
+        self.assertTrue(all("node_hash" in record for record in dominant),
+                        "the dominant records lost node_hash, so this test is measuring something else")
+        with_path = [r for r in dominant if "node_path" in r]
+        self.assertEqual([], with_path,
+                         "the owner now carries node_path; revisit whether the skip is still needed")
+
+    def test_the_skip_list_owns_it_and_the_match_rule_does_not(self):
+        """Where the field is dropped matters: the match rule could never reach it."""
+        self.assertIn("node_path", _EMBEDDING_META_SKIP)
+        self.assertNotIn("node_path", _EMBEDDING_META_SAME_AS_OWNER)
+        # The rule still has work to do for the fields the owner really does carry.
+        self.assertIn("node_hash", _EMBEDDING_META_SAME_AS_OWNER)
+        self.assertIn("updated_at_ms", _EMBEDDING_META_SAME_AS_OWNER)
+
+    def test_the_model_identity_fields_are_kept(self):
+        """`model` and `model_ref` scan just as clean and are deliberately NOT removed: a mis-set
+        model path falls back to a different vector dimension, and the model identity on an
+        embedding is what makes that detectable."""
+        self.assertNotIn("model", _EMBEDDING_META_SKIP)
+        self.assertNotIn("model_ref", _EMBEDDING_META_SKIP)
+        records = self._records()
+        metas = [r["embedding_meta"] for r in records if isinstance(r.get("embedding_meta"), dict)]
+        self.assertTrue(metas)
+        self.assertTrue(all("model" in meta for meta in metas))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`embedding_meta` restates the owning record's path on every record, and nothing reads it.

## What it costs

On a corpus of 1.00 MB skills, `embedding_meta` is 154 B a row and **every subfield in it holds one
distinct value**:

| subfield | B/row | distinct |
|---|---|---|
| `node_path` | 54.9 | 1 |
| `model_ref` | 52.0 | 1 |
| `model` | 39.0 | 1 |
| `dim` | 8.0 | 1 |

It is written out per record, unlike its neighbours: in a 4,438-record log, `storage_options`,
`storage_route` and `access_scope` appear 17, 38 and 4 times, and `embedding_meta` 4,384 times.

## Why it survived

`node_path` sat in `_EMBEDDING_META_SAME_AS_OWNER`, which drops a field only where it **matches the
owner's**. The two record types that are 99.1% of a skill corpus -- `skill_section` and
`resource_chunk` -- carry `node_hash` and no `node_path`, so the comparison never runs and the field
is kept by default. The rule was never wrong; it simply could not reach this field.

## Evidence it is unread, both sides

* **Runtime.** Every `embedding_meta` wrapped in a dict that records each key anyone looks up, driven
  through `read_all` and a retrieve: `node_path` asked for **0 times across 4,326 records**, while
  the positive control `model` was read **4,324 times**.
* **Source.** No Python reader outside a comment. The `node_path` matches in the Rust crates are an
  unrelated Raft file-path helper (`wal.node_path(shard_id, node_id) -> PathBuf`).

Only the copy inside `embedding_meta` is removed. The top-level `node_path` that other record types
carry is referenced in 614 places and is untouched -- the same split as `row_key`, where only the
top-level one is ever read.

## Measured

Three 1.00 MB skills, 6,554 records, same corpus through both arms:

```
embedding_meta     160.2 -> 103.2 B/row
durable per record 1,921 -> 1,864
at 2.35M records   4.51 -> 4.38 GB      (~130 MB)
```

Record count, record types and their distribution are identical. Retrieval answers are identical on
**5 of 5** queries, compared as the ordered list of section identities returned.

That comparison had to be built carefully: comparing the whole serialized retrieve result finds
**0 of 5 answers identical across two runs of the same tree**, because the payload carries timestamps
and recall markers. Section identities are stable (5 of 5 when asked twice on either arm), so they
are what the answer test compares.

## Kept deliberately

`model` and `model_ref` scan just as clean and are **not** removed. A mis-set model path falls back
to a different vector dimension, and the model identity on an embedding is what makes that
detectable.

## Tests

`test_matrixark_the_meta_does_not_restate_the_path.py`. Each absence assertion is paired with one
that fails if the meta were simply empty -- a test that a field is absent passes loudest when there
is nothing to be absent from. It also pins the premise (the owner has no `node_path` to compare
against) so that a future change giving these types their own path is noticed rather than silently
making this redundant.

Both mutations are caught: restoring `node_path` to the skip list's absence, and handing it back to
the match rule.
