### PR TITLE
A batch with no writes reads where the table says

### DIFF
--- a/crates/temporalstore-rust/src/client.rs
+++ b/crates/temporalstore-rust/src/client.rs
@@ -32,6 +32,7 @@ mod table_control_state;
 mod retry;
 mod routing;
 
+use client_routing::batch_read_policy;
 use commands::{command_is_dropped, command_key, is_write};
 use retry::{
     classify_retry_decision, replica_read_policy_from_meta, retry_attempts_for,
@@ -1578,14 +1579,19 @@ impl TemporalStoreTable {
         table_options: TableOptions,
     ) -> Result<BatchExecuteResponse, ClientError> {
         let write = request.commands.iter().any(is_write);
+        // A batch with no writes reads under the table's policy, like any other read. A batch
+        // that carries one takes the primary, because the write has to.
+        let (replica_read_policy, preferred_location) = batch_read_policy(write, &table_options);
         let retry_budget_attempts = retry_attempts_for(&table_options, write);
         let mut attempt = 0;
         let mut topology_refresh_used = false;
         let response = loop {
-            let current = self.client.batch_execute_with_http(
+            let current = self.client.batch_execute_with_http_and_policy(
                 request.clone(),
                 self.http_options(&table_options),
                 Some(table_options.continuous_failed_time_ms),
+                replica_read_policy,
+                preferred_location,
             )?;
             let decision = classify_retry_decision(
                 &current.status,

--- a/crates/temporalstore-rust/src/client/client_routing.rs
+++ b/crates/temporalstore-rust/src/client/client_routing.rs
@@ -220,9 +220,37 @@ impl TemporalStoreClient {
         http_options: HttpRequestOptions,
         continuous_failed_time_ms: Option<u64>,
     ) -> Result<BatchExecuteResponse, ClientError> {
+        self.batch_execute_with_http_and_policy(
+            request,
+            http_options,
+            continuous_failed_time_ms,
+            ReplicaReadPolicy::PinPrimary,
+            None,
+        )
+    }
+
+    /// A batch sent under a chosen replica read policy.
+    ///
+    /// The route is resolved with the policy on every attempt, including the refreshes after a
+    /// backend failure -- a retry that silently fell back to the primary would make the policy
+    /// hold only until the first error.
+    pub(super) fn batch_execute_with_http_and_policy(
+        &self,
+        request: BatchExecuteRequest,
+        http_options: HttpRequestOptions,
+        continuous_failed_time_ms: Option<u64>,
+        replica_read_policy: ReplicaReadPolicy,
+        preferred_location: Option<&str>,
+    ) -> Result<BatchExecuteResponse, ClientError> {
         if self.inner.options.meta_addr.is_some() {
             let server_addr =
-                self.resolve_route(request.shard_id, false, continuous_failed_time_ms)?;
+                self.resolve_route_with_policy(
+                request.shard_id,
+                false,
+                continuous_failed_time_ms,
+                replica_read_policy,
+                preferred_location,
+            )?;
             return post_json_with_options(&server_addr, "/batch_execute", &request, http_options)
                 .or_else(|err| {
                     let became_continuous = self.record_backend_failure(
@@ -244,12 +272,22 @@ impl TemporalStoreClient {
                             .lock()
                             .expect("client stats lock poisoned")
                             .record_write_of_unknown_outcome();
-                        let _ =
-                            self.resolve_route(request.shard_id, true, continuous_failed_time_ms);
+                        let _ = self.resolve_route_with_policy(
+                            request.shard_id,
+                            true,
+                            continuous_failed_time_ms,
+                            replica_read_policy,
+                            preferred_location,
+                        );
                         return Err(ClientError::WriteOutcomeUnknown(err.to_string()));
                     }
-                    let refreshed =
-                        self.resolve_route(request.shard_id, true, continuous_failed_time_ms)?;
+                    let refreshed = self.resolve_route_with_policy(
+                        request.shard_id,
+                        true,
+                        continuous_failed_time_ms,
+                        replica_read_policy,
+                        preferred_location,
+                    )?;
                     let response = post_json_with_options(
                         &refreshed,
                         "/batch_execute",
@@ -451,23 +489,45 @@ impl TemporalStoreClient {
     }
 }
 
+/// Which replica policy a batch reads under, and from where.
+///
+/// A batch may carry writes and those must reach the primary, so the table's policy applies only
+/// to a batch that carries none -- the same distinction `force_primary` draws on the single
+/// command path, drawn from the same two inputs. `pin_primary` still wins, and a table that has
+/// configured nothing reads `PinPrimary`, so a default table's batches do not move.
+pub(super) fn batch_read_policy(
+    write: bool,
+    table_options: &TableOptions,
+) -> (ReplicaReadPolicy, Option<&str>) {
+    if write || table_options.pin_primary {
+        return (ReplicaReadPolicy::PinPrimary, None);
+    }
+    (
+        table_options.replica_read_policy,
+        if table_options.preferred_location.is_empty() {
+            None
+        } else {
+            Some(table_options.preferred_location.as_str())
+        },
+    )
+}
+
 #[cfg(test)]
 mod batch_routing_tests {
     use super::*;
 
-    /// A batch is always sent to the primary; a single command is not.
+    /// The client-level batch still takes the primary. The table-level one no longer has to.
     ///
-    /// `execute_routed_with_http_and_policy` threads the table's `ReplicaReadPolicy` and its
-    /// `preferred_location` through to route selection, so a table configured to read from a
-    /// nearby replica does. `batch_execute_with_options` calls plain `resolve_route`, which
-    /// hard-codes `PinPrimary` and no location -- so the same table's batch reads go to the
-    /// primary, and cross-zone if that is where it is.
+    /// `batch_execute_with_options` resolves through plain `resolve_route`, which hard-codes
+    /// `PinPrimary` and no location. It is handed a bare `BatchExecuteRequest` with no table
+    /// options, so there is no policy for it to read and it stays as it is -- this holds it there.
     ///
-    /// Pinned rather than changed. Sending a batch to the primary is SAFE: a batch may contain
-    /// writes and those must go there. What is not distinguished is a batch containing none,
-    /// which is the case that could follow the table's policy. Making that distinction moves
-    /// read traffic onto replicas, so it wants a deliberate decision and a check that a replica
-    /// serves `/batch_execute` at all -- neither of which belongs in a quiet change.
+    /// The table-level batch is what changed. It has the table's options, so `batch_read_policy`
+    /// gives a batch carrying no writes the table's own policy and location, and a table
+    /// configured to read from a nearby replica now does so for its batches too. A batch carrying
+    /// a write still takes the primary, because the write must; so does `pin_primary`, which is
+    /// on by default -- so a default table's batches do not move. The tests below hold each of
+    /// those.
     #[test]
     fn a_batch_goes_to_the_primary_even_when_a_single_read_would_not() {
         let client = TemporalStoreClient::new("127.0.0.1:1");
@@ -499,6 +559,94 @@ mod batch_routing_tests {
         assert_ne!(
             single, batch,
             "the two paths disagree by construction -- if they ever agree, one of them changed              and the comment above needs to change with it"
+        );
+    }
+
+    /// A batch carrying no writes reads under the table's own policy, and from its own location.
+    #[test]
+    fn a_read_only_batch_reads_under_the_table_policy() {
+        let options = TableOptions {
+            pin_primary: false,
+            replica_read_policy: ReplicaReadPolicy::FirstReplica,
+            preferred_location: "zone-a".to_string(),
+            ..TableOptions::default()
+        };
+        assert_eq!(
+            batch_read_policy(false, &options),
+            (ReplicaReadPolicy::FirstReplica, Some("zone-a")),
+            "a batch of reads should route like the reads it is made of"
+        );
+    }
+
+    /// One write in the batch sends the whole batch to the primary.
+    ///
+    /// The batch is one request to one server, so the policy is decided for the batch, not per
+    /// command. A single write in it therefore takes all of it to the primary -- there is no
+    /// splitting the difference.
+    #[test]
+    fn one_write_takes_the_whole_batch_to_the_primary() {
+        let options = TableOptions {
+            pin_primary: false,
+            replica_read_policy: ReplicaReadPolicy::FirstReplica,
+            preferred_location: "zone-a".to_string(),
+            ..TableOptions::default()
+        };
+        assert_eq!(
+            batch_read_policy(true, &options),
+            (ReplicaReadPolicy::PinPrimary, None),
+            "a batch containing a write must reach the primary"
+        );
+    }
+
+    /// `pin_primary` outranks the read policy, as it does on the single-command path.
+    #[test]
+    fn pin_primary_outranks_the_read_policy() {
+        let options = TableOptions {
+            pin_primary: true,
+            replica_read_policy: ReplicaReadPolicy::FirstReplica,
+            preferred_location: "zone-a".to_string(),
+            ..TableOptions::default()
+        };
+        assert_eq!(
+            batch_read_policy(false, &options),
+            (ReplicaReadPolicy::PinPrimary, None),
+            "pin_primary is the operator saying primary, and it wins"
+        );
+    }
+
+    /// A table that configured nothing routes exactly where it did before.
+    ///
+    /// The blast radius of the change, stated as a test: `TableOptions::default()` sets
+    /// `pin_primary` AND `PinPrimary`, so a table nobody configured sends its batches to the
+    /// primary whether or not they carry writes. Only a table that asked for replica reads moves.
+    #[test]
+    fn a_default_table_batches_where_it_always_did() {
+        let options = TableOptions::default();
+        assert_eq!(
+            batch_read_policy(false, &options),
+            (ReplicaReadPolicy::PinPrimary, None)
+        );
+        assert_eq!(
+            batch_read_policy(true, &options),
+            (ReplicaReadPolicy::PinPrimary, None)
+        );
+    }
+
+    /// An unset location is no location, not a location named "".
+    ///
+    /// `preferred_location` is a `String` and its unset value is empty, so passing it through
+    /// unchecked would ask route selection to match a zone whose name is the empty string.
+    #[test]
+    fn an_unset_location_is_no_location() {
+        let options = TableOptions {
+            pin_primary: false,
+            replica_read_policy: ReplicaReadPolicy::FirstReplica,
+            preferred_location: String::new(),
+            ..TableOptions::default()
+        };
+        assert_eq!(
+            batch_read_policy(false, &options),
+            (ReplicaReadPolicy::FirstReplica, None)
         );
     }
 }

--- a/crates/temporalstore-rust/src/client/tests/part2.rs
+++ b/crates/temporalstore-rust/src/client/tests/part2.rs
@@ -1065,6 +1065,138 @@ fn table_read_policy_can_select_secondary_from_metaserver_topology() {
     assert!(client.stats().route_cache_hits >= 2);
 }
 
+/// A batch of reads reaches the replica; a batch carrying a write reaches the primary.
+///
+/// This is the WIRING, not the decision. `batch_read_policy` is unit-tested beside the route
+/// selection it feeds, but a correct decision that nothing consults routes nothing -- reverting
+/// the call site leaves those unit tests green. Both servers answer `/batch_execute` with their
+/// own name, so the value that comes back names the node that served the batch.
+#[test]
+fn a_read_only_batch_reaches_the_replica_and_a_write_batch_the_primary() {
+    fn answering(addr: &str, name: &'static str) {
+        let addr = addr.to_string();
+        std::thread::spawn(move || {
+            serve(&addr, move |request| {
+                match (request.method.as_str(), request.path.as_str()) {
+                    ("POST", "/batch_execute") => {
+                        let req = parse_json::<BatchExecuteRequest>(&request.body).unwrap();
+                        json_response(
+                            200,
+                            &BatchExecuteResponse {
+                                status: Status::ok(),
+                                responses: req
+                                    .commands
+                                    .iter()
+                                    .map(|_| ExecuteResponse {
+                                        status: Status::ok(),
+                                        response: CommandResponse::Bytes {
+                                            value: Some(name.as_bytes().to_vec()),
+                                        },
+                                    })
+                                    .collect(),
+                            },
+                        )
+                    }
+                    _ => json_response(404, &Status::error("not_found", "not found")),
+                }
+            })
+            .unwrap();
+        });
+    }
+
+    let primary_addr = free_local_addr();
+    let replica_addr = free_local_addr();
+    let meta_addr = free_local_addr();
+    answering(&primary_addr, "primary");
+    answering(&replica_addr, "replica");
+
+    let primary_for_meta = primary_addr.clone();
+    let replica_for_meta = replica_addr.clone();
+    let meta_addr_for_listener = meta_addr.clone();
+    std::thread::spawn(move || {
+        serve(&meta_addr_for_listener, move |request| {
+            match (request.method.as_str(), request.path.as_str()) {
+                ("POST", "/tables/topology") => json_response(
+                    200,
+                    &TableTopologyResponse {
+                        status: Status::ok(),
+                        table: Some(TableMetaInfo {
+                            table_id: 7,
+                            namespace: "ns".to_string(),
+                            table_name: "tbl".to_string(),
+                            state: crate::meta::MetaEntityState::Normal,
+                            topology_version: 1,
+                            first_shard_id: 1,
+                            shard_count: 1,
+                            replica_count: 2,
+                            partition_version: 0,
+                            serving_options: crate::meta::TableServingOptions::default(),
+                        }),
+                        shards: vec![TableShard {
+                            shard_id: 1,
+                            start_bucket: 0,
+                            end_bucket: u64::MAX,
+                            primary: Some(primary_for_meta.clone()),
+                            replicas: vec![primary_for_meta.clone(), replica_for_meta.clone()],
+                            primary_endpoint: None,
+                            replica_endpoints: Vec::new(),
+                        }],
+                        unchanged: false,
+                    },
+                ),
+                _ => json_response(404, &Status::error("not_found", "not found")),
+            }
+        })
+        .unwrap();
+    });
+    wait_for_http(&primary_addr);
+    wait_for_http(&replica_addr);
+    wait_for_http(&meta_addr);
+
+    let client = TemporalStoreClient::with_options(ClientOptions {
+        proxy_addr: "127.0.0.1:1".to_string(),
+        meta_addr: Some(meta_addr.clone()),
+        route_cache_ttl_ms: 60_000,
+        ..ClientOptions::default()
+    });
+    let synced = client.sync_table_topology("ns", "tbl").unwrap();
+    let table = client.open_table(
+        "ns",
+        "tbl",
+        TableOptions {
+            pin_primary: false,
+            replica_read_policy: ReplicaReadPolicy::FirstReplica,
+            ..synced
+        },
+    );
+
+    let reads = table
+        .batch_execute(vec![
+            Command::StringGet { key: "k".to_string() },
+            Command::StringGet { key: "k2".to_string() },
+        ])
+        .unwrap();
+    assert!(reads.status.ok, "{:?}", reads.status);
+    assert_eq!(
+        reads.responses[0].response,
+        CommandResponse::Bytes { value: Some(b"replica".to_vec()) },
+        "a batch carrying no writes must follow the table's replica policy, as its reads do          one at a time"
+    );
+
+    let mixed = table
+        .batch_execute(vec![
+            Command::StringGet { key: "k".to_string() },
+            Command::StringSet { key: "k".to_string(), value: b"v".to_vec() },
+        ])
+        .unwrap();
+    assert!(mixed.status.ok, "{:?}", mixed.status);
+    assert_eq!(
+        mixed.responses[0].response,
+        CommandResponse::Bytes { value: Some(b"primary".to_vec()) },
+        "one write takes the whole batch to the primary"
+    );
+}
+
 #[test]
 fn client_router_matches_crc64_bucket_formula() {
     assert_eq!(crc64_jones(b"123456789"), 0xe9c6d914c4b8d9ca);


### PR DESCRIPTION
A single read follows the table's replica policy and preferred location. The same table's **batch did not** -- the batch path resolved through plain `resolve_route`, which hard-codes `PinPrimary` and no location. A table configured to read from a nearby replica still sent its batches to the primary, cross-zone if that is where it sits.

That was pinned rather than changed, because the pin named two things to settle first. Both are settled here.

**A batch may carry writes, and those must reach the primary.** The table path already computes `let write = commands.iter().any(is_write)` for its retry budget -- the distinction was being made and then not used. `batch_read_policy` turns it into the route decision: no writes takes the table's policy and location, a write takes the primary, and `pin_primary` still wins.

**A replica has to serve `/batch_execute` at all.** It does, on the same unguarded arm block that serves `/execute` and `/async_execute`; `data_node::batch_execute` validates writes and mirrors writes, both keyed off command kind, so a read-only batch triggers neither.

## Blast radius

`TableOptions::default()` sets both `pin_primary: true` and `PinPrimary`, so **a table nobody configured routes exactly where it always did** -- asserted as a test. Only a table that asked for replica reads moves, and it moves to what it asked for.

Both batch paths are covered: the grouped multi-shard path funnels through `batch_execute_single_shard_with_retry` as well. The policy is applied on the post-failure refresh as well as the first attempt -- a retry falling back to the primary would make the policy hold only until the first error.

The client-level `batch_execute_with_options` is unchanged and still pins the primary: it is handed a bare request with no table options, so there is no policy for it to read.

## Tested both ways

Five unit tests hold the decision. One end-to-end test holds the wiring -- two servers each answer `/batch_execute` with their own name, so the value returned names the node that served the batch.

| wiring reverted | result |
|---|---|
| the five unit tests | still green |
| the end-to-end test | fails |

Which is why the end-to-end one is there.