### PR TITLE
Show the retrieval budget this build uses, not the one the registry declares

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -702,6 +702,24 @@ _KNOB_ENV_FROZEN_AT_IMPORT = {
 }
 
 
+def _build_default(name: str) -> Optional[str]:
+    """What retrieval uses for this knob when nobody has set anything.
+
+    Read from the module that decides it, never re-typed here. A table of numbers in this file
+    would be the second copy the section above refuses to keep, and it would drift the moment a
+    budget moved.
+    """
+    try:
+        try:
+            from tools import matrixark_mcp_runtime_config as runtime  # type: ignore
+        except ImportError:
+            import matrixark_mcp_runtime_config as runtime  # type: ignore
+    except Exception:  # pragma: no cover - portal still works without the retrieval modules
+        return None
+    value = getattr(runtime, "DEFAULT_" + name.upper(), None)
+    return None if value is None else str(value)
+
+
 def _knob_settings() -> List[Setting]:
     try:
         try:
@@ -721,6 +739,26 @@ def _knob_settings() -> List[Setting]:
         choices = sorted(knob.choices) if getattr(knob, "choices", None) else None
         default = knob.default
         default = ("1" if default else "0") if isinstance(default, bool) else str(default)
+        description = knob.description
+        # For the five frozen budgets the registry's default is NOT what a deployment gets.
+        # `_tenant_retrieval_limit` in matrixark_local_adapter_retrieve deliberately does not
+        # resolve() them -- resolving would "silently multiply the budget for every deployment
+        # that never configured one" -- so with nothing set retrieval uses the build constant,
+        # which is 10x to 156x smaller. Showing the registry number told an operator their
+        # deployment does something it does not, and export_settings(include_defaults=True) then
+        # wrote that number to the target as an EXPLICIT value, so cloning a deployment raised
+        # its budgets by up to 156x. Show what this build uses, and say where the other number
+        # applies.
+        if env in _KNOB_ENV_FROZEN_AT_IMPORT:
+            build = _build_default(name)
+            if build is not None and build != default:
+                description = (
+                    knob.description
+                    + " -- With nothing set this deployment uses %s, not the %s above: retrieval "
+                      "reads an explicit tenant record or an explicit value here, and otherwise "
+                      "its own build default. The number above applies where someone sets it."
+                    % (build, default))
+                default = build
         derived.append(Setting(
             "behaviour." + name, "behaviour", env, _humanize(name), kind, default,
             # tenant_policy.resolve() reads os.environ per call, so most of these are live.
@@ -736,7 +774,7 @@ def _knob_settings() -> List[Setting]:
             # matrixark_mcp_budget_policies. A comment asserting a broken thing works is what
             # stops anyone checking, so it is worth more care than the code it sits beside.
             "restart" if env in _KNOB_ENV_FROZEN_AT_IMPORT else "live",
-            knob.description, choices))
+            description, choices))
     return derived
 
 

--- a/tools/test_matrixark_gateway_config_audit.py
+++ b/tools/test_matrixark_gateway_config_audit.py
@@ -261,9 +261,78 @@ class RegistryShapeTest(unittest.TestCase):
                         % sorted(derived - set(policy.KNOBS)))
         for name in derived:
             with self.subTest(knob=name):
+                knob = policy.KNOBS[name]
                 setting = cfgmod.SETTINGS_BY_KEY["behaviour." + name]
