### PR TITLE
The shipped config was the only surface saying pages ship uncompressed

### DIFF
--- a/config/temporalstore.toml
+++ b/config/temporalstore.toml
@@ -68,9 +68,17 @@ block_slab_target_bytes = 1073741824   # TS_BLOCK_SEGMENT_TARGET_BYTES  data-sla
 # page_index_cache_bytes = 0           # TS_PAGE_INDEX_CACHE_BYTES  page-index cache budget (bytes)
 # block_index_cache_bytes = 0          # TS_BLOCK_INDEX_CACHE_BYTES block-index cache budget (bytes)
 cold_scan_no_cache_fill = 0            # TS_COLD_SCAN_NO_CACHE_FILL  1 = cold scans bypass cache fill (avoid cache pollution)
-page_store_compression_enabled = 0     # TS_PAGE_STORE_COMPRESSION_ENABLED  1 = compress data pages at rest
+# The engine enables this itself (default_page_record_compression_enabled -> true), the deploy
+# profile exports it as 1, and a running box has it on. This file said 0, which made the
+# shipped config the only surface claiming the product ships without page compression.
+page_store_compression_enabled = 1     # TS_PAGE_STORE_COMPRESSION_ENABLED  1 = compress data pages at rest
 page_store_compression_level = 3       # TS_PAGE_STORE_COMPRESSION_LEVEL    compression level (algorithm-dependent)
-page_store_compression_min_bytes = 4096  # TS_PAGE_STORE_COMPRESSION_MIN_BYTES  skip compressing pages smaller than this
+# 4096 is the value the engine measured and rejected: over 120 adds it wrote 176.8 KB per add
+# at 4096 against 148.1 KB at 256, and the adds were no slower (152.5 -> 144.7 ms). The bytes
+# a 4 KB floor excluded are the index writes -- postings, placement rows, locator entries --
+# which are both the smallest and the most repetitive in the system. Compressing everything is
+# worse again: at a 1-byte floor the saving stops and the median add rises to 256.0 ms.
+page_store_compression_min_bytes = 256  # TS_PAGE_STORE_COMPRESSION_MIN_BYTES  skip compressing pages smaller than this
 cross_shard_reclaim_guard = 1          # TS_CROSS_SHARD_RECLAIM_GUARD  1 = retain slabs referenced by ANY loaded shard during GC (safe default; 0 = legacy per-shard, unsafe under multi-shard hosting)
 index_dump_oplog_gap_bytes = 1048576   # TS_INDEX_DUMP_OPLOG_GAP_BYTES  undumped index-log gap (bytes, 1 MiB) that triggers a background catalog/index dump under the manifest-parity catalog fold (TS_INDEX_CATALOG_FOLD); 0 disables the threshold cadence
 # index_catalog_fold = 1               # TS_INDEX_CATALOG_FOLD  1 = fold the band/zone catalog into the index-log MetaItem (reference conformance) and drive it via the threshold dump above, instead of the per-write band-manifest file. Ships OFF (byte-identical); uncomment to enable.

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -48,7 +48,7 @@ Anything else is blank, and a blank means go and look.
 |---|---|
 | total | 296 |
 | booleans whose default this could read off the source | 33 |
-| numbers whose default this could read off the source | 31 |
+| numbers whose default this could read off the source | 35 |
 | **defaulting on, and set by nothing** | 2 |
 | offered on the portal | 25 |
 | **that nothing in this repository sets** | 175 |
@@ -208,8 +208,8 @@ Sizes, ceilings and intervals. The tuning a deployment actually reaches for.
 | flag | default | set by | files | keeps an older path |
 |---|---|---|---|---|
 | `TS_RAFT_HEARTBEAT_INTERVAL_MS` | — | harness, script | 3 | — |
-| `TS_PAGE_STORE_COMPRESSION_MIN_BYTES` | — | config, test | 2 | — |
-| `TS_PROXY_CONTEXT_IO_TIMEOUT_MS` | — | nothing | 2 | — |
+| `TS_PAGE_STORE_COMPRESSION_MIN_BYTES` | 256 | config, test | 2 | — |
+| `TS_PROXY_CONTEXT_IO_TIMEOUT_MS` | 30000 | nothing | 2 | — |
 | `TS_RAFT_MAX_CATCHUP_ENTRIES_PER_HEARTBEAT` | — | nothing | 2 | — |
 | `MATRIXARK_BACKFILL_CACHE_BYTES` | — | nothing | 1 | — |
 | `MATRIXARK_BACKFILL_MAX_BODY` | 2000 | nothing | 1 | — |
