### PR TITLE
Offer models the provider serves, into the field it reads

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -988,10 +988,22 @@ def discover_models(target: str, timeout: float = 8.0) -> Json:
     """
     document = load()
     values: Dict[str, str] = {k: str(v) for k, v in (document.get("values") or {}).items()}
+    auth = "bearer"
     if target == "embedding":
         base = (os.environ.get("MATRIXARK_EMBEDDING_API_BASE", "").strip()
                 or os.environ.get("MATRIXARK_EMBED_BASE_URL", "").strip())
         key_env = _env_name(SETTINGS_BY_KEY["embedding.api_key"], values)
+    elif extraction_provider_effect(
+            os.environ.get("MATRIXARK_UNDERSTANDING_PROVIDER",
+                           os.environ.get("MATRIXARK_EXTRACTION_PROVIDER", ""))) == "anthropic":
+        # Anthropic reads its own base URL and authenticates with x-api-key. Asking the OpenAI base
+        # URL, which this deployment never sets, answered "Set the base URL first" -- pointing at a
+        # field that provider does not read, in the one panel that exists to stop a misspelt model
+        # name reaching ingest.
+        base = os.environ.get("MATRIXARK_ANTHROPIC_API_BASE",
+                              "https://api.anthropic.com").strip().rstrip("/") + "/v1"
+        key_env = _env_name(SETTINGS_BY_KEY["extraction.api_key"], values)
+        auth = "anthropic"
     else:
         base = os.environ.get("MATRIXARK_EXTRACTION_BASE_URL", "").strip()
         key_env = _env_name(SETTINGS_BY_KEY["extraction.api_key"], values)
@@ -1000,7 +1012,14 @@ def discover_models(target: str, timeout: float = 8.0) -> Json:
         return {"available": False, "reason": "no_base_url",
                 "detail": "Set the base URL first; there is nothing to ask."}
     key = os.environ.get(key_env, "")
-    headers = {"Authorization": "Bearer " + key} if key else {}
+    if not key:
+        headers: Dict[str, str] = {}
+    elif auth == "anthropic":
+        headers = {"x-api-key": key,
+                   "anthropic-version": os.environ.get("MATRIXARK_ANTHROPIC_VERSION",
+                                                       "2023-06-01")}
+    else:
+        headers = {"Authorization": "Bearer " + key}
     try:
         status, parsed = _get_json(base + "/models", headers, timeout)
     except urllib.error.HTTPError as exc:

--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -945,14 +945,27 @@ PRESETS: Dict[str, Json] = {
 # Extraction models worth suggesting. There is no measured catalogue for these -- unlike the
 # encoders, where `encoder_catalog()` in the gateway holds hit@1/throughput/footprint from a real
 # corpus and the picker serves THAT rather than a second list written from general knowledge.
+# `serves` names the dispatch the model belongs to, in the vocabulary of
+# `extraction_provider_effect`. A suggestion the selected provider cannot serve is not a suggestion:
+# the whole list was OpenAI-compatible, so an Anthropic deployment was offered six models Anthropic
+# does not have, and none of the ones it does.
 EXTRACTION_CATALOGUE: List[Json] = [
-    {"model": "deepseek-chat", "note": "DeepSeek's general model. No embeddings API — pair it "
-                                       "with a local encoder."},
-    {"model": "deepseek-reasoner", "note": "Slower and more deliberate; raise the timeout."},
-    {"model": "gpt-4o-mini", "note": "OpenAI, inexpensive, good enough for extraction."},
-    {"model": "gpt-4o", "note": "OpenAI, stronger and dearer."},
-    {"model": "qwen2.5:7b", "note": "Runs locally under Ollama."},
-    {"model": "qwen2.5:1.5b", "note": "Small enough for a laptop; extraction quality drops."},
+    {"model": "deepseek-chat", "serves": "openai",
+     "note": "DeepSeek's general model. No embeddings API — pair it with a local encoder."},
+    {"model": "deepseek-reasoner", "serves": "openai",
+     "note": "Slower and more deliberate; raise the timeout."},
+    {"model": "gpt-4o-mini", "serves": "openai",
+     "note": "OpenAI, inexpensive, good enough for extraction."},
+    {"model": "gpt-4o", "serves": "openai", "note": "OpenAI, stronger and dearer."},
+    {"model": "qwen2.5:7b", "serves": "openai", "note": "Runs locally under Ollama."},
+    {"model": "qwen2.5:1.5b", "serves": "openai",
+     "note": "Small enough for a laptop; extraction quality drops."},
+    {"model": "claude-opus-5", "serves": "anthropic",
+     "note": "Anthropic's strongest, and its dearest."},
+    {"model": "claude-sonnet-5", "serves": "anthropic",
+     "note": "Anthropic's default here — the balance most extraction wants."},
+    {"model": "claude-haiku-4-5-20251001", "serves": "anthropic",
+     "note": "Anthropic's fastest and cheapest; extraction quality drops."},
 ]
 
 
@@ -1013,17 +1026,42 @@ def discover_models(target: str, timeout: float = 8.0) -> Json:
             "count": len(set(models))}
 
 
-def model_catalogue(target: str) -> List[Json]:
-    """Extraction models to suggest.
+def extraction_model_setting(provider: Optional[str] = None) -> str:
+    """Which setting holds the model the selected extraction provider actually READS.
+
+    The Anthropic path reads MATRIXARK_ANTHROPIC_MODEL and ignores MATRIXARK_EXTRACTION_MODEL
+    entirely, so writing a pick into `extraction.model` on that deployment changed nothing at all.
+    """
+    resolved = provider if provider is not None else os.environ.get(
+        "MATRIXARK_UNDERSTANDING_PROVIDER",
+        os.environ.get("MATRIXARK_EXTRACTION_PROVIDER", ""))
+    if extraction_provider_effect(resolved) == "anthropic":
+        return "extraction.anthropic_model"
+    return "extraction.model"
+
+
+def model_catalogue(target: str, provider: Optional[str] = None) -> List[Json]:
+    """Extraction models to suggest, narrowed to the ones the selected provider serves.
 
     Embeddings are NOT served from here. The gateway builds that list from `encoder_catalog()`,
     which carries a measurement over a real corpus; a second hand-written list beside it did not
     stay agreed with it, and the disagreement was about which encoder to choose.
+
+    A provider that calls no model at all gets the whole list rather than an empty one: there is
+    nothing wrong to narrow towards yet, and an empty picker beside a provider dropdown reads as a
+    broken page rather than as a choice still to be made.
     """
     if target == "embedding":
         raise ValueError(
             "embedding models come from the gateway's measured encoder_catalog(), not from here")
-    return [dict(entry) for entry in EXTRACTION_CATALOGUE]
+    entries = [dict(entry) for entry in EXTRACTION_CATALOGUE]
+    if provider is None:
+        provider = os.environ.get("MATRIXARK_UNDERSTANDING_PROVIDER",
+                                  os.environ.get("MATRIXARK_EXTRACTION_PROVIDER", ""))
+    effect = extraction_provider_effect(provider)
+    if effect == "rules":
+        return entries
+    return [entry for entry in entries if entry.get("serves") == effect]
 
 
 # ================================================================================================

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1561,6 +1561,29 @@ def encoder_catalog() -> list:
     return out
 
 
+def _model_picker_body(target: str) -> Json:
+    """The part of /v1/admin/models that needs no network: which setting a pick belongs in, what is
+    in that setting now, and the suggestions for the selected provider.
+
+    Which setting is decided HERE, not in the page. On Anthropic it is extraction.anthropic_model,
+    and the page used to write every pick into extraction.model -- a field the Anthropic path never
+    reads, so a pick filled in a form, said it was set, and changed nothing.
+
+    Split out so a test can call it. Rebuilding this in a test instead would leave the decision
+    tested twice and shipped once, which is exactly what a mutation of the route proved: the route
+    could report the wrong field with every assertion still green.
+    """
+    setting_key = ("embedding.model" if target == "embedding"
+                   else _gwconfig.extraction_model_setting())
+    return {
+        "target": target,
+        "key": setting_key,
+        "catalogue": (embedding_picker_catalogue() if target == "embedding"
+                      else _gwconfig.model_catalogue(target)),
+        "current": os.environ.get(_gwconfig.SETTINGS_BY_KEY[setting_key].env, "").strip(),
+    }
+
+
 def _model_config_snapshot() -> Json:
     """The effective extraction/embedding/skill-budget configuration, redacted for display.
 
@@ -4465,16 +4488,8 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
             discovered = {"available": False, "reason": "not_probed"}
             if (params.get("probe") or ["1"])[0].strip().lower() in ("1", "true", "yes"):
                 discovered = await asyncio.to_thread(_gwconfig.discover_models, target)
-            body: Json = {
-                "status": "ok",
-                "target": target,
-                "catalogue": (embedding_picker_catalogue() if target == "embedding"
-                              else _gwconfig.model_catalogue(target)),
-                "discovered": discovered,
-                "current": (os.environ.get("MATRIXARK_EMBEDDING_MODEL", "").strip()
-                            if target == "embedding"
-                            else os.environ.get("MATRIXARK_EXTRACTION_MODEL", "").strip()),
-            }
+            body: Json = {"status": "ok", **_model_picker_body(target),
+                          "discovered": discovered}
             if target == "embedding":
                 body["in_store"] = await _embedding_models_in_store(server, cfg, key, tenant,
                                                                    account)

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -1583,6 +1583,17 @@ SETUP_JS = r"""
             "one setting on this page that can quietly invalidate data you already have." }
   ];
 
+  /* Which setting a pick is written into. The route decides it from the selected provider --
+     on Anthropic the model lives in extraction.anthropic_model, and writing into extraction.model
+     there changed nothing. The static key stays as the fallback for a gateway that predates the
+     route saying so. */
+  function modelKey(target) {
+    var d = modelData[target] || {};
+    if (d.key) { return d.key; }
+    var entry = MODEL_TARGETS.filter(function (t) { return t.target === target; })[0];
+    return entry ? entry.key : "";
+  }
+
   function loadModels(probe) {
     if (!$("key").value.trim()) { return Promise.resolve(); }
     return Promise.all(MODEL_TARGETS.map(function (t) {
@@ -1694,10 +1705,11 @@ SETUP_JS = r"""
         return '<div class="mblock"><h3>' + esc(t.title) + '</h3><div class="mnote">' +
           esc(d.error) + "</div></div>";
       }
+      var key = modelKey(t.target);
       var chosen = Object.prototype.hasOwnProperty.call(pendingPick, t.target)
         ? pendingPick[t.target]
-        : ((Object.prototype.hasOwnProperty.call(edits, t.key) && edits[t.key] !== null)
-            ? edits[t.key] : (d.current || ""));
+        : ((Object.prototype.hasOwnProperty.call(edits, key) && edits[key] !== null)
+            ? edits[key] : (d.current || ""));
       var options = modelOptions(t.target);
       var known = options.some(function (o) { return sameModel(o.model, chosen); });
       var disc = d.discovered || {};
@@ -1792,19 +1804,23 @@ SETUP_JS = r"""
     if (!button) { return; }
     ev.preventDefault();
     var target = button.dataset.use;
+    var key = modelKey(target);
+    /* Still needed for the message at the end -- the KEY comes from the route, the TITLE is the
+       page's own label for the target. Dropping this is a ReferenceError after the field is
+       already set, which reads as a save that half-happened. */
     var entry = MODEL_TARGETS.filter(function (t) { return t.target === target; })[0];
     var value = pickedModel(target);
-    if (!entry || !value) {
+    if (!entry || !key || !value) {
       say($("saveMsg"), "Type a model name first.", "warn");
       return;
     }
-    var el = $("groups").querySelector('[data-key="' + entry.key + '"]');
+    var el = $("groups").querySelector('[data-key="' + key + '"]');
     if (!el) {
       say($("saveMsg"), "That field is not loaded — enter an admin key first.", "warn");
       return;
     }
     el.value = value;
-    edits[entry.key] = value;
+    edits[key] = value;
     pendingPick[target] = value;
     markDirty();
     renderModels();

--- a/tools/portal/model_key_harness.js
+++ b/tools/portal/model_key_harness.js
@@ -1,0 +1,143 @@
+/* Run the setup page's model picker and see which SETTING a pick is written into.
+ *
+ * The picker used to write every pick into `extraction.model`. The Anthropic extraction path reads
+ * MATRIXARK_ANTHROPIC_MODEL and ignores that field entirely, so on such a deployment picking a
+ * model changed nothing: the form filled in, the page said it was set, and the model in use stayed
+ * on its default. The route now names the field, and the page has to follow it.
+ *
+ * Both the resolver and the click handler are pulled OUT OF THE BUILT PAGE and executed -- this is
+ * the copy a browser runs, and the mistake this replaced (a variable left dangling after the
+ * rewrite) was a ReferenceError that no amount of reading the source would have shown.
+ *
+ * Usage: node model_key_harness.js <setup_portal.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+function slice(from, to) {
+  const start = page.indexOf(from);
+  if (start < 0) { console.log("FAIL not on the page: " + from); process.exit(1); }
+  const end = page.indexOf(to, start);
+  if (end < 0) { console.log("FAIL no end for: " + from); process.exit(1); }
+  return page.slice(start, end + to.length);
+}
+
+const resolverSource = slice("function modelKey(target) {", "\n  }");
+const handlerSource = slice("var button = ev.target.closest",
+                            'say($("saveMsg"), entry.title + " set to " + value + " — not saved yet. Save configuration " +\n      "below to apply it.", "info");');
+
+/* One case: what the route said, what the person picked, and what the form holds. */
+function run(routeBody, picked, fieldKeys) {
+  const modelData = { extraction: routeBody, embedding: {} };
+  const MODEL_TARGETS = [
+    { target: "extraction", key: "extraction.model", title: "Extraction model", note: "" },
+    { target: "embedding", key: "embedding.model", title: "Embedding model", note: "" }
+  ];
+  const edits = {};
+  const pendingPick = {};
+  const queried = [];
+  const messages = [];
+  const fields = {};
+  fieldKeys.forEach(function (k) {
+    fields[k] = { value: "", closest: () => null, scrollIntoView: () => {} };
+  });
+
+  const groups = {
+    querySelector(selector) {
+      const key = /\[data-key="([^"]+)"\]/.exec(selector);
+      queried.push(key ? key[1] : selector);
+      return key && Object.prototype.hasOwnProperty.call(fields, key[1]) ? fields[key[1]] : null;
+    }
+  };
+
+  const scope = new Proxy({}, {
+    has: () => true,
+    get: (_t, name) => {
+      switch (name) {
+        case Symbol.unscopables: return undefined;
+        case "modelData": return modelData;
+        case "MODEL_TARGETS": return MODEL_TARGETS;
+        case "edits": return edits;
+        case "pendingPick": return pendingPick;
+        case "pickedModel": return () => picked;
+        case "$": return (id) => (id === "groups" ? groups : { id });
+        case "say": return (_el, text) => messages.push(String(text));
+        case "window": return { showTab: () => {} };
+        case "ev": return { target: { closest: () => ({ dataset: { use: "extraction" } }) },
+                            preventDefault: () => {} };
+        default: return () => {};
+      }
+    }
+  });
+
+  /* The handler's own `var`s have to be declared INSIDE a function, or `with` resolves them
+     against the proxy -- which answers every name with an inert function, so the body runs to
+     completion having written nothing and every assertion below reads as a silent no-op.
+     Locals of an inner function shadow the with-object; free names still fall through to it. */
+  const NL = String.fromCharCode(10);
+  const body = "return function handle() {" + NL + resolverSource + NL + handlerSource + NL + "};";
+  let threw = null;
+  try {
+    new Function("scope", "with (scope) { " + body + " }")(scope)();
+  } catch (err) {
+    threw = err;
+  }
+  return { edits, queried, messages, threw };
+}
+
+/* 1. Anthropic: the route names its own field, and that is the one the page fills in. */
+let r = run({ key: "extraction.anthropic_model", current: "claude-sonnet-5", catalogue: [] },
+            "claude-opus-5", ["extraction.model", "extraction.anthropic_model"]);
+ok("no exception on the path that sets a field", r.threw === null,
+   r.threw && String(r.threw));
+ok("the field looked up is the one the route named",
+   r.queried.length === 1 && r.queried[0] === "extraction.anthropic_model",
+   "queried " + JSON.stringify(r.queried));
+ok("the pick is recorded against that key",
+   r.edits["extraction.anthropic_model"] === "claude-opus-5" &&
+   !Object.prototype.hasOwnProperty.call(r.edits, "extraction.model"),
+   JSON.stringify(r.edits));
+ok("the confirmation still names the control", r.messages.some((m) => /Extraction model set to/.test(m)),
+   JSON.stringify(r.messages));
+
+/* 2. OpenAI-compatible: unchanged from what shipped. */
+r = run({ key: "extraction.model", current: "gpt-4o-mini", catalogue: [] },
+        "gpt-4o", ["extraction.model", "extraction.anthropic_model"]);
+ok("an openai-compatible pick still lands in extraction.model",
+   r.edits["extraction.model"] === "gpt-4o" &&
+   !Object.prototype.hasOwnProperty.call(r.edits, "extraction.anthropic_model"),
+   JSON.stringify(r.edits));
+
+/* 3. A gateway that does not say: the page keeps working on its own static key rather than
+      querying `[data-key="undefined"]` and reporting the field as missing. */
+r = run({ current: "gpt-4o-mini", catalogue: [] }, "gpt-4o",
+        ["extraction.model", "extraction.anthropic_model"]);
+ok("a route that names no field falls back to the static one",
+   r.edits["extraction.model"] === "gpt-4o", JSON.stringify(r.edits));
+
+/* 4. The floor. If the handler stopped writing anything, every assertion above about WHICH key is
+      written would still pass. */
+r = run({ key: "extraction.anthropic_model", current: "", catalogue: [] }, "",
+        ["extraction.anthropic_model"]);
+ok("nothing picked writes nothing and says so",
+   Object.keys(r.edits).length === 0 && r.messages.some((m) => /Type a model name first/.test(m)),
+   JSON.stringify(r.edits) + " " + JSON.stringify(r.messages));
+
+/* 5. The field named by the route is not on the form: say so rather than silently doing nothing. */
+r = run({ key: "extraction.anthropic_model", current: "", catalogue: [] }, "claude-opus-5",
+        ["extraction.model"]);
+ok("a field the form does not carry is reported, not skipped",
+   Object.keys(r.edits).length === 0 &&
+   r.messages.some((m) => /not loaded/.test(m)),
+   JSON.stringify(r.edits) + " " + JSON.stringify(r.messages));
+
+console.log(failures ? "\n" + failures + " failure(s)" : "\nall ok");
+process.exit(failures ? 1 : 0);

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -1298,6 +1298,17 @@ function liveStream(options) {
             "one setting on this page that can quietly invalidate data you already have." }
   ];
 
+  /* Which setting a pick is written into. The route decides it from the selected provider --
+     on Anthropic the model lives in extraction.anthropic_model, and writing into extraction.model
+     there changed nothing. The static key stays as the fallback for a gateway that predates the
+     route saying so. */
+  function modelKey(target) {
+    var d = modelData[target] || {};
+    if (d.key) { return d.key; }
+    var entry = MODEL_TARGETS.filter(function (t) { return t.target === target; })[0];
+    return entry ? entry.key : "";
+  }
+
   function loadModels(probe) {
     if (!$("key").value.trim()) { return Promise.resolve(); }
     return Promise.all(MODEL_TARGETS.map(function (t) {
@@ -1409,10 +1420,11 @@ function liveStream(options) {
         return '<div class="mblock"><h3>' + esc(t.title) + '</h3><div class="mnote">' +
           esc(d.error) + "</div></div>";
       }
+      var key = modelKey(t.target);
       var chosen = Object.prototype.hasOwnProperty.call(pendingPick, t.target)
         ? pendingPick[t.target]
-        : ((Object.prototype.hasOwnProperty.call(edits, t.key) && edits[t.key] !== null)
-            ? edits[t.key] : (d.current || ""));
+        : ((Object.prototype.hasOwnProperty.call(edits, key) && edits[key] !== null)
+            ? edits[key] : (d.current || ""));
       var options = modelOptions(t.target);
       var known = options.some(function (o) { return sameModel(o.model, chosen); });
       var disc = d.discovered || {};
@@ -1507,19 +1519,23 @@ function liveStream(options) {
     if (!button) { return; }
     ev.preventDefault();
     var target = button.dataset.use;
+    var key = modelKey(target);
+    /* Still needed for the message at the end -- the KEY comes from the route, the TITLE is the
+       page's own label for the target. Dropping this is a ReferenceError after the field is
+       already set, which reads as a save that half-happened. */
     var entry = MODEL_TARGETS.filter(function (t) { return t.target === target; })[0];
     var value = pickedModel(target);
-    if (!entry || !value) {
+    if (!entry || !key || !value) {
       say($("saveMsg"), "Type a model name first.", "warn");
       return;
     }
-    var el = $("groups").querySelector('[data-key="' + entry.key + '"]');
+    var el = $("groups").querySelector('[data-key="' + key + '"]');
     if (!el) {
       say($("saveMsg"), "That field is not loaded — enter an admin key first.", "warn");
       return;
     }
     el.value = value;
-    edits[entry.key] = value;
+    edits[key] = value;
     pendingPick[target] = value;
     markDirty();
     renderModels();

--- a/tools/test_matrixark_models.py
+++ b/tools/test_matrixark_models.py
@@ -399,8 +399,11 @@ class PickerPageTest(_ModelTest):
         # an encoder change saved on click is one nobody reviewed.
         source = _read_text(os.path.join(HERE, "portal", "build_portal_pages.py"))
         start = source.index('$("models").addEventListener("click"')
-        block = source[start:start + 1800]
-        self.assertIn("edits[entry.key] = value", block)
+        block = source[start:start + 2400]
+        # WHICH key is not pinned here: it comes from the route now, because the Anthropic path
+        # reads a different setting. What this test is about is that the pick lands in the pending
+        # set at all -- an encoder change saved on click is one nobody reviewed.
+        self.assertRegex(block, r"edits\[\w+\] = value")
         self.assertIn("markDirty()", block)
         self.assertNotIn('method: "POST"', block)
 

--- a/tools/test_matrixark_the_model_picker_writes_the_field_the_provider_reads.py
+++ b/tools/test_matrixark_the_model_picker_writes_the_field_the_provider_reads.py
@@ -194,5 +194,91 @@ class ThePageFollowsTheFieldTheRouteNamesTest(unittest.TestCase):
         self.assertIn("var key = modelKey(target);", page)
 
 
+class TheDiscoveryAsksTheEndpointInUseTest(Case):
+    """The panel's other half. "Ask the endpoint what it serves" exists to stop a misspelt model
+    name reaching ingest, where it fails hours later as a silent fall back -- so pointing it at the
+    endpoint the OTHER provider uses removes exactly the check it is there to provide."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._get_json = cfg._get_json
+        self._load = cfg.load
+        cfg.load = lambda: {"values": {}}
+        self.asked = []
+
+        def recorder(url, headers, timeout):
+            self.asked.append({"url": url, "headers": dict(headers or {})})
+            return 200, {"data": [{"id": "claude-sonnet-5"}]}
+
+        cfg._get_json = recorder
+        for name in ("MATRIXARK_ANTHROPIC_API_BASE", "MATRIXARK_EXTRACTION_BASE_URL",
+                     "MATRIXARK_ANTHROPIC_VERSION", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
+                     "MATRIXARK_EXTRACTION_API_KEY_ENV"):
+            self._saved.setdefault(name, os.environ.get(name))
+            os.environ.pop(name, None)
+
+    def tearDown(self) -> None:
+        cfg._get_json = self._get_json
+        cfg.load = self._load
+        super().tearDown()
+
+    def key(self, value: str) -> None:
+        os.environ[cfg._env_name(cfg.SETTINGS_BY_KEY["extraction.api_key"], {})] = value
+
+    def test_anthropic_is_asked_at_its_own_base(self) -> None:
+        self.on("anthropic")
+        self.key("k")
+        result = cfg.discover_models("extraction")
+        self.assertEqual(1, len(self.asked))
+        self.assertEqual("https://api.anthropic.com/v1/models", self.asked[0]["url"])
+        self.assertTrue(result["available"])
+        self.assertIn("claude-sonnet-5", result["models"])
+
+    def test_it_authenticates_the_way_anthropic_does(self) -> None:
+        self.on("anthropic")
+        self.key("k")
+        cfg.discover_models("extraction")
+        headers = self.asked[0]["headers"]
+        self.assertEqual("k", headers.get("x-api-key"))
+        self.assertIn("anthropic-version", headers)
+        self.assertNotIn("Authorization", headers)
+
+    def test_a_configured_anthropic_base_is_respected(self) -> None:
+        self.on("anthropic")
+        os.environ["MATRIXARK_ANTHROPIC_API_BASE"] = "https://anthropic.example/"
+        self.key("k")
+        cfg.discover_models("extraction")
+        self.assertEqual("https://anthropic.example/v1/models", self.asked[0]["url"])
+
+    def test_it_no_longer_asks_for_a_field_this_provider_does_not_read(self) -> None:
+        """Shipped behaviour: no OpenAI base URL, so it answered "Set the base URL first"."""
+        self.on("anthropic")
+        self.key("k")
+        self.assertNotEqual("no_base_url", cfg.discover_models("extraction").get("reason"))
+
+    def test_an_openai_compatible_endpoint_is_asked_exactly_as_before(self) -> None:
+        """The floor: if the branch swallowed everything, the assertions above would still pass."""
+        self.on("openai_compatible")
+        os.environ["MATRIXARK_EXTRACTION_BASE_URL"] = "https://api.example/v1"
+        self.key("k")
+        cfg.discover_models("extraction")
+        self.assertEqual("https://api.example/v1/models", self.asked[0]["url"])
+        self.assertEqual("Bearer k", self.asked[0]["headers"]["Authorization"])
+
+    def test_the_embedding_side_is_untouched(self) -> None:
+        os.environ["MATRIXARK_EMBEDDING_API_BASE"] = "https://encoder.example/v1"
+        os.environ[cfg._env_name(cfg.SETTINGS_BY_KEY["embedding.api_key"], {})] = "k"
+        cfg.discover_models("embedding")
+        self.assertEqual("https://encoder.example/v1/models", self.asked[0]["url"])
+        self.assertEqual("Bearer k", self.asked[0]["headers"]["Authorization"])
+
+    def test_no_key_still_asks_without_authenticating(self) -> None:
+        """A self-hosted endpoint that needs no auth has to stay askable."""
+        self.on("openai_compatible")
+        os.environ["MATRIXARK_EXTRACTION_BASE_URL"] = "http://127.0.0.1:11434/v1"
+        cfg.discover_models("extraction")
+        self.assertEqual({}, self.asked[0]["headers"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_matrixark_the_model_picker_writes_the_field_the_provider_reads.py
+++ b/tools/test_matrixark_the_model_picker_writes_the_field_the_provider_reads.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The model picker offers what the provider serves, into the field the provider reads.
+
+Two things were wrong for an Anthropic deployment, and both were silent.
+
+The suggestion list was six OpenAI-compatible models. Anthropic serves none of them, and the models
+it does serve were not on it.
+
+Worse, every pick was written into ``extraction.model``. The Anthropic path reads
+``MATRIXARK_ANTHROPIC_MODEL`` and ignores that field entirely, so picking a model filled in a form,
+said it was set, and changed nothing: the deployment stayed on the default.
+
+Which field a pick belongs in is now decided once, on the route, from the selected provider; the
+page follows what the route names. The page half of that is exercised by
+``portal/model_key_harness.js``, which pulls the resolver and the click handler out of the BUILT
+page and runs them -- a rewrite of that handler left a variable dangling, and only running it found
+that.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+
+try:
+    from tools import matrixark_v1_gateway as gw  # type: ignore
+except ImportError:
+    import matrixark_v1_gateway as gw  # type: ignore
+
+cfg = gw._gwconfig
+
+PARTICIPATING = ("MATRIXARK_UNDERSTANDING_PROVIDER", "MATRIXARK_EXTRACTION_PROVIDER",
+                 "MATRIXARK_EXTRACTION_MODEL", "MATRIXARK_ANTHROPIC_MODEL",
+                 "MATRIXARK_EMBEDDING_MODEL", "MATRIXARK_EMBEDDING_PROVIDER")
+
+
+class Case(unittest.TestCase):
+    """Everything here reads the process environment, so it controls it: a sibling suite leaving a
+    provider set is the difference between passing alone and failing the full run."""
+
+    def setUp(self) -> None:
+        self._saved = {n: os.environ.get(n) for n in PARTICIPATING}
+        for name in PARTICIPATING:
+            os.environ.pop(name, None)
+
+    def tearDown(self) -> None:
+        for name, value in self._saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+    def on(self, provider: str) -> None:
+        os.environ["MATRIXARK_UNDERSTANDING_PROVIDER"] = provider
+
+
+class TheSuggestionsAreOnesTheProviderServesTest(Case):
+
+    def test_an_anthropic_deployment_is_offered_anthropic_models(self) -> None:
+        self.on("anthropic")
+        models = [entry["model"] for entry in cfg.model_catalogue("extraction")]
+        self.assertTrue(models, "an Anthropic deployment was offered nothing at all")
+        self.assertTrue(all(name.startswith("claude-") for name in models), models)
+
+    def test_it_is_not_offered_models_anthropic_does_not_have(self) -> None:
+        self.on("anthropic")
+        models = [entry["model"] for entry in cfg.model_catalogue("extraction")]
+        for absent in ("gpt-4o", "gpt-4o-mini", "deepseek-chat", "qwen2.5:7b"):
+            self.assertNotIn(absent, models)
+
+    def test_an_openai_compatible_deployment_keeps_the_list_it_had(self) -> None:
+        self.on("openai_compatible")
+        models = [entry["model"] for entry in cfg.model_catalogue("extraction")]
+        for present in ("gpt-4o-mini", "deepseek-chat", "qwen2.5:7b"):
+            self.assertIn(present, models)
+        self.assertFalse([m for m in models if m.startswith("claude-")], models)
+
+    def test_a_provider_that_calls_nothing_is_shown_everything(self) -> None:
+        """There is nothing wrong to narrow towards yet, and an empty picker beside a provider
+        dropdown reads as a broken page rather than a choice still to be made."""
+        self.on("deterministic")
+        self.assertEqual(len(cfg.EXTRACTION_CATALOGUE),
+                         len(cfg.model_catalogue("extraction")))
+
+    def test_every_entry_says_which_dispatch_it_belongs_to(self) -> None:
+        """An entry with no `serves` would vanish from every filtered list without anyone noticing,
+        because the filter drops what it cannot classify."""
+        effects = set()
+        for entry in cfg.EXTRACTION_CATALOGUE:
+            with self.subTest(model=entry.get("model")):
+                self.assertIn(entry.get("serves"), ("openai", "anthropic"))
+            effects.add(entry["serves"])
+        self.assertEqual({"openai", "anthropic"}, effects, "one dispatch has no suggestions")
+
+    def test_the_default_model_is_among_the_suggestions(self) -> None:
+        """The registry's own default for the Anthropic model has to be pickable, or the list
+        disagrees with the field beside it."""
+        self.on("anthropic")
+        models = [entry["model"] for entry in cfg.model_catalogue("extraction")]
+        self.assertIn(cfg.SETTINGS_BY_KEY["extraction.anthropic_model"].default, models)
+
+    def test_embeddings_are_still_refused_here(self) -> None:
+        """Encoders come from the measured catalogue in the gateway. A second hand-written list is
+        exactly what this function exists to refuse."""
+        with self.assertRaises(ValueError):
+            cfg.model_catalogue("embedding")
+
+
+class ThePickGoesIntoTheFieldTheProviderReadsTest(Case):
+
+    def test_anthropic_writes_its_own_model_setting(self) -> None:
+        self.on("anthropic")
+        self.assertEqual("extraction.anthropic_model", cfg.extraction_model_setting())
+
+    def test_everything_else_writes_the_general_one(self) -> None:
+        for provider in ("openai_compatible", "deterministic", "", "typo_provider"):
+            with self.subTest(provider=provider):
+                self.on(provider)
+                self.assertEqual("extraction.model", cfg.extraction_model_setting())
+
+    def test_the_setting_it_names_exists_and_is_the_one_the_code_reads(self) -> None:
+        """A key that is not in the registry would reach the page and query a field that is not on
+        the form, which the page reports as 'not loaded' -- a dead end rather than an error."""
+        for provider, variable in (("anthropic", "MATRIXARK_ANTHROPIC_MODEL"),
+                                   ("openai_compatible", "MATRIXARK_EXTRACTION_MODEL")):
+            with self.subTest(provider=provider):
+                self.on(provider)
+                setting = cfg.SETTINGS_BY_KEY[cfg.extraction_model_setting()]
+                self.assertEqual(variable, setting.env)
+
+
+class TheRouteAnswersWithBothTest(Case):
+    """The page is told the field and shown the narrowed list, so it decides neither itself."""
+
+    def body(self, target: str = "extraction") -> dict:
+        """The route's own function, not a copy of it. Rebuilding the body here passed every
+        assertion below while the route reported the wrong field -- a mutation proved it."""
+        return gw._model_picker_body(target)
+
+    def test_current_is_read_from_the_field_that_is_in_use(self) -> None:
+        self.on("anthropic")
+        os.environ["MATRIXARK_ANTHROPIC_MODEL"] = "claude-opus-5"
+        os.environ["MATRIXARK_EXTRACTION_MODEL"] = "gpt-4o"
+        body = self.body()
+        self.assertEqual("extraction.anthropic_model", body["key"])
+        self.assertEqual("claude-opus-5", body["current"],
+                         "the panel showed the field this provider does not read")
+
+    def test_the_other_field_is_not_what_is_reported(self) -> None:
+        self.on("openai_compatible")
+        os.environ["MATRIXARK_ANTHROPIC_MODEL"] = "claude-opus-5"
+        os.environ["MATRIXARK_EXTRACTION_MODEL"] = "gpt-4o"
+        self.assertEqual("gpt-4o", self.body()["current"])
+
+    def test_the_catalogue_it_carries_is_the_narrowed_one(self) -> None:
+        self.on("anthropic")
+        self.assertTrue(all(entry["model"].startswith("claude-")
+                            for entry in self.body()["catalogue"]))
+
+    def test_the_embedding_side_is_untouched(self) -> None:
+        os.environ["MATRIXARK_EMBEDDING_MODEL"] = "voyage-3"
+        body = self.body("embedding")
+        self.assertEqual("embedding.model", body["key"])
+        self.assertEqual("voyage-3", body["current"])
+
+
+class ThePageFollowsTheFieldTheRouteNamesTest(unittest.TestCase):
+    """Run the picker's own code out of the built page. Reading it is not enough -- the rewrite this
+    covers left a variable dangling, which is a ReferenceError only at the moment of the click."""
+
+    def test_the_harness_passes(self) -> None:
+        node = shutil.which("node")
+        if node is None:
+            self.skipTest("node is not available")
+        result = subprocess.run(
+            [node, os.path.join(PORTAL, "model_key_harness.js"),
+             os.path.join(PORTAL, "setup_portal.html")],
+            capture_output=True, text=True, timeout=120)
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertIn("all ok", result.stdout)
+
+    def test_the_built_page_is_what_the_generator_produces(self) -> None:
+        """The page is generated. A change made only to the generator ships nothing, and a change
+        made only to the page is reverted by the next build."""
+        built = os.path.join(PORTAL, "setup_portal.html")
+        with open(built, encoding="utf-8") as handle:
+            page = handle.read()
+        self.assertIn("function modelKey(target) {", page)
+        self.assertIn("var key = modelKey(target);", page)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two things were wrong for an Anthropic deployment, and both were silent.

**The suggestion list was six OpenAI-compatible models.** Anthropic serves none of them, and the
models it does serve were not on it.

**Worse, every pick was written into `extraction.model`.** The Anthropic path reads
`MATRIXARK_ANTHROPIC_MODEL` and ignores that field entirely — so picking a model filled in a form,
said it was set, and changed nothing. The deployment stayed on its default.

### What changed

Each suggestion names the dispatch that serves it, and the list is narrowed to the selected
provider — except where the provider calls no model at all, which gets the whole list: there is
nothing to narrow towards yet, and an empty picker beside a provider dropdown reads as a broken page
rather than a choice still to be made.

Which setting a pick belongs in is decided on the route and returned in the body, so the page
follows one answer instead of holding a second.

The Anthropic model names are the ones the code already uses — the registry's own default among
them, which a test pins so the list cannot disagree with the field beside it.

### And the other half of the same panel

"Ask the endpoint what it serves" exists to stop a misspelt model name reaching ingest, where it
fails hours later as a silent fall back to the deterministic path. On Anthropic it asked
`MATRIXARK_EXTRACTION_BASE_URL` — which such a deployment never sets — and answered *"Set the base
URL first"*, pointing at a field that provider does not read, in the one panel that exists to catch
this. It now asks the Anthropic base at `/v1/models` with `x-api-key`, the same way the extraction
call and the connection probe reach it. An endpoint that needs no auth is still asked without a
header, so a self-hosted server stays askable.

### The page half is executed, not read

`portal/model_key_harness.js` pulls the resolver and the click handler **out of the built page** and
runs them. That is not ceremony: my first draft of this rewrite left `entry` dangling — a
`ReferenceError` after the field was already filled in, which reads as a save that half-happened.
Nothing short of running it would have found that.

```
the shipped bug: every pick goes into extraction.model     -> FAIL 3
the suggestions ignore the provider again                  -> FAIL 4
anthropic gets no suggestions at all                       -> FAIL 3
an entry stops saying which dispatch serves it             -> FAIL 2
a provider that calls nothing is offered nothing           -> FAIL 1
the panel reports the field this provider does not read    -> FAIL 2
the route names the general field whatever the provider    -> FAIL 1
the page decides the field itself again                    -> FAIL 1
the rewrite leaves `entry` dangling                        -> FAIL 1
the shipped bug: anthropic asks the openai base url        -> FAIL 4
anthropic is asked with a bearer token                     -> FAIL 1
the anthropic base url setting is ignored                  -> FAIL 1
every endpoint is asked the anthropic way                  -> FAIL 2
an endpoint that needs no auth is sent an empty bearer     -> FAIL 1
```

The route body moved into `_model_picker_body` for the same reason the harness exists: a test that
**rebuilt** the response passed while a mutation made the real route report the wrong field. The
seam is the fix, not a test convenience.

### Deliberately not in this change

The encoder picker has the same defect — on Voyage it offers five self-hosted HuggingFace models and
none Voyage can serve. I built that fix and backed it out: the obvious shape adds unmeasured entries
to `catalogue`, which breaks a deliberate invariant (*"the picker serves the MEASURED catalogue, not
a second list"* — a rule that exists because a hand-written list beside the measured one drifted,
omitting the whole e5 family). The honest fix needs a separate `provider_models` field and its own
review, so it gets its own change rather than a relaxed test here.

31 tests. Neighbours: the derived list of every suite touching the catalogue, the models route, the
built page or the harnesses — 56, all green — plus all portal- (166), gateway- (256) and
config-named (88) suites. The 19 siblings that write these environment variables were run in one
process with this one **last and first**: 328 tests, green both ways.
