### PR TITLE
Land the API key in the variable the selected provider reads

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -261,9 +261,11 @@ SETTINGS: List[Setting] = [
             "Used when Extraction provider is anthropic, which does not read Extraction base URL. "
             "The Messages API path is added to this, so give the host without /v1."),
     Setting("extraction.api_key_env", "extraction", "MATRIXARK_EXTRACTION_API_KEY_ENV",
-            "Extraction key variable", "str", "OPENAI_API_KEY", "restart",
-            "Name of the environment variable holding the extraction key. The key you enter below "
-            "is written into this variable."),
+            "Extraction key variable", "str", "", "restart",
+            "Name of the environment variable holding the extraction key -- the key you enter below "
+            "is written into it. Leave it empty and it follows the provider: ANTHROPIC_API_KEY for "
+            "Anthropic, OPENAI_API_KEY otherwise. Set it only to point at a variable your own "
+            "launcher already fills, such as DEEPSEEK_API_KEY."),
     Setting("extraction.api_key", "extraction", "", "Extraction API key", "secret", "", "live",
             "Stored owner-only and never returned by any read. Written into the variable named "
             "above, which the extraction request reads on every call — so a new key is live "
@@ -342,8 +344,11 @@ SETTINGS: List[Setting] = [
             "Local path to a downloaded encoder; wins over the model name when set."
             + ENCODER_SERVER_NOTE + ENCODER_CHANGE_NOTE),
     Setting("embedding.api_key_env", "embedding", "MATRIXARK_EMBEDDING_API_KEY_ENV",
-            "Embedding key variable", "str", "OPENAI_API_KEY", "live",
-            "Name of the environment variable holding the encoder key."),
+            "Embedding key variable", "str", "", "live",
+            "Name of the environment variable holding the encoder key -- the key you enter below is "
+            "written into it. Leave it empty and it follows the provider: VOYAGE_API_KEY for Voyage, "
+            "OPENAI_API_KEY otherwise. Set it only to point at a variable your own launcher already "
+            "fills."),
     Setting("embedding.api_key", "embedding", "", "Embedding API key", "secret", "", "live",
             "Stored owner-only and never returned. A LOCAL encoder still needs a non-empty value "
             "here — the call is skipped before it is attempted when the variable is empty."),
@@ -841,6 +846,27 @@ PRESETS: Dict[str, Json] = {
             "embedding.require_model_embeddings": "1",
         },
     },