@@ -220,9 +220,9 @@ Sizes, ceilings and intervals. The tuning a deployment actually reaches for.
 | `MATRIXARK_EMBED_DRAINER_MAX_NODES_PER_PASS` | — | nothing | 1 | — |
 | `MATRIXARK_RETRIEVAL_MAX_CANDIDATES` | 64 | nothing | 1 | — |
 | `MATRIXARK_RUST_PROXY_CACHE_BYTES` | — | nothing | 1 | — |
-| `MATRIXARK_RUST_PROXY_PAGE_COMPRESSION_MIN_BYTES` | — | test | 1 | — |
+| `MATRIXARK_RUST_PROXY_PAGE_COMPRESSION_MIN_BYTES` | 256 | test | 1 | — |
 | `MATRIXARK_TEMPORALSTORE_PROXY_CONNECT_TIMEOUT_MS` | — | nothing | 1 | — |
-| `MATRIXARK_TEMPORALSTORE_PROXY_IO_TIMEOUT_MS` | — | nothing | 1 | — |
+| `MATRIXARK_TEMPORALSTORE_PROXY_IO_TIMEOUT_MS` | 30000 | nothing | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_INGEST_CHUNK_SIZE` | 64 | nothing | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_MAX_EVENTS` | 32 | nothing | 1 | — |
 | `TS_BLOB_CHUNK_BYTES` | — | config | 1 | — |

--- a/tools/build_engine_flag_inventory.py
+++ b/tools/build_engine_flag_inventory.py
@@ -307,6 +307,92 @@ UNWRAP_NUMBER = re.compile(r"\.unwrap_or\(\s*(-?\d[\d_]*)\s*\)")
 UNWRAP_NAMED = re.compile(r"\.unwrap_or\(\s*([A-Z][A-Z0-9_]{2,})\s*\)")
 CONST_LITERAL = re.compile(
     r"const ([A-Z][A-Z0-9_]+)\s*:\s*[a-z][a-z0-9]*\s*=\s*([^;]+);")
+# `env_usize_any(&[A, B], 256)` and friends: one knob, several accepted spellings, one default.
+_ANY_HELPER = re.compile(r"env_(?:bool|usize|u64|u32|i32|i64|f64)_any\s*\(")
+_INT_LITERAL = re.compile(r"-?\d[\d_]*")
+_CONST_NAME = re.compile(r"[A-Z][A-Z0-9_]{2,}")
+
+
+def _balanced(text: str, open_paren: int) -> int:
+    """Index of the ) that closes the ( at `open_paren`, or -1."""
+    depth = 0
+    for index in range(open_paren, len(text)):
+        char = text[index]
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return index
+    return -1
+
+
+def _last_argument(span: str) -> str:
+    """The last top-level argument of an argument list.
+
+    Comments are removed FIRST, because a comma inside one is not an argument separator and the
+    numbers here are surrounded by prose that has commas in it -- the measurement that chose the
+    value is written directly above it. Splitting first put half a sentence in the result.
+    """
+    clean = NEWLINE.join(line.split("//")[0] for line in span.split(NEWLINE))
+    depth = 0
+    start = 0
+    pieces = []
+    for index, char in enumerate(clean):
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+        elif char == "," and depth == 0:
+            pieces.append(clean[start:index])
+            start = index + 1
+    pieces.append(clean[start:])
+    # Rust permits a trailing comma, so the last piece is usually empty.
+    for piece in reversed(pieces):
+        stripped = piece.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def _any_helper_default(lines, read_line, consts):
+    """The default of a knob offered under SEVERAL names by one `env_*_any` call.
+
+    These helpers take a list of accepted spellings -- a current name and the one it replaced --
+    and ONE default that belongs to all of them. The statement is the wrong unit here: the calls
+    sit as fields of a struct literal, so the statement runs to the end of the struct and picks up
+    the sibling knobs' names and numbers. The call itself is the unit, bounded by its own
+    parentheses, and the default is its last top-level argument.
+
+    A default that is an expression rather than a literal or a named const is left unread. That is
+    most of `compression_enabled`, whose default is `defaults.compression_enabled` -- following
+    that would mean evaluating Rust.
+    """
+    text = NEWLINE.join(lines)
+    offset = sum(len(line) + 1 for line in lines[:read_line])
+    match = FLAG_READ.search(text, offset)
+    if not match:
+        return ""
+    helper = None
+    for found in _ANY_HELPER.finditer(text, max(0, match.start() - 4000)):
+        if found.start() > match.start():
+            break
+        helper = found
+    if helper is None:
+        return ""
+    open_paren = text.index("(", helper.end() - 1)
+    close = _balanced(text, open_paren)
+    if close < 0 or not open_paren < match.start() < close:
+        return ""
+    tail = _last_argument(text[open_paren + 1:close])
+    if _INT_LITERAL.fullmatch(tail):
+        return tail.replace("_", "")
+    if _CONST_NAME.fullmatch(tail) and tail in consts:
+        value = consts[tail]
+        return value if value not in ("on", "off") else ""
+    return ""
+
+
 ARITHMETIC = re.compile(r"^[\d_ ()*<+]+$")
 
 
