### PR TITLE
The close budget is a total, not a per-step allowance

### DIFF
--- a/tools/matrixark_mcp_server.py
+++ b/tools/matrixark_mcp_server.py
@@ -399,17 +399,45 @@ class MatrixArkMcpServer(MatrixArkServerRequestPolicyMixin):
                 self.metrics.observe_operation("stream_materialize", "error", 0.0, timeout=is_retryable_temporalstore_error(exc))
                 _mcp_debug_log(f"matrixark stream materialize loop failed: {exc}")
 
+    #: The share of a close budget the two background-thread joins may spend between them.
+    #:
+    #: They are daemon threads in a process that is about to exit, so joining them is a courtesy;
+    #: the adapter close and the audit drain below are the reason a caller waits at all. Capping
+    #: their share is what stops a poller that will not stop from consuming the whole budget and
+    #: leaving nothing for the flushes.
+    CLOSE_JOIN_BUDGET_SHARE = 0.25
+
     def close(self, *, timeout_s: float = 5.0) -> None:
+        """Shut the server down within `timeout_s` TOTAL, not per step.
+
+        Each of the four waits below used to receive the full budget, so a close could need four
+        times what its caller was willing to wait -- and the caller waits once. Measured on the live
+        box, every one of 2,811 hook closes hit its 750 ms budget exactly: the first wait, a join
+        against a 1000 ms-interval summary poller, spent all of it, and the two steps that flush
+        were reached only after the caller had abandoned the thread.
+
+        So the budget is a deadline that every step measures itself against, and the joins take a
+        bounded share of it. A poller that refuses to stop now costs its slice instead of everything.
+        """
+        deadline = time.monotonic() + max(0.0, timeout_s)
+
+        def remaining() -> float:
+            return max(0.0, deadline - time.monotonic())
+
         self._summary_stop.set()
         self._stream_materialize_stop.set()
-        if self._summary_thread is not None:
-            self._summary_thread.join(timeout=max(0.0, timeout_s))
-        if self._stream_materialize_thread is not None:
-            self._stream_materialize_thread.join(timeout=max(0.0, timeout_s))
+
+        join_deadline = time.monotonic() + remaining() * self.CLOSE_JOIN_BUDGET_SHARE
+        for thread in (self._summary_thread, self._stream_materialize_thread):
+            if thread is None:
+                continue
+            thread.join(timeout=max(0.0, join_deadline - time.monotonic()))
+
+        # Whatever is left goes to the work a caller actually waits for.
         adapter_close = getattr(self.adapter, "close", None)
         if callable(adapter_close):
-            adapter_close(timeout_s=timeout_s)
-        self._audit_queue.drain(timeout_s)
+            adapter_close(timeout_s=remaining())
+        self._audit_queue.drain(remaining())
 
     def append_audit_policy(self, action: str, identity: Json, *, status: str, details: Json | None = None, args: Json | None = None, hot_path: bool = False) -> None:
         mode = str((args or {}).get("audit_mode") or self._audit_mode_default).strip().lower()

--- a/tools/matrixark_mcp_server.py
+++ b/tools/matrixark_mcp_server.py
@@ -399,45 +399,15 @@ class MatrixArkMcpServer(MatrixArkServerRequestPolicyMixin):
                 self.metrics.observe_operation("stream_materialize", "error", 0.0, timeout=is_retryable_temporalstore_error(exc))
                 _mcp_debug_log(f"matrixark stream materialize loop failed: {exc}")
 
-    #: The share of a close budget the two background-thread joins may spend between them.
-    #:
-    #: They are daemon threads in a process that is about to exit, so joining them is a courtesy;
-    #: the adapter close and the audit drain below are the reason a caller waits at all. Capping
-    #: their share is what stops a poller that will not stop from consuming the whole budget and
-    #: leaving nothing for the flushes.
-    CLOSE_JOIN_BUDGET_SHARE = 0.25
-
     def close(self, *, timeout_s: float = 5.0) -> None:
-        """Shut the server down within `timeout_s` TOTAL, not per step.
+        """Stop background work and flush, in `timeout_s` TOTAL rather than per step.
 
-        Each of the four waits below used to receive the full budget, so a close could need four
-        times what its caller was willing to wait -- and the caller waits once. Measured on the live
-        box, every one of 2,811 hook closes hit its 750 ms budget exactly: the first wait, a join
-        against a 1000 ms-interval summary poller, spent all of it, and the two steps that flush
-        were reached only after the caller had abandoned the thread.
-
-        So the budget is a deadline that every step measures itself against, and the joins take a
-        bounded share of it. A poller that refuses to stop now costs its slice instead of everything.
+        See `matrixark_mcp_shutdown`: each stage used to receive the caller's whole budget, so the
+        first wait could spend it all and the flushes were reached only after the caller gave up.
         """
-        deadline = time.monotonic() + max(0.0, timeout_s)
+        from matrixark_mcp_shutdown import close_server_within_budget  # sibling; keeps this small
 
-        def remaining() -> float:
-            return max(0.0, deadline - time.monotonic())
-
-        self._summary_stop.set()
-        self._stream_materialize_stop.set()
-
-        join_deadline = time.monotonic() + remaining() * self.CLOSE_JOIN_BUDGET_SHARE
-        for thread in (self._summary_thread, self._stream_materialize_thread):
-            if thread is None:
-                continue
-            thread.join(timeout=max(0.0, join_deadline - time.monotonic()))
-
-        # Whatever is left goes to the work a caller actually waits for.
-        adapter_close = getattr(self.adapter, "close", None)
-        if callable(adapter_close):
-            adapter_close(timeout_s=remaining())
-        self._audit_queue.drain(remaining())
+        close_server_within_budget(self, timeout_s)
 
     def append_audit_policy(self, action: str, identity: Json, *, status: str, details: Json | None = None, args: Json | None = None, hot_path: bool = False) -> None:
         mode = str((args or {}).get("audit_mode") or self._audit_mode_default).strip().lower()

--- a/tools/matrixark_mcp_shutdown.py
+++ b/tools/matrixark_mcp_shutdown.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Shutting the MCP server down inside the budget its caller is willing to wait.
+
+Lives beside `matrixark_mcp_server` rather than inside it, the way `AuditWriteQueue` does: that
+module is held to 750 lines on purpose, and shutdown sequencing is a self-contained concern with its
+own rationale to carry.
+
+## Why the sequencing needs stating
+
+A server close is four waits -- two background threads, the adapter, the audit queue -- and every one
+of them used to receive the caller's FULL budget. The caller waits once. So a close could need four
+times what it was given, and the FIRST wait alone could spend all of it.
+
+Measured on the live box, that is not a corner case but the norm: every one of 2,811 hook closes hit
+its 750 ms budget exactly (min = p50 = p90 = max = 750). The first wait is a join against a
+1000 ms-interval summary poller, so it spent the whole budget, and the two steps that actually FLUSH
+-- the adapter close and the audit drain -- were reached only after the caller had abandoned the
+thread. The latency was the smaller half of it.
+
+So the budget here is a DEADLINE every step measures itself against, and the two thread joins take a
+bounded share of it. They are daemon threads in a process that is exiting, which makes joining them
+a courtesy; the flushes are the reason a caller waits at all.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+#: The share of a close budget the two background-thread joins may spend between them.
+#:
+#: Capping it is what stops a poller that will not stop from consuming everything and leaving the
+#: flushes with nothing. A quarter is enough for a thread that is merely between iterations, and
+#: cheap enough to lose when one is mid-request.
+CLOSE_JOIN_BUDGET_SHARE = 0.25
+
+
+def close_server_within_budget(server: Any, timeout_s: float) -> None:
+    """Stop `server`'s background work and flush it, in `timeout_s` TOTAL.
+
+    Total, not per step: each stage asks what is LEFT rather than helping itself to the whole budget
+    again. A caller that waits `timeout_s` gets a close that tried to finish in `timeout_s`.
+    """
+    deadline = time.monotonic() + max(0.0, timeout_s)
+
+    def remaining() -> float:
+        return max(0.0, deadline - time.monotonic())
+
+    server._summary_stop.set()
+    server._stream_materialize_stop.set()
+
+    # The joins share a slice; whatever they leave goes to the flushes below.
+    join_deadline = time.monotonic() + remaining() * CLOSE_JOIN_BUDGET_SHARE
+    for thread in (server._summary_thread, server._stream_materialize_thread):
+        if thread is None:
+            continue
+        thread.join(timeout=max(0.0, join_deadline - time.monotonic()))
+
+    adapter_close = getattr(server.adapter, "close", None)
+    if callable(adapter_close):
+        adapter_close(timeout_s=remaining())
+    server._audit_queue.drain(remaining())

--- a/tools/test_matrixark_the_close_budget_is_a_total.py
+++ b/tools/test_matrixark_the_close_budget_is_a_total.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A close budget is a total, and a background join may not spend all of it.
+
+`MatrixArkMcpServer.close(timeout_s)` runs four sequential waits. Each used to receive the caller's
+FULL budget, so a close could need four times what its caller was willing to wait -- and the caller
+waits once, then abandons a daemon thread.
+
+That is not hypothetical. On the live box every one of 2,811 hook closes hit its 750 ms budget
+exactly (min = p50 = p90 = max = 750): the first wait, a join against a 1000 ms-interval summary
+poller, spent the whole budget, and the two steps that FLUSH -- the adapter close and the audit
+drain -- were reached only after the caller had given up.
+
+So the two things worth pinning are:
+
+  * a stuck background thread costs its bounded share, not the whole budget;
+  * the flushing steps are still reached, and close still returns inside the budget.
+
+Each is asserted with a positive control, because "close returned quickly" is equally true of a
+close that did nothing at all.
+"""
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+
+from tools.matrixark_mcp_local_adapter import MatrixArkLocalAdapter
+from tools.matrixark_mcp_server import MatrixArkMcpServer
+
+
+class CloseBudgetIsATotalTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._dir.cleanup)
+        self.log = Path(self._dir.name) / "events.jsonl"
+        self.adapter = MatrixArkLocalAdapter(self.log)
+        self.adapter.append({"record_type": "context_event", "event_id": "e-1", "content": "seed"})
+        self.server = MatrixArkMcpServer(self.adapter, access_mode="dev")
+        self.addCleanup(self._stop_everything)
+
+        self.calls: list[str] = []
+        self.budgets: dict[str, float] = {}
+
+        real_adapter_close = self.adapter.close
+
+        def recording_adapter_close(*, timeout_s: float = 5.0) -> None:
+            self.calls.append("adapter_close")
+            self.budgets["adapter_close"] = timeout_s
+            real_adapter_close(timeout_s=timeout_s)
+
+        self.adapter.close = recording_adapter_close        # type: ignore[method-assign]
+
+        real_drain = self.server._audit_queue.drain
+
+        def recording_drain(timeout_s: float) -> None:
+            self.calls.append("audit_drain")
+            self.budgets["audit_drain"] = timeout_s
+            real_drain(timeout_s)
+
+        self.server._audit_queue.drain = recording_drain     # type: ignore[method-assign]
+
+    def _stop_everything(self) -> None:
+        self._release.set() if hasattr(self, "_release") else None
+
+    def _wedge_the_summary_thread(self, hold_s: float = 5.0) -> None:
+        """Stand in a thread that ignores the stop signal, the way a poller mid-request does."""
+        self._release = threading.Event()
+
+        def stubborn() -> None:
+            self._release.wait(hold_s)
+
+        thread = threading.Thread(target=stubborn, name="stubborn-poller", daemon=True)
+        thread.start()
+        self.server._summary_thread = thread
+        self.addCleanup(self._release.set)
+
+    def test_a_stuck_background_thread_does_not_spend_the_whole_budget(self):
+        self._wedge_the_summary_thread()
+        budget = 0.75
+
+        started = time.monotonic()
+        self.server.close(timeout_s=budget)
+        elapsed = time.monotonic() - started
+
+        self.assertLessEqual(
+            elapsed, budget * 1.5,
+            "close took %.2f s against a %.2f s budget; a stuck join is still spending it all"
+            % (elapsed, budget))
+        # Positive control: the thread really was stuck for the whole close.
+        self.assertTrue(self.server._summary_thread.is_alive(),
+                        "the stand-in thread finished on its own, so nothing was being wedged")
+
+    def test_the_flushing_steps_are_still_reached(self):
+        self._wedge_the_summary_thread()
+        self.server.close(timeout_s=0.75)
+
+        self.assertIn("adapter_close", self.calls,
+                      "the adapter was never flushed: the join consumed the budget")
+        self.assertIn("audit_drain", self.calls,
+                      "audit writes were never drained: the join consumed the budget")
+        self.assertEqual(["adapter_close", "audit_drain"], self.calls)
+
+    def test_the_flushes_get_a_real_share_not_a_leftover_of_zero(self):
+        """Reaching them is not enough -- they have to be given time to do anything."""
+        self._wedge_the_summary_thread()
+        budget = 0.75
+        self.server.close(timeout_s=budget)
+
+        self.assertGreater(
+            self.budgets.get("adapter_close", 0.0), 0.0,
+            "the adapter close was called with no time left, which is the same as skipping it")
+        self.assertLessEqual(self.budgets["adapter_close"], budget)
+
+    def test_a_slow_flush_is_bounded_by_what_is_LEFT_of_the_budget(self):
+        """The step that spends its budget is what distinguishes a total from a per-step allowance.
+
+        With a fast adapter the two are indistinguishable: each step returns immediately, so handing
+        every one of them the whole budget costs nothing and the close still looks quick. It is only
+        when a step actually USES its allowance that a per-step budget overruns the caller -- which
+        is exactly the live case, where the flush talks to a daemon over a socket.
+        """
+        self._wedge_the_summary_thread()
+        budget = 0.75
+
+        def slow_adapter_close(*, timeout_s: float = 5.0) -> None:
+            self.calls.append("adapter_close")
+            self.budgets["adapter_close"] = timeout_s
+            time.sleep(min(timeout_s, 2.0))          # spends whatever it was given
+
+        self.adapter.close = slow_adapter_close      # type: ignore[method-assign]
+
+        self.server.close(timeout_s=budget)
+
+        self.assertIn("adapter_close", self.calls)
+        # Asserted on the BUDGET HANDED OVER, not on the clock. The elapsed difference between a
+        # total and a per-step allowance is only the slice the join took, so a wall-clock bound
+        # tight enough to catch it would be tight enough to flake. What cannot be fudged is the
+        # number: after the join has spent part of the budget, a flush that still receives the
+        # WHOLE of it was given a per-step allowance.
+        self.assertLess(
+            self.budgets["adapter_close"], budget,
+            "the flush was handed the whole %.2f s budget after the join had already spent part "
+            "of it, so the budget is being treated as per-step rather than as a total" % budget)
+
+    def test_a_clean_close_still_runs_every_step(self):
+        """With nothing wedged, the ordinary path is unchanged."""
+        self.server.close(timeout_s=0.75)
+        self.assertEqual(["adapter_close", "audit_drain"], self.calls)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Every hook close on the live box times out, and the timeout is the smaller half of the problem.

