### PR TITLE
An example that asks the log what it is holding

### DIFF
--- a/crates/temporalstore-rust/examples/wal_scan_probe.rs
+++ b/crates/temporalstore-rust/examples/wal_scan_probe.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+//! What a recovered record actually carries: a command to re-run, an outcome naming a page, or
+//! the page bytes themselves. With the pages wiped, only the last two of those can rebuild a value.
+//!
+//!     cargo run --example wal_scan_probe -- <store-root>
+
+use std::path::PathBuf;
+
+use temporalstore_rust::wal::LocalWriteAheadLogStore;
+
+fn main() {
+    let root = PathBuf::from(std::env::args().nth(1).expect("usage: wal_scan_probe <store-root>"));
+    let wals = root.join("indexes").join("wals");
+    let store = LocalWriteAheadLogStore::new(&wals);
+
+    let records = match store.scan(1, 0, u64::MAX, u64::MAX) {
+        Ok(records) => records,
+        Err(err) => {
+            println!("scan ERROR: {err}");
+            return;
+        }
+    };
+    println!("scan returned {} record(s)", records.len());
+
+    let mut with_command = 0usize;
+    let mut with_outcomes = 0usize;
+    let mut outcome_items = 0usize;
+    let mut outcomes_carrying_a_value = 0usize;
+    let mut with_staged_pages = 0usize;
+    let mut staged_page_bytes = 0usize;
+    let mut undecodable = 0usize;
+
+    for (_, bytes) in &records {
+        match temporalstore_rust::wal::decode_wal_line(bytes) {
+            Ok(record) => {
+                if record.command.is_some() {
+                    with_command += 1;
+                }
+                if !record.outcomes.is_empty() {
+                    with_outcomes += 1;
+                    outcome_items += record.outcomes.len();
+                    for item in &record.outcomes {
+                        if item.value.as_ref().map(|v| !v.is_empty()).unwrap_or(false) {
+                            outcomes_carrying_a_value += 1;
+                        }
+                    }
+                }
+                if !record.staged_pages.is_empty() {
+                    with_staged_pages += 1;
+                    staged_page_bytes += record.staged_pages.iter().map(|p| p.bytes.len()).sum::<usize>();
+                }
+            }
+            Err(_) => undecodable += 1,
+        }
+    }
+
+    println!("  carrying a COMMAND to re-run          {with_command}");
+    println!("  carrying OUTCOMES                     {with_outcomes}  ({outcome_items} items)");
+    println!("     of those items, carrying a VALUE   {outcomes_carrying_a_value}");
+    println!("  carrying STAGED PAGES                 {with_staged_pages}  ({staged_page_bytes} bytes)");
+    println!("  undecodable                           {undecodable}");
+    println!();
+    println!("With the pages wiped, a value can only come back from a command to re-run, an");
+    println!("outcome that carries the value, or a staged page. A record with none of those");
+    println!("names an address that no longer exists.");
+}


### PR DESCRIPTION
When a recovery test reports that it recovered nothing, there are two very different explanations and
no way to tell them apart from outside: **the scan returned no records**, or **it returned records
replay could not use**. Answering that meant writing a throwaway program. This is that program, kept.

It scans a shard's log from zero, decodes every record, and reports what they **carry** rather than
how many there are:

- a command that can be re-run
- an outcome — and whether that outcome brings the **value** with it
- the page bytes, as a staged page

Those are exactly the three ways a value can come back when the pages are gone. A record with none of
them names an address that no longer exists.

### What it said on the crash-recovery harness's store

After the power-loss step wiped everything but the log:

```
scan returned 300 record(s)
  carrying a COMMAND to re-run          0
  carrying OUTCOMES                     300  (300 items)
     of those items, carrying a VALUE   0
  carrying STAGED PAGES                 0  (0 bytes)
  undecodable                           0
```

The log was **intact and complete** — 300 records, all decoding, `last_sequence` agreeing. That is
what makes the reading worth having: counting records would have said the log was fine.

### Scope

Reading is all it does. It opens the log store directly, takes no lock the writer needs, and writes
nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
