### PR TITLE
State a flag's numeric default on the page an operator reads to change it

### DIFF
--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -5,8 +5,10 @@
 //!
 //! A shard's log is a sequence of pieces. `shard-{id}.wal.jsonl` is the one being written;
 //! sealed ones are `shard-{id}.wal.{start_log_id:020}.jsonl`, named so they sort into log order.
-//! `TS_WAL_SEGMENT_BYTES` sets when a piece is sealed; zero, the default, never seals one, and
-//! then the log is a single file and behaves exactly as it did before pieces existed.
+//! `TS_WAL_SEGMENT_BYTES` sets when a piece is sealed. It defaults to
+//! [`DEFAULT_WAL_SEGMENT_BYTES`], 256 KiB, so a log ROLLS unless something says
+//! otherwise. Zero is still accepted and still means never seal, which leaves the log a
+//! single file behaving exactly as it did before pieces existed.
 //!
 //! Positions are **log ids**: a byte position in the log's whole history, not in whichever file
 //! happens to hold it. Each piece records in its first bytes the log id its contents start at, so

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -47,7 +47,8 @@ Anything else is blank, and a blank means go and look.
 | flags | count |
 |---|---|
 | total | 296 |
-| booleans whose default this could read off the source | 32 |
+| booleans whose default this could read off the source | 33 |
+| numbers whose default this could read off the source | 31 |
 | **defaulting on, and set by nothing** | 2 |
 | offered on the portal | 25 |
 | **that nothing in this repository sets** | 175 |
@@ -67,10 +68,10 @@ Where this node is and what it talks to. Set by whoever provisions the node; not
 | `TS_RAFT_NODE_ID` | — | harness, script | 3 | — |
 | `TS_RAFT_SHARD_ID` | — | harness, script | 3 | — |
 | `TS_RAFT_WAL_DIR` | — | config, harness, script | 3 | — |
-| `TS_SHARD_ID` | — | config, launch | 3 | — |
+| `TS_SHARD_ID` | 1 | config, launch | 3 | — |
 | `TS_META_RAFT_NODES` | — | config | 2 | — |
 | `TS_RAFT_BIND_ADDR` | — | harness, script | 2 | — |
-| `MATRIXARK_CONTEXT_EVENT_FANOUT_NODES` | — | nothing | 1 | — |
+| `MATRIXARK_CONTEXT_EVENT_FANOUT_NODES` | 4 | nothing | 1 | — |
 | `MATRIXARK_TEMPORALSTORE_PROXY_ADDR` | — | nothing | 1 | — |
 | `TS_BLOB_STORE_DIR` | — | config, launch, script | 1 | — |
 | `TS_CACHE_DIR` | — | config, launch, script | 1 | — |
@@ -166,16 +167,16 @@ What is written, when it is flushed, and what is reclaimed. The escape hatches h
 |---|---|---|---|---|
 | `MATRIXARK_BULK_INGEST_EXPECTED_WAL_COMMANDS` | — | test | 2 | — |
 | `TS_RAFT_SNAPSHOT_CHECK_INTERVAL_MS` | — | nothing | 2 | — |
-| `MATRIXARK_RUST_PROXY_LOG_RECLAIM_INTERVAL_MS` | — | nothing | 1 | — |
-| `TS_BARRIER_PROFILE_WRITES` | — | nothing | 1 | — |
+| `MATRIXARK_RUST_PROXY_LOG_RECLAIM_INTERVAL_MS` | 1000 | nothing | 1 | — |
+| `TS_BARRIER_PROFILE_WRITES` | 50 | nothing | 1 | — |
 | `TS_CROSS_SHARD_RECLAIM_GUARD` | on | config | 1 | yes |
 | `TS_DATA_NODE_LIFECYCLE_SNAPSHOT` | — | nothing | 1 | — |
-| `TS_INDEX_DUMP_WAL_GAP_BYTES` | — | portal | 1 | — |
+| `TS_INDEX_DUMP_WAL_GAP_BYTES` | 1048576 | portal | 1 | — |
 | `TS_META_RAFT_SNAPSHOT_CHECK_INTERVAL_MS` | — | nothing | 1 | — |
 | `TS_META_SCHEDULER_SNAPSHOT` | — | nothing | 1 | — |
 | `TS_WAL_BINARY_FRAME` | on | launch, test, portal | 1 | — |
 | `TS_WAL_BINARY_RECORDS` | on | launch, test, portal | 1 | — |
