### PR TITLE
A rotated shard is stored compressed

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -163,6 +163,23 @@ _SNAPSHOT_CODEC_ZLIB = b"\x01"
 #: one would have to unstuff every record to be sure it had not.
 _DELTA_BLOCK_CODEC_ZLIB = b"\x01"
 _DELTA_BLOCK_HEADER_BYTES = 5
+#: A SEALED shard: the magic, a codec byte, then the whole shard compressed. A JSONL shard always
+#: starts with `{`, so a reader can tell the two apart without being told which it has.
+#:
+#: Only ROTATED shards are sealed, and that is the whole safety argument: a rotated shard is
+#: finished -- nothing appends to it again -- while the ACTIVE shard stays plain text, so appending,
+#: recovering and reading the log by hand are untouched by this.
+#:
+#: Measured on the corpus this module is tuned for: once the read snapshot became a container the
+#: event log was 94.3% of everything written here, and at the default retention the rotated shards
+#: are 74.9% of the log and compress 11.91x.
+_SHARD_CONTAINER_MAGIC = b"MASHRD\x01"
+_SHARD_CODEC_ZLIB = b"\x01"
+#: On, and reversible: the reader takes either form, so a store written with this on still reads
+#: with it off, and a shard sealed once never needs unsealing.
+LOCAL_JSONL_COMPRESS_SEALED = os.environ.get(
+    "MATRIXARK_LOCAL_JSONL_COMPRESS_SEALED", "1"
+).strip().lower() not in ("0", "false", "no", "off")
 
 LOCAL_DURABLE_READ_CACHE_MAX_DELTA = max(
     1, int(os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_CACHE_MAX_DELTA", "250"))
@@ -229,6 +246,48 @@ def _decode_delta_blocks(raw: bytes) -> list[Json]:
                 records.append(loads_with_interned_keys(line))
         at = start + length
     return records
+
+
+def _iter_shard_lines(path: Path):
+    """Every line of a shard, whichever form it is stored in.
+
+    The PLAIN shard keeps the buffered text iterator it always had. Reading it as bytes and decoding
+    each line in Python instead cost +67% on a cold read (72.8 -> 121.7 ms median) -- a cost that
+    would have been charged to compression by anyone measuring the two together. The plain shard is
+    the ACTIVE one, so that is the common case, and the seven-byte sniff is one extra syscall.
+
+    A sealed shard is decompressed in chunks rather than whole. A shard runs to
+    MATRIXARK_LOCAL_JSONL_MAX_BYTES -- 64 MB by default -- and four of this module's five readers
+    scan it for one record type, so materialising the whole thing would trade the bytes this saves
+    on disk for the same bytes in memory.
+    """
+    with path.open("rb") as probe:
+        head = probe.read(len(_SHARD_CONTAINER_MAGIC))
+    if head != _SHARD_CONTAINER_MAGIC:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                yield line
+        return
+    with path.open("rb") as handle:
+        handle.seek(len(_SHARD_CONTAINER_MAGIC))
+        codec = handle.read(1)
+        if codec != _SHARD_CODEC_ZLIB:
+            raise ValueError("unknown sealed-shard codec %r" % codec)
+        decompressor = zlib.decompressobj()
+        pending = b""
+        while True:
+            chunk = handle.read(1 << 20)
+            if not chunk:
+                break
+            pending += decompressor.decompress(chunk)
+            parts = pending.split(b"\n")
+            pending = parts.pop()
+            for part in parts:
+                yield part.decode("utf-8")
+        pending += decompressor.flush()
+        for part in pending.split(b"\n"):
+            if part:
+                yield part.decode("utf-8")
 
 
 def _decode_snapshot_bytes(raw: bytes) -> Json:
@@ -4819,6 +4878,42 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
     def _jsonl_rotated_path(self, index: int) -> Path:
         return self.event_log.with_name(f"{self.event_log.name}.{index}")
 
+    def _seal_rotated_shard(self, path: Path) -> None:
+        """Store a just-rotated shard compressed.
+
+        Called AFTER the rename that rotated it, never instead of it: the rename is the commit
+        point and stays one atomic operation. This is a follow-up -- temp write, fsync, atomic
+        replace -- and a crash anywhere in it leaves the plain shard, which every reader here still
+        accepts. The worst outcome is a shard that was not compressed, never one that was lost.
+
+        The temp file is dot-prefixed so it sits outside the <event log name>* namespace, for the
+        reason the read-cache files are: a sidecar picked up under that prefix is replayed as
+        durable history.
+
+        Sealing happens AT rotation, in the same moment as the rename, so the shard's mtime still
+        marks when it was rotated -- which is what the age-based retention prune reads. A lazy sweep
+        that sealed shards later would reset that clock and keep them past their age.
+
+        Sealing happens AT rotation, in the same moment as the rename, so the shard's mtime still
+        marks when it was rotated -- which is what the age-based retention prune reads. A lazy sweep
+        that sealed shards later would reset that clock and keep them past their age.
+        """
+        if not LOCAL_JSONL_COMPRESS_SEALED:
+            return
+        try:
+            raw = path.read_bytes()
+            if raw.startswith(_SHARD_CONTAINER_MAGIC):
+                return
+            tmp = path.with_name(f".{path.name}.seal.{os.getpid()}.tmp")
+            with tmp.open("wb") as handle:
+                handle.write(_SHARD_CONTAINER_MAGIC + _SHARD_CODEC_ZLIB)
+                handle.write(zlib.compress(raw, LOCAL_DURABLE_READ_CACHE_COMPRESS_LEVEL))
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp, path)
+        except OSError:
+            pass
+
     def _retained_jsonl_paths(self) -> list[Path]:
         if not self._local_jsonl_enabled:
             return []
@@ -5394,6 +5489,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 source.replace(self._jsonl_rotated_path(index + 1))
         if self.event_log.exists():
             self.event_log.replace(self._jsonl_rotated_path(1))
+            self._seal_rotated_shard(self._jsonl_rotated_path(1))
         self._clear_jsonl_read_caches()
 
     @contextmanager
@@ -5720,23 +5816,22 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             return
         try:
             for path in self._retained_jsonl_paths():
-                with path.open("r", encoding="utf-8") as handle:
-                    for line in handle:
-                        line = line.strip()
-                        if not line or INTERN_DICT_RECORD_TYPE not in line:
+                for line in _iter_shard_lines(path):
+                    line = line.strip()
+                    if not line or INTERN_DICT_RECORD_TYPE not in line:
+                        continue
+                    try:
+                        record = loads_with_interned_keys(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(record, dict) and str(record.get("record_type") or "") == INTERN_DICT_RECORD_TYPE:
+                        token = record.get("im_token")
+                        if isinstance(token, str) and isinstance(record.get("im_bundle"), dict):
+                            self._intern_emitted_tokens.add((INTERN_BUNDLE_EMIT_KEY, token))
                             continue
-                        try:
-                            record = loads_with_interned_keys(line)
-                        except json.JSONDecodeError:
-                            continue
-                        if isinstance(record, dict) and str(record.get("record_type") or "") == INTERN_DICT_RECORD_TYPE:
-                            token = record.get("im_token")
-                            if isinstance(token, str) and isinstance(record.get("im_bundle"), dict):
-                                self._intern_emitted_tokens.add((INTERN_BUNDLE_EMIT_KEY, token))
-                                continue
-                            field = record.get("im_field")
-                            if isinstance(field, str) and isinstance(token, str):
-                                self._intern_emitted_tokens.add((field, token))
+                        field = record.get("im_field")
+                        if isinstance(field, str) and isinstance(token, str):
+                            self._intern_emitted_tokens.add((field, token))
         except OSError:
             pass
 
@@ -5763,17 +5858,16 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             return
         try:
             for path in self._retained_jsonl_paths():
-                with path.open("r", encoding="utf-8") as handle:
-                    for line in handle:
-                        line = line.strip()
-                        if not line or "context_model_registry" not in line:
-                            continue
-                        try:
-                            record = loads_with_interned_keys(line)
-                        except json.JSONDecodeError:
-                            continue
-                        if isinstance(record, dict) and str(record.get("record_type") or "") == "context_model_registry":
-                            self._model_registry_seen.add(_model_registry_identity(record))
+                for line in _iter_shard_lines(path):
+                    line = line.strip()
+                    if not line or "context_model_registry" not in line:
+                        continue
+                    try:
+                        record = loads_with_interned_keys(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(record, dict) and str(record.get("record_type") or "") == "context_model_registry":
+                        self._model_registry_seen.add(_model_registry_identity(record))
         except OSError:
             pass
 
@@ -6557,11 +6651,10 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         records = []
         with self._event_log_lock:
             for path in paths:
-                with path.open("r", encoding="utf-8") as handle:
-                    for line in handle:
-                        line = line.strip()
-                        if line:
-                            records.append(loads_with_interned_keys(line))
+                for line in _iter_shard_lines(path):
+                    line = line.strip()
+                    if line:
+                        records.append(loads_with_interned_keys(line))
         # Expand interned metadata BEFORE compaction/caching so the read cache, durable cache, and
         # every downstream consumer see fully-expanded, token-free records.
         records = expand_interned_records(records)
@@ -7648,11 +7741,10 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             return raw
         with self._event_log_lock:
             for path in self._retained_jsonl_paths():
-                with path.open("r", encoding="utf-8") as handle:
-                    for line in handle:
-                        line = line.strip()
-                        if line:
-                            raw.append(loads_with_interned_keys(line))
+                for line in _iter_shard_lines(path):
+                    line = line.strip()
+                    if line:
+                        raw.append(loads_with_interned_keys(line))
         return expand_interned_records(raw)
 
     def _count_raw_tombstones(self) -> int:
@@ -7686,11 +7778,10 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 return {"purged": False, "reason": "empty"}
             raw: list[Json] = []
             for path in paths:
-                with path.open("r", encoding="utf-8") as handle:
-                    for line in handle:
-                        line = line.strip()
-                        if line:
-                            raw.append(loads_with_interned_keys(line))
+                for line in _iter_shard_lines(path):
+                    line = line.strip()
+                    if line:
+                        raw.append(loads_with_interned_keys(line))
             tombstone_count = sum(
                 1 for record in raw
                 if str(record.get("record_type") or "") == MEMORY_TOMBSTONE_RECORD_TYPE

--- a/tools/test_matrixark_a_rotated_shard_is_sealed.py
+++ b/tools/test_matrixark_a_rotated_shard_is_sealed.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A rotated shard is stored compressed; the active shard stays plain text.
+
+Once the read snapshot became a container the event log was 94.3% of everything this module writes,
+and at the default retention the ROTATED shards are 74.9% of the log -- 11.91x compressible. That is
+where the durable bytes are.
+
+What makes it safe is what a rotated shard is: sealed at rotation, never appended to again, reached
+only through `_retained_jsonl_paths()`. The active shard -- the one appends land in, the one a
+person greps -- is untouched, so nothing about appending or recovering changes.
+
+The rename that rotates a shard stays the commit point. Sealing is a follow-up (temp write, fsync,
+atomic replace), so a crash anywhere in it leaves a plain shard, which every reader still accepts.
+"""
+import tempfile
+import unittest
+import zlib
+from pathlib import Path
+
+from tools import matrixark_mcp_local_adapter as adapter_module
+from tools.matrixark_mcp_local_adapter import (
+    _SHARD_CODEC_ZLIB,
+    _SHARD_CONTAINER_MAGIC,
+    _iter_shard_lines,
+    MatrixArkLocalAdapter,
+    _LOCAL_READ_CACHE,
+    _LOCAL_READ_CACHE_LOCK,
+)
+
+
+def _clear_process_read_cache() -> None:
+    with _LOCAL_READ_CACHE_LOCK:
+        _LOCAL_READ_CACHE.clear()
+
+
+def _records(start: int, count: int) -> list[dict]:
+    return [
+        {
+            "record_type": "context_event",
+            "event_id_hash": index,
+            "text": "event %d " % index + "x" * 400,
+            "updated_at_ms": 1780000000000 + index,
+        }
+        for index in range(start, start + count)
+    ]
+
+
+class SealedShardTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        self.addCleanup(self._dir.cleanup)
+        self.log = Path(self._dir.name) / "events.jsonl"
+        _clear_process_read_cache()
+        self.addCleanup(_clear_process_read_cache)
+        # Module globals read at call time, so they are set here and RESTORED -- a test that leaves
+        # process-global state behind changes the tests after it.
+        for name in ("LOCAL_JSONL_COMPRESS_SEALED", "LOCAL_JSONL_MAX_BYTES"):
+            self.addCleanup(setattr, adapter_module, name, getattr(adapter_module, name))
+        adapter_module.LOCAL_JSONL_MAX_BYTES = 40_000
+
+    def _fill(self, batches: int = 6, per_batch: int = 20) -> list[dict]:
+        adapter = MatrixArkLocalAdapter(self.log)
+        for batch in range(batches):
+            adapter.append_many(_records(batch * per_batch, per_batch))
+        _clear_process_read_cache()
+        return MatrixArkLocalAdapter(self.log).read_all()
+
+    def _rotated(self) -> list[Path]:
+        return [path for path in sorted(self.log.parent.iterdir())
+                if path.name.startswith("events.jsonl.") and path.suffix.lstrip(".").isdigit()]
+
+    def test_a_rotated_shard_is_stored_compressed(self):
+        adapter_module.LOCAL_JSONL_COMPRESS_SEALED = True
+        self._fill()
+        rotated = self._rotated()
+        self.assertTrue(rotated, "nothing rotated, so this proves nothing about sealing")
+        for path in rotated:
+            raw = path.read_bytes()
+            self.assertTrue(raw.startswith(_SHARD_CONTAINER_MAGIC),
+                            "%s was not sealed" % path.name)
+            codec = raw[len(_SHARD_CONTAINER_MAGIC):len(_SHARD_CONTAINER_MAGIC) + 1]
+            self.assertEqual(_SHARD_CODEC_ZLIB, codec)
+            body = zlib.decompress(raw[len(_SHARD_CONTAINER_MAGIC) + 1:])
+            self.assertLess(len(raw), len(body) / 2,
+                            "%s is not materially smaller, so it is not earning its format"
+                            % path.name)
+
+    def test_the_active_shard_stays_plain_text(self):
+        """Appends, crash recovery and anyone reading the log by hand all go to this file."""
+        adapter_module.LOCAL_JSONL_COMPRESS_SEALED = True
+        self._fill()
+        self.assertTrue(self._rotated(), "nothing rotated, so there was no seal to over-reach")
+        head = self.log.read_bytes()[:len(_SHARD_CONTAINER_MAGIC)]
+        self.assertFalse(head.startswith(_SHARD_CONTAINER_MAGIC),
+                         "the ACTIVE shard was sealed; appends land in this file")
+        self.assertTrue(self.log.read_text(encoding="utf-8").lstrip().startswith("{"))
+
+    def test_sealing_does_not_change_the_view(self):
+        adapter_module.LOCAL_JSONL_COMPRESS_SEALED = False
+        plain = self._fill()
+        self.assertTrue(self._rotated(), "nothing rotated in the plain arm")
+
+        self._dir.cleanup()
+        self._dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        self.addCleanup(self._dir.cleanup)
+        self.log = Path(self._dir.name) / "events.jsonl"
+        _clear_process_read_cache()
+        adapter_module.LOCAL_JSONL_COMPRESS_SEALED = True
+        sealed = self._fill()
+
+        self.assertEqual(plain, sealed,
+                         "the two storage forms disagree about the record set")
+
+    def test_a_plain_rotated_shard_still_reads(self):
+        """No migration: a store rotated before this keeps loading once it is on."""
+        adapter_module.LOCAL_JSONL_COMPRESS_SEALED = False
+        written = self._fill()
+        rotated = self._rotated()
+        self.assertTrue(rotated)
+        self.assertFalse(rotated[0].read_bytes().startswith(_SHARD_CONTAINER_MAGIC))
+
+        adapter_module.LOCAL_JSONL_COMPRESS_SEALED = True
+        _clear_process_read_cache()
+        self.assertEqual(written, MatrixArkLocalAdapter(self.log).read_all())
+
+    def test_an_unknown_shard_codec_is_refused_rather_than_guessed(self):
+        path = Path(self._dir.name) / "sealed.bin"
+        path.write_bytes(_SHARD_CONTAINER_MAGIC + b"\x7f" + b"whatever")
+        with self.assertRaises(ValueError):
+            list(_iter_shard_lines(path))
+
+    def test_the_reader_takes_either_form(self):
+        plain = Path(self._dir.name) / "plain.jsonl"
+        plain.write_text('{"a":1}\n{"b":2}\n', encoding="utf-8")
+        sealed = Path(self._dir.name) / "sealed.jsonl"
+        sealed.write_bytes(_SHARD_CONTAINER_MAGIC + _SHARD_CODEC_ZLIB
+                           + zlib.compress(b'{"a":1}\n{"b":2}\n', 6))
+        self.assertEqual([line.strip() for line in _iter_shard_lines(plain) if line.strip()],
+                         [line.strip() for line in _iter_shard_lines(sealed) if line.strip()])
+
+    def test_appending_still_works_after_a_rotation(self):
+        adapter_module.LOCAL_JSONL_COMPRESS_SEALED = True
+        self._fill()
+        self.assertTrue(self._rotated(), "nothing rotated, so nothing was appended past a seal")
+        adapter = MatrixArkLocalAdapter(self.log)
+        adapter.append_many(_records(9000, 5))
+        _clear_process_read_cache()
+        view = MatrixArkLocalAdapter(self.log).read_all()
+        hashes = {record.get("event_id_hash") for record in view}
+        self.assertTrue({9000, 9004}.issubset(hashes),
+                        "records appended after a rotation are missing from the view")
+
+
+    def test_the_active_shard_is_never_handed_to_the_sealer(self):
+        """The ORDER is the crash-safety argument, and the end state does not show it.
+
+        Sealing the active log and then renaming it produces exactly the same files as renaming and
+        then sealing -- so no assertion about the result can tell them apart. The difference is what
+        a crash in between leaves: renaming first leaves a plain rotated shard, which every reader
+        accepts; sealing first leaves a COMPRESSED file still named events.jsonl, which the next
+        append would extend with plain JSON. This pins the order instead of the result.
+        """
+        adapter_module.LOCAL_JSONL_COMPRESS_SEALED = True
+        seen = []
+        original = adapter_module.MatrixArkLocalAdapter._seal_rotated_shard
+
+        def spy(self, path):
+            seen.append(Path(path).name)
+            return original(self, path)
+
+        adapter_module.MatrixArkLocalAdapter._seal_rotated_shard = spy
+        self.addCleanup(setattr, adapter_module.MatrixArkLocalAdapter,
+                        "_seal_rotated_shard", original)
+
+        self._fill()
+        self.assertTrue(seen, "the sealer never ran, so this proves nothing about what it is given")
+        self.assertNotIn("events.jsonl", seen,
+                         "the ACTIVE log was handed to the sealer; a crash mid-seal would leave a "
+                         "compressed file that the next append extends with plain JSON")
+
+    def test_a_shard_whose_last_line_has_no_newline_is_read_whole(self):
+        """Nothing guarantees a shard ends with a newline, and the last record is only reachable
+        through the reader's post-loop path."""
+        sealed = Path(self._dir.name) / "no-newline.jsonl"
+        payload = b'{"a":1}' + b"\n" + b'{"b":2}'
+        sealed.write_bytes(_SHARD_CONTAINER_MAGIC + _SHARD_CODEC_ZLIB + zlib.compress(payload, 6))
+        self.assertEqual(['{"a":1}', '{"b":2}'],
+                         [line.strip() for line in _iter_shard_lines(sealed) if line.strip()])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Once the read snapshot became a compressed container, the **event log** was 94.3% of everything the
local adapter writes — and at the default retention the **rotated** shards are 74.9% of the log.
They compress **11.91×**. That is where the durable bytes now are.

Both changes together, 60 documents on the same corpus, same 424 records:

```
                    main       both
store bytes    1,691,381    231,325     7.31x
per record         3,989        546
```

What is left is the **active** shard at 53.1% — the one this deliberately does not touch.

## Why a rotated shard is the safe one

A rotated shard is a different thing from the active one: it is sealed at rotation, **never appended
to again**, and reached only through `_retained_jsonl_paths()`. The active shard — the one appends
land in, the one recovery reads, the one a person greps — is left exactly as it was, plain text.

```
MASHRD\x01 | codec byte | zlib(the whole shard)
```

A JSONL shard always starts with `{`, so a reader tells the two apart without being told which it
has.

## The rename stays the commit point

Rotation is one atomic `replace`, and it stays that way. Sealing is a **follow-up**: temp write,
fsync, atomic replace. A crash anywhere in it leaves a plain shard, which every reader here still
accepts — so the worst outcome is a shard that was not compressed, never one that was lost.

The order is the whole argument, and **the end state cannot show it**: sealing first and renaming
second produces exactly the same files. The difference is what a crash in between leaves — a
compressed file still named `events.jsonl`, which the next append would extend with plain JSON. So
the test pins the order rather than the result, and the mutation that swaps them fails it.

The temp file is dot-prefixed so it sits outside the `<event log name>*` namespace, for the reason
the read-cache files are: a sidecar picked up under that prefix is replayed as durable history.

## Five copies of one read loop become one

Every shard reader opened the file with `open("r", encoding="utf-8")` and iterated it — five
identical copies. They now go through `_iter_shard_lines`. Consolidating was not optional: five
copies of a format decision are five chances to teach only some of them, which is exactly the defect
the two tail-append paths had in #939.

**The plain branch keeps the buffered text iterator it always had.** Reading it as bytes and decoding
each line in Python instead cost **+67%** on a cold read (72.8 → 121.7 ms median) — a cost that would
have been charged to compression by anyone measuring the two together. The plain shard is the
*active* one, so that is the common case; the seven-byte sniff is one extra syscall per shard.

A sealed shard is decompressed in 1 MB chunks rather than whole. A shard runs to
`MATRIXARK_LOCAL_JSONL_MAX_BYTES` — 64 MB by default — and four of the five readers scan it for one
record type, so materialising it would trade the bytes this saves on disk for the same bytes in
memory.

## Measured

40 documents, rotation at 256 KB, four rounds with the order alternated:

```
shard bytes   985,256 -> 309,287   3.19x
store bytes 1,049,500 -> 373,541
cold read      91.0 ms -> 98.9 ms  +8.7%
```

3.19× rather than 11.91× because the **active** shard is a quarter of the bytes at default retention
and stays plain — that is the trade, not a shortfall.

A **warm** read touches no shard at all; the snapshot answers it. The cold number is what a first
read after a restart pays, against a quarter of the disk bytes to read.

## On, and reversible

The reader takes either form, so a store written with this on still reads with it off, and a plain
shard already on disk keeps loading. No migration: a shard is sealed when it rotates.

## Tests

`test_matrixark_a_rotated_shard_is_sealed.py` — a rotated shard is stored compressed and says what
it is, the active shard stays plain text, sealing does not change the view, a plain rotated shard
still reads, an unknown codec is refused rather than guessed, the reader takes either form, appending
still works after a rotation, the active log is never handed to the sealer, and a shard whose last
line has no newline is read whole.

Five mutations, five caught: a rotated shard left plain, an unknown codec guessed, the sniff always
answering plain, the shard sealed **before** the rename, and the reader dropping whatever follows the
last newline. `decompressobj.flush()` is the documented terminator and returns empty here, so it is
belt-and-braces rather than covered — said plainly rather than counted as coverage.
