### PR TITLE
Say in the crash-recovery tests why five of them fail

### DIFF
--- a/crates/temporalstore-rust/tests/wal_single_barrier_recovery.rs
+++ b/crates/temporalstore-rust/tests/wal_single_barrier_recovery.rs
@@ -9,6 +9,52 @@
 //! power cut, replay rebuilds every key. A final phase exercises the TS_WAL_LEGACY_RECOVERY escape
 //! hatch (legacy multi-barrier write + delta-fold recovery) so the fallback stays covered. Each
 //! phase runs in its own subprocess so any mode env var never leaks into the rest of the suite.
+//!
+//! # The premise above no longer holds, and five of these fail because of it
+//!
+//! "The WAL is self-sufficient (it embeds the full command payload)" was true when this was
+//! written. It is not true now, and nothing here was changed to say so -- these tests have been
+//! failing on main ever since, and the CI step that runs them carries `continue-on-error: true`.
+//!
+//! Three defaults meet to produce it:
+//!
+//!   * single-barrier acks once the WAL is fsynced; the data-page fdatasync is deferred BY DESIGN,
+//!     which is the whole point of the mode and is what the power-loss step models by deleting the
+//!     pages;
+//!   * `TS_WAL_OUTCOME_ITEMS` (default ON) records what a write DID rather than what it was;
+//!   * `TS_WAL_DATA_ONLY` (default ON) then removes the command -- "stop writing the operation into
+//!     a record that already states its results ... the operation is consulted only when there are
+//!     none."
+//!
+//! An outcome states "this object's page is at this address". With the page write deferred and then
+//! lost, the address names nothing and the command that could have re-derived the value is gone.
+//! Staged pages (`TS_BLOCK_IN_WAL`) would carry the bytes, but staging happens on the ASYNC storage
+//! path; a synchronous write stages nothing.
+//!
+//! Measured on the store these tests leave behind, with `examples/wal_scan_probe.rs`:
+//!
+//! ```text
+//! scan returned 300 record(s)
+//!   carrying a COMMAND to re-run          0
+//!   carrying OUTCOMES                     300  (300 items)
+//!      of those items, carrying a VALUE   0
+//!   carrying STAGED PAGES                 0  (0 bytes)
+//!   undecodable                           0
+//! ```
+//!
+//! So the log is intact and complete -- 300 records, all decoding, `last_sequence` agreeing -- and
+//! holds nothing any replay could rebuild a value from. The failure is not the harness: its
+//! `abort()` models process loss faithfully, the WAL survives it, and the records are all there.
+//!
+//! `legacy_recovery_escape_hatch_delta_fold_recovers_every_ack` still passes, which is the shape of
+//! the thing: the hatch recovers where the default does not.
+//!
+//! Fixing it is a choice about what an ack means, not a tidy-up -- an outcome could carry the value
+//! when the page it names is not yet durable; the sync path could stage pages as the async path
+//! does; the command could stay while single-barrier is on; or the page fsync could stop being
+//! deferred in this mode. Each trades write cost against the promise. Whoever takes it should start
+//! from the probe output above rather than from the assertion message, which only says a key was
+//! missing.
 
 use std::process::Command;
 


### PR DESCRIPTION
The module doc opens with the premise the whole file rests on:

> the WAL is self-sufficient (it embeds the full command payload), so even if … the pages are lost to
> a simulated power cut, replay rebuilds every key

**That was true when it was written and is not true now** — and nothing here was changed to say so,
which is why five of these have been failing on main with no explanation attached. The CI step that
runs them carries `continue-on-error: true`, so nothing brings it up either.

### Three defaults meet

- **single-barrier** acks once the WAL is fsynced, deferring the data-page fdatasync *by design* —
  the point of the mode, and what the power-loss step models by deleting the pages
- **`TS_WAL_OUTCOME_ITEMS`** records what a write *did* rather than what it *was*
- **`TS_WAL_DATA_ONLY`** then removes the command, reasoning that "the operation is consulted only
  when there are none"

So an acked write leaves a record saying where its page is, the page write is deferred and lost, and
the operation that could have re-derived the value has been taken out. Staged pages would carry the
bytes, but staging happens on the async storage path — a synchronous write stages nothing.

### The measurement, not the assertion message

From `examples/wal_scan_probe.rs` on the store these tests leave behind:

```
scan returned 300 record(s)
  carrying a COMMAND to re-run          0
  carrying OUTCOMES                     300  (300 items)
     of those items, carrying a VALUE   0
  carrying STAGED PAGES                 0  (0 bytes)
  undecodable                           0
```

The log is **intact and complete** and holds nothing a replay could rebuild from. Worth stating
precisely, because "recovered 0 of 300" reads like a lost log.

It is **not the harness**: its `abort()` models process loss faithfully, the WAL survives it, every
record is there. And `legacy_recovery_escape_hatch_delta_fold_recovers_every_ack` still passes —
the hatch recovers where the default does not.

### Scope

No test is changed and no default is moved. Fixing this is a choice about what an ack means, and the
doc names the four candidates rather than picking one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