@@ -350,8 +436,10 @@ def numeric_default_of_statement(lines, read_line, consts):
     """
     statement = statement_around(lines, read_line)
     first = FLAG_READ.search(statement)
-    if not first or len(FLAG_READ.findall(statement)) != 1:
+    if not first:
         return ""
+    if len(FLAG_READ.findall(statement)) != 1:
+        return _any_helper_default(lines, read_line, consts)
     after = statement[first.end():]
     number = UNWRAP_NUMBER.search(after)
     if number:


### PR DESCRIPTION
Four authorities describe page compression. Three agree:

| authority | says |
|---|---|
| the engine | **on** — `default_page_record_compression_enabled() -> true` |
| `deploy_profile_common.sh` | **on** — exports `TS_PAGE_STORE_COMPRESSION_ENABLED=1` |
| a running box (sets neither) | **on** — inherits the engine default |
| `config/temporalstore.toml` | **off** — `= 0` |

Its floor disagreed too, and worse: **4096 is the value the engine measured and rejected.**
The measurement sits beside the code that chose 256 instead — over 120 adds, **176.8 KB per
add at 4096 against 148.1 KB at 256, and the adds were no slower** (152.5 → 144.7 ms). The
bytes a 4 KB floor excludes are the index writes — postings, placement rows, locator entries
— which are both the smallest in the system and the most repetitive, so they are exactly what
compression is good at. Compressing everything is worse again: at a 1-byte floor the saving
stops and the median add rises to 256.0 ms.

Neither key was annotated as a decision, nothing anywhere records a reason, and the line
dates to an early bulk import. So this is stale boilerplate rather than a choice, and it is
**corrected** rather than documented as an override.

`compression_level` is left alone: the engine's constant is `0` and this file says `3`, and
for zstd those select the same level.

### Why the guard that exists for this could not see it

Both keys are read through `env_*_any`, which offers **one knob under several spellings with
one default**, and the extractor required a statement to hold exactly one flag name. The call
is now the unit rather than the statement it sits in — find the `env_*_any` whose parentheses
contain the name, take its last top-level argument. Two smaller things had to be right, and
each was wrong first:

- Rust permits a trailing comma, so the last argument is usually *empty* — take the last one
  that still says something.
- Comments are stripped **before** splitting on commas, because the prose above these numbers
  contains commas and splitting first returned half a sentence.

A default that is an expression rather than a literal or named const is still left unread.
`compression_enabled` is one of those — following `defaults.compression_enabled` would mean
evaluating Rust — so that key stays outside the guard and is corrected here on the evidence
of the other three authorities.

### Result

**31 → 35** numeric defaults readable. Beyond the compression pair, the two new ones are the
proxy IO timeout under both its spellings, verified by hand as `env_u64_any(…, 30_000)`.

### Checks

- With the extension and **before** the config fix, the guard fails naming
  `page_store_compression_min_bytes`. After the fix it passes. Re-mutated to confirm.
- The generated document regenerates **byte-identical**.
- `python3 -m unittest` over every config / flag / inventory / engine / gateway / policy guard
  in `tools/`: **538 tests, OK**.
