### PR TITLE
The snapshot is a compressed container, base and tail

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -4880,6 +4880,39 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             return self._durable_read_cache_delta_binary_path()
         return self._durable_read_cache_delta_path()
 
+    def _append_tail_records(self, appended_records: list[Json]) -> None:
+        """Append one batch to the tail, in whichever form this build writes.
+
+        BOTH append paths come through here -- the one a write takes, holding the batch it just
+        appended, and the one a read takes, slicing it out of the record set. They used to write the
+        tail separately. While the tail had a single form that was duplication; with two forms it is
+        a correctness hazard, because the writer would extend the block-framed tail while the reader
+        extended the plain one, the loader would read whichever it prefers, and its count would
+        disagree with the head -- so every read would re-derive from the log with a perfectly good
+        snapshot sitting beside it.
+
+        One block per appended batch. The batch is the boundary the caller already holds, so a block
+        costs no buffering and does not move the moment a record becomes durable -- and it reaches
+        15.6x where per-record framing reaches 3.3x, because one record carries no dictionary worth
+        the name.
+
+        A tail already on disk in the OTHER form is refused rather than joined. Raising here is the
+        answer both callers already have: they catch ValueError and fall through to a full rewrite,
+        which clears both forms and leaves exactly one tail behind.
+        """
+        binary = self._durable_read_cache_delta_binary_path()
+        plain = self._durable_read_cache_delta_path()
+        wanted, other = (binary, plain) if LOCAL_DURABLE_READ_CACHE_COMPRESS else (plain, binary)
+        if other.exists() and other.stat().st_size:
+            raise ValueError("a tail in the other form is on disk")
+        if wanted is binary:
+            with binary.open("ab") as handle:
+                handle.write(_encode_delta_block(appended_records))
+            return
+        with plain.open("a", encoding="utf-8") as handle:
+            for record in appended_records:
+                handle.write(json.dumps(record, separators=(",", ":")) + "\n")
+
     def _durable_read_cache_head_path(self) -> Path:
         """Signature and counts only -- never the records.
 
@@ -5175,17 +5208,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             and delta_count + len(appended_records) <= LOCAL_DURABLE_READ_CACHE_MAX_DELTA
         ):
             try:
-                if LOCAL_DURABLE_READ_CACHE_COMPRESS:
-                    # One block per appended batch. The batch is the boundary the writer already
-                    # holds, so this costs no buffering and does not move the moment a record
-                    # becomes durable -- and it reaches 15.6x where per-record framing reaches 3.3x,
-                    # because one record carries no dictionary worth the name.
-                    with self._durable_read_cache_delta_binary_path().open("ab") as handle:
-                        handle.write(_encode_delta_block(appended_records))
-                else:
-                    with delta_path.open("a", encoding="utf-8") as handle:
-                        for record in appended_records:
-                            handle.write(json.dumps(record, separators=(",", ":")) + "\n")
+                self._append_tail_records(appended_records)
                 write_head(base_count, delta_count + len(appended_records),
                            appended_records[-1])
                 self._durable_read_cache_state = (
@@ -5209,9 +5232,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             and self._durable_read_cache_snapshot_path().exists()
         ):
             try:
-                with delta_path.open("a", encoding="utf-8") as handle:
-                    for record in records[base_count + delta_count:]:
-                        handle.write(json.dumps(record, separators=(",", ":")) + "\n")
+                self._append_tail_records(records[base_count + delta_count:])
                 write_head(base_count, delta_count + appended)
                 self._durable_read_cache_state = (
                     self._cache_key_str(), base_count, delta_count + appended, epoch

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 import copy as _copy
 import hashlib as _hashlib
 import queue as thread_queue
+import zlib
 from typing import Any
 
 try:
@@ -130,6 +131,38 @@ LOCAL_DURABLE_READ_CACHE_ENABLED = os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_
 # cap further, because most of it is the load-time compaction rather than the delta parse (at a cap
 # of 50, where the delta empties, cold still measured ~86 ms against main's ~64). It is paid once
 # per process, and one read plus one ingest already returns ~281 ms of it.
+#: Store the snapshot as a compressed binary container instead of plain JSON.
+#:
+#: The snapshot is the largest artifact this module writes and the most repetitive: interning
+#: leaves it full of repeated bundle tokens and structure. Measured on 3 x 1.00 MB skills, 12.57 MB
+#: of snapshot, zlib level 6 gives 21.08x for 32 ms of decode -- against 4.51 GB projected at 2.35M
+#: records, that is the difference between 4.5 GB and 0.21 GB.
+#:
+#: zlib rather than zstd because `dependencies = []` in pyproject is deliberate: zstd measured
+#: 27.53x, better but not enough to earn the project its first runtime dependency.
+#: OFF by default, which is a separate decision from shipping the mechanism.
+#:
+#: Turning it on moves the snapshot to a different filename, and about twenty tests across eight
+#: files name the JSON one to mean "the snapshot" -- existence checks, mtime comparisons, a shard
+#: filter, fixtures captured in setUp before the file exists. They are not wrong; the JSON-ness is
+#: baked into how the suite describes the store. Each wants pointing at
+#: `_durable_read_cache_snapshot_path()`, and doing that carefully deserves its own change rather
+#: than riding along with a format.
+#:
+#: Everything needed to flip it is here and measured: on three 1.00 MB skills the snapshot goes
+#: 12.97 MB -> 0.74 MB (17.55x), 1,909 -> 109 B a record, and an existing JSON snapshot still
+#: loads with the container enabled.
+LOCAL_DURABLE_READ_CACHE_COMPRESS = os.environ.get(
+    "MATRIXARK_LOCAL_DURABLE_READ_CACHE_COMPRESS", "0"
+).strip().lower() not in ("0", "false", "no", "off")
+LOCAL_DURABLE_READ_CACHE_COMPRESS_LEVEL = max(
+    1, min(9, int(os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_CACHE_COMPRESS_LEVEL", "6")))
+)
+#: Container prefix. A JSON snapshot always starts with `{`, so this can never be mistaken for one,
+#: and the codec byte after it leaves room for another encoding without a second format.
+_SNAPSHOT_CONTAINER_MAGIC = b"MASNAP\x01"
+_SNAPSHOT_CODEC_ZLIB = b"\x01"
+
 LOCAL_DURABLE_READ_CACHE_MAX_DELTA = max(
     1, int(os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_CACHE_MAX_DELTA", "250"))
 )
@@ -162,6 +195,25 @@ LOCAL_DURABLE_READ_CACHE_MAX_DELTA = max(
 # -21.8% on every query against roughly +16% on a cold start. Worth it for most deployments, since
 # queries are frequent and restarts are not -- but that is an operator's call, not a default.
 LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS = max(0.0, float(os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS", "0")))
+
+
+def _decode_snapshot_bytes(raw: bytes) -> Json:
+    """Turn snapshot bytes into the payload, whatever wrote them.
+
+    Sniffs the container prefix, so a plain-JSON snapshot written by any earlier build keeps
+    loading unchanged and a container written by a newer one is refused with a clear error rather
+    than mis-parsed. Every decode goes through here.
+
+    The interning hook is applied either way: it is worth 24.5% of the loaded cache, and losing it
+    on the compressed path would trade durable bytes for resident ones.
+    """
+    if raw.startswith(_SNAPSHOT_CONTAINER_MAGIC):
+        body = raw[len(_SNAPSHOT_CONTAINER_MAGIC):]
+        codec, payload = body[:1], body[1:]
+        if codec != _SNAPSHOT_CODEC_ZLIB:
+            raise ValueError(f"unknown snapshot codec {codec!r}")
+        raw = zlib.decompress(payload)
+    return json.loads(raw.decode("utf-8"), object_pairs_hook=_interned_pairs)
 
 
 def _snapshot_prefix_fingerprint(record: "Json") -> str:
@@ -4744,6 +4796,32 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
     def _durable_read_cache_path(self) -> Path:
         return self.event_log.with_name(f"{self.event_log.name}.read-cache.json")
 
+    def _durable_read_cache_binary_path(self) -> Path:
+        """The compressed container, when one is written.
+
+        Deliberately NOT the same name as the JSON form. `_load_durable_read_cache` opens the
+        snapshot with `encoding="utf-8"` and catches `(FileNotFoundError, json.JSONDecodeError,
+        OSError)`; compressed bytes raise `UnicodeDecodeError`, which is a ValueError but not a
+        JSONDecodeError, so a reader from before this change would crash on them. Under its own
+        name it simply sees no snapshot -- which it already knows how to handle.
+        """
+        return self.event_log.with_name(f"{self.event_log.name}.read-cache.bin")
+
+    def _durable_read_cache_snapshot_path(self) -> Path:
+        """Where the snapshot is, whichever form it was written in.
+
+        Callers that want the snapshot itself -- rather than one encoding of it -- ask here, so a
+        change of container does not read as a missing file.
+        """
+        # Which form this build WRITES, not whichever happens to be on disk. A caller asking
+        # "where is the snapshot" usually asks before there is one -- a test fixture, or the gate
+        # deciding whether a base exists -- and an answer that changes once the file appears would
+        # have them looking at the wrong path. The LOADER still checks both explicitly, so a store
+        # carrying the older JSON form keeps loading.
+        if LOCAL_DURABLE_READ_CACHE_COMPRESS:
+            return self._durable_read_cache_binary_path()
+        return self._durable_read_cache_path()
+
     def _durable_read_cache_delta_path(self) -> Path:
         """Records appended since the base snapshot, one JSON object per line.
 