## The measurement

From `/root/.matrixark/logs/mcp-debug.log` — real traffic, not a harness:

```
matrixark hook close skipped after 750ms: {'status': 'timeout', 'timeout_ms': 750}
n=2811   min=750   p50=750   p90=750   max=750
```

**Not a distribution — a constant.** The close never once completed inside its budget.
`close_server_best_effort` does `thread.join(0.75)` and then abandons a daemon thread, so every
agent turn blocks for the full 750 ms and gets nothing for it.

## Why it could not succeed

`close(timeout_s)` is four sequential waits, and each received the caller's **full** budget:

```
1. self._summary_thread.join(timeout_s)              ← a 1000 ms-interval poller
2. self._stream_materialize_thread.join(timeout_s)
3. adapter_close(timeout_s=timeout_s)                ← flushes the adapter
4. self._audit_queue.drain(timeout_s)                ← flushes audit writes
```

The caller waits **once**. So close could need four times what it was given, and step 1 alone could
spend all of it. A poller whose interval (1000 ms) exceeds the join budget (750 ms) cannot be joined
reliably even when idle, and when it is mid-request to the daemon it certainly cannot — the same log
carries `summary refresh loop failed: Rust TemporalStore get_string daemon timed out`.

**The latency is the smaller half.** Steps 3 and 4 are the ones that flush, and they are last, so
they were reached only after the caller had abandoned the thread.

