### PR TITLE
An engine setting must offer the default the engine actually uses

### DIFF
--- a/tools/test_engine_settings_offer_the_engine_default.py
+++ b/tools/test_engine_settings_offer_the_engine_default.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""An engine setting must offer the default the engine actually uses.
+
+mx#959 found the portal advertising retrieval budgets 10x to 156x larger than any deployment
+gets, because the display was derived from a registry the serving path had been taught to
+distrust. The display and the code that consumes it were both correct in isolation; nothing
+compared them. This asks the same question one layer down, of the storage engine.
+
+`crates/temporalstore-rust/src/storage_config.rs` is the whole answer for this family: it declares
+the env NAME and the DEFAULT as neighbouring consts, and `from_getter` reads one with the other.
+So the engine's default is derivable, and the portal's copy of it can be checked rather than
+trusted.
+
+The pairing is on the IDENTIFIER, not the string, and that distinction is the point:
+
+    pub const TS_BLOCK_SLAB_TARGET_BYTES: &str = "TS_BLOCK_SEGMENT_TARGET_BYTES";
+    pub const DEFAULT_BLOCK_SLAB_TARGET_BYTES: u64 = 1 << 30;
+
+The variable an operator sets is `TS_BLOCK_SEGMENT_TARGET_BYTES`; the constants around it are
+named `SLAB`. Matching the portal's env name against the const IDENTIFIER would find nothing here
+and quietly pass, so the identifier pairs the two consts and the string is what the portal must
+match.
+
+Only literal const expressions are evaluated -- integers, `*`, `<<`, parentheses, and the two
+booleans. Anything else is left UNCOMPARED rather than guessed at, so a wrong reading cannot
+present itself as a finding.
+"""
+from __future__ import annotations
+
+import os
+import re
+import unittest
+from typing import Dict, Optional
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(TOOLS)
+STORAGE_CONFIG = os.path.join(
+    REPO, "crates", "temporalstore-rust", "src", "storage_config.rs")
+
+_NAME_CONST = re.compile(
+    r'pub const (TS_[A-Z0-9_]+)\s*:\s*&str\s*=\s*"([A-Z0-9_]+)"\s*;')
+_DEFAULT_CONST = re.compile(
+    r'pub const DEFAULT_([A-Z0-9_]+)\s*:\s*[a-z0-9]+\s*=\s*([^;]+);')
+
+_LITERAL = re.compile(r"^[\d_ ()*<]+$")
+
+# 9 name/default pairs when this was written.
+EXPECTED_PAIR_FLOOR = 8
+
+
+def _value(expr: str) -> Optional[str]:
+    expr = expr.strip()
+    if expr in ("true", "false"):
+        return "1" if expr == "true" else "0"
+    if not _LITERAL.match(expr):
+        return None
+    try:
+        return str(eval(expr.replace("_", ""), {"__builtins__": {}}, {}))  # noqa: S307
+    except Exception:
+        return None
+
+
+def _engine_defaults() -> Dict[str, str]:
+    """env name -> the default the engine uses, paired through the const identifier."""
+    with open(STORAGE_CONFIG, encoding="utf-8") as handle:
+        source = handle.read()
+    defaults = {}
+    for match in _DEFAULT_CONST.finditer(source):
+        value = _value(match.group(2))
+        if value is not None:
+            defaults[match.group(1)] = value
+    out = {}
+    for match in _NAME_CONST.finditer(source):
+        identifier, env = match.group(1), match.group(2)
+        suffix = identifier[len("TS_"):]
+        if suffix in defaults:
+            out[env] = defaults[suffix]
+    return out
+
+
+class EngineSettingsOfferTheEngineDefaultTest(unittest.TestCase):
+
+    def test_the_storage_config_is_where_this_says_it_is(self) -> None:
+        self.assertTrue(
+            os.path.exists(STORAGE_CONFIG),
+            "%s is gone, so every assertion below compares an empty set" % STORAGE_CONFIG)
+
+    def test_the_scan_still_pairs_names_with_defaults(self) -> None:
+        pairs = _engine_defaults()
+        self.assertGreaterEqual(
+            len(pairs), EXPECTED_PAIR_FLOOR,
+            "paired %d env names with a default, expected at least %d -- if the const shape "
+            "changed, the comparison below runs on nothing"
+            % (len(pairs), EXPECTED_PAIR_FLOOR))
+
+    def test_the_pairing_survives_a_name_that_differs_from_its_identifier(self) -> None:
+        # The case this file exists to not miss: identifier SLAB, variable SEGMENT.
+        pairs = _engine_defaults()
+        self.assertIn(
+            "TS_BLOCK_SEGMENT_TARGET_BYTES", pairs,
+            "the slab/segment pair is no longer resolved. Either it was renamed -- fine, say so "
+            "here -- or the pairing has quietly gone back to matching on the env string, which "
+            "would drop every const whose identifier differs from the variable it names.")
+
+    def test_the_portal_offers_what_the_engine_uses(self) -> None:
+        import matrixark_gateway_config as cfgmod
+        pairs = _engine_defaults()
+        checked = 0
+        for setting in cfgmod.SETTINGS:
+            engine = pairs.get(setting.env)
+            if engine is None:
+                continue
+            checked += 1
+            with self.subTest(env=setting.env):
+                self.assertEqual(
+                    engine, setting.default,
+                    "the portal offers %s as the default for %s; the engine uses %s when nothing "
+                    "is set" % (setting.default, setting.env, engine))
+        self.assertTrue(
+            checked, "no engine setting on the portal matched a name in storage_config.rs, so "
+                     "this compared nothing at all")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[#959](https://github.com/matrixarkai/TemporalStore/pull/959) found the portal advertising
retrieval budgets 10×–156× larger than any deployment gets: the display derived from a
registry the serving path had been taught to distrust, both sides were correct in isolation,
and nothing compared them.

This asks the same question one layer down — of the storage engine — where nothing compared
them either. **All nine agree today**, so this changes no behaviour; it states a property
that currently holds and fails when it stops.

### Why it is derivable

`storage_config.rs` declares the env name and the default as neighbouring consts and reads
one with the other, so the engine's default is a fact, not a guess:

| env | engine | portal |
|---|---|---|
| `TS_CONTEXT_PAGE_TARGET_BYTES` | `64 * 1024` → 65536 | 65536 |
| `TS_BLOCK_SEGMENT_TARGET_BYTES` | `1 << 30` → 1073741824 | 1073741824 |
| `TS_STORAGE_ZONE_SIZE` | `1 << 30` | 1073741824 |
| `TS_STREAM_MAX_BLOB_SIZE` | `10 * 1024 * 1024` | 10485760 |
| `TS_COMPACTION_WATERMARK_BYTES` | `256 * 1024 * 1024` | 268435456 |
| `TS_COLD_SCAN_NO_CACHE_FILL` | `true` | 1 |
| `TS_PAGE_INDEX_CACHE_BYTES` | `64 * 1024 * 1024` | 67108864 |
| `TS_BLOCK_INDEX_CACHE_BYTES` | `64 * 1024 * 1024` | 67108864 |
| `TS_INDEX_DUMP_WAL_GAP_BYTES` | `1024 * 1024` | 1048576 |

### The pairing is on the identifier, not the string

```rust
pub const TS_BLOCK_SLAB_TARGET_BYTES: &str = "TS_BLOCK_SEGMENT_TARGET_BYTES";
pub const DEFAULT_BLOCK_SLAB_TARGET_BYTES: u64 = 1 << 30;
```

The variable an operator sets is `SEGMENT`; the consts around it are named `SLAB`. Pairing on
the env string drops that knob silently and the remaining eight still pass — so a dedicated
test asserts the slab/segment pair resolves, and fails if the pairing regresses.

Only literal const expressions are evaluated (integers, `*`, `<<`, parens, the two booleans,
under a whitelist). Anything else is left uncompared rather than guessed at.

### Mutation test

| mutation | result |
|---|---|
| portal number changed | **FAILED**, naming `TS_PAGE_INDEX_CACHE_BYTES` |
| engine const moved to `32 * 1024 * 1024` | **FAILED**, naming the same knob |
| pairing regressed to the env string | **FAILED**, naming the slab/segment pair |
| unmodified | **OK** |

### One note for the next person mutation-testing anything here

The first attempt reported **OK when it should have failed**. The edit was the same byte
length as the original and landed in the same second, so the interpreter's `(mtime, size)`
check kept a stale `.pyc` and the "restored" run was still executing the mutant. Remove
`__pycache__` between arms — otherwise the test that proves a guard works can itself be the
thing that is not running.

### Checks

`python3 -m unittest` over every gateway / flag / policy / config / launcher / retrieval /
budget / tenant / engine guard in `tools/`: **610 tests, OK**.