+    "voyage": {
+        "label": "Voyage (embedding)",
+        "note": "Voyage supplies embeddings only -- pair it with an extraction provider. The key "
+                "variable is left to follow the provider, so it lands in VOYAGE_API_KEY.",
+        "values": {
+            "embedding.provider": "voyage",
+            "embedding.api_base": "https://api.voyageai.com/v1",
+            "embedding.model": "voyage-3",
+            "embedding.require_model_embeddings": "1",
+        },
+    },
+    "anthropic": {
+        "label": "Anthropic (extraction)",
+        "note": "Anthropic has no embeddings API, so pair it with a local encoder or an "
+                "OpenAI-compatible embedding endpoint.",
+        "values": {
+            "extraction.provider": "anthropic",
+            "extraction.anthropic_base_url": "https://api.anthropic.com",
+            "extraction.anthropic_model": "claude-sonnet-5",
+        },
+    },
     "ollama": {
         "label": "Ollama (local extraction)",
         "note": "Ollama's OpenAI-compatible shim, on the default port.",
@@ -991,19 +1017,47 @@ def _store(document: Json) -> None:
 # ================================================================================================
 # Applying stored values to the process environment
 # ================================================================================================
+# What each provider reads when nothing names the variable. These mirror the fallbacks written in
+# the provider code -- matrixark_mcp_embeddings._api_embedding_config and the ANTHROPIC_/EXTRACTION_
+# module constants in matrixark_mcp_core -- and a test parses those modules and fails if they drift.
+# Flattening them to one name is how the key ended up in a variable the provider never read: pick
+# Voyage or Anthropic, type the key, and it landed in OPENAI_API_KEY while the encoder looked in
+# VOYAGE_API_KEY and found nothing. Nothing reports that; embeddings just quietly go back to hash
+# vectors unless "Fail instead of falling back" is on.
+_PROVIDER_KEY_VARIABLE: Dict[str, Dict[str, str]] = {
+    "embedding.api_key": {"voyage": "VOYAGE_API_KEY"},
+    "extraction.api_key": {"anthropic": "ANTHROPIC_API_KEY"},
+}
+_KEY_VARIABLE_FALLBACK = "OPENAI_API_KEY"
+
+
+def _selected_provider(secret_key: str, values: Dict[str, str]) -> str:
+    """Which provider the deployment is on, by the same precedence the key itself uses: what the
+    portal stored, else what the launcher set, else the registry default."""
+    setting = SETTINGS_BY_KEY[secret_key.rsplit(".", 1)[0] + ".provider"]
+    return (values.get(setting.key)
+            or os.environ.get(setting.env, "").strip()
+            or setting.default).strip()
+
+
 def _env_name(setting: Setting, values: Dict[str, str]) -> str:
     """The environment variable a setting writes to. For the two secrets that is not fixed: the key
     lands in whatever variable ``*.api_key_env`` names, so a customer on DeepSeek gets their key in
-    DEEPSEEK_API_KEY rather than a MatrixArk-specific name the provider code never reads."""
-    if setting.key == "extraction.api_key":
-        return (values.get("extraction.api_key_env")
-                or os.environ.get("MATRIXARK_EXTRACTION_API_KEY_ENV", "").strip()
-                or "OPENAI_API_KEY")
-    if setting.key == "embedding.api_key":
-        return (values.get("embedding.api_key_env")
-                or os.environ.get("MATRIXARK_EMBEDDING_API_KEY_ENV", "").strip()
-                or "OPENAI_API_KEY")
-    return setting.env
+    DEEPSEEK_API_KEY rather than a MatrixArk-specific name the provider code never reads.
+
+    Left empty -- the default -- the name follows the selected provider, so the common case needs no
+    decision at all. Every other provider-dependent field here already defaults to empty for the
+    same reason; these two used to pin one provider's name.
+    """
+    if setting.key not in _PROVIDER_KEY_VARIABLE:
+        return setting.env
+    group = setting.key.rsplit(".", 1)[0]
+    chosen = (values.get(group + ".api_key_env")
+              or os.environ.get(SETTINGS_BY_KEY[group + ".api_key_env"].env, "").strip())
+    if chosen:
+        return chosen
+    provider = _selected_provider(setting.key, values)
+    return _PROVIDER_KEY_VARIABLE[setting.key].get(provider, _KEY_VARIABLE_FALLBACK)
 
 
 def apply_boot(document: Optional[Json] = None) -> List[str]:

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1588,9 +1588,14 @@ def _model_config_snapshot() -> Json:
     extraction_provider = _env(
         "MATRIXARK_UNDERSTANDING_PROVIDER", _env("MATRIXARK_EXTRACTION_PROVIDER", "deterministic")
     )
-    extraction_key_env = _env("MATRIXARK_EXTRACTION_API_KEY_ENV", "OPENAI_API_KEY")
     embedding_provider = _env("MATRIXARK_EMBEDDING_PROVIDER", "deterministic")
-    embedding_key_env = _env("MATRIXARK_EMBEDDING_API_KEY_ENV", "OPENAI_API_KEY")
+    # Which variable a key lands in is the registry's decision, and asking it is the only way this
+    # page can be right about it. Recomputing the name here is what let the portal report
+    # OPENAI_API_KEY -- flat, for every provider -- while a Voyage encoder read VOYAGE_API_KEY and
+    # an Anthropic extraction read ANTHROPIC_API_KEY. The warnings below tell a customer where to
+    # put their key, so a second answer here is worse than none.
+    extraction_key_env = _gwconfig._env_name(_gwconfig.SETTINGS_BY_KEY["extraction.api_key"], {})
+    embedding_key_env = _gwconfig._env_name(_gwconfig.SETTINGS_BY_KEY["embedding.api_key"], {})
     require_model_embeddings = _env("MATRIXARK_REQUIRE_MODEL_EMBEDDINGS") in {"1", "true", "yes", "on"}
 
     extraction: Json = {

--- a/tools/test_matrixark_the_key_lands_in_the_variable_the_provider_reads.py
+++ b/tools/test_matrixark_the_key_lands_in_the_variable_the_provider_reads.py
@@ -90,6 +90,31 @@ def resolved(group: str, values: dict) -> str:
     return cfg._env_name(cfg.SETTINGS_BY_KEY[SECRETS[group]], values)
 
 
+class _NothingInherited(unittest.TestCase):
+    """Resolution reads the process environment on purpose: a variable the LAUNCHER set outranks the
+    provider default, and the provider code resolves the same way, so the two still agree. That
+    makes these assertions -- which compare a runtime resolution against the fallback written in the
+    source -- true only when nothing else has set one. Sibling suites in the same process do set
+    them, which is why this passed alone and failed in the full run.
+    """
+
+    PARTICIPATING = ("MATRIXARK_EXTRACTION_API_KEY_ENV", "MATRIXARK_EMBEDDING_API_KEY_ENV",
+                     "MATRIXARK_UNDERSTANDING_PROVIDER", "MATRIXARK_EXTRACTION_PROVIDER",
+                     "MATRIXARK_EMBEDDING_PROVIDER")
+
+    def setUp(self) -> None:
+        self._inherited = {n: os.environ.get(n) for n in self.PARTICIPATING}
+        for name in self.PARTICIPATING:
+            os.environ.pop(name, None)
+
+    def tearDown(self) -> None:
+        for name, value in self._inherited.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
 class TheSourceStillSaysWhatWeThinkItSaysTest(unittest.TestCase):
     """The rest of this file is only as good as the parse. If these stop finding branches, every
     other assertion here would pass vacuously."""
@@ -103,7 +128,7 @@ class TheSourceStillSaysWhatWeThinkItSaysTest(unittest.TestCase):
         self.assertEqual({"anthropic", None}, set(extraction_key_variables()))
 
 
-class TheKeyLandsWhereTheProviderLooksTest(unittest.TestCase):
+class TheKeyLandsWhereTheProviderLooksTest(_NothingInherited):
     """The defect, from the customer's side: pick a provider, type a key, and it must reach it."""
 
     def test_every_encoder_branch_agrees(self) -> None:
@@ -145,7 +170,7 @@ class TheKeyLandsWhereTheProviderLooksTest(unittest.TestCase):
                 os.environ[setting.env] = previous
 
 
-class AnExplicitVariableStillWinsTest(unittest.TestCase):
+class AnExplicitVariableStillWinsTest(_NothingInherited):
     """The field is an override, not a suggestion -- a deployment pointing at a variable its own
     launcher fills, DEEPSEEK_API_KEY being the shipped example, must keep working."""
 
@@ -168,7 +193,7 @@ class AnExplicitVariableStillWinsTest(unittest.TestCase):
                 os.environ[variable] = previous
 
 
-class TheDefaultNoLongerPinsOneProviderTest(unittest.TestCase):
+class TheDefaultNoLongerPinsOneProviderTest(_NothingInherited):
 
     def test_it_defaults_the_way_every_other_provider_dependent_field_does(self) -> None:
         """api_base, model and base_url all default to empty, meaning 'follow the provider'. These
@@ -191,7 +216,7 @@ class TheDefaultNoLongerPinsOneProviderTest(unittest.TestCase):
         self.assertIn(extraction_key_variables()[None], extraction)
 
 
-class EveryPresetLandsItsKeySomewhereTheProviderReadsTest(unittest.TestCase):
+class EveryPresetLandsItsKeySomewhereTheProviderReadsTest(_NothingInherited):
     """Presets were never wrong, because every one of them named a variable explicitly. The two
     providers that had no preset were the two that broke, so both now have one."""
 
@@ -232,7 +257,7 @@ class EveryPresetLandsItsKeySomewhereTheProviderReadsTest(unittest.TestCase):
                         self.assertIn(value, setting.choices)
 
 
-class TheStatusPageReportsTheSameVariableTest(unittest.TestCase):
+class TheStatusPageReportsTheSameVariableTest(_NothingInherited):
     """The portal's model-configuration panel names the variable a customer should put their key in.
     It used to work that name out for itself, flat across providers, so it could disagree with where
     the key was actually written -- and the customer would follow the wrong instruction."""

--- a/tools/test_matrixark_the_key_lands_in_the_variable_the_provider_reads.py
+++ b/tools/test_matrixark_the_key_lands_in_the_variable_the_provider_reads.py
@@ -232,5 +232,76 @@ class EveryPresetLandsItsKeySomewhereTheProviderReadsTest(unittest.TestCase):
                         self.assertIn(value, setting.choices)
 
 
+class TheStatusPageReportsTheSameVariableTest(unittest.TestCase):
+    """The portal's model-configuration panel names the variable a customer should put their key in.
+    It used to work that name out for itself, flat across providers, so it could disagree with where
+    the key was actually written -- and the customer would follow the wrong instruction."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        try:
+            from tools import matrixark_v1_gateway as gw  # type: ignore
+        except ImportError:
+            import matrixark_v1_gateway as gw  # type: ignore
+        cls.gw = gw
+        # The gateway binds its own module object for the registry. Comparing against a separately
+        # imported one compares two different modules, which is how an earlier suite passed while
+        # the thing it tested was broken.
+        cls.cfg = gw._gwconfig
+
+    def _snapshot_for(self, provider_variable: str, provider: str) -> dict:
+        previous = os.environ.get(provider_variable)
+        os.environ[provider_variable] = provider
+        try:
+            return self.gw._model_config_snapshot()
+        finally:
+            if previous is None:
+                os.environ.pop(provider_variable, None)
+            else:
+                os.environ[provider_variable] = previous
+
+    def test_the_encoder_panel_names_what_the_encoder_reads(self) -> None:
+        for provider, reads in encoder_key_variables().items():
+            chosen = provider or "openai_compatible"
+            with self.subTest(provider=chosen):
+                snapshot = self._snapshot_for("MATRIXARK_EMBEDDING_PROVIDER", chosen)
+                self.assertEqual(reads, snapshot["embedding"]["api_key_env"])
+
+    def test_the_extraction_panel_names_what_extraction_reads(self) -> None:
+        for provider, reads in extraction_key_variables().items():
+            chosen = provider or "openai_compatible"
+            with self.subTest(provider=chosen):
+                snapshot = self._snapshot_for("MATRIXARK_UNDERSTANDING_PROVIDER", chosen)
+                self.assertEqual(reads, snapshot["extraction"]["api_key_env"])
+
+    def test_the_panel_and_the_registry_are_one_answer_not_two(self) -> None:
+        """Both sides must be read while the SAME provider is selected. Taking the registry's answer
+        after the environment is restored compares two different deployments, which is how this
+        first failed against a snapshot that was already right."""
+        for group, variable in (("embedding", "MATRIXARK_EMBEDDING_PROVIDER"),
+                                ("extraction", "MATRIXARK_UNDERSTANDING_PROVIDER")):
+            secret = self.cfg.SETTINGS_BY_KEY[group + ".api_key"]
+            for choice in self.cfg.SETTINGS_BY_KEY[group + ".provider"].choices:
+                with self.subTest(group=group, provider=choice):
+                    previous = os.environ.get(variable)
+                    os.environ[variable] = choice
+                    try:
+                        panel = self.gw._model_config_snapshot()[group]["api_key_env"]
+                        registry = self.cfg._env_name(secret, {})
+                    finally:
+                        if previous is None:
+                            os.environ.pop(variable, None)
+                        else:
+                            os.environ[variable] = previous
+                    self.assertEqual(registry, panel)
+
+    def test_the_warning_still_tells_the_customer_where_the_key_goes(self) -> None:
+        """The name is only useful because a warning quotes it; if the warning stops naming a
+        variable the panel is back to being a number nobody can act on."""
+        snapshot = self._snapshot_for("MATRIXARK_EMBEDDING_PROVIDER", "voyage")
+        named = [w for w in snapshot["warnings"] if snapshot["embedding"]["api_key_env"] in w]
+        self.assertTrue(named, "no warning names the variable the encoder key goes into")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_matrixark_the_key_lands_in_the_variable_the_provider_reads.py
+++ b/tools/test_matrixark_the_key_lands_in_the_variable_the_provider_reads.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The portal's API key lands in the variable the SELECTED provider actually reads.
+
+Both secrets are written into whatever variable ``*.api_key_env`` names. That name used to fall back
+to ``OPENAI_API_KEY`` for every provider, while the provider code's own fallback is per provider:
+the encoder reads ``VOYAGE_API_KEY`` on Voyage, and extraction reads ``ANTHROPIC_API_KEY`` on
+Anthropic. So a customer who picked either of those, left the variable field alone and typed their
+key got it written into a variable their provider never reads -- with no error, because an
+unreachable encoder falls back to hash vectors unless "Fail instead of falling back" is on.
+
+Every expectation here is PARSED OUT OF THE PROVIDER MODULES rather than restated, so a new provider
+branch, or a renamed fallback, fails this instead of silently reopening the hole.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+import matrixark_gateway_config as cfg  # noqa: E402
+
+ENCODER = "matrixark_mcp_embeddings.py"
+CORE = "matrixark_mcp_core.py"
+SECRETS = {"embedding": "embedding.api_key", "extraction": "extraction.api_key"}
+
+
+def parse(filename: str) -> ast.Module:
+    with open(os.path.join(TOOLS, filename), encoding="utf-8") as handle:
+        return ast.parse(handle.read(), filename=filename)
+
+
+def _environ_get_default(node: ast.AST, variable: str) -> str | None:
+    """The literal fallback in ``os.environ.get(variable, "...")``, wherever it sits under node."""
+    for sub in ast.walk(node):
+        if not isinstance(sub, ast.Call) or len(sub.args) != 2:
+            continue
+        target = sub.func
+        if not (isinstance(target, ast.Attribute) and target.attr in {"get", "getenv"}):
+            continue
+        first, second = sub.args
+        if (isinstance(first, ast.Constant) and first.value == variable
+                and isinstance(second, ast.Constant) and isinstance(second.value, str)):
+            return second.value
+    return None
+
+
+def encoder_key_variables() -> dict:
+    """{provider or None for 'anything else': the variable the encoder reads}, from the source."""
+    tree = parse(ENCODER)
+    function = next(node for node in ast.walk(tree)
+                    if isinstance(node, ast.FunctionDef) and node.name == "_api_embedding_config")
+    found = {}
+    for node in ast.walk(function):
+        if not isinstance(node, ast.If):
+            continue
+        names = [c.value for c in ast.walk(node.test)
+                 if isinstance(c, ast.Constant) and isinstance(c.value, str)]
+        variable = "MATRIXARK_EMBEDDING_API_KEY_ENV"
+        for branch, key in ((node.body, names[0] if names else None), (node.orelse, None)):
+            if not branch:
+                continue
+            default = _environ_get_default(ast.Module(body=list(branch), type_ignores=[]), variable)
+            if default is not None:
+                found[key] = default
+    return found
+
+
+def extraction_key_variables() -> dict:
+    """Same, for the two module constants extraction resolves its key variable through."""
+    tree = parse(CORE)
+    by_constant = {"ANTHROPIC_LLM_API_KEY_ENV": "anthropic", "EXTRACTION_LLM_API_KEY_ENV": None}
+    found = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id in by_constant:
+                default = _environ_get_default(node, "MATRIXARK_EXTRACTION_API_KEY_ENV")
+                if default is not None:
+                    found[by_constant[target.id]] = default
+    return found
+
+
+def resolved(group: str, values: dict) -> str:
+    return cfg._env_name(cfg.SETTINGS_BY_KEY[SECRETS[group]], values)
+
+
+class TheSourceStillSaysWhatWeThinkItSaysTest(unittest.TestCase):
+    """The rest of this file is only as good as the parse. If these stop finding branches, every
+    other assertion here would pass vacuously."""
+
+    def test_the_encoder_has_a_per_provider_fallback_and_a_general_one(self) -> None:
+        found = encoder_key_variables()
+        self.assertIn(None, found, "no else branch found in _api_embedding_config")
+        self.assertTrue([k for k in found if k], "no per-provider branch found; the parse broke")
+
+    def test_extraction_has_both_constants(self) -> None:
+        self.assertEqual({"anthropic", None}, set(extraction_key_variables()))
+
+
+class TheKeyLandsWhereTheProviderLooksTest(unittest.TestCase):
+    """The defect, from the customer's side: pick a provider, type a key, and it must reach it."""
+
+    def test_every_encoder_branch_agrees(self) -> None:
+        for provider, reads in encoder_key_variables().items():
+            chosen = provider or "openai_compatible"
+            with self.subTest(provider=chosen):
+                self.assertEqual(reads, resolved("embedding", {"embedding.provider": chosen}))
+
+    def test_every_extraction_branch_agrees(self) -> None:
+        for provider, reads in extraction_key_variables().items():
+            chosen = provider or "openai_compatible"
+            with self.subTest(provider=chosen):
+                self.assertEqual(reads, resolved("extraction", {"extraction.provider": chosen}))
+
+    def test_every_offered_provider_choice_reaches_a_variable_its_code_reads(self) -> None:
+        """Nothing selectable in the portal may resolve to a name its own module never mentions."""
+        sources = {"embedding": ENCODER, "extraction": CORE}
+        for group, filename in sources.items():
+            with open(os.path.join(TOOLS, filename), encoding="utf-8") as handle:
+                text = handle.read()
+            for choice in cfg.SETTINGS_BY_KEY[group + ".provider"].choices:
+                with self.subTest(group=group, provider=choice):
+                    name = resolved(group, {group + ".provider": choice})
+                    self.assertTrue(name, "resolved to no variable at all")
+                    self.assertIn(name, text)
+
+    def test_the_provider_may_come_from_the_launcher_rather_than_the_portal(self) -> None:
+        """A deployment that sets the provider in the environment and the key in the portal is the
+        mixed case, and it has to resolve the same way."""
+        setting = cfg.SETTINGS_BY_KEY["embedding.provider"]
+        previous = os.environ.get(setting.env)
+        os.environ[setting.env] = "voyage"
+        try:
+            self.assertEqual(encoder_key_variables()["voyage"], resolved("embedding", {}))
+        finally:
+            if previous is None:
+                os.environ.pop(setting.env, None)
+            else:
+                os.environ[setting.env] = previous
+
+
+class AnExplicitVariableStillWinsTest(unittest.TestCase):
+    """The field is an override, not a suggestion -- a deployment pointing at a variable its own
+    launcher fills, DEEPSEEK_API_KEY being the shipped example, must keep working."""
+
+    def test_a_stored_name_beats_the_provider_default(self) -> None:
+        self.assertEqual("DEEPSEEK_API_KEY", resolved(
+            "extraction", {"extraction.provider": "anthropic",
+                           "extraction.api_key_env": "DEEPSEEK_API_KEY"}))
+
+    def test_a_launcher_set_name_beats_the_provider_default(self) -> None:
+        variable = cfg.SETTINGS_BY_KEY["embedding.api_key_env"].env
+        previous = os.environ.get(variable)
+        os.environ[variable] = "LAUNCHER_KEY"
+        try:
+            self.assertEqual("LAUNCHER_KEY",
+                             resolved("embedding", {"embedding.provider": "voyage"}))
+        finally:
+            if previous is None:
+                os.environ.pop(variable, None)
+            else:
+                os.environ[variable] = previous
+
+
+class TheDefaultNoLongerPinsOneProviderTest(unittest.TestCase):
+
+    def test_it_defaults_the_way_every_other_provider_dependent_field_does(self) -> None:
+        """api_base, model and base_url all default to empty, meaning 'follow the provider'. These
+        two were the exception, and they were the two that misrouted the key."""
+        neighbours = ("embedding.api_base", "embedding.model", "extraction.base_url",
+                      "extraction.model")
+        for key in neighbours:
+            self.assertEqual("", cfg.SETTINGS_BY_KEY[key].default, key + " changed shape")
+        for key in ("embedding.api_key_env", "extraction.api_key_env"):
+            with self.subTest(setting=key):
+                self.assertEqual("", cfg.SETTINGS_BY_KEY[key].default)
+
+    def test_the_help_names_the_variable_each_provider_gets(self) -> None:
+        """A customer has to be able to answer 'where did my key go' from the portal alone."""
+        embedding = cfg.SETTINGS_BY_KEY["embedding.api_key_env"].help
+        self.assertIn(encoder_key_variables()["voyage"], embedding)
+        self.assertIn(encoder_key_variables()[None], embedding)
+        extraction = cfg.SETTINGS_BY_KEY["extraction.api_key_env"].help
+        self.assertIn(extraction_key_variables()["anthropic"], extraction)
+        self.assertIn(extraction_key_variables()[None], extraction)
+
+
+class EveryPresetLandsItsKeySomewhereTheProviderReadsTest(unittest.TestCase):
+    """Presets were never wrong, because every one of them named a variable explicitly. The two
+    providers that had no preset were the two that broke, so both now have one."""
+
+    def test_each_preset_resolves_to_what_its_provider_reads(self) -> None:
+        encoder, extraction = encoder_key_variables(), extraction_key_variables()
+        for name, preset in cfg.PRESETS.items():
+            values = dict(preset["values"])
+            for group, table in (("embedding", encoder), ("extraction", extraction)):
+                if group + ".provider" not in values:
+                    continue
+                with self.subTest(preset=name, group=group):
+                    provider = values[group + ".provider"]
+                    expected = values.get(group + ".api_key_env") or table.get(
+                        provider, table[None])
+                    self.assertEqual(expected, resolved(group, values))
+
+    def test_both_previously_uncovered_providers_now_have_a_starting_point(self) -> None:
+        chosen = set()
+        for preset in cfg.PRESETS.values():
+            for key in ("embedding.provider", "extraction.provider"):
+                if key in preset["values"]:
+                    chosen.add(preset["values"][key])
+        self.assertIn("voyage", chosen)
+        self.assertIn("anthropic", chosen)
+
+    def test_no_preset_carries_a_secret(self) -> None:
+        for name, preset in cfg.PRESETS.items():
+            for key in preset["values"]:
+                with self.subTest(preset=name, setting=key):
+                    self.assertNotEqual("secret", cfg.SETTINGS_BY_KEY[key].kind)
+
+    def test_every_preset_value_is_a_real_setting_with_a_permitted_value(self) -> None:
+        for name, preset in cfg.PRESETS.items():
+            for key, value in preset["values"].items():
+                with self.subTest(preset=name, setting=key):
+                    setting = cfg.SETTINGS_BY_KEY[key]
+                    if setting.choices:
+                        self.assertIn(value, setting.choices)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Pick Voyage or Anthropic in the portal, type your API key, press save — and the key was written into
a variable that provider never reads.

Both secrets land in whatever variable `*.api_key_env` names. That name fell back to
`OPENAI_API_KEY` for every provider. The provider code's own fallback is per provider:

```
provider                        portal wrote the key to      the code read
embedding / voyage              OPENAI_API_KEY               VOYAGE_API_KEY        <-- mismatch
embedding / openai_compatible   OPENAI_API_KEY               OPENAI_API_KEY
extraction / anthropic          OPENAI_API_KEY               ANTHROPIC_API_KEY     <-- mismatch
extraction / openai_compatible  OPENAI_API_KEY               OPENAI_API_KEY
```

Nothing reports it. The provider is simply unreachable, and an unreachable encoder falls back to
hash vectors unless *Fail instead of falling back* is on — so the deployment keeps answering
queries and quietly stops being semantic.

### Why exactly those two

Every preset already names its key variable explicitly, which is why no preset was ever wrong.
`voyage` and `anthropic` were the only two provider choices with **no** preset — the only two you
could reach solely by picking from the dropdown — and they are exactly the two that broke.

The same pattern shows in the registry. `embedding.api_base`, `embedding.model`,
`extraction.base_url` and `extraction.model` all default to empty, meaning *follow the provider*.
The two `api_key_env` settings were the only provider-dependent fields pinning one provider's name.

### The fix

`_env_name` resolves the variable from the selected provider when the field is left empty, using the
same precedence as everything else here — stored value, then launcher environment, then default. An
explicitly named variable still wins, so pointing at a `DEEPSEEK_API_KEY` your own launcher fills
keeps working. Both defaults become empty, matching their neighbours. Voyage and Anthropic get
starting points, so no provider choice is reachable without one any more.

### Derived, not restated

Every expectation is parsed out of the provider modules — the `if provider == …` branches in
`_api_embedding_config`, and the `ANTHROPIC_LLM_API_KEY_ENV` / `EXTRACTION_LLM_API_KEY_ENV`
constants — so a renamed fallback or a new provider branch fails these instead of silently
reopening the hole. Two tests guard the parse itself, since the rest would pass vacuously if it
found nothing.

```
the original bug: one key variable for every provider    -> FAIL 5
voyage routed to a name the encoder never reads          -> FAIL 4
the customer's own variable stops winning                -> FAIL 5
the provider set by the launcher is ignored              -> FAIL 1
the default goes back to pinning one provider            -> FAIL 1
the help stops naming the variable voyage gets           -> FAIL 1
the voyage starting point is dropped                     -> FAIL 1
a preset offers a value the control does not             -> FAIL 2
the encoder renames the variable it falls back to        -> FAIL 5
the encoder loses its per-provider branch entirely       -> FAIL 2 + 2 errors
```

The first is the shipped bug restored; the last two are drift in the source the tests read.

14 tests. Neighbours: the derived list of every suite touching the settings registry, `_env_name`,
`api_key_env` or the presets — 37, all green — plus all portal-named suites (166) and all
gateway-named suites (256) together.

### A third copy of the same decision

The portal's model-configuration panel worked the variable name out for itself, with the same flat
`OPENAI_API_KEY` fallback. Left alone it would have reported `OPENAI_API_KEY` while the key was
written into `VOYAGE_API_KEY` — and the warning that tells a customer *where to put their key* would
have named the wrong variable. It now asks `_env_name`, so the panel and the write are one answer.

```
the panel goes back to working the name out itself       -> FAIL 4
the panel names the encoder's variable on extraction     -> FAIL 2
the warning stops quoting the variable                   -> FAIL 1
```

Both sides of that comparison are read with the **same provider selected**. Taking the registry's
answer after the environment is restored compares two different deployments — which is how the
first version of that test failed against a snapshot that was already right.

18 tests. Neighbours re-run after the panel change with the list widened to `_model_config_snapshot`
and the warnings: 43 suites, plus all portal- (166), gateway- (256) and config-named (88) suites.
The one failure, `test_python_module_boundaries_part3`, is the known `No module named 'tools'`
standalone-import limitation and fails the same way on the base.
