### PR TITLE
Reading a record does not depend on the frame flag. Finding the tail does.

### DIFF
--- a/crates/temporalstore-rust/src/log_framing.rs
+++ b/crates/temporalstore-rust/src/log_framing.rs
@@ -79,9 +79,21 @@ pub(crate) const FRAME_MAGIC_V3: u8 = 0xB3;
 /// records where its last record is as it writes, which bounds even that; the descriptors for
 /// it exist in `storage_descriptor` and are not yet wired.)
 ///
-/// Off (`TS_WAL_BINARY_FRAME=0`) writes the delimited frame again. Reading never depends on this
-/// flag: which frame a record uses is a property of the record, so a log holding both -- which
-/// is what an upgrade leaves -- reads end to end either way.
+/// Off (`TS_WAL_BINARY_FRAME=0`) writes the delimited frame again.
+///
+/// DECODING a record never depends on this flag: which frame a record uses is a property of the
+/// record, and `next_frame` dispatches on its first bytes across all four shapes, so a log holding
+/// both -- which is what an upgrade leaves -- reads end to end either way.
+///
+/// Finding the TAIL does depend on it, and the doc here used to say otherwise.
+/// `last_wal_sequence_in` chooses its strategy from this flag rather than from the file: on, it
+/// takes the footer hint and walks forward; off, it searches BACKWARDS for the last newline, which
+/// is an assumption only a delimited log satisfies. A binary frame carries newlines freely inside
+/// its payload, so that search is not looking for a record boundary in a log written binary.
+///
+/// So the off position belongs to a log whose records are delimited. It is not a switch that can
+/// be thrown over an existing binary-framed log and it never was; what was wrong is the sentence
+/// that said it could be.
 pub(crate) fn binary_frame_enabled() -> bool {
     !matches!(
         std::env::var("TS_WAL_BINARY_FRAME")


### PR DESCRIPTION
`TS_WAL_BINARY_FRAME` documented itself as write-only:

> Reading never depends on this flag: which frame a record uses is a property of the record, so a log
> holding both — which is what an upgrade leaves — reads end to end either way.

**The first half is true and the second is not.**

Decoding a record really is shape-agnostic: `next_frame` dispatches on the first bytes across all
four framings, and the forward walk reads a log holding any mixture of them.

**Finding the tail takes its strategy from the flag rather than from the file.** With it on,
`last_wal_sequence_in` uses the footer hint and walks forward. With it off, it searches *backwards
for the last newline* — an assumption only a delimited log satisfies, because a binary frame carries
newlines freely inside its payload. A newline found in a length-framed log is not a record boundary.

So the off position belongs to a log whose records are delimited. It never was a switch that could be
thrown over an existing binary-framed log; the sentence saying it could be is what was wrong — and it
is the more dangerous half, because a guarantee about *reading* is exactly what someone would act on
before pulling a hatch on a store that matters.

### The scan is untouched, deliberately

Making it unconditional would be the tidier change, and I am not making it here. The backwards window
exists because `last_wal_sequence_in` sits on the **append path**, and it reads a tail rather than a
file. Sending a delimited log down the forward walk turns that into an O(file) scan per append — a
fix for a documentation defect should not carry a performance cliff for the very fleet the
documentation was wrong about.

`cargo check --all-targets` clean · 35 flag guards pass · nothing the code *does* has changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