-| `TS_WAL_COMMIT_DELAY_US` | — | config | 1 | — |
+| `TS_WAL_COMMIT_DELAY_US` | 0 | config | 1 | — |
 | `TS_WAL_DATA_ONLY` | on | launch, test | 1 | — |
 | `TS_WAL_LEGACY_RECOVERY` | off | config, harness, script | 1 | yes |
 | `TS_WAL_OUTCOME_ITEMS` | on | launch, test | 1 | — |
@@ -183,9 +184,9 @@ What is written, when it is flushed, and what is reclaimed. The escape hatches h
 | `TS_WAL_PREALLOCATE_CHUNK` | — | nothing | 1 | — |
 | `TS_WAL_RECLAIM_MAX_SEGMENTS_PER_PASS` | — | test | 1 | — |
 | `TS_WAL_RECLAIM_MIN_COPY_BYTES` | — | nothing | 1 | — |
-| `TS_WAL_RECLAIM_MIN_FREED_PERCENT` | — | nothing | 1 | — |
-| `TS_WAL_RESIDENT_PAGES` | — | test | 1 | — |
-| `TS_WAL_SEGMENT_BYTES` | — | nothing | 1 | — |
+| `TS_WAL_RECLAIM_MIN_FREED_PERCENT` | 25 | nothing | 1 | — |
+| `TS_WAL_RESIDENT_PAGES` | 4096 | test | 1 | — |
+| `TS_WAL_SEGMENT_BYTES` | 262144 | nothing | 1 | — |
 
 ## format (6)
 
@@ -211,34 +212,34 @@ Sizes, ceilings and intervals. The tuning a deployment actually reaches for.
 | `TS_PROXY_CONTEXT_IO_TIMEOUT_MS` | — | nothing | 2 | — |
 | `TS_RAFT_MAX_CATCHUP_ENTRIES_PER_HEARTBEAT` | — | nothing | 2 | — |
 | `MATRIXARK_BACKFILL_CACHE_BYTES` | — | nothing | 1 | — |
-| `MATRIXARK_BACKFILL_MAX_BODY` | — | nothing | 1 | — |
+| `MATRIXARK_BACKFILL_MAX_BODY` | 2000 | nothing | 1 | — |
 | `MATRIXARK_CONTEXT_COMPRESSION_MAX_AGE_MS` | — | nothing | 1 | — |
 | `MATRIXARK_CONTEXT_COMPRESSION_MAX_RAW_EVENTS` | — | nothing | 1 | — |
 | `MATRIXARK_EMBED_DRAINER_INTERVAL_MS` | — | config, launch, portal | 1 | — |
 | `MATRIXARK_EMBED_DRAINER_MAX_EVENTS` | — | nothing | 1 | — |
 | `MATRIXARK_EMBED_DRAINER_MAX_NODES_PER_PASS` | — | nothing | 1 | — |
-| `MATRIXARK_RETRIEVAL_MAX_CANDIDATES` | — | nothing | 1 | — |
+| `MATRIXARK_RETRIEVAL_MAX_CANDIDATES` | 64 | nothing | 1 | — |
 | `MATRIXARK_RUST_PROXY_CACHE_BYTES` | — | nothing | 1 | — |
 | `MATRIXARK_RUST_PROXY_PAGE_COMPRESSION_MIN_BYTES` | — | test | 1 | — |
 | `MATRIXARK_TEMPORALSTORE_PROXY_CONNECT_TIMEOUT_MS` | — | nothing | 1 | — |
 | `MATRIXARK_TEMPORALSTORE_PROXY_IO_TIMEOUT_MS` | — | nothing | 1 | — |
