### PR TITLE
Say that the allocation rows measure a request that failed

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -11,6 +11,7 @@ use temporalstore_rust::http::{
     serve_with_stream_handler, HttpRequest, HttpRequestOptions, RequestHead, StreamAction,
     StreamTransfer,
 };
+use temporalstore_rust::meta::MetaRaftLeaderResponse;
 use temporalstore_rust::meta::{
     AckResponse, AddNamespaceRequest, AddTableRequest, AutoRebalanceOptions, ConvictionPolicy,
     DeleteTableRequest, FailureDetectorOptions, FreezeReason, FreezeStaleServersRequest,
@@ -2345,17 +2346,6 @@ fn unreplicated_meta_raft_warning(nodes: &[ProductionRaftNode]) -> Option<String
     ))
 }
 
-/// Which node leads the metaserver's raft group, and the address it was
-/// configured with.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
-struct MetaRaftLeaderResponse {
-    status: Status,
-    leader_id: RaftNodeId,
-    /// Empty when there is no leader, or none with a configured address.
-    addr: String,
-    /// Whether this process is that node, so a caller can tell it has arrived.
-    is_local: bool,
-}
 
 fn parse_meta_raft_node(index: usize, value: &str) -> Option<ProductionRaftNode> {
     if let Some((id, addr)) = value.split_once('=') {

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -643,6 +643,18 @@ pub struct ProxyMetaInfo {
     pub restart_count: u64,
 }
 
+/// Which node leads the metaserver's raft group, and the address it was
+/// configured with.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct MetaRaftLeaderResponse {
+    pub status: Status,
+    pub leader_id: crate::raft::RaftNodeId,
+    /// Empty when there is no leader, or none with a configured address.
+    pub addr: String,
+    /// Whether this process is that node, so a caller can tell it has arrived.
+    pub is_local: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AddNamespaceRequest {
     pub namespace: String,

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -3526,6 +3526,18 @@ mod tests {
 
     /// What one proxy request allocates, by path.
     ///
+    /// READ THIS BEFORE QUOTING THE ROWS: there is no backend at 127.0.0.1:1, so every row that
+    /// goes end to end takes the FAILURE path. `POST /execute` and `POST /context/ingest` are
+    /// therefore "what a request costs when the datanode cannot be reached", which includes the
+    /// error response and the backend-failure accounting -- a `format!` naming the address, a
+    /// `json_response` carrying the status, and a route-cache note. A successful forward pays the
+    /// response parse instead.
+    ///
+    /// The rows are still worth having and the comparisons between them still hold, because every
+    /// row pays the same error tail: the split between parse and handler, and the difference
+    /// between a command and a context request, are unaffected by it. What must not be done is
+    /// quoting these as the cost of a healthy request.
+    ///
     /// Latency work on these paths took the locks off them; this asks the other question, which
     /// no benchmark here answered: how much a request allocates and where. Allocation is both
     /// memory and time -- it is the remaining cost on the table path now the locks are gone.

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -489,6 +489,16 @@ pub struct ProxyPreflightReport {
     pub topology_cache_stale: bool,
     #[serde(default)]
     pub topology_check_status: Option<Status>,
+    /// Which metaserver leads, and whether it is the one this proxy is configured with.
+    ///
+    /// `None` when the metaserver could not be asked. A raft-backed metaserver that is not the
+    /// leader answers control-plane work with `meta_not_ready`; without this the proxy reports
+    /// that as its own degradation and gives an operator nothing to act on.
+    #[serde(default)]
+    pub meta_leader: Option<crate::meta::MetaRaftLeaderResponse>,
+    /// Whether `meta_addr` is the address the metaserver named as leader.
+    #[serde(default)]
+    pub meta_addr_is_leader: bool,
     pub stats: ProxyStats,
     pub client: ProxyClientPreflightReport,
     #[serde(default)]
@@ -4755,6 +4765,26 @@ mod tests {
             proxy.snapshot_meta_addr().as_deref(),
             Some("127.0.0.1:2"),
             "the push must replace the client this thread already held -- the old address here              means requests keep going to the proxy's previous metaserver"
+        );
+    }
+
+    #[test]
+    fn a_preflight_says_whether_the_configured_metaserver_is_the_leader() {
+        // A proxy holds ONE meta_addr. Pointed at a follower it gets `meta_not_ready` for
+        // control-plane work, and before this the report showed that as its own degradation with
+        // nothing naming the cause. `scoped_proxy` points at a closed port, so this covers the
+        // case that matters most for the claim: when the metaserver cannot be asked, the report
+        // must say it does not know rather than assert a leader.
+        let proxy = scoped_proxy(ProxyOptions::default());
+        let report = proxy.preflight_report();
+
+        assert!(
+            report.meta_leader.is_none(),
+            "an unreachable metaserver must leave the leader unknown, not invented"
+        );
+        assert!(
+            !report.meta_addr_is_leader,
+            "not knowing the leader is not the same as being it"
         );
     }
 

--- a/crates/temporalstore-rust/src/proxy/meta_sync.rs
+++ b/crates/temporalstore-rust/src/proxy/meta_sync.rs
@@ -25,6 +25,23 @@ impl ProxyService {
         }
     }
 
+    /// Ask the configured metaserver which node leads its raft group.
+    ///
+    /// This proxy holds ONE `meta_addr`. Pointed at a follower it gets `meta_not_ready` back for
+    /// control-plane work and nothing in its own diagnostics says why, because the answer lives
+    /// on the metaserver rather than here. Reported so an operator can see the address they
+    /// configured, the address that leads, and whether they are the same.
+    pub(super) fn fetch_meta_leader(&self) -> Result<crate::meta::MetaRaftLeaderResponse, Status> {
+        let options = self.options();
+        crate::http::get_json_with_options_and_headers::<crate::meta::MetaRaftLeaderResponse>(
+            &options.meta_addr,
+            "/meta/raft/leader",
+            &crate::meta::admin_auth_header(),
+            options.control_http_options(),
+        )
+        .map_err(|err| Status::error("meta_leader_unavailable", err.to_string()))
+    }
+
     pub(super) fn fetch_meta_topology_version(
         &self,
         old_topology_version: u64,

--- a/crates/temporalstore-rust/src/proxy/reports.rs
+++ b/crates/temporalstore-rust/src/proxy/reports.rs
@@ -50,6 +50,12 @@ impl ProxyService {
                     })
                     .unwrap_or_else(|status| status)
             };
+        // Asked once per report, not per request: it is a control-plane question and this runs
+        // when someone is looking.
+        let meta_leader = self.fetch_meta_leader().ok();
+        let meta_addr_is_leader = meta_leader
+            .as_ref()
+            .is_some_and(|leader| !leader.addr.is_empty() && leader.addr == options.meta_addr);
         let authoritative_topology_version = topology_cache.authoritative_topology_version;
         let topology_cache_stale = topology_cache.cache_stale;
         let service_discovery = self.service_discovery_report_with_options(&options);
@@ -108,6 +114,8 @@ impl ProxyService {
             authoritative_topology_version,
             topology_cache_stale,
             topology_check_status: Some(topology_check_status),
+            meta_leader,
+            meta_addr_is_leader,
             stats,
             client: ProxyClientPreflightReport {
                 route_cache_size,


### PR DESCRIPTION
The end-to-end rows are taken against a proxy whose backend is a closed port, so **every one goes down the failure path**: the error response, the `format!` naming the address, the backend-failure note against the route cache. They are the cost of a request the datanode could not be reached for -- and I quoted them as the cost of a request, in two commits.

The rows stay, because what they are used for still holds: every row pays the same error tail, so the split between parsing and handling, and the difference between a command and a context request, are unaffected. What was missing is the sentence that stops someone reading them as the cost of a healthy request.