### PR TITLE
Take the always-true wrapper off the tail scan

### DIFF
--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -3714,10 +3714,10 @@ fn last_wal_sequence_in(path: &Path) -> Result<(u64, u64), WriteAheadLogError> {
     }
     if crate::log_framing::binary_frame_enabled() {
         // The footer says where to start, so the walk covers the open block instead of the log.
-        if true {
-            if let Some((sequence, from)) = footer_tail_hint(path)? {
-                return last_wal_sequence_forward_from(path, from, sequence);
-            }
+        // Without one -- a log written before blocks, or an empty one -- the walk starts at the
+        // header and covers everything, which is the same answer for more reading.
+        if let Some((sequence, from)) = footer_tail_hint(path)? {
+            return last_wal_sequence_forward_from(path, from, sequence);
         }
         return last_wal_sequence_forward(path);
     }


### PR DESCRIPTION
`last_wal_sequence_in` wrapped its footer-hint lookup in `if true {`.

A conditional that cannot be false is scaffolding left where a real condition used to be, and it
costs a reader twice: once working out that it does nothing, and again wondering what used to be
there and whether removing it changes anything.

Nothing else changes. The block keeps its comment and gains the sentence the `if` was standing in
for — without a footer (a log written before blocks, or an empty one) the walk starts at the header
and covers everything, which is the same answer for more reading.

This is the function documented two changes ago: it picks its strategy from `TS_WAL_BINARY_FRAME`
rather than from the file, which is why turning that flag off over a length-framed log is
unsupported. Unchanged here — only the dead wrapper is gone.

### The other one in this file stays

`shard_uses_blocks` opens with `if false { return Ok(false); }` and says why in the line above it:
*kept as a false branch so the surrounding shape stays reviewable.* Deleting something whose comment
explains why it is there is a decision for whoever wrote it.

`cargo check --all-targets` clean · 34 WAL, footer and tail tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