-| `TEMPORALSTORE_CONTEXT_BENCHMARK_INGEST_CHUNK_SIZE` | — | nothing | 1 | — |
-| `TEMPORALSTORE_CONTEXT_BENCHMARK_MAX_EVENTS` | — | nothing | 1 | — |
+| `TEMPORALSTORE_CONTEXT_BENCHMARK_INGEST_CHUNK_SIZE` | 64 | nothing | 1 | — |
+| `TEMPORALSTORE_CONTEXT_BENCHMARK_MAX_EVENTS` | 32 | nothing | 1 | — |
 | `TS_BLOB_CHUNK_BYTES` | — | config | 1 | — |
 | `TS_BLOB_PEER_FETCH_TIMEOUT_MS` | — | nothing | 1 | — |
-| `TS_BLOCK_INDEX_CACHE_BYTES` | — | config, portal | 1 | — |
-| `TS_BLOCK_SEGMENT_TARGET_BYTES` | — | config, portal | 1 | — |
+| `TS_BLOCK_INDEX_CACHE_BYTES` | 67108864 | config, portal | 1 | — |
+| `TS_BLOCK_SEGMENT_TARGET_BYTES` | 1073741824 | config, portal | 1 | — |
 | `TS_CACHE_MEMORY_BYTES` | — | config, launch | 1 | — |
-| `TS_COMPACTION_WATERMARK_BYTES` | — | config, portal | 1 | — |
-| `TS_CONTEXT_PAGE_TARGET_BYTES` | — | config, portal | 1 | — |
+| `TS_COMPACTION_WATERMARK_BYTES` | 268435456 | config, portal | 1 | — |
+| `TS_CONTEXT_PAGE_TARGET_BYTES` | 65536 | config, portal | 1 | — |
 | `TS_DATA_RAFT_BOUNDED_STALE_MAX_INDEX_LAG` | — | nothing | 1 | — |
 | `TS_DATA_RAFT_READ_INDEX_TIMEOUT_MS` | — | nothing | 1 | — |
-| `TS_DISTRIBUTED_RAFT_CATCHUP_TIMEOUT_SECS` | — | nothing | 1 | — |
+| `TS_DISTRIBUTED_RAFT_CATCHUP_TIMEOUT_SECS` | 30 | nothing | 1 | — |
 | `TS_EVICT_POOL_SIZE` | — | nothing | 1 | — |
 | `TS_INDEX_DUMP_OPLOG_GAP_BYTES` | — | config | 1 | — |
 | `TS_MATRIXOBJECT_FLUSH_INTERVAL_MS` | — | nothing | 1 | — |
 | `TS_MATRIXOBJECT_PROBE_TIMEOUT_MS` | — | nothing | 1 | — |
-| `TS_MAX_RETAINED_FINISHED_JOBS` | — | portal | 1 | — |
+| `TS_MAX_RETAINED_FINISHED_JOBS` | 64 | portal | 1 | — |
 | `TS_META_AUTO_REBALANCE_CONNECT_TIMEOUT_MS` | — | nothing | 1 | — |
 | `TS_META_AUTO_REBALANCE_INTERVAL_MS` | — | nothing | 1 | — |
 | `TS_META_AUTO_REBALANCE_IO_TIMEOUT_MS` | — | nothing | 1 | — |
@@ -263,8 +264,8 @@ Sizes, ceilings and intervals. The tuning a deployment actually reaches for.
 | `TS_META_TASK_SCHEDULER_MAX_INFLIGHT` | — | nothing | 1 | — |
 | `TS_META_TASK_SCHEDULER_MAX_POSTPONE_MS` | — | nothing | 1 | — |
 | `TS_META_TASK_SCHEDULER_MAX_RETRY_TIMES` | — | nothing | 1 | — |
-| `TS_METRICS_MAX_SLOT_SERIES` | — | portal | 1 | — |
-| `TS_PAGE_INDEX_CACHE_BYTES` | — | config, portal | 1 | — |
+| `TS_METRICS_MAX_SLOT_SERIES` | 1024 | portal | 1 | — |
+| `TS_PAGE_INDEX_CACHE_BYTES` | 67108864 | config, portal | 1 | — |
 | `TS_PROXY_AUTO_REGISTER_MIN_INTERVAL_MS` | — | nothing | 1 | — |
 | `TS_PROXY_CONNECT_TIMEOUT_MS` | — | config | 1 | — |
 | `TS_PROXY_DROP_PERCENT` | — | nothing | 1 | — |