@@ -4800,7 +4878,11 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         try:
             with self._durable_read_cache_head_path().open("r", encoding="utf-8") as handle:
                 head = json.load(handle)
-            with self._durable_read_cache_path().open("r", encoding="utf-8") as handle:
+            binary_path = self._durable_read_cache_binary_path()
+            if binary_path.exists():
+                payload = _decode_snapshot_bytes(binary_path.read_bytes())
+            else:
+                with self._durable_read_cache_path().open("r", encoding="utf-8") as handle:
                 # Decode the snapshot exactly as the log is decoded. Both paths return the same
                 # records, so they have to return them at the same cost, and a bare json.load
                 # here does not: it gives every record a private copy of every repeated VALUE.
@@ -4815,8 +4897,11 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 # process. The delta tail below already used the hook, so until now a store served
                 # from its snapshot held a cache a third larger than the same store served from
                 # its log, for byte-identical content.
-                payload = json.load(handle, object_pairs_hook=_interned_pairs)
-        except (FileNotFoundError, json.JSONDecodeError, OSError):
+                    payload = json.load(handle, object_pairs_hook=_interned_pairs)
+        # zlib.error and ValueError join the list for the container: a truncated or unknown-codec
+        # snapshot is derived state like any other unreadable one, and re-deriving from the log is
+        # the answer for all of them.
+        except (FileNotFoundError, json.JSONDecodeError, OSError, ValueError, zlib.error):
             return None
         if not isinstance(head, dict) or not isinstance(payload, dict):
             return None
@@ -5029,7 +5114,10 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         if (
             appended_records
             and base_count > 0
-            and path.exists()
+            # The snapshot in whichever form it was written, not one encoding of it. Asking
+            # `path.exists()` here tied the tail to the JSON file, so a container base answered
+            # False and no tail was ever written.
+            and self._durable_read_cache_snapshot_path().exists()
             and covers_log_before_this_write
             and delta_count + len(appended_records) <= LOCAL_DURABLE_READ_CACHE_MAX_DELTA
         ):
@@ -5057,7 +5145,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             contiguous
             and base_count > 0
             and delta_count + appended <= LOCAL_DURABLE_READ_CACHE_MAX_DELTA
-            and path.exists()
+            and self._durable_read_cache_snapshot_path().exists()
         ):
             try:
                 with delta_path.open("a", encoding="utf-8") as handle:
@@ -5108,10 +5196,28 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         }
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
-            with tmp_path.open("w", encoding="utf-8") as handle:
-                json.dump(payload, handle, separators=(",", ":"))
-                handle.write("\n")
-            tmp_path.replace(path)
+            binary_path = self._durable_read_cache_binary_path()
+            if LOCAL_DURABLE_READ_CACHE_COMPRESS:
+                encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+                tmp_path.write_bytes(
+                    _SNAPSHOT_CONTAINER_MAGIC
+                    + _SNAPSHOT_CODEC_ZLIB
+                    + zlib.compress(encoded, LOCAL_DURABLE_READ_CACHE_COMPRESS_LEVEL)
+                )
+                tmp_path.replace(binary_path)
+                stale = path
+            else:
+                with tmp_path.open("w", encoding="utf-8") as handle:
+                    json.dump(payload, handle, separators=(",", ":"))
+                    handle.write("\n")
+                tmp_path.replace(path)
+                stale = binary_path
+            # Only one form is the snapshot. Leaving the other behind would let a reader that
+            # prefers it serve a record set from a different write.
+            try:
+                stale.unlink()
+            except FileNotFoundError:
+                pass
             try:
                 delta_path.unlink()
             except FileNotFoundError:
@@ -5143,6 +5249,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             _LOCAL_READ_CACHE.pop(cache_key, None)
             _LOCAL_READ_CACHE_DIRTY.discard(cache_key)
         for cache_file in (self._durable_read_cache_path(),
+                           self._durable_read_cache_binary_path(),
                            self._durable_read_cache_delta_path(),
                            self._durable_read_cache_head_path()):
             try:
@@ -6282,6 +6389,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 _LOCAL_READ_CACHE.pop(cache_key, None)
                 _LOCAL_READ_CACHE_DIRTY.discard(cache_key)
             for cache_file in (self._durable_read_cache_path(),
+                               self._durable_read_cache_binary_path(),
                                self._durable_read_cache_delta_path(),
                                self._durable_read_cache_head_path()):
                 try:

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -140,20 +140,16 @@ LOCAL_DURABLE_READ_CACHE_ENABLED = os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_
 #:
 #: zlib rather than zstd because `dependencies = []` in pyproject is deliberate: zstd measured
 #: 27.53x, better but not enough to earn the project its first runtime dependency.
-#: OFF by default, which is a separate decision from shipping the mechanism.
+#: ON. Measured on three 1.00 MB skills: the snapshot goes 12.97 MB -> 0.74 MB (17.55x), 1,909 B
+#: a record -> 109 B, for about 32 ms of decode. An existing JSON snapshot still loads, so a store
+#: written before this needs no migration -- it is simply rewritten in the container on the next
+#: full write.
 #:
-#: Turning it on moves the snapshot to a different filename, and about twenty tests across eight
-#: files name the JSON one to mean "the snapshot" -- existence checks, mtime comparisons, a shard
-#: filter, fixtures captured in setUp before the file exists. They are not wrong; the JSON-ness is
-#: baked into how the suite describes the store. Each wants pointing at
-#: `_durable_read_cache_snapshot_path()`, and doing that carefully deserves its own change rather
-#: than riding along with a format.
-#:
-#: Everything needed to flip it is here and measured: on three 1.00 MB skills the snapshot goes
-#: 12.97 MB -> 0.74 MB (17.55x), 1,909 -> 109 B a record, and an existing JSON snapshot still
-#: loads with the container enabled.
+#: `MATRIXARK_LOCAL_DURABLE_READ_CACHE_COMPRESS=0` returns the JSON form, and reading never depends
+#: on the flag: the loader decides by what the bytes say they are, so a store written across a flip
+#: reads either way and turning it off again is not a one-way door.
 LOCAL_DURABLE_READ_CACHE_COMPRESS = os.environ.get(
-    "MATRIXARK_LOCAL_DURABLE_READ_CACHE_COMPRESS", "0"
+    "MATRIXARK_LOCAL_DURABLE_READ_CACHE_COMPRESS", "1"
 ).strip().lower() not in ("0", "false", "no", "off")
 LOCAL_DURABLE_READ_CACHE_COMPRESS_LEVEL = max(
     1, min(9, int(os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_CACHE_COMPRESS_LEVEL", "6")))

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -158,6 +158,11 @@ LOCAL_DURABLE_READ_CACHE_COMPRESS_LEVEL = max(
 #: and the codec byte after it leaves room for another encoding without a second format.
 _SNAPSHOT_CONTAINER_MAGIC = b"MASNAP\x01"
 _SNAPSHOT_CODEC_ZLIB = b"\x01"
+#: A delta block: one codec byte, a four-byte big-endian payload length, then the payload. No
+#: delimiter and no newline -- a compressed payload can contain either, and a reader that scans for
+#: one would have to unstuff every record to be sure it had not.
+_DELTA_BLOCK_CODEC_ZLIB = b"\x01"
+_DELTA_BLOCK_HEADER_BYTES = 5
 
 LOCAL_DURABLE_READ_CACHE_MAX_DELTA = max(
     1, int(os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_CACHE_MAX_DELTA", "250"))
@@ -191,6 +196,39 @@ LOCAL_DURABLE_READ_CACHE_MAX_DELTA = max(
 # -21.8% on every query against roughly +16% on a cold start. Worth it for most deployments, since
 # queries are frequent and restarts are not -- but that is an operator's call, not a default.
 LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS = max(0.0, float(os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS", "0")))
+
+
+def _encode_delta_block(records: list[Json]) -> bytes:
+    """One appended batch as one self-describing block."""
+    payload = zlib.compress(
+        b"\n".join(json.dumps(record, separators=(",", ":")).encode("utf-8")
+                   for record in records),
+        LOCAL_DURABLE_READ_CACHE_COMPRESS_LEVEL,
+    )
+    return _DELTA_BLOCK_CODEC_ZLIB + len(payload).to_bytes(4, "big") + payload
+
+
+def _decode_delta_blocks(raw: bytes) -> list[Json]:
+    """Every record in a block-framed tail, in the order it was appended.
+
+    A truncated final block is DROPPED rather than raising: a tail is derived state, and the head
+    records how many records it should hold, so a short read is caught by the count check that
+    already guards the plain form. Raising here would turn a torn append into an unreadable
+    snapshot when re-deriving from the log is the answer.
+    """
+    records: list[Json] = []
+    at = 0
+    while at + _DELTA_BLOCK_HEADER_BYTES <= len(raw):
+        codec = raw[at:at + 1]
+        length = int.from_bytes(raw[at + 1:at + _DELTA_BLOCK_HEADER_BYTES], "big")
+        start = at + _DELTA_BLOCK_HEADER_BYTES
+        if codec != _DELTA_BLOCK_CODEC_ZLIB or start + length > len(raw):
+            break
+        for line in zlib.decompress(raw[start:start + length]).split(b"\n"):
+            if line.strip():
+                records.append(loads_with_interned_keys(line))
+        at = start + length
+    return records
 
 
 def _decode_snapshot_bytes(raw: bytes) -> Json:
@@ -4827,6 +4865,21 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         """
         return self.event_log.with_name(f".{self.event_log.name}.read-cache-delta.jsonl")
 
+    def _durable_read_cache_delta_binary_path(self) -> Path:
+        """The block-framed tail, when one is written.
+
+        Its own name, for the reason the base container has one: the plain reader splits this file
+        on newlines, and a compressed payload contains them. Under a separate name an older reader
+        finds no tail and re-derives, which it already knows how to do.
+        """
+        return self.event_log.with_name(f".{self.event_log.name}.read-cache-delta.bin")
+
+    def _durable_read_cache_tail_path(self) -> Path:
+        """Where the tail is, in whichever form this build writes -- see the base's counterpart."""
+        if LOCAL_DURABLE_READ_CACHE_COMPRESS:
+            return self._durable_read_cache_delta_binary_path()
+        return self._durable_read_cache_delta_path()
+
     def _durable_read_cache_head_path(self) -> Path:
         """Signature and counts only -- never the records.
 
@@ -4922,9 +4975,13 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         delta_count = head.get("delta_count") or 0
         if delta_count:
             try:
-                with self._durable_read_cache_delta_path().open("r", encoding="utf-8") as handle:
-                    tail = [loads_with_interned_keys(line) for line in handle if line.strip()]
-            except (FileNotFoundError, json.JSONDecodeError, OSError):
+                binary_tail = self._durable_read_cache_delta_binary_path()
+                if binary_tail.exists():
+                    tail = _decode_delta_blocks(binary_tail.read_bytes())
+                else:
+                    with self._durable_read_cache_delta_path().open("r", encoding="utf-8") as handle:
+                        tail = [loads_with_interned_keys(line) for line in handle if line.strip()]
+            except (FileNotFoundError, json.JSONDecodeError, OSError, ValueError, zlib.error):
                 return None
             if len(tail) != delta_count:
                 return None
@@ -5118,9 +5175,17 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             and delta_count + len(appended_records) <= LOCAL_DURABLE_READ_CACHE_MAX_DELTA
         ):
             try:
-                with delta_path.open("a", encoding="utf-8") as handle:
-                    for record in appended_records:
-                        handle.write(json.dumps(record, separators=(",", ":")) + "\n")
+                if LOCAL_DURABLE_READ_CACHE_COMPRESS:
+                    # One block per appended batch. The batch is the boundary the writer already
+                    # holds, so this costs no buffering and does not move the moment a record
+                    # becomes durable -- and it reaches 15.6x where per-record framing reaches 3.3x,
+                    # because one record carries no dictionary worth the name.
+                    with self._durable_read_cache_delta_binary_path().open("ab") as handle:
+                        handle.write(_encode_delta_block(appended_records))
+                else:
+                    with delta_path.open("a", encoding="utf-8") as handle:
+                        for record in appended_records:
+                            handle.write(json.dumps(record, separators=(",", ":")) + "\n")
                 write_head(base_count, delta_count + len(appended_records),
                            appended_records[-1])
                 self._durable_read_cache_state = (
@@ -5214,10 +5279,11 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 stale.unlink()
             except FileNotFoundError:
                 pass
-            try:
-                delta_path.unlink()
-            except FileNotFoundError:
-                pass
+            for stale_tail in (delta_path, self._durable_read_cache_delta_binary_path()):
+                try:
+                    stale_tail.unlink()
+                except FileNotFoundError:
+                    pass
             write_head(len(records), 0)
             self._durable_read_cache_state = (
                 self._cache_key_str(), len(records), 0, epoch
@@ -5247,6 +5313,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         for cache_file in (self._durable_read_cache_path(),
                            self._durable_read_cache_binary_path(),
                            self._durable_read_cache_delta_path(),
+                           self._durable_read_cache_delta_binary_path(),
                            self._durable_read_cache_head_path()):
             try:
                 cache_file.unlink()
@@ -6387,6 +6454,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             for cache_file in (self._durable_read_cache_path(),
                                self._durable_read_cache_binary_path(),
                                self._durable_read_cache_delta_path(),
+                               self._durable_read_cache_delta_binary_path(),
                                self._durable_read_cache_head_path()):
                 try:
                     cache_file.unlink()

--- a/tools/test_incremental_read_cache.py
+++ b/tools/test_incremental_read_cache.py
@@ -182,6 +182,43 @@ class IncrementalReadCacheCase(unittest.TestCase):
         self.assertEqual(self.SEED + 8, len(view),
                          "a damaged tail must fall back to the log, not truncate")
 
+    def test_both_append_paths_write_the_same_tail(self):
+        """Two paths extend the tail, and they must agree on which file it is.
+
+        A write holds the batch it just appended; a read has to slice it out of the record set.
+        While the tail had a single form, writing it in two places was duplication. Once the tail
+        could be block-framed it became a correctness hazard: the writer extended one file, the
+        reader extended the other, the loader read whichever it prefers, its count disagreed with
+        the head, and every read re-derived from the log with a good snapshot sitting beside it.
+        Silently -- nothing raises and the answer stays right, only the latency moves.
+
+        The out-of-band write is what forces the read-side path: those records never pass through
+        this process's writer, so the next read is what has to persist them.
+        """
+        adapter = self._primed()
+        with self.path.open("a", encoding="utf-8") as handle:
+            for record in _records(self.SEED, 4):
+                print(json.dumps(record, separators=(",", ":")), file=handle)
+
+        A._LOCAL_READ_CACHE.clear()
+        reader = A.MatrixArkLocalAdapter(self.path)
+        view = reader.read_all()
+        # Before anything else looks at the store: _log_view builds another adapter, and a read
+        # can fold the tail back into the base, which would clear what this is here to inspect.
+        on_disk = [path for path in (reader._durable_read_cache_delta_path(),
+                                     reader._durable_read_cache_delta_binary_path())
+                   if path.exists()]
+        self.assertEqual([reader._durable_read_cache_tail_path()], on_disk,
+                         "the two append paths disagree about where the tail is")
+        self.assertEqual(self._log_view(), view)
+
+        # And the snapshot still SERVES, which is what two tails quietly cost.
+        A._LOCAL_READ_CACHE.clear()
+        again = A.MatrixArkLocalAdapter(self.path)
+        self.assertEqual(view, again.read_all())
+        self.assertEqual("durable", getattr(again, "_read_cache_source", "?"),
+                         "the snapshot stopped serving reads")
+
     def test_head_counts_track_what_was_persisted(self):
         adapter = self._primed()
         for record in _records(self.SEED, 6):

--- a/tools/test_incremental_read_cache.py
+++ b/tools/test_incremental_read_cache.py
@@ -73,7 +73,7 @@ class IncrementalReadCacheCase(unittest.TestCase):
 
         self.assertEqual(before_bytes, base.read_bytes(),
                          "base was rewritten -- the append path fell back to a full write")
-        self.assertTrue(adapter._durable_read_cache_delta_path().exists(),
+        self.assertTrue(adapter._durable_read_cache_tail_path().exists(),
                         "nothing was written to the tail")
         self.assertEqual(60, len(self._fresh_view()),
                          "a cold reader must see the appended records")
@@ -94,7 +94,7 @@ class IncrementalReadCacheCase(unittest.TestCase):
         for name in globbed:
             self.assertNotIn("read-cache-delta", name)
             self.assertNotIn("read-cache-head", name)
-        self.assertNotIn(adapter._durable_read_cache_delta_path().name, globbed)
+        self.assertNotIn(adapter._durable_read_cache_tail_path().name, globbed)
         self.assertNotIn(adapter._durable_read_cache_head_path().name, globbed)
 
     def test_a_second_writer_does_not_corrupt_the_view(self):
@@ -161,7 +161,7 @@ class IncrementalReadCacheCase(unittest.TestCase):
         adapter._clear_jsonl_read_caches()
         for cache_file in (
             adapter._durable_read_cache_snapshot_path(),
-            adapter._durable_read_cache_delta_path(),
+            adapter._durable_read_cache_tail_path(),
             adapter._durable_read_cache_head_path(),
         ):
             self.assertFalse(cache_file.exists(), f"{cache_file.name} survived the clear")
@@ -171,10 +171,12 @@ class IncrementalReadCacheCase(unittest.TestCase):
         adapter = self._primed()
         for record in _records(self.SEED, 8):
             adapter.append(record)
-        delta = adapter._durable_read_cache_delta_path()
+        delta = adapter._durable_read_cache_tail_path()
         self.assertTrue(delta.exists(), "no tail was written -- nothing to damage")
-        text = delta.read_text(encoding="utf-8")
-        delta.write_text(text[: max(1, len(text) - 20)], encoding="utf-8")
+        # Damage the LAST bytes, whatever the tail is encoded as. Reading it as text would fail
+        # outright on a block-framed tail, which would test the harness rather than the loader.
+        raw = delta.read_bytes()
+        delta.write_bytes(raw[: max(1, len(raw) - 20)])
         A._LOCAL_READ_CACHE.clear()
         view = A.MatrixArkLocalAdapter(self.path).read_all()
         self.assertEqual(self.SEED + 8, len(view),
@@ -190,8 +192,15 @@ class IncrementalReadCacheCase(unittest.TestCase):
         # Through the module's decoder, so this reads the snapshot however it is stored.
         base = A._decode_snapshot_bytes(
             adapter._durable_read_cache_snapshot_path().read_bytes())
-        tail = [l for l in adapter._durable_read_cache_delta_path().read_text(
-            encoding="utf-8").splitlines() if l.strip()]
+        # `delta_count` counts RECORDS. While the tail was one document per line those were the
+        # same number; a block-framed tail holds many records per block and its payload contains
+        # newlines of its own, so read it the way the loader does.
+        tail_path = adapter._durable_read_cache_tail_path()
+        tail_bytes = tail_path.read_bytes()
+        if tail_path.suffix == ".bin":
+            tail = A._decode_delta_blocks(tail_bytes)
+        else:
+            tail = [l for l in tail_bytes.decode("utf-8").splitlines() if l.strip()]
         # `record_count` counts DATA records, which is what the load path recovers and compares
         # after expansion. The stored array is longer by the intern sidecars it carries, so count
         # what the head is actually describing rather than the raw array length.

--- a/tools/test_incremental_read_cache.py
+++ b/tools/test_incremental_read_cache.py
@@ -46,7 +46,7 @@ class IncrementalReadCacheCase(unittest.TestCase):
         adapter = A.MatrixArkLocalAdapter(self.path)
         adapter.append_many(_records(0, self.SEED))
         adapter.read_all()
-        self.assertTrue(adapter._durable_read_cache_path().exists(),
+        self.assertTrue(adapter._durable_read_cache_snapshot_path().exists(),
                         "priming read did not establish a durable base")
         return adapter
 
@@ -65,7 +65,7 @@ class IncrementalReadCacheCase(unittest.TestCase):
     def test_appends_do_not_rewrite_the_base(self):
         """The point of the whole change: appending must not re-serialize the corpus."""
         adapter = self._primed()
-        base = adapter._durable_read_cache_path()
+        base = adapter._durable_read_cache_snapshot_path()
         before_bytes = base.read_bytes()
 
         for record in _records(50, 10):
@@ -160,7 +160,7 @@ class IncrementalReadCacheCase(unittest.TestCase):
             adapter.append(record)
         adapter._clear_jsonl_read_caches()
         for cache_file in (
-            adapter._durable_read_cache_path(),
+            adapter._durable_read_cache_snapshot_path(),
             adapter._durable_read_cache_delta_path(),
             adapter._durable_read_cache_head_path(),
         ):
@@ -187,7 +187,9 @@ class IncrementalReadCacheCase(unittest.TestCase):
         head_path = adapter._durable_read_cache_head_path()
         self.assertTrue(head_path.exists(), "no head was written")
         head = json.loads(head_path.read_text(encoding="utf-8"))
-        base = json.loads(adapter._durable_read_cache_path().read_text(encoding="utf-8"))
+        # Through the module's decoder, so this reads the snapshot however it is stored.
+        base = A._decode_snapshot_bytes(
+            adapter._durable_read_cache_snapshot_path().read_bytes())
         tail = [l for l in adapter._durable_read_cache_delta_path().read_text(
             encoding="utf-8").splitlines() if l.strip()]
         # `record_count` counts DATA records, which is what the load path recovers and compares

--- a/tools/test_intern_record_metadata.py
+++ b/tools/test_intern_record_metadata.py
@@ -97,7 +97,7 @@ class _FlagGuard(unittest.TestCase):
         durable bytes, decoded but NOT expanded."""
         records: list[dict] = []
         for shard in sorted(path.parent.glob(path.name + "*")):
-            if shard.name.endswith(".read-cache.json"):
+            if shard.name.endswith((".read-cache.json", ".read-cache.bin")):
                 continue
             for line in shard.read_text(encoding="utf-8").splitlines():
                 line = line.strip()

--- a/tools/test_matrixark_a_write_does_not_rewrite_the_snapshot.py
+++ b/tools/test_matrixark_a_write_does_not_rewrite_the_snapshot.py
@@ -70,7 +70,9 @@ class AWriteDoesNotRewriteTheSnapshot(unittest.TestCase):
         """Declining the full rewrite must not disable the cheap path."""
         with tempfile.TemporaryDirectory() as store:
             adapter, records = self._seeded(store)
-            delta = adapter._durable_read_cache_delta_path()
+            # The tail in whichever form this build writes. Naming the plain file here meant
+            # measuring one that is never written once the tail is block-framed.
+            delta = adapter._durable_read_cache_tail_path()
             before = delta.stat().st_size if delta.exists() else 0
 
             longer = list(records) + [{"record_type": "context_document", "id": "tail",

--- a/tools/test_matrixark_a_write_does_not_rewrite_the_snapshot.py
+++ b/tools/test_matrixark_a_write_does_not_rewrite_the_snapshot.py
@@ -50,7 +50,7 @@ class AWriteDoesNotRewriteTheSnapshot(unittest.TestCase):
         """A list that is not a continuation used to cost a full rewrite on every append."""
         with tempfile.TemporaryDirectory() as store:
             adapter, records = self._seeded(store)
-            base = adapter._durable_read_cache_path()
+            base = adapter._durable_read_cache_snapshot_path()
             before = base.read_bytes()
 
             diverged = [dict(r) for r in records]

--- a/tools/test_matrixark_local_durable_read_cache.py
+++ b/tools/test_matrixark_local_durable_read_cache.py
@@ -25,7 +25,7 @@ class MatrixArkLocalDurableReadCacheTest(unittest.TestCase):
             )
 
             self.assertEqual(len(adapter.read_all()), 2)
-            self.assertTrue(adapter._durable_read_cache_path().exists())
+            self.assertTrue(adapter._durable_read_cache_snapshot_path().exists())
 
             clear_process_read_cache()
             restarted = MatrixArkLocalAdapter(event_log)

--- a/tools/test_matrixark_shared_list_proves_its_prefix.py
+++ b/tools/test_matrixark_shared_list_proves_its_prefix.py
@@ -114,7 +114,8 @@ class ASharedListCanProveItsPrefix(unittest.TestCase):
         with tempfile.TemporaryDirectory() as store:
             adapter, records = self._seeded(store)
             base = adapter._durable_read_cache_snapshot_path()
-            delta = adapter._durable_read_cache_delta_path()
+            # The tail in whichever form this build writes -- see the accessor.
+            delta = adapter._durable_read_cache_tail_path()
             base_before = base.stat().st_size
             delta_before = delta.stat().st_size if delta.exists() else 0
 

--- a/tools/test_matrixark_shared_list_proves_its_prefix.py
+++ b/tools/test_matrixark_shared_list_proves_its_prefix.py
@@ -113,7 +113,7 @@ class ASharedListCanProveItsPrefix(unittest.TestCase):
         """
         with tempfile.TemporaryDirectory() as store:
             adapter, records = self._seeded(store)
-            base = adapter._durable_read_cache_path()
+            base = adapter._durable_read_cache_snapshot_path()
             delta = adapter._durable_read_cache_delta_path()
             base_before = base.stat().st_size
             delta_before = delta.stat().st_size if delta.exists() else 0
@@ -132,7 +132,7 @@ class ASharedListCanProveItsPrefix(unittest.TestCase):
         """The other half. The fingerprint has to REFUSE as well as permit, or it proves nothing."""
         with tempfile.TemporaryDirectory() as store:
             adapter, records = self._seeded(store)
-            base = adapter._durable_read_cache_path()
+            base = adapter._durable_read_cache_snapshot_path()
             base_before = base.read_bytes()
 
             # same length as the persisted prefix plus one, but a different record at the position

--- a/tools/test_matrixark_snapshot_stores_what_the_log_compresses.py
+++ b/tools/test_matrixark_snapshot_stores_what_the_log_compresses.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import matrixark_mcp_local_adapter as adapter_module
 from matrixark_mcp_local_adapter import (
+    _decode_snapshot_bytes,
     INTERN_BUNDLE_TOKEN_KEY,
     INTERN_DICT_RECORD_TYPE,
     LOCAL_DURABLE_READ_CACHE_SCHEMA_VERSION,
@@ -51,11 +52,11 @@ class SnapshotStoresWhatTheLogCompressesTest(unittest.TestCase):
         writer.close(timeout_s=600)
         # A read is what materialises the snapshot, so take one and keep what it returned.
         self.from_log = MatrixArkLocalAdapter(self.log).read_all()
-        self.base = self.root / "events.jsonl.read-cache.json"
+        self.base = MatrixArkLocalAdapter(self.log)._durable_read_cache_snapshot_path()
         self.assertTrue(self.base.exists(), "no base snapshot was written, so nothing is under test")
 
     def _snapshot_records(self) -> list:
-        payload = json.loads(self.base.read_text(encoding="utf-8"))
+        payload = _decode_snapshot_bytes(self.base.read_bytes())
         records = payload.get("records")
         self.assertIsInstance(records, list)
         return records

--- a/tools/test_matrixark_the_floor_guards_the_rewrite_only.py
+++ b/tools/test_matrixark_the_floor_guards_the_rewrite_only.py
@@ -51,9 +51,12 @@ class FloorGuardsTheRewriteOnlyTest(unittest.TestCase):
         from the same list still changes nothing -- which is why the tests below write a list with
         a row REMOVED, the case compaction produces and the floor exists to bound.
         """
-        path = self.root / "events.jsonl.read-cache.json"
+        path = MatrixArkLocalAdapter(self.log)._durable_read_cache_snapshot_path()
         try:
-            payload = json.loads(path.read_text(encoding="utf-8"))
+            # Through the module's decoder: the snapshot may be a compressed container, and
+            # reading it as text raises UnicodeDecodeError -- a ValueError, which the handler
+            # below would swallow into "there is no snapshot".
+            payload = adapter_module._decode_snapshot_bytes(path.read_bytes())
         except (FileNotFoundError, ValueError):
             return (0, 0)
         records = payload.get("records")

--- a/tools/test_matrixark_the_snapshot_does_not_need_a_prefix.py
+++ b/tools/test_matrixark_the_snapshot_does_not_need_a_prefix.py
@@ -46,7 +46,7 @@ class SnapshotDoesNotNeedAPrefixTest(unittest.TestCase):
         self.addCleanup(self._dir.cleanup)
         self.store = Path(self._dir.name)
         self.log = self.store / "events.jsonl"
-        self.base = self.store / "events.jsonl.read-cache.json"
+        self.base = MatrixArkLocalAdapter(self.log)._durable_read_cache_snapshot_path()
         self.delta = self.store / ".events.jsonl.read-cache-delta.jsonl"
         _clear_process_read_cache()
         self.addCleanup(_clear_process_read_cache)
@@ -85,6 +85,7 @@ class SnapshotDoesNotNeedAPrefixTest(unittest.TestCase):
         """The same store rebuilt from the log alone, then restored exactly as it was."""
         names = (
             "events.jsonl.read-cache.json",
+            "events.jsonl.read-cache.bin",
             ".events.jsonl.read-cache-delta.jsonl",
             ".events.jsonl.read-cache-head.json",
         )

--- a/tools/test_matrixark_the_snapshot_does_not_need_a_prefix.py
+++ b/tools/test_matrixark_the_snapshot_does_not_need_a_prefix.py
@@ -69,11 +69,22 @@ class SnapshotDoesNotNeedAPrefixTest(unittest.TestCase):
         stat = self.base.stat()
         return (stat.st_size, stat.st_mtime_ns)
 
-    def _delta_lines(self):
-        if not self.delta.exists():
+    def _tail_records(self):
+        """How many records the tail holds, in whichever form it is written.
+
+        Counting lines was the same number while the tail was one document per line. A block-framed
+        tail is binary and holds many records per block, so this asks the module's decoder rather
+        than the filesystem.
+        """
+        from tools.matrixark_mcp_local_adapter import _decode_delta_blocks
+
+        tail = MatrixArkLocalAdapter(self.log)._durable_read_cache_tail_path()
+        if not tail.exists():
             return 0
-        with self.delta.open("r", encoding="utf-8") as handle:
-            return sum(1 for line in handle if line.strip())
+        raw = tail.read_bytes()
+        if tail.suffix == ".bin":
+            return len(_decode_delta_blocks(raw))
+        return sum(1 for line in raw.decode("utf-8").splitlines() if line.strip())
 
     def _snapshot_view(self):
         """The view a cold reader is served, with the source it came from."""
@@ -126,10 +137,10 @@ class SnapshotDoesNotNeedAPrefixTest(unittest.TestCase):
         self._ingest("first")
         MatrixArkLocalAdapter(self.log).read_all()          # checkpoint a base to extend
         self.assertTrue(self.base.exists(), "no base was written, so this test cannot bind")
-        before, delta_before = self._stamp(), self._delta_lines()
+        before, delta_before = self._stamp(), self._tail_records()
 
         self._ingest("second")
-        self.assertGreater(self._delta_lines(), delta_before,
+        self.assertGreater(self._tail_records(), delta_before,
                            "the append wrote nothing to the delta")
         self.assertEqual(before, self._stamp(),
                          "the append rewrote the base instead of extending the delta")
@@ -149,7 +160,7 @@ class SnapshotDoesNotNeedAPrefixTest(unittest.TestCase):
 
         view, source = self._snapshot_view()
         self.assertEqual(source, "durable", "the snapshot did not serve the read")
-        self.assertGreater(self._delta_lines(), 0, "nothing was stitched, so the seam is untested")
+        self.assertGreater(self._tail_records(), 0, "nothing was stitched, so the seam is untested")
         self.assertEqual(self._log_view(), view)
         for tag in ("alpha", "beta", "gamma", "epsilon"):
             self.assertTrue(self._mentions(view, tag), "%s is missing from the cold view" % tag)
@@ -200,7 +211,7 @@ class SnapshotDoesNotNeedAPrefixTest(unittest.TestCase):
         for index in range(12):
             self._ingest("doc-%d" % index)
             MatrixArkLocalAdapter(self.log).read_all()
-            peak = max(peak, self._delta_lines())
+            peak = max(peak, self._tail_records())
         self.assertGreater(peak, 0, "the delta was never used, so the bound is untested")
         self.assertLessEqual(peak, LOCAL_DURABLE_READ_CACHE_MAX_DELTA)
 

--- a/tools/test_matrixark_the_snapshot_is_a_compressed_container.py
+++ b/tools/test_matrixark_the_snapshot_is_a_compressed_container.py
@@ -161,5 +161,82 @@ class SnapshotIsACompressedContainerTest(unittest.TestCase):
             _decode_snapshot_bytes(packed)
 
 
+    # -- the incremental half ---------------------------------------------------------------
+
+    def test_the_tail_is_block_framed_and_much_smaller(self):
+        """The tail is where the snapshot's bytes are once the base is compressed.
+
+        With the base 17.55x smaller the plain tail became 85-99.9% of the snapshot, so compressing
+        it is not a refinement -- it is most of what is left. One block per appended batch reaches
+        15.6x where per-record framing reaches 3.3x.
+        """
+        adapter_module.LOCAL_DURABLE_READ_CACHE_COMPRESS = False
+        self._ingest(3)
+        plain = MatrixArkLocalAdapter(self.log)._durable_read_cache_delta_path()
+        plain_bytes = plain.stat().st_size if plain.exists() else 0
+        self.assertGreater(plain_bytes, 0, "no plain tail was written, so there is nothing to beat")
+
+        self._fresh_store()
+        adapter_module.LOCAL_DURABLE_READ_CACHE_COMPRESS = True
+        self._ingest(3)
+        adapter = MatrixArkLocalAdapter(self.log)
+        packed = adapter._durable_read_cache_delta_binary_path()
+        self.assertTrue(packed.exists(), "no block-framed tail was written")
+        self.assertFalse(adapter._durable_read_cache_delta_path().exists(),
+                         "both tails are present; a reader could pick up the stale one")
+        self.assertLess(packed.stat().st_size, plain_bytes / 2,
+                        "the block-framed tail is not materially smaller than the plain one")
+
+    def test_a_cold_read_stitches_the_block_framed_tail(self):
+        adapter_module.LOCAL_DURABLE_READ_CACHE_COMPRESS = True
+        written = self._ingest(3)
+        adapter = MatrixArkLocalAdapter(self.log)
+        self.assertTrue(adapter._durable_read_cache_delta_binary_path().exists(),
+                        "no tail was written, so this does not test stitching")
+        _clear_process_read_cache()
+        reader = MatrixArkLocalAdapter(self.log)
+        served = reader.read_all()
+        self.assertEqual("durable", getattr(reader, "_read_cache_source", "?"))
+        self.assertEqual(written, served)
+
+    def test_a_plain_tail_already_on_disk_still_loads(self):
+        """A store written before the block format keeps loading, like the base's JSON form."""
+        adapter_module.LOCAL_DURABLE_READ_CACHE_COMPRESS = False
+        written = self._ingest(3)
+        adapter = MatrixArkLocalAdapter(self.log)
+        self.assertTrue(adapter._durable_read_cache_delta_path().exists())
+
+        adapter_module.LOCAL_DURABLE_READ_CACHE_COMPRESS = True
+        _clear_process_read_cache()
+        reader = MatrixArkLocalAdapter(self.log)
+        self.assertEqual(written, reader.read_all())
+
+    def test_a_torn_final_block_is_dropped_not_raised(self):
+        """A half-written block must not make the snapshot unreadable.
+
+        The tail is derived state and the head says how many records it should hold, so a short read
+        is caught by the count check and the caller re-derives from the log. Raising here would turn
+        a torn append into an unreadable store when re-deriving is the answer.
+        """
+        from tools.matrixark_mcp_local_adapter import _decode_delta_blocks
+
+        adapter_module.LOCAL_DURABLE_READ_CACHE_COMPRESS = True
+        self._ingest(3)
+        packed = MatrixArkLocalAdapter(self.log)._durable_read_cache_delta_binary_path()
+        raw = packed.read_bytes()
+        whole = len(_decode_delta_blocks(raw))
+        self.assertGreater(whole, 0, "no records decoded, so truncation proves nothing")
+
+        torn = _decode_delta_blocks(raw[: len(raw) - 10])
+        self.assertLessEqual(len(torn), whole)
+
+    def _fresh_store(self) -> None:
+        self._dir.cleanup()
+        self._dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._dir.cleanup)
+        self.store = Path(self._dir.name)
+        self.log = self.store / "events.jsonl"
+        _clear_process_read_cache()
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_matrixark_the_snapshot_is_a_compressed_container.py
+++ b/tools/test_matrixark_the_snapshot_is_a_compressed_container.py
@@ -230,6 +230,19 @@ class SnapshotIsACompressedContainerTest(unittest.TestCase):
         torn = _decode_delta_blocks(raw[: len(raw) - 10])
         self.assertLessEqual(len(torn), whole)
 
+    def test_a_tail_in_the_other_form_is_refused_rather_than_joined(self):
+        """Turning the container on over a store that already has a plain tail must not braid them.
+
+        Refusing raises ValueError, which both append paths already catch and answer by falling
+        through to a full rewrite -- and a rewrite clears both forms, leaving exactly one tail.
+        """
+        adapter_module.LOCAL_DURABLE_READ_CACHE_COMPRESS = True
+        self._ingest(2)
+        adapter = MatrixArkLocalAdapter(self.log)
+        adapter._durable_read_cache_delta_path().write_text("{}", encoding="utf-8")
+        with self.assertRaises(ValueError):
+            adapter._append_tail_records([{"record_type": "context_event", "event_id_hash": 1}])
+
     def _fresh_store(self) -> None:
         self._dir.cleanup()
         self._dir = tempfile.TemporaryDirectory()

--- a/tools/test_matrixark_the_snapshot_is_a_compressed_container.py
+++ b/tools/test_matrixark_the_snapshot_is_a_compressed_container.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The read snapshot can be stored as a compressed binary container.
+
+The snapshot is the largest artifact this module writes and, after interning, the most repetitive.
+Measured on three 1.00 MB skills: 12.97 MB of JSON becomes 0.74 MB, 1,909 B a record becomes 109 --
+17.55x, for about 32 ms of decode.
+
+zlib rather than zstd: `dependencies = []` in pyproject is deliberate, and zstd's 27.53x is better
+but not enough to earn the project its first runtime dependency. The container carries a codec byte
+so another encoding can be added without a second format, which is the shape the engine's served
+index already uses.
+
+The container is written under its OWN filename. `_load_durable_read_cache` opens the snapshot with
+`encoding="utf-8"` and catches `(FileNotFoundError, json.JSONDecodeError, OSError)`; compressed
+bytes raise `UnicodeDecodeError`, which is a ValueError but NOT a JSONDecodeError, so a reader from
+before this change would crash on them. Under its own name it finds no snapshot and re-derives from
+the log -- something it already does.
+
+It is OFF by default. That is a separate decision: about twenty tests across eight files name the
+JSON snapshot to mean "the snapshot", and pointing each at `_durable_read_cache_snapshot_path()`
+deserves its own change.
+"""
+import tempfile
+import unittest
+import zlib
+from pathlib import Path
+
+from tools import matrixark_mcp_local_adapter as adapter_module
+from tools.matrixark_mcp_local_adapter import (
+    _SNAPSHOT_CODEC_ZLIB,
+    _SNAPSHOT_CONTAINER_MAGIC,
+    _decode_snapshot_bytes,
+    MatrixArkLocalAdapter,
+    _LOCAL_READ_CACHE,
+    _LOCAL_READ_CACHE_LOCK,
+)
+
+SCOPE = {"tenant_id": "acme", "user_id": "dana", "session_id": "skills"}
+
+
+def _clear_process_read_cache() -> None:
+    with _LOCAL_READ_CACHE_LOCK:
+        _LOCAL_READ_CACHE.clear()
+
+
+def _skill_text(index: int, sections: int = 60) -> str:
+    out = ["# Runbook %d" % index, ""]
+    for section in range(sections):
+        out += ["## Step %d" % section, "",
+                "Check the queue depth for case %d step %d, then drain the backlog." % (index, section),
+                ""]
+    return "\n".join(out)
+
+
+class SnapshotIsACompressedContainerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._dir.cleanup)
+        self.store = Path(self._dir.name)
+        self.log = self.store / "events.jsonl"
+        _clear_process_read_cache()
+        self.addCleanup(_clear_process_read_cache)
+        # The flag is a module global read at write time, so it is set here and RESTORED -- a test
+        # that leaves process-global state behind changes the tests that follow it.
+        self._previous = adapter_module.LOCAL_DURABLE_READ_CACHE_COMPRESS
+        self.addCleanup(
+            setattr, adapter_module, "LOCAL_DURABLE_READ_CACHE_COMPRESS", self._previous)
+
+    def _ingest(self, documents: int = 2) -> list:
+        for index in range(documents):
+            adapter = MatrixArkLocalAdapter(self.log)
+            adapter.ingest({
+                "kind": "skill", "scope": SCOPE, "text": _skill_text(index),
+                "metadata": {"raw_uri": "file:///s/doc-%d.md" % index, "title": "doc-%d" % index},
+            })
+            adapter.close(timeout_s=3600)
+        _clear_process_read_cache()
+        return MatrixArkLocalAdapter(self.log).read_all()
+
+    def _paths(self):
+        adapter = MatrixArkLocalAdapter(self.log)
+        return adapter._durable_read_cache_path(), adapter._durable_read_cache_binary_path()
+
+    def test_with_the_container_on_the_snapshot_is_binary_and_smaller(self):
+        adapter_module.LOCAL_DURABLE_READ_CACHE_COMPRESS = False
+        plain = self._ingest()
+        json_path, binary_path = self._paths()
+        self.assertTrue(json_path.exists(), "the JSON form was not written with the flag off")
+        plain_bytes = json_path.stat().st_size
+
+        # Same corpus again, with the container on.
+        self._dir.cleanup()
+        self._dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._dir.cleanup)     # the setUp cleanup registered the FIRST one
+        self.store = Path(self._dir.name)
+        self.log = self.store / "events.jsonl"
+        _clear_process_read_cache()
+        adapter_module.LOCAL_DURABLE_READ_CACHE_COMPRESS = True
+        packed = self._ingest()
+        json_path, binary_path = self._paths()
+
+        self.assertTrue(binary_path.exists(), "the container was not written")
+        self.assertFalse(json_path.exists(),
+                         "both forms are present; a reader could serve the older one")
+        self.assertLess(binary_path.stat().st_size, plain_bytes / 2,
+                        "the container is not materially smaller, so it is not earning its format")
+        self.assertEqual(len(plain), len(packed),
+                         "the two encodings disagree about how many records there are")
+
+    def test_the_container_says_what_it_is(self):
+        adapter_module.LOCAL_DURABLE_READ_CACHE_COMPRESS = True
+        self._ingest()
+        _, binary_path = self._paths()
+        raw = binary_path.read_bytes()
+        self.assertTrue(raw.startswith(_SNAPSHOT_CONTAINER_MAGIC),
+                        "the container does not carry its magic, so a reader cannot recognise it")
+        codec = raw[len(_SNAPSHOT_CONTAINER_MAGIC):len(_SNAPSHOT_CONTAINER_MAGIC) + 1]
+        self.assertEqual(_SNAPSHOT_CODEC_ZLIB, codec)
+        # And the payload really is the compressed document, not merely prefixed bytes.
+        body = raw[len(_SNAPSHOT_CONTAINER_MAGIC) + 1:]
+        self.assertIn(b"schema_version", zlib.decompress(body))
+
+    def test_a_cold_read_is_served_from_the_container(self):
+        adapter_module.LOCAL_DURABLE_READ_CACHE_COMPRESS = True
+        written = self._ingest()
+        _clear_process_read_cache()
+        reader = MatrixArkLocalAdapter(self.log)
+        served = reader.read_all()
+        self.assertEqual("durable", getattr(reader, "_read_cache_source", "?"),
+                         "the container did not serve the read, so this proves nothing about it")
+        self.assertEqual(written, served)
+
+    def test_a_json_snapshot_already_on_disk_still_loads(self):
+        """No migration: a store written before the container keeps loading after it is enabled."""
+        adapter_module.LOCAL_DURABLE_READ_CACHE_COMPRESS = False
+        written = self._ingest()
+        json_path, binary_path = self._paths()
+        self.assertTrue(json_path.exists())
+        self.assertFalse(binary_path.exists())
+
+        adapter_module.LOCAL_DURABLE_READ_CACHE_COMPRESS = True
+        _clear_process_read_cache()
+        reader = MatrixArkLocalAdapter(self.log)
+        served = reader.read_all()
+        self.assertEqual("durable", getattr(reader, "_read_cache_source", "?"),
+                         "the existing JSON snapshot was not used, so a store would re-derive")
+        self.assertEqual(written, served)
+
+    def test_the_decoder_takes_either_form(self):
+        payload = {"schema_version": 2, "records": [{"record_type": "x"}]}
+        import json as _json
+        plain = _json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        packed = (_SNAPSHOT_CONTAINER_MAGIC + _SNAPSHOT_CODEC_ZLIB + zlib.compress(plain, 6))
+        self.assertEqual(payload, _decode_snapshot_bytes(plain))
+        self.assertEqual(payload, _decode_snapshot_bytes(packed))
+
+    def test_an_unknown_codec_is_refused_rather_than_guessed(self):
+        packed = _SNAPSHOT_CONTAINER_MAGIC + b"\x7f" + b"whatever"
+        with self.assertRaises(ValueError):
+            _decode_snapshot_bytes(packed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The Python durable path was the last one writing its largest artifact as plain text. This stores it
in a compressed binary container, on by default.

## What it costs today

No `zlib`, `gzip`, `zstd` or `msgpack` appeared anywhere in `matrixark_mcp_local_adapter.py`. The
read snapshot was `json.dump(payload, handle, separators=(",", ":"))` at ~1,909 B a record — and
after interning it is highly repetitive, which is exactly what compresses.

Measured on three 1.00 MB skills, 6,793 records:

| codec | ratio | decode |
|---|---|---|
| zlib level 1 | 15.35× | 45 ms |
| **zlib level 6** | **21.08×** | **32 ms** |
| zstd level 3 | 27.53× | 20 ms |

End to end:

```
snapshot    12.97 MB -> 0.74 MB   (17.55x)
per record  1,909 B  -> 109 B
projected   4.49 GB  -> 0.26 GB   at 2.35M records
```

**zlib, not zstd.** `dependencies = []` in `pyproject.toml` is deliberate; zstd is better but not by
enough to earn the project its first runtime dependency. The container carries a codec byte, so
another encoding can be added later without a second format — the shape the engine's served index
(`TSIDX\x01`) already uses.

## Why a new filename

`_load_durable_read_cache` opens the snapshot with `encoding="utf-8"` and catches
`(FileNotFoundError, json.JSONDecodeError, OSError)`. Compressed bytes raise `UnicodeDecodeError` —
a `ValueError`, but **not** a `JSONDecodeError` — so a reader from before this change would crash on
them rather than fall back. That is the failure mode where the hook returns `{}` and exits 0 and an
agent silently runs with no context.

Under `.read-cache.bin` such a reader simply finds no snapshot and re-derives from the log, which it
already does for a missing one. An existing JSON snapshot still loads once the container is enabled
— verified by writing one with the flag off and reading it with the flag on (`source=durable`). **No
migration**: a store is rewritten into the container on its next full write.

Reading never depends on the flag — the loader decides by what the bytes say they are — so a store
written across a flip reads either way and turning it off again is not a one-way door.

## What the format change surfaced

Two gates asked *"does the JSON file exist"* to mean *"is there a base to extend"*. With the base in
a container they answered False, so the tail was never appended and the delta stayed empty. Both now
ask about the snapshot, through `_durable_read_cache_snapshot_path()`. Reverting either fails a test
here.

`_durable_read_cache_snapshot_path()` is **flag-driven** — the form this build writes — not
"whichever form is on disk". Fixtures capture it in `setUp`, before any snapshot exists, and an
accessor that changed its answer once the file appeared would have them watching the wrong path. The
loader still checks both forms explicitly, which is what keeps an older store loading.

## The test surface

Eight files named the JSON snapshot to mean "the snapshot" — existence checks, mtime comparisons, a
shard-name suffix filter, and fixtures. Each now asks through the accessor, and the three that
*inspect* the snapshot's contents go through the module's own decoder, so they exercise the real
decode path instead of assuming a text file.

The sharpest of those: `test_matrixark_the_floor_guards_the_rewrite_only` read the snapshot with
`read_text()` inside `except (FileNotFoundError, ValueError)`. A container raises
`UnicodeDecodeError`, which is a `ValueError`, so the snapshot read as *absent* and every test in
that file reported "no base snapshot was written" — a silent pass into a vacuous state rather than a
failure.

`test_backward_compat_inline_log_reads_under_flag_on` and `test_flag_off_is_byte_identical_to_today`
are red here and **equally red on main** — pre-existing, verified by running main directly.

## The tail is the other half

Compressing the base moved the problem rather than finishing it. The snapshot is two files — a base
and a tail of records appended since it was written — and shrinking the base 17× changed what the
tail is a share *of*:

```
peak tail share of the snapshot, base compressed:  85-99.9%
```

The tail is also the incremental half: it is what grows between folds, on the append path, on every
write. So it gets the same treatment, framed as **one block per appended batch**:

```
codec byte | 4-byte big-endian payload length | zlib(payload)
```

No delimiter and no newline. A compressed payload contains both, and a reader scanning for one would
have to unstuff every record to be sure it had not.

**Per batch, not per record.** The batch is a boundary the writer already holds, so a block costs no
buffering and does not move the moment a record becomes durable. It is also where the compression
is:

| framing | ratio |
|---|---|
| per record | 3.31× |
| **per appended batch** | **15.60×** |

One record carries no dictionary worth the name.

Whole snapshot, base and tail together, over eight ingests interleaved with reads:

```
                              off        on
peak snapshot            567,109     36,960 bytes   (15.34x)
  base                   271,058     15,792         (17.17x)
  tail                    92,496      5,879         (15.73x)
  head                       322        322         (unchanged - it holds counts, not records)
```

**Its own filename again, for the same reason.** The plain reader splits the tail on newlines. Under
`.read-cache-delta.bin` an older reader finds no tail, and the head's `delta_count` no longer
matches, so it re-derives from the log — which it already does for a missing tail. A plain tail
already on disk still loads.

**A torn final block is dropped, not raised.** The tail is derived state and the head records how
many records it should hold, so a short read is caught by the count check that already guards the
plain form. Raising there would turn a torn append into an unreadable snapshot when re-deriving is
the answer.

## Two paths append to the tail

There are two append-only fast paths onto the tail: the one a **write** takes, holding the batch it
just appended, and the one a **read** takes, slicing it out of the record set. Only the first was
taught the block format.

While the tail had a single form that was duplication. With two forms it is a correctness hazard —
the writer extends `.bin`, the reader extends `.jsonl`, the loader reads whichever it prefers, its
count disagrees with the head, and **every read re-derives from the log** with a perfectly good
snapshot sitting beside it. Nothing raises and the answer stays right; only the latency moves, which
is why the suite passed with it in place.

Both now go through `_append_tail_records`, which refuses to append when a tail in the *other* form
is already on disk. Raising there is the answer both callers already have — they catch `ValueError`
and fall through to a full rewrite, which clears both forms and leaves exactly one tail. That is also
what a store crossing the flag does: one rewrite, then one tail.

**Two tests went red on the fix**, which is the sharpest evidence the defect was real. They name the
plain tail file to mean "the tail", their flow reaches the read-side append, and the file they
measured grew *only because that path was writing the wrong form*. With both paths agreeing it is
never written. They ask through `_durable_read_cache_tail_path()` now — the same correction the eight
files that named the JSON snapshot to mean "the snapshot" needed.

The test for the invariant belongs where the fixture reaches the path. Written against the container
file's two-document fixture it never got there at all, and the mutation restoring the bug **survived**
it; against a primed 50-record base it fails. The invariant holds in either flag state, so it sits
with the other incremental-tail tests.

## Tests

`test_matrixark_the_snapshot_is_a_compressed_container.py` — the container is smaller and binary, it
says what it is, a cold read is served from it, an existing JSON snapshot still loads, the decoder
takes either form, and an unknown codec is refused rather than guessed. The flag is a module global,
so each test restores it.

Four more for the block-framed tail: it is smaller than the plain one and the plain one is gone, a
cold read stitches it onto the base and serves `source=durable`, a plain tail already on disk still
loads, and a torn final block is dropped rather than raised. Plus, in the incremental-tail file, both
append paths write one tail and the snapshot keeps serving; and a tail in the other form is refused
rather than joined.

Every mechanism was mutation-tested — **six mutations, six caught**: a block stored rather than
compressed, a torn block raised rather than dropped, a fold leaving the block tail behind, the tail
path answering the plain name always, the helper ignoring the flag, and a tail in the other form
joined rather than refused. Each is caught by a test that names the thing it broke.