-                self.assertEqual(policy.KNOBS[name].env, setting.env)
-                self.assertEqual(policy.KNOBS[name].description, setting.help)
+                self.assertEqual(knob.env, setting.env)
+                # The description is still derived either way -- corrected knobs APPEND to it, so
+                # a retyped description still fails here.
+                self.assertTrue(
+                    setting.help.startswith(knob.description),
+                    "the help for %s no longer starts with the registry description, so the "
+                    "portal has grown a second copy of it" % name)
+                if knob.env not in cfgmod._KNOB_ENV_FROZEN_AT_IMPORT:
+                    self.assertEqual(knob.description, setting.help)
+
+    def test_a_frozen_budget_shows_what_this_build_actually_uses(self) -> None:
+        """The five budgets retrieval does not resolve() must not advertise the registry number.
+
+        `_tenant_retrieval_limit` reads an explicit tenant record or an explicit env value and
+        otherwise the build constant -- deliberately never the registry default, because resolving
+        it would multiply the budget of every deployment that never configured one. The portal used
+        to show the registry number anyway, so a deployment running on 64 reported 10000, and
+        `export_settings(include_defaults=True)` wrote that 10000 to the target as an explicit
+        value: cloning a deployment raised its budgets by 10x to 156x.
+        """
+        import matrixark_mcp_runtime_config as runtime
+        import matrixark_tenant_policy as policy
+        checked = 0
+        for name, knob in policy.KNOBS.items():
+            if knob.env not in cfgmod._KNOB_ENV_FROZEN_AT_IMPORT:
+                continue
+            build = getattr(runtime, "DEFAULT_" + name.upper(), None)
+            self.assertIsNotNone(
+                build, "%s is frozen at import but the retrieval build defines no default for it, "
+                       "so the portal has nothing truthful to show" % name)
+            setting = cfgmod.SETTINGS_BY_KEY["behaviour." + name]
+            with self.subTest(knob=name):
+                self.assertEqual(
+                    str(build), setting.default,
+                    "the portal offers %s as the default for %s; this build uses %s when nothing "
+                    "is set" % (setting.default, name, build))
+                self.assertIn(
+                    str(build), setting.help,
+                    "the help for %s does not name the value the deployment actually uses" % name)
+            checked += 1
+        self.assertEqual(
+            5, checked,
+            "expected the five budgets _tenant_retrieval_limit covers, checked %d -- if that set "
+            "moved, this test is guarding the wrong knobs" % checked)
+
+    def test_the_frozen_set_is_exactly_what_retrieval_refuses_to_resolve(self) -> None:
+        """Keep the frozen list tied to the code it describes, not to a memory of it."""
+        import re
+        path = os.path.join(os.path.dirname(cfgmod.__file__),
+                            "matrixark_local_adapter_retrieve.py")
+        with open(path, encoding="utf-8") as handle:
+            source = handle.read()
+        called = set(re.findall(r'_tenant_retrieval_limit\(\s*["\']([a-z_]+)["\']', source))
+        self.assertTrue(called, "found no _tenant_retrieval_limit call sites; the scan is broken")
+        import matrixark_tenant_policy as policy
+        frozen = {name for name, knob in policy.KNOBS.items()
+                  if knob.env in cfgmod._KNOB_ENV_FROZEN_AT_IMPORT}
+        self.assertTrue(
+            called <= frozen,
+            "retrieval takes a build default for %s, which the portal does not correct, so the "
+            "portal advertises a number that deployment will not use" % sorted(called - frozen))
+        # One frozen knob is not wired to a tenant record at all: cross_session_profile_max_
+        # candidates is read straight from the build constant in matrixark_mcp_budget_policies,
+        # so it reaches the same place by a shorter road and the portal must still show the build
+        # number. Anything ELSE that turns up here has not been looked at.
+        self.assertEqual(
+            {"cross_session_profile_max_candidates"}, frozen - called,
+            "these are frozen at import and are not wired through _tenant_retrieval_limit: %s. "
+            "Work out where each one actually gets its value before trusting what the portal "
+            "shows for it." % sorted(frozen - called))
 
 
 class EssentialSettingsTest(unittest.TestCase):


### PR DESCRIPTION
The portal derives its behaviour group from the tenant-policy registry — right for almost
every knob, and wrong for five.

`matrixark_local_adapter_retrieve` resolves those five through `_tenant_retrieval_limit`,
which reads an explicit tenant record or an explicit env value and otherwise **the build
constant** — deliberately never the registry default. Its docstring says why:

> Deliberately NOT `resolve()`. […] resolving would read as "the knob works now" while
> silently multiplying the budget for every deployment that never configured one.

The portal showed the registry number anyway:

| knob | portal showed | build uses | ratio |
|---|---|---|---|
| `top_k_per_layer` | 240 | 8 | 30× |
| `max_candidates_per_node` | 10240 | 1024 | 10× |
| `max_global_candidates` | 20480 | 512 | 40× |
| `max_selected_refs` | 10000 | 64 | **156×** |
| `cross_session_profile_max_candidates` | 2000 | 48 | 42× |

Neither the live processes nor the stored config set any of the five, so this deployment
runs on the right-hand column while its own portal reports the left-hand one.

### The display was the smaller half

`export_settings(include_defaults=True)` resolves an unset setting to the number the portal
shows and writes it to the target as an **explicit** value. So cloning a deployment did not
reproduce it — it raised the clone's budgets by 10× to 156×, on the one path whose entire
purpose is carrying a configuration across unchanged.

Measured before and after, same call:

```
before   240   10240   20480   10000   2000
after      8    1024     512      64      48
```

### Derived, not retyped

Build defaults are read from `matrixark_mcp_runtime_config`; a table of numbers in the
config file would be the second copy that section explicitly refuses to keep. The registry
description is **kept and appended to**, so a corrected setting still says where the larger
number applies — it is what a tenant record or an explicit setting puts into effect, not
something anyone gets by default.

### Three assertions, two new

- behaviour help must still **start with** the registry description, so a retyped
  description fails exactly as before;
- a frozen budget must offer the build default and name it in the help;
- the frozen set must stay tied to the call sites in the retrieval module.

The third **failed when first written**, which is what it is for: only four of the five go
through `_tenant_retrieval_limit`. `cross_session_profile_max_candidates` is read straight
from the build constant, reaching the same value by a shorter road. It is now listed as
such, so a sixth has to be explained rather than joining it quietly.

### Checks

- Mutation test: reverting the change fails the new assertions, naming each knob, the
  portal number and the build number. Restoring it passes.
- `python3 -m unittest` over every gateway / flag / policy / config / launcher / retrieval /
  budget / tenant guard in `tools/`: **652 tests, OK**.
