### PR TITLE
Name a provider the deployment does not recognise

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -1560,6 +1560,66 @@ _API_EMBEDDING_PROVIDERS = {"openai", "openai_compatible", "openai-compatible", 
                             "voyage", "api"}
 
 
+# The encoder also has an in-process branch that loads a model instead of calling one. It is not
+# an endpoint, so the probe skips it -- but it produces REAL embeddings, so it is not the hash
+# fallback either, and the two must not be reported as the same thing.
+_OSS_EMBEDDING_PROVIDERS = {"oss", "open_source", "sentence_transformers", "sentence-transformers"}
+
+# Names a customer sets on purpose to get the local rules. Everything else that ends up there ended
+# up there by accident.
+_DELIBERATE_FALLBACK_PROVIDERS = {"", "deterministic", "rules", "local", "hash"}
+
+
+def embedding_provider_effect(provider: str) -> str:
+    """What the ENCODER does with this name: "api", "local_model" or "hash".
+
+    Three places asked this separately and each answered with the same hand-written literal set,
+    which caught "local" and nothing else. A name the encoder does not recognise -- a typo, or a
+    provider that simply is not supported -- falls through to the hash fallback exactly as
+    "deterministic" does, and none of the three knew it.
+    """
+    name = (provider or "").strip().lower()
+    if name in _API_EMBEDDING_PROVIDERS:
+        return "api"
+    if name in _OSS_EMBEDDING_PROVIDERS:
+        return "local_model"
+    return "hash"
+
+
+def extraction_provider_effect(provider: str) -> str:
+    """What EXTRACTION does with this name: "openai", "anthropic" or "rules", matching the dispatch
+    in matrixark_mcp_core -- where an unrecognised name falls past both branches to the same
+    rule-based path a customer gets by asking for it."""
+    name = (provider or "").strip().lower()
+    if name in _OPENAI_EXTRACTION_PROVIDERS:
+        return "openai"
+    if name in _ANTHROPIC_EXTRACTION_PROVIDERS:
+        return "anthropic"
+    return "rules"
+
+
+def provider_is_unrecognised(group: str, provider: str) -> bool:
+    """True when this name yields the fallback WITHOUT anyone having asked for it.
+
+    The distinction is the whole point. "deterministic" is a choice, and the portal should explain
+    it. "openai_compatibl" is a mistake, and the portal should say so and name the value -- it used
+    to report that deployment as a working API encoder.
+    """
+    name = (provider or "").strip().lower()
+    if name in _DELIBERATE_FALLBACK_PROVIDERS:
+        return False
+    if group == "embedding":
+        return embedding_provider_effect(name) == "hash"
+    return extraction_provider_effect(name) == "rules"
+
+
+def recognised_providers(group: str) -> List[str]:
+    """What to offer someone whose value matched nothing, so the message can be acted on."""
+    if group == "embedding":
+        return sorted(_API_EMBEDDING_PROVIDERS | _OSS_EMBEDDING_PROVIDERS)
+    return sorted(_OPENAI_EXTRACTION_PROVIDERS | _ANTHROPIC_EXTRACTION_PROVIDERS)
+
+
 def _probe(kind: str, url: str, payload: Json, headers: Dict[str, str], timeout: float) -> Json:
     started = time.time()
     result: Json = {"target": kind, "url": url, "ok": False}

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1633,8 +1633,23 @@ def _model_config_snapshot() -> Json:
             "out-of-the-box default so the API works with no configuration. Set "
             "MATRIXARK_REQUIRE_AUTH=1 and MATRIXARK_ACCESS_MODE=enforced, then restart."
         )
