### PR TITLE
Offer the read-snapshot rewrite floor to the operator it belongs to

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -635,6 +635,16 @@ SETTINGS: List[Setting] = [
             "reads without replaying it. Turning it off makes the first read after a restart "
             "much slower and saves the disk the snapshot occupies, which is comparable to the "
             "event log itself."),
+    Setting("ingestion.durable_read_cache_min_write_ms", "ingestion",
+            "MATRIXARK_LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS",
+            "Durable read snapshot rewrite floor (ms)", "float", "0", "restart",
+            "How long to leave between full rewrites of that snapshot. At 0, every write the "
+            "append-only path cannot apply rewrites the whole record set. Measured over 12 "
+            "queries interleaved with ingest across 128 documents: a floor of 5000 removed all "
+            "12 rewrites and took the median query from 2,352 ms to 1,922 ms, while the cold "
+            "load rose from 1,391 ms to 1,507 ms. Queries are frequent and restarts are not, so "
+            "a floor pays for most deployments -- but it buys query time with startup time, "
+            "which is why it ships at 0 and is offered here."),
 
     # ---- edge limits ---------------------------------------------------------------------------
     Setting("limits.ingest_rps", "limits", "MATRIXARK_RL_INGEST_RPS",


### PR DESCRIPTION
`MATRIXARK_LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS` decides how often a write that the
append-only path cannot apply rewrites the whole record set as JSON. Its own comment in
`tools/matrixark_mcp_local_adapter.py` measures the choice in both directions and then
hands it over:

> The default stays 0, because turning it on is a real trade rather than a free win.
> [...] Worth it for most deployments, since queries are frequent and restarts are not —
> but that is an operator's call, not a default.

The operator had no way to make that call. The variable is on no portal page and in no
shipped config file — the only route to it was the process environment. Meanwhile its
sibling `MATRIXARK_LOCAL_DURABLE_READ_CACHE_ENABLED` has been offered on the portal all
along, so the switch that turns the snapshot **off** was adjustable while the knob that
decides what keeping it **on** costs was not.

This adds the field. The default does not move.

### What the operator sees

The help text carries the measurement that was already in the source, so the field states
its own trade rather than asking for a number:

| floor | base rewrites | median query | cold load |
|---|---|---|---|
| 0 (ships) | 12 of 12 | 2,352 / 2,713 ms | 1,391 / 1,368 ms |
| 5000 | 0 of 12 | 1,922 / 2,037 ms | 1,507 / 1,694 ms |

Measured over 12 queries interleaved with ingest, 128 documents, both orderings.

### Marked restart, not live

The value is read once into a module-level constant, so a later write to the environment
cannot reach it. `applies="restart"` is the honest label; claiming `live` here would be a
promise the process cannot keep, and the existing guard for that would fail it.

### Checks

`python3 -m unittest` over every gateway / flag / policy / config / launcher guard in
`tools/`: **490 tests, OK**. Setting keys stay unique, and the setting resolves with
`kind=float default=0 applies=restart`.