@@ -280,12 +281,12 @@ Sizes, ceilings and intervals. The tuning a deployment actually reaches for.
 | `TS_RAFT_AUTO_FAILOVER_IO_TIMEOUT_MS` | — | nothing | 1 | — |
 | `TS_RAFT_MAX_APPLIED_LOG_BYTES` | — | nothing | 1 | — |
 | `TS_RAFT_MAX_INFLIGHTS_REPLICATE` | — | test | 1 | — |
-| `TS_SERVER_HEARTBEAT_INTERVAL_MS` | — | config | 1 | — |
+| `TS_SERVER_HEARTBEAT_INTERVAL_MS` | 3000 | config | 1 | — |
 | `TS_SERVER_MAX_BACKGROUND_QUEUE_DEPTH` | — | config | 1 | — |
 | `TS_SERVER_MAX_QUEUE_DEPTH` | — | config | 1 | — |
-| `TS_SHARED_STORE_MAX_PENDING` | — | nothing | 1 | yes |
-| `TS_STORAGE_ZONE_SIZE` | — | config, portal | 1 | — |
-| `TS_STREAM_MAX_BLOB_SIZE` | — | config, portal | 1 | — |
+| `TS_SHARED_STORE_MAX_PENDING` | 50000 | nothing | 1 | yes |
+| `TS_STORAGE_ZONE_SIZE` | 1073741824 | config, portal | 1 | — |
+| `TS_STREAM_MAX_BLOB_SIZE` | 10485760 | config, portal | 1 | — |
 
 ## context (25)
 
@@ -294,17 +295,17 @@ The memory pipeline: what gets extracted, embedded, drained and packed. The surf
 | flag | default | set by | files | keeps an older path |
 |---|---|---|---|---|
 | `MATRIXARK_BACKFILL_CHECKPOINT_ONLY` | — | nothing | 1 | — |
-| `MATRIXARK_BACKFILL_FLUSH_EVERY_ACCEPTED` | — | nothing | 1 | — |
+| `MATRIXARK_BACKFILL_FLUSH_EVERY_ACCEPTED` | 10000 | nothing | 1 | — |
 | `MATRIXARK_BACKFILL_FLUSH_EVERY_SESSION` | — | nothing | 1 | — |
 | `MATRIXARK_BACKFILL_GLOBAL_SESSION` | — | nothing | 1 | — |
 | `MATRIXARK_BACKFILL_RAW_FIRST` | — | nothing | 1 | — |
 | `MATRIXARK_BACKFILL_SKIP_COVERED_SESSIONS` | — | nothing | 1 | — |
-| `MATRIXARK_BACKFILL_SUB_BATCH` | — | nothing | 1 | — |
+| `MATRIXARK_BACKFILL_SUB_BATCH` | 250 | nothing | 1 | — |
 | `MATRIXARK_CONTEXT_COMPRESSION_ENABLED` | — | nothing | 1 | — |
 | `MATRIXARK_CONTEXT_COMPRESSION_KEEP_RECENT` | — | nothing | 1 | — |
 | `MATRIXARK_CONTEXT_COMPRESSION_WINDOW` | — | nothing | 1 | — |
-| `MATRIXARK_CONTEXT_EVENT_QUERY_OVERFETCH` | — | nothing | 1 | — |
-| `MATRIXARK_CONTEXT_EVENT_SCAN_CAP` | — | nothing | 1 | — |
+| `MATRIXARK_CONTEXT_EVENT_QUERY_OVERFETCH` | 2 | nothing | 1 | — |
+| `MATRIXARK_CONTEXT_EVENT_SCAN_CAP` | 64 | nothing | 1 | — |
 | `MATRIXARK_CONTEXT_PACK_INCLUDE_SCORES` | off | nothing | 1 | — |
 | `MATRIXARK_CONTEXT_SECONDARY_INDEX` | off | test | 1 | — |
 | `MATRIXARK_EMBEDDING_MODEL` | — | config, script, portal | 1 | — |
@@ -312,7 +313,7 @@ The memory pipeline: what gets extracted, embedded, drained and packed. The surf
 | `MATRIXARK_EMBED_BASE_URL` | — | config, script | 1 | — |
 | `MATRIXARK_EMBED_DRAINER` | off | config, launch, portal | 1 | — |
 | `MATRIXARK_EMBED_DRAINER_BATCH` | — | config, portal | 1 | — |