-    deterministic = {"", "deterministic", "rules", "local"}
-    if extraction_provider in deterministic:
+    def _unrecognised(group: str, provider: str) -> str:
+        """The warning for a value nothing matches. It names the value, because the whole failure is
+        that the value looks configured -- and lists what would have worked."""
+        return (
+            "The " + group + " provider is set to " + repr(provider) + ", which nothing recognises. "
+            "It is not rejected: the request falls through to the same local path as "
+            "'deterministic', so the deployment answers 200 and looks configured. Set it to one of "
+            + ", ".join(_gwconfig.recognised_providers(group)) + ".")
+
+    unrecognised_extraction = _gwconfig.provider_is_unrecognised("extraction", extraction_provider)
+    unrecognised_embedding = _gwconfig.provider_is_unrecognised("embedding", embedding_provider)
+    if unrecognised_extraction:
+        warnings.append(_unrecognised("extraction", extraction_provider))
+    if unrecognised_embedding:
+        warnings.append(_unrecognised("embedding", embedding_provider))
+    if _gwconfig.extraction_provider_effect(extraction_provider) == "rules" \
+            and not unrecognised_extraction:
         warnings.append(
             "Extraction provider is deterministic: no model is called, so ingest stores only "
             "what the local rules extract. Set Extraction provider to openai_compatible, then fill "
@@ -1647,14 +1662,15 @@ def _model_config_snapshot() -> Json:
             "deterministic path. The key goes into " + extraction_key_env + ", which is what "
             "Extraction key variable names."
         )
-    if embedding_provider in deterministic:
+    if _gwconfig.embedding_provider_effect(embedding_provider) == "hash" \
+            and not unrecognised_embedding:
         warnings.append(
             "Embedding provider is deterministic: retrieval uses hash vectors, not semantic "
             "embeddings. Set Embedding provider to the encoder you run, and turn on Fail instead "
             "of falling back so an unreachable one is not answered with hash vectors."
         )
     else:
