### PR TITLE
Point the README at the flag inventory it generates

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,11 @@ Every knob is environment-overridable; defaults are tuned for large-window servi
 | `MATRIXARK_OBJECT_RPC_URL` / `MATRIXARK_OBJECT_STORE_DIR` | — | store resource/skill raw blobs in **MatrixObject** (object storage) in distributed mode |
 | `MATRIXARK_EAGER_CACHE_WARM_ON_LOAD` | on | promote disk → memory on restart for a warm start |
 
+Those are the ones worth knowing first. The full list — every `TS_*`, `MATRIXARK_*` and
+`TEMPORALSTORE_*` variable the engine reads, grouped by what it decides, with its default where
+the source states one, who sets it, and whether the portal offers it — is generated from the
+source into [`docs/ops/temporalstore-engine-flags.md`](docs/ops/temporalstore-engine-flags.md).
+
 ---
 
 ## Deploy: laptop → replicated cluster


### PR DESCRIPTION
`docs/ops/temporalstore-engine-flags.md` lists **every variable the engine reads** — 296 of them,
grouped by what they decide, each with its default where the source states one, who sets it, and
whether the portal offers it. It is generated from the source on every change and guarded by a test
that regenerates and compares.

**Nothing linked to it.** Not the README, not another document, not the portal.

The README's configuration section shows six common variables and says every knob is
environment-overridable — the exact place a reader would look for the rest and not find it.

The six stay where they are: they are the ones worth knowing first, and a table of 296 is not a
README. What follows them now is a sentence saying where the rest live and what the document can
answer — which is the question it was built for: whether anything anywhere selects a flag's other
position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