-| `MATRIXARK_HOOK_ADDITIONAL_CONTEXT_CHAR_LIMIT` | — | launch | 1 | — |
+| `MATRIXARK_HOOK_ADDITIONAL_CONTEXT_CHAR_LIMIT` | 40000 | launch | 1 | — |
 | `MATRIXARK_REQUIRE_MODEL_EMBEDDINGS` | off | config, portal | 1 | — |
 | `MATRIXARK_REQUIRE_MODEL_SUMMARIES` | off | config, portal | 1 | — |
 | `MATRIXARK_RETRIEVAL_TRAVERSAL_TOP_K` | — | nothing | 1 | — |
@@ -356,7 +357,7 @@ Read only by the benchmark harnesses. Never consulted on a serving path.
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_DIRECT_SOURCE_SCORING` | off | nothing | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_EXTERNAL_ONLY` | off | nothing | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_JSONL` | — | script | 1 | — |
-| `TEMPORALSTORE_CONTEXT_BENCHMARK_SELECTED_ID_LIMIT` | — | nothing | 1 | — |
+| `TEMPORALSTORE_CONTEXT_BENCHMARK_SELECTED_ID_LIMIT` | 128 | nothing | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_SOURCE_ORDER_RANKING` | off | nothing | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_STORED_RECORD_SCORING` | on | nothing | 1 | — |
 
@@ -386,7 +387,7 @@ Everything else that changes what the engine does.
 | `TS_BLOB_PEER_FETCH` | — | nothing | 1 | — |
 | `TS_BLOB_RUNTIME_THREADS` | — | nothing | 1 | — |
 | `TS_CACHE_DISK_TIER` | — | test | 1 | — |
-| `TS_COLD_SCAN_NO_CACHE_FILL` | — | config, portal | 1 | — |
+| `TS_COLD_SCAN_NO_CACHE_FILL` | on | config, portal | 1 | — |
 | `TS_DATA_RAFT_READ_MODE` | — | config | 1 | — |
 | `TS_EVICT_SAMPLES` | — | nothing | 1 | — |
 | `TS_EVICT_SCAN_TURNS` | — | nothing | 1 | — |

--- a/tools/build_engine_flag_inventory.py
+++ b/tools/build_engine_flag_inventory.py
@@ -220,6 +220,20 @@ def _end_of_flag_chain(body: str) -> int:
     return len(body) if later < 0 else later
 
 
+def statement_around(lines, read_line):
+    """The whole statement a flag read sits in, so a default is never taken from a neighbour."""
+    start = read_line
+    while start > 0:
+        previous = lines[start - 1].strip()
+        if previous.endswith((";", "{", "}")) or not previous:
+            break
+        start -= 1
+    end = read_line
+    while end < len(lines) - 1 and not lines[end].strip().endswith(";"):
+        end += 1
+    return NEWLINE.join(lines[start:end + 1])
+
+
 def default_of_statement(lines, read_line):
     """"on", "off", or "" -- the default of a flag read INLINE, from its own statement.
 
@@ -233,16 +247,7 @@ def default_of_statement(lines, read_line):
     same statement, so a statement always carries its own negation, while a window of n lines
     carries it only when n happens to be large enough.
     """
-    start = read_line
-    while start > 0:
-        previous = lines[start - 1].strip()
-        if previous.endswith((";", "{", "}")) or not previous:
-            break
-        start -= 1
-    end = read_line
-    while end < len(lines) - 1 and not lines[end].strip().endswith(";"):
-        end += 1
-    statement = NEWLINE.join(lines[start:end + 1])
+    statement = statement_around(lines, read_line)
     if len(FLAG_READ.findall(statement)) != 1:
         return ""
     # Boolean-shaped only. A statement reading a millisecond count has no ON/OFF to state.
@@ -297,6 +302,67 @@ def default_of(body: str, flags_read: int) -> str:
     return "on" if index > 0 and body[index - 1] == "!" else "off"
 
 
+# A number stated in the read itself, and the named constants such a read can point at.
+UNWRAP_NUMBER = re.compile(r"\.unwrap_or\(\s*(-?\d[\d_]*)\s*\)")
+UNWRAP_NAMED = re.compile(r"\.unwrap_or\(\s*([A-Z][A-Z0-9_]{2,})\s*\)")
+CONST_LITERAL = re.compile(
+    r"const ([A-Z][A-Z0-9_]+)\s*:\s*[a-z][a-z0-9]*\s*=\s*([^;]+);")
+ARITHMETIC = re.compile(r"^[\d_ ()*<+]+$")
+
+
+def literal_consts(bodies):
+    """Every `const NAME = <literal>` whose value is a plain number or bool, as display text.
+
+    Only arithmetic on literals is evaluated -- digits, `*`, `<<`, `+`, parentheses. A const
+    computed from another const, or from a function call, is left out rather than guessed at: a
+    wrong number in this table would be published as fact for every flag pointing at it.
+    """
+    found = {}
+    for rel in sorted(bodies):
+        for name, expr in CONST_LITERAL.findall(bodies[rel]):
+            expr = expr.strip()
+            if expr in ("true", "false"):
+                found.setdefault(name, "on" if expr == "true" else "off")
+            elif ARITHMETIC.match(expr):
+                try:
+                    found.setdefault(
+                        name, str(eval(expr.replace("_", ""), {"__builtins__": {}}, {})))
+                except Exception:
+                    pass
+    return found
+
+
+def numeric_default_of_statement(lines, read_line, consts):
+    """A number, as text, or "" -- the default of a flag whose read states one.
+
+    `default_of_statement` answers this for booleans and says so: a statement reading a
+    millisecond count has no ON/OFF to state. It had no answer for the count itself, so a page
+    an operator consults to decide what to change showed an em dash for 26 flags whose default
+    is written down three lines from the name.
+
+    Only what comes AFTER the read can be its default. Scanning the whole statement reported
+    `MATRIXARK_ACCOUNT_ID` -- which defaults to the string "acct_codex" -- as defaulting to
+    1024, borrowed from a neighbouring field of the same struct literal, because a struct
+    literal separates its fields with commas and so is one statement. Reading forward from the
+    name cannot make that mistake.
+
+    `unwrap_or_else(` cannot match `unwrap_or\(`, so a string fallback never reads as a number.
+    """
+    statement = statement_around(lines, read_line)
+    first = FLAG_READ.search(statement)
+    if not first or len(FLAG_READ.findall(statement)) != 1:
+        return ""
+    after = statement[first.end():]
+    number = UNWRAP_NUMBER.search(after)
+    if number:
+        return number.group(1).replace("_", "")
+    named = UNWRAP_NAMED.search(after)
+    if named and named.group(1) in consts:
+        value = consts[named.group(1)]
+        return value if value not in ("on", "off") else ""
+    return ""
+
+
 def classify(name: str) -> str:
     for label, pattern in CLASS_RULES:
         if pattern.search(name):
@@ -311,6 +377,9 @@ for path in sorted(SRC.rglob("*.rs")):
 
 prod = {k: strip_test_modules(v) for k, v in sources.items()
         if "/tests" not in k and not k.startswith("tests")}
+
+# Named constants a numeric read can point at, resolved once so every flag sees the same table.
+CONSTS = literal_consts(prod)
 
 flags = {}
 # Distinct functions that read a flag, as (file, line) -> name. Several flags can share one, so
@@ -359,6 +428,8 @@ for rel, text in prod.items():
             entry["default"] = default_of(body, len(set(FLAG_READ.findall(body))))
         if not entry["default"]:
             entry["default"] = default_of_statement(lines, line_no)
+        if not entry["default"]:
+            entry["default"] = numeric_default_of_statement(lines, line_no, CONSTS)
         if entry["doc"]:
             continue
         text_doc, shared_with = doc_for_flag(name, " ".join(doc), lines, fn_line)
@@ -373,6 +444,13 @@ for rel, text in prod.items():
         r'"((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)"', text):
         entry = flags.setdefault(value, {"sites": set(), "doc": "", "default": ""})
         entry["sites"].add(rel)
+        # storage_config.rs declares the variable NAME and its DEFAULT as neighbouring consts and
+        # reads one with the other, so the default is derivable even though no scan of string
+        # literals can see the read. The pairing is on the const IDENTIFIER, not the string:
+        # `TS_BLOCK_SLAB_TARGET_BYTES` names the variable `TS_BLOCK_SEGMENT_TARGET_BYTES`, and
+        # matching on the string would silently drop it.
+        if not entry["default"] and ident.startswith("TS_"):
+            entry["default"] = CONSTS.get("DEFAULT_" + ident[len("TS_"):], "")
 
 # Where a flag is given a value, as opposed to read.
 #
@@ -527,7 +605,9 @@ lines = [
     "|---|---|",
     "| total | %d |" % len(rows),
     "| booleans whose default this could read off the source | %d |"
-    % sum(1 for r in rows if r["default"]),
+    % sum(1 for r in rows if r["default"] in ("on", "off")),
+    "| numbers whose default this could read off the source | %d |"
+    % sum(1 for r in rows if r["default"] and r["default"] not in ("on", "off")),
     "| **defaulting on, and set by nothing** | %d |"
     % sum(1 for r in rows if r["default"] == "on" and not r["set_by"]),
     "| offered on the portal | %d |" % sum(1 for r in rows if r["offered"]),


### PR DESCRIPTION
The ops inventory extracted on/off for booleans and printed an em dash for everything else.
For a path or an address that is right — there is nothing to state. For a flag whose read
carries a literal number it is a hole: someone deciding what to set could not see what they
would be changing **from**.

**31 flags gain a number; one more boolean resolves.**

```
| booleans whose default this could read off the source | 33 |   (was 32)
| numbers  whose default this could read off the source | 31 |   (new)
```

### Two shapes, both read conservatively

**A number stated in the read.** Only what comes *after* the name can be its default — that
is the whole safety argument. Scanning the whole statement reported
`MATRIXARK_ACCOUNT_ID` as defaulting to `1024`; it defaults to the string `"acct_codex"`,
and the 1024 was borrowed from a neighbouring field of the same struct literal (a struct
literal separates fields with commas, so it is one statement). Reading forward from the name
cannot make that mistake, and `unwrap_or_else(` cannot match `unwrap_or\(`, so a string
fallback never reads as a number. Both flags still show a dash in the output.

**A number named by a constant.** `storage_config.rs` declares the variable name and its
default as neighbouring consts and reads one with the other, so nine flags — for which no
scan of string literals can even see the read — now state their default. The pairing is on
the const **identifier**, not the string:

```rust
pub const TS_BLOCK_SLAB_TARGET_BYTES: &str = "TS_BLOCK_SEGMENT_TARGET_BYTES";
pub const DEFAULT_BLOCK_SLAB_TARGET_BYTES: u64 = 1 << 30;
```

Only arithmetic on literals is evaluated. A const computed from another const is left out
rather than guessed at — a wrong number here is published as fact.

### Verification

Seventeen values are confirmed against something other than the extractor: **nine** against
what the portal offers for the same variable (per
[#961](https://github.com/matrixarkai/TemporalStore/pull/961)), and **eight** read by hand at
the site — `TS_WAL_RESIDENT_PAGES` 4096, `TS_WAL_COMMIT_DELAY_US` 0, `TS_SHARD_ID` 1,
`TS_WAL_SEGMENT_BYTES` 262144, the two traversal consts 8 and 64, and the two the portal
already agreed on.

The document regenerates **byte-identical**, checked by generating it twice.

### One correction the new numbers forced

The WAL module header said:

> `TS_WAL_SEGMENT_BYTES` sets when a piece is sealed; zero, the default, never seals one

The single read site defaults to `DEFAULT_WAL_SEGMENT_BYTES` = 256 KiB, **nothing in the tree
or on a running box sets the variable**, and the const's own doc calls itself "the rolling
threshold when nothing sets one". So the log rolls by default, and has since #713 — the
header described the behaviour before that and was never updated. Zero is still accepted and
still means never seal; that half was true and is kept.

### Checks

`python3 -m unittest` over every flag / inventory / engine / gateway / config guard in
`tools/`: **388 tests, OK**. The Rust change is a comment; intra-doc links are not denied in
this crate, and the const it links is `pub` in the same module.