-        if not require_model_embeddings:
+        if not require_model_embeddings and not unrecognised_embedding:
             warnings.append(
                 "Fail instead of falling back is off: if the encoder becomes unreachable the "
                 "gateway answers with hash vectors instead of failing the request, and retrieval "
@@ -1687,7 +1703,8 @@ def _model_config_snapshot() -> Json:
     # sharing the key is the point, and warning there would be noise on a correct configuration.
     extraction_endpoint = str(extraction["base_url"] or "").rstrip("/")
     embedding_endpoint = str(embedding["api_base"] or "").rstrip("/")
-    if (extraction_provider not in deterministic and embedding_provider not in deterministic
+    if (_gwconfig.extraction_provider_effect(extraction_provider) != "rules"
+            and _gwconfig.embedding_provider_effect(embedding_provider) == "api"
             and extraction_key_env and extraction_key_env == embedding_key_env
             and extraction_endpoint and embedding_endpoint
             and extraction_endpoint != embedding_endpoint):
@@ -2925,7 +2942,6 @@ def _readiness_checks(config_snapshot: Json, counts: Json, cfg: Any,
     """
     extraction = config_snapshot.get("extraction") or {}
     embedding = config_snapshot.get("embedding") or {}
-    deterministic = {"", "deterministic", "rules", "local"}
     checks: List[Json] = []
 
     def plural(count: int, one: str, many: str = "") -> str:
@@ -2971,7 +2987,10 @@ def _readiness_checks(config_snapshot: Json, counts: Json, cfg: Any,
             "The datanode reported a state this gateway does not recognise: %r." % datanode,
             "/v1/admin/setup", "Deployment")
 
-    model_on = str(extraction.get("provider", "")).lower() not in deterministic
+    # A name nothing recognises is not "on". It used to pass this test, so the checklist showed
+    # a tick and the provider's own name beside it on a deployment running the local rules.
+    model_on = _gwconfig.extraction_provider_effect(
+        str(extraction.get("provider", ""))) != "rules"
     add("extraction", "Extraction model", "ok" if model_on else "todo",
         ("Ingest calls " + str(extraction.get("model") or extraction.get("provider")) + ".")
         if model_on else
@@ -3004,7 +3023,8 @@ def _readiness_checks(config_snapshot: Json, counts: Json, cfg: Any,
                 "The key is stored owner-only and is never returned by any read.",
             ])
 
-    semantic = str(embedding.get("provider", "")).lower() not in deterministic
+    semantic = _gwconfig.embedding_provider_effect(
+        str(embedding.get("provider", ""))) != "hash"
     add("embedding", "Embedding model", "ok" if semantic else "todo",
         ("Retrieval encodes with " + str(embedding.get("model") or embedding.get("provider")) + ".")
         if semantic else

--- a/tools/test_matrixark_an_unrecognised_provider_name_is_named.py
+++ b/tools/test_matrixark_an_unrecognised_provider_name_is_named.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A provider name nothing recognises is named, not treated as configured.
+
+Three places asked "is this provider deterministic?" and each answered with the same hand-written
+literal set, ``{"", "deterministic", "rules", "local"}``. That set catches the names a customer
+chooses on purpose. It does not catch a name nothing matches -- ``openai_compatibl`` with one
+character missing, or ``cohere``, which simply is not supported. Both fall through to the same local
+path, and all three places reported the deployment as configured:
+
+* the model panel raised no warning at all;
+* the setup checklist printed a tick and *"Retrieval encodes with openai_compatibl."*
+
+The classification now lives once, beside the sets it reads, and the tests derive those sets from
+the provider modules. The distinction it draws is the point: ``deterministic`` is a choice and keeps
+its own explanation; an unrecognised value is a mistake, and the message names the value.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+try:
+    from tools import matrixark_v1_gateway as gw  # type: ignore
+except ImportError:
+    import matrixark_v1_gateway as gw  # type: ignore
+
+# The gateway binds its own module object for the registry; a separate import is a different module.
+cfg = gw._gwconfig
+
+ENCODER = "matrixark_mcp_embeddings.py"
+CORE = "matrixark_mcp_core.py"
+PARTICIPATING = ("MATRIXARK_EMBEDDING_PROVIDER", "MATRIXARK_UNDERSTANDING_PROVIDER",
+                 "MATRIXARK_EXTRACTION_PROVIDER", "MATRIXARK_EMBEDDING_API_BASE",
+                 "MATRIXARK_EMBED_BASE_URL", "MATRIXARK_EXTRACTION_BASE_URL",
+                 "MATRIXARK_EXTRACTION_MODEL", "MATRIXARK_EMBEDDING_MODEL",
+                 "MATRIXARK_REQUIRE_MODEL_EMBEDDINGS")
+
+
+def parse(filename: str) -> ast.Module:
+    with open(os.path.join(TOOLS, filename), encoding="utf-8") as handle:
+        return ast.parse(handle.read(), filename=filename)
+
+
+def assigned_string_set(filename: str, name: str) -> set:
+    for node in parse(filename).body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == name:
+                    return {e.value for e in node.value.elts
+                            if isinstance(e, ast.Constant) and isinstance(e.value, str)}
+    raise AssertionError("%s not found in %s" % (name, filename))
+
+
+def provider_membership_sets(filename: str) -> list:
+    found = []
+    for node in ast.walk(parse(filename)):
+        if not (isinstance(node, ast.Compare) and len(node.ops) == 1
+                and isinstance(node.ops[0], ast.In)):
+            continue
+        left, right = node.left, node.comparators[0]
+        if not (isinstance(left, ast.Name) and left.id == "provider"):
+            continue
+        if isinstance(right, (ast.Set, ast.List, ast.Tuple)):
+            members = {e.value for e in right.elts
+                       if isinstance(e, ast.Constant) and isinstance(e.value, str)}
+            if members:
+                found.append(members)
+    return found
+
+
+class Case(unittest.TestCase):
+    """Every one of these reads the process environment, so it must control it -- a sibling suite
+    leaving a provider set is the difference between passing alone and failing the full run."""
+
+    def setUp(self) -> None:
+        self._saved = {n: os.environ.get(n) for n in PARTICIPATING}
+        for name in PARTICIPATING:
+            os.environ.pop(name, None)
+
+    def tearDown(self) -> None:
+        for name, value in self._saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+    def snapshot(self, **environment) -> dict:
+        for name, value in environment.items():
+            os.environ[name] = value
+        return gw._model_config_snapshot()
+
+    def check(self, snapshot: dict, check_id: str) -> dict:
+        for row in gw._readiness_checks(snapshot, {}, None):
+            if row["id"] == check_id:
+                return row
+        raise AssertionError("no readiness check %r" % check_id)
+
+    def named(self, snapshot: dict) -> list:
+        return [w for w in snapshot["warnings"] if "nothing recognises" in w]
+
+
+class TheSetsAreTheProviderCodesTest(unittest.TestCase):
+    """These decide whether a deployment is reported as working. Restating them by hand is how the
+    three copies drifted; if the parse stops matching, the classification is guessing again."""
+
+    def test_the_api_set_is_the_encoders(self) -> None:
+        self.assertEqual(assigned_string_set(ENCODER, "_API_EMBEDDING_PROVIDERS"),
+                         cfg._API_EMBEDDING_PROVIDERS)
+
+    def test_the_in_process_set_is_a_dispatch_set_in_the_encoder(self) -> None:
+        self.assertIn(cfg._OSS_EMBEDDING_PROVIDERS, provider_membership_sets(ENCODER))
+
+    def test_both_extraction_sets_are_dispatch_sets_in_the_core(self) -> None:
+        sets = provider_membership_sets(CORE)
+        self.assertIn(cfg._OPENAI_EXTRACTION_PROVIDERS, sets)
+        self.assertIn(cfg._ANTHROPIC_EXTRACTION_PROVIDERS, sets)
+
+    def test_the_deliberate_set_is_the_cores(self) -> None:
+        """"deterministic", "rules" and "local" are what a customer asks for. The core treats them
+        as one set, and so must this, or a deliberate choice gets reported as a mistake."""
+        self.assertTrue(any(members <= cfg._DELIBERATE_FALLBACK_PROVIDERS
+                            and {"deterministic", "rules", "local"} <= members
+                            for members in provider_membership_sets(CORE)))
+
+
+class TheClassifierMatchesWhatTheCodeDoesTest(unittest.TestCase):
+
+    def test_every_api_provider_is_called_api(self) -> None:
+        for provider in assigned_string_set(ENCODER, "_API_EMBEDDING_PROVIDERS"):
+            with self.subTest(provider=provider):
+                self.assertEqual("api", cfg.embedding_provider_effect(provider))
+
+    def test_an_in_process_encoder_is_not_called_a_hash(self) -> None:
+        """It makes no HTTP call, but it produces real embeddings. Reporting it as the hash
+        fallback would be a new wrong answer in the other direction."""
+        for provider in cfg._OSS_EMBEDDING_PROVIDERS:
+            with self.subTest(provider=provider):
+                self.assertEqual("local_model", cfg.embedding_provider_effect(provider))
+
+    def test_an_unrecognised_name_is_the_hash_fallback(self) -> None:
+        for provider in ("openai_compatibl", "cohere", "OpenAI-Compatible-Typo"):
+            with self.subTest(provider=provider):
+                self.assertEqual("hash", cfg.embedding_provider_effect(provider))
+
+    def test_extraction_names_map_to_their_dispatch(self) -> None:
+        for provider in cfg._OPENAI_EXTRACTION_PROVIDERS:
+            self.assertEqual("openai", cfg.extraction_provider_effect(provider))
+        for provider in cfg._ANTHROPIC_EXTRACTION_PROVIDERS:
+            self.assertEqual("anthropic", cfg.extraction_provider_effect(provider))
+        for provider in ("anthropi", "gemini", ""):
+            self.assertEqual("rules", cfg.extraction_provider_effect(provider))
+
+    def test_case_and_padding_do_not_change_the_answer(self) -> None:
+        """The provider code lowercases and strips before dispatching, so a value that works there
+        must not be reported as unrecognised here."""
+        self.assertEqual("api", cfg.embedding_provider_effect("  Voyage  "))
+        self.assertEqual("anthropic", cfg.extraction_provider_effect(" ANTHROPIC "))
+
+    def test_a_deliberate_choice_is_not_a_mistake(self) -> None:
+        for group in ("embedding", "extraction"):
+            for provider in ("", "deterministic", "rules", "local"):
+                with self.subTest(group=group, provider=provider):
+                    self.assertFalse(cfg.provider_is_unrecognised(group, provider))
+
+
+class TheMisspeltProviderIsReportedTest(Case):
+
+    def test_the_warning_names_the_value(self) -> None:
+        snapshot = self.snapshot(MATRIXARK_EMBEDDING_PROVIDER="openai_compatibl",
+                                 MATRIXARK_EMBEDDING_API_BASE="https://encoder.example/v1")
+        named = self.named(snapshot)
+        self.assertEqual(1, len(named), snapshot["warnings"])
+        self.assertIn("openai_compatibl", named[0])
+
+    def test_the_warning_says_what_would_have_worked(self) -> None:
+        snapshot = self.snapshot(MATRIXARK_EMBEDDING_PROVIDER="cohere")
+        self.assertIn("voyage", self.named(snapshot)[0])
+
+    def test_the_checklist_row_is_not_green(self) -> None:
+        """The sharpest form of the bug: a tick, with the misspelt name printed beside it."""
+        snapshot = self.snapshot(MATRIXARK_EMBEDDING_PROVIDER="openai_compatibl",
+                                 MATRIXARK_EMBEDDING_API_BASE="https://encoder.example/v1")
+        self.assertNotEqual("ok", self.check(snapshot, "embedding")["status"])
+
+    def test_the_extraction_checklist_row_is_not_green_either(self) -> None:
+        snapshot = self.snapshot(MATRIXARK_UNDERSTANDING_PROVIDER="openai_compatibl",
+                                 MATRIXARK_EXTRACTION_BASE_URL="https://api.example/v1",
+                                 MATRIXARK_EXTRACTION_MODEL="gpt-4o-mini")
+        self.assertNotEqual("ok", self.check(snapshot, "extraction")["status"])
+
+    def test_each_side_is_reported_on_its_own(self) -> None:
+        snapshot = self.snapshot(MATRIXARK_EMBEDDING_PROVIDER="cohere",
+                                 MATRIXARK_UNDERSTANDING_PROVIDER="gemini")
+        named = self.named(snapshot)
+        self.assertEqual(2, len(named))
+        self.assertTrue(any("cohere" in w for w in named))
+        self.assertTrue(any("gemini" in w for w in named))
+
+
+class ADeliberateChoiceKeepsItsOwnExplanationTest(Case):
+
+    def test_deterministic_is_explained_not_reported_as_a_mistake(self) -> None:
+        snapshot = self.snapshot(MATRIXARK_EMBEDDING_PROVIDER="deterministic")
+        self.assertEqual([], self.named(snapshot))
+        self.assertTrue([w for w in snapshot["warnings"] if "hash vectors, not semantic" in w])
+
+    def test_local_is_still_explained_the_way_it_was(self) -> None:
+        snapshot = self.snapshot(MATRIXARK_EMBEDDING_PROVIDER="local")
+        self.assertEqual([], self.named(snapshot))
+        self.assertTrue([w for w in snapshot["warnings"] if "hash vectors, not semantic" in w])
+
+    def test_a_misspelt_name_is_not_told_both_things(self) -> None:
+        """Two warnings for one setting, one of them saying it is deterministic when the customer
+        did not choose that, reads as two problems."""
+        snapshot = self.snapshot(MATRIXARK_EMBEDDING_PROVIDER="cohere")
+        self.assertEqual([], [w for w in snapshot["warnings"]
+                              if "hash vectors, not semantic" in w])
+
+
+class AWorkingDeploymentIsStillReportedWorkingTest(Case):
+    """The floor. Every assertion above would pass on a build that called everything unrecognised."""
+
+    def test_an_api_encoder_raises_nothing_new(self) -> None:
+        snapshot = self.snapshot(MATRIXARK_EMBEDDING_PROVIDER="voyage",
+                                 MATRIXARK_EMBEDDING_API_BASE="https://api.voyageai.example/v1",
+                                 MATRIXARK_REQUIRE_MODEL_EMBEDDINGS="1")
+        self.assertEqual([], self.named(snapshot))
+        self.assertEqual("ok", self.check(snapshot, "embedding")["status"])
+
+    def test_an_in_process_encoder_is_treated_as_configured(self) -> None:
+        snapshot = self.snapshot(MATRIXARK_EMBEDDING_PROVIDER="oss",
+                                 MATRIXARK_REQUIRE_MODEL_EMBEDDINGS="1")
+        self.assertEqual([], self.named(snapshot))
+        self.assertEqual("ok", self.check(snapshot, "embedding")["status"])
+
+    def test_an_openai_compatible_extraction_is_still_green(self) -> None:
+        snapshot = self.snapshot(MATRIXARK_UNDERSTANDING_PROVIDER="openai_compatible",
+                                 MATRIXARK_EXTRACTION_BASE_URL="https://api.example/v1",
+                                 MATRIXARK_EXTRACTION_MODEL="gpt-4o-mini")
+        self.assertEqual([], self.named(snapshot))
+        self.assertEqual("ok", self.check(snapshot, "extraction")["status"])
+
+    def test_anthropic_counts_as_a_configured_extraction_provider(self) -> None:
+        snapshot = self.snapshot(MATRIXARK_UNDERSTANDING_PROVIDER="anthropic")
+        self.assertEqual([], self.named(snapshot))
+        self.assertEqual("ok", self.check(snapshot, "extraction")["status"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_every_choice_is_explained.py
+++ b/tools/test_matrixark_every_choice_is_explained.py
@@ -113,10 +113,21 @@ class TheClaimsAboutLocalAreTrueTest(unittest.TestCase):
 
     def test_the_deterministic_set_still_counts_local_as_one_of_its_own(self) -> None:
         """What makes `local` a synonym rather than an unknown value: the warning that fires for
-        deterministic fires for it too."""
-        with open(os.path.join(TOOLS, "matrixark_v1_gateway.py"), encoding="utf-8") as handle:
-            source = handle.read()
-        self.assertIn('deterministic = {"", "deterministic", "rules", "local"}', source)
+        deterministic fires for it too, and it is never reported as a name nothing recognises.
+
+        Asserted through the classifier rather than by matching a literal set in the gateway source.
+        That set existed in three copies and caught only the names written into it -- a misspelt
+        provider fell past all three -- so the classifier that replaced it is now the thing that has
+        to keep treating `local` as a deliberate choice.
+        """
+        try:
+            from tools import matrixark_gateway_config as gwcfg  # type: ignore
+        except ImportError:
+            import matrixark_gateway_config as gwcfg  # type: ignore
+        self.assertEqual("hash", gwcfg.embedding_provider_effect("local"))
+        for group in ("embedding", "extraction"):
+            with self.subTest(group=group):
+                self.assertFalse(gwcfg.provider_is_unrecognised(group, "local"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Three places asked "is this provider deterministic?" and each answered with the same hand-written
literal set:

```python
deterministic = {"", "deterministic", "rules", "local"}
```

That catches the names a customer chooses on purpose. It does not catch a name nothing matches.

```
provider              encoder calls an API   portal said "hash vectors"
openai_compatible     yes                    no      <- correct
openai_compatibl      NO                     no      <- one character missing
voyage                yes                    no      <- correct
local                 no                     YES     <- caught, because it is in the literal
cohere                NO                     no      <- plausible, unsupported
```

Both of the wrong rows fall through to the same local path `deterministic` reaches. All three places
reported those deployments as configured — and the setup checklist did the loudest version of it:

> ✓ **Embedding model** — Retrieval encodes with `openai_compatibl`.

A tick, and the misspelt name printed beside it, on a deployment answering every query with hash
vectors.

### One classification, and it draws the distinction that matters

`deterministic` is a **choice**, and keeps the explanation it already had. An unrecognised value is a
**mistake**, so the message names the value and lists what would have worked. Telling someone who
typed `cohere` that they have chosen the deterministic path would be a second wrong answer.

The in-process encoder (`oss`, `sentence_transformers`) is separated from the hash fallback as well:
it makes no HTTP call but produces real embeddings, so reporting the two as the same thing would be
a new wrong answer in the other direction.

```
the shipped bug: no name is ever unrecognised               -> FAIL 4
a deliberate choice is reported as a mistake                -> FAIL 4
an in-process encoder is called the hash fallback           -> FAIL 2
the classifier stops normalising case and padding           -> FAIL 1
the checklist decides extraction from the literal set again -> FAIL 1
the checklist decides embedding from the literal set again  -> FAIL 1
the warning stops naming the value                          -> FAIL 3
the warning stops saying what would have worked             -> FAIL 1
a mistake is also told it chose the deterministic path      -> FAIL 1
```

Every set is parsed out of the provider modules by the tests — `_API_EMBEDDING_PROVIDERS` from the
encoder, the `provider in {…}` dispatch sets from `matrixark_mcp_core` — so a new provider branch
fails these rather than quietly reopening the hole.

### One neighbour test changed

`test_matrixark_every_choice_is_explained` pinned the literal set by matching the gateway source. Its
stated intent — *"the warning that fires for deterministic fires for `local` too"* — is unchanged and
now asserted through the classifier, so it holds for every name rather than for the four written into
a set. Checked that the rewritten assertion still fails when `local` is dropped from the deliberate
set.

22 tests. Neighbours: the derived list of every suite touching the settings registry, the snapshot,
the readiness checks or the warnings — 50 suites, 2 failing, both failing identically on the base
(`test_validate_matrixark_context_backfill_readiness`, and the known `No module named 'tools'` limit
in `test_python_module_boundaries_part3`). Plus all portal- (166), gateway- (256) and config-named
(88) suites. And since a suite that passes alone can fail in the full run, the 14 siblings that write
these variables were run in one process with this one **last and first**: 270 tests, green both ways.
