### PR TITLE
Offer the two settings that decide most of what the store holds

### DIFF
--- a/crates/temporalstore-rust/src/wal_proto.rs
+++ b/crates/temporalstore-rust/src/wal_proto.rs
@@ -97,9 +97,19 @@ fn unescape_newlines(bytes: &[u8]) -> Result<Vec<u8>, String> {
 /// written across the flip reads end to end in either direction, and turning it off again is not
 /// a one-way door.
 pub(crate) fn binary_records_enabled() -> bool {
-    std::env::var("TS_WAL_BINARY_RECORDS")
-        .map(|value| !(value == "0" || value.eq_ignore_ascii_case("false")))
-        .unwrap_or(true)
+    // Spelled the way every other engine flag is spelled. This read used to accept only "0" and
+    // "false", so "off" and "no" -- which turn any of its neighbours off -- left protobuf on
+    // here. It also put the default somewhere no check could find it, which is why the portal
+    // could not offer this setting: an offered knob has to show a default the source can be
+    // asked for.
+    !matches!(
+        std::env::var("TS_WAL_BINARY_RECORDS")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "0" | "false" | "no" | "off"
+    )
 }
 /// The kinds common enough to be worth a code rather than a string on every item.
 ///

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -49,7 +49,7 @@ Anything else is blank, and a blank means go and look.
 | total | 296 |
 | booleans whose default this could read off the source | 30 |
 | **defaulting on, and set by nothing** | 2 |
-| offered on the portal | 23 |
+| offered on the portal | 25 |
 | **that nothing in this repository sets** | 175 |
 | documented as keeping an older path alive | 5 |
 | reaching more than two files | 15 |
@@ -173,8 +173,8 @@ What is written, when it is flushed, and what is reclaimed. The escape hatches h
 | `TS_INDEX_DUMP_WAL_GAP_BYTES` | — | portal | 1 | — |
 | `TS_META_RAFT_SNAPSHOT_CHECK_INTERVAL_MS` | — | nothing | 1 | — |
 | `TS_META_SCHEDULER_SNAPSHOT` | — | nothing | 1 | — |
-| `TS_WAL_BINARY_FRAME` | on | launch, test | 1 | — |
-| `TS_WAL_BINARY_RECORDS` | on | launch, test | 1 | — |
+| `TS_WAL_BINARY_FRAME` | on | launch, test, portal | 1 | — |
+| `TS_WAL_BINARY_RECORDS` | on | launch, test, portal | 1 | — |
 | `TS_WAL_COMMIT_DELAY_US` | — | config | 1 | — |
 | `TS_WAL_DATA_ONLY` | on | launch, test | 1 | — |
 | `TS_WAL_LEGACY_RECOVERY` | — | config, harness, script | 1 | yes |

--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -497,6 +497,24 @@ SETTINGS: List[Setting] = [
             "WAL growth before an index dump", "int", "1048576", "live",
             "How much undumped WAL growth triggers a background index dump. A dump writes the "
             "served index, so lowering this makes dumps more frequent and each recovery shorter."),
+    Setting("storage_engine.wal_binary_records", "storage_engine",
+            "TS_WAL_BINARY_RECORDS",
+            "Write log records as protobuf", "bool", "1", "restart",
+            "On, a write-ahead log record is protobuf rather than JSON. Reading never consults "
+            "this: a payload is decoded by what its first byte says it is, so a log written "
+            "across a change reads end to end and turning it back off is not a one-way door. "
+            "Measured on a live store, text records and their frames are the larger part of what "
+            "the store holds."),
+    Setting("storage_engine.wal_binary_frame", "storage_engine",
+            "TS_WAL_BINARY_FRAME",
+            "Frame log records by length", "bool", "1", "restart",
+            "On, each record carries a length and a checksum in about seven bytes. Off, records "
+            "are delimited by a newline in about twenty, and every newline inside a payload has to "
+            "be escaped out and back -- two more copies of every record. Decoding handles either, "
+            "so a log holding both still loads. Turning it OFF on a store already written with "
+            "length frames is NOT supported: finding the tail of the log follows this setting, and "
+            "off it searches backwards for a newline, which is not a record boundary in a "
+            "length-framed log."),
     Setting("storage_engine.vector_scaled", "storage_engine",
             "TS_VECTOR_SCALED",
             "Store vectors in the scaled form", "bool", "1", "live",


### PR DESCRIPTION
The portal's storage-engine group offers thirteen knobs — page sizes, cache bytes, vector forms,
malloc trim — and **none of them decides what a record is written as**. The two that do were
reachable only by setting an environment variable on the process.

That matters more than a missing control usually would. Measured on the live store: **929 MB of
1,308 MB is text**, and it is the write-ahead log and the served index that make it so. These two
settings decide the first of those.

| setting | what it decides |
|---|---|
| `storage_engine.wal_binary_records` | records as protobuf rather than JSON |
| `storage_engine.wal_binary_frame` | a length + checksum in ~7 bytes, or a newline delimiter in ~20 with every payload newline escaped out and back — two more copies of every record |

Reading never consults the first: a payload is decoded by what its first byte says it is, so a log
written across a change reads end to end and turning it back off is not a one-way door.

The second's help says the thing an operator most needs and could not otherwise know: **turning it
off on a store already written with length frames is not supported**, because finding the tail of the
log follows this setting, and off it searches backwards for a newline — which is not a record
boundary in a length-framed log.

Both are `restart`, because the encoding is read as a record is written and a running process carries
the environment it started with.

### A guard refused the first one, and was right to

Offered knobs must show a default the source can be asked for, so the portal's number is checked
against the engine. `binary_records_enabled` accepted only `"0"` and `"false"` — so `off` and `no`,
which turn any of its neighbours off, left protobuf **on** — and its default sat in a shape nothing
could read.

It is spelled like every other engine flag now: same accepted set, same default, and a default the
inventory can derive.

Engine flags offered on the portal: 23 → **25**.

`cargo check --all-targets` clean · 66 settings/portal tests pass · 35 flag guards pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