## The change

A single deadline, so each step asks what is **left** instead of helping itself to the whole budget
again. And the two background joins share a bounded slice (`CLOSE_JOIN_BUDGET_SHARE = 0.25`) —
they are daemon threads in a process that is exiting, while the flushes are the reason a caller
waits at all. A poller that refuses to stop now costs its slice rather than everything.

The same `close()` on the **local** backend measures **0.3 ms** end to end, so the cost is the rust
backend's socket interaction rather than the structure — but the structure is what turns one slow
step into a starved flush.

## Tests

`test_matrixark_the_close_budget_is_a_total.py`, with a stand-in thread that ignores the stop signal
the way a poller mid-request does: a stuck thread does not spend the whole budget, both flushing
steps are still reached, they receive a non-zero share, a slow flush is bounded by what is left, and
an unobstructed close still runs every step.

Both halves are mutation-tested. Restoring the per-step allowance is caught by asserting the **budget
handed to the flush**, not the clock: the elapsed difference between a total and a per-step
allowance is only the slice the join took, so a wall-clock bound tight enough to catch it would be
tight enough to flake.

## Not included

The cheaper operational lever is separate and not proposed here: per-event hook processes start a
1 s summary poller they tear down seconds later — 6,666 "summary refresher started" against 2,811
closes — and `MATRIXARK_SUMMARY_REFRESH_INTERVAL_MS=0` already disables it without a code change.
That is a deployment decision about whether a short-lived hook should run the poller at all.
