### PR TITLE
The shipped config exported the name the engine reads LAST

### DIFF
--- a/config/temporalstore.toml
+++ b/config/temporalstore.toml
@@ -80,7 +80,7 @@ page_store_compression_level = 3       # TS_PAGE_STORE_COMPRESSION_LEVEL    comp
 # worse again: at a 1-byte floor the saving stops and the median add rises to 256.0 ms.
 page_store_compression_min_bytes = 256  # TS_PAGE_STORE_COMPRESSION_MIN_BYTES  skip compressing pages smaller than this
 cross_shard_reclaim_guard = 1          # TS_CROSS_SHARD_RECLAIM_GUARD  1 = retain slabs referenced by ANY loaded shard during GC (safe default; 0 = legacy per-shard, unsafe under multi-shard hosting)
-index_dump_oplog_gap_bytes = 1048576   # TS_INDEX_DUMP_OPLOG_GAP_BYTES  undumped index-log gap (bytes, 1 MiB) that triggers a background catalog/index dump under the manifest-parity catalog fold (TS_INDEX_CATALOG_FOLD); 0 disables the threshold cadence
+index_dump_oplog_gap_bytes = 1048576   # TS_INDEX_DUMP_WAL_GAP_BYTES  undumped index-log gap (bytes, 1 MiB) that triggers a background catalog/index dump under the manifest-parity catalog fold (TS_INDEX_CATALOG_FOLD); 0 disables the threshold cadence. TS_INDEX_DUMP_OPLOG_GAP_BYTES is the previous variable name, still honoured by the engine when this one is unset
 # index_catalog_fold = 1               # TS_INDEX_CATALOG_FOLD  1 = fold the band/zone catalog into the index-log MetaItem (reference conformance) and drive it via the threshold dump above, instead of the per-write band-manifest file. Ships OFF (byte-identical); uncomment to enable.
 
 

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -171,7 +171,7 @@ What is written, when it is flushed, and what is reclaimed. The escape hatches h
 | `TS_BARRIER_PROFILE_WRITES` | 50 | nothing | 1 | — |
 | `TS_CROSS_SHARD_RECLAIM_GUARD` | on | config | 1 | yes |
 | `TS_DATA_NODE_LIFECYCLE_SNAPSHOT` | — | nothing | 1 | — |
-| `TS_INDEX_DUMP_WAL_GAP_BYTES` | 1048576 | portal | 1 | — |
+| `TS_INDEX_DUMP_WAL_GAP_BYTES` | 1048576 | config, portal | 1 | — |
 | `TS_META_RAFT_SNAPSHOT_CHECK_INTERVAL_MS` | — | nothing | 1 | — |
 | `TS_META_SCHEDULER_SNAPSHOT` | — | nothing | 1 | — |
 | `TS_WAL_BINARY_FRAME` | on | launch, test, portal | 1 | — |

--- a/tools/matrixark_load_config.py
+++ b/tools/matrixark_load_config.py
@@ -90,7 +90,14 @@ ENV_MAP: Dict[str, str] = {
     "storage.page_store_compression_level": "TS_PAGE_STORE_COMPRESSION_LEVEL",
     "storage.page_store_compression_min_bytes": "TS_PAGE_STORE_COMPRESSION_MIN_BYTES",
     "storage.cross_shard_reclaim_guard": "TS_CROSS_SHARD_RECLAIM_GUARD",
-    "storage.index_dump_oplog_gap_bytes": "TS_INDEX_DUMP_OPLOG_GAP_BYTES",
+    # The engine reads TS_INDEX_DUMP_WAL_GAP_BYTES first and falls back to
+    # TS_INDEX_DUMP_OPLOG_GAP_BYTES only when it is unset, so exporting the older name put
+    # every value from this file behind anything that set the current one -- including a
+    # portal write, which offers exactly that variable. The key keeps its name so deployed
+    # files keep working; only the variable it exports moves to the one the engine reads
+    # first. (Key and variable already differ elsewhere: block_slab_target_bytes exports
+    # TS_BLOCK_SEGMENT_TARGET_BYTES.)
+    "storage.index_dump_oplog_gap_bytes": "TS_INDEX_DUMP_WAL_GAP_BYTES",
     # ---- [wal] --------------------------------------------------------------
     "wal.wal_legacy_recovery": "TS_WAL_LEGACY_RECOVERY",
     "wal.raft_wal_dir": "TS_RAFT_WAL_DIR",

--- a/tools/test_config_says_when_it_overrides.py
+++ b/tools/test_config_says_when_it_overrides.py
@@ -241,5 +241,66 @@ class TheShippedConfigSaysWhenItOverridesANumberTest(unittest.TestCase):
             "them off -- either the default moved to meet them, or the key did." % stale)
 
 
+class AConfigKeyExportsTheNameTheEngineReadsFirstTest(unittest.TestCase):
+    """A key in the shipped config must not export a variable the engine has superseded.
+
+    `storage_config.rs` keeps a previous name for a renamed knob so a deployment that sets it goes
+    on working, and says exactly what that costs: it is "read only when the current name is
+    unset". A config file that exports the OLD name therefore does not lose loudly. It loses to
+    anything that sets the current one -- including a write from the portal, which offers exactly
+    that variable -- while the operator reads their value in the file and believes it applies.
+
+    That is what `storage.index_dump_oplog_gap_bytes` did: it exported
+    TS_INDEX_DUMP_OPLOG_GAP_BYTES, the fallback, rather than TS_INDEX_DUMP_WAL_GAP_BYTES. The key
+    keeps its name so deployed files keep working; only the variable moved.
+
+    The superseded names are read from the engine rather than listed here, so retiring another one
+    needs no edit to this file -- and if the engine stops marking them, the floor below fails
+    rather than the check going quiet.
+    """
+
+    STORAGE_CONFIG = os.path.join(
+        REPO, "crates", "temporalstore-rust", "src", "storage_config.rs")
+    LOADER = os.path.join(TOOLS, "matrixark_load_config.py")
+
+    _SUPERSEDED = re.compile(
+        r'pub const [A-Z][A-Z0-9_]*_PREVIOUS_NAME\s*:\s*&str\s*=\s*"([A-Z0-9_]+)"\s*;')
+    _MAPPING = re.compile(r'^\s*"([a-z0-9_.]+)"\s*:\s*"([A-Z][A-Z0-9_]+)"\s*,', re.M)
+
+    EXPECTED_MAPPING_FLOOR = 30
+
+    def _superseded(self):
+        with open(self.STORAGE_CONFIG, encoding="utf-8") as handle:
+            return set(self._SUPERSEDED.findall(handle.read()))
+
+    def _mappings(self):
+        with open(self.LOADER, encoding="utf-8") as handle:
+            return self._MAPPING.findall(handle.read())
+
+    def test_the_engine_still_marks_a_superseded_name(self) -> None:
+        found = self._superseded()
+        self.assertTrue(
+            found,
+            "no const named *_PREVIOUS_NAME in storage_config.rs, so the check below compares "
+            "against an empty set and would pass over any deprecated export.")
+
+    def test_the_scan_still_reads_the_mapping_table(self) -> None:
+        mappings = self._mappings()
+        self.assertGreaterEqual(
+            len(mappings), self.EXPECTED_MAPPING_FLOOR,
+            "read %d config-key mappings, expected at least %d -- if the table's shape changed, "
+            "the assertion below is checking nothing"
+            % (len(mappings), self.EXPECTED_MAPPING_FLOOR))
+
+    def test_no_config_key_exports_a_superseded_variable(self) -> None:
+        superseded = self._superseded()
+        wrong = ["%s -> %s" % (key, env) for key, env in self._mappings() if env in superseded]
+        self.assertEqual(
+            [], wrong,
+            "these config keys export a variable the engine reads only when the current one is "
+            "unset, so their value loses silently to anything that sets the current name: %s"
+            % wrong)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`storage_config.rs` keeps a previous name for a renamed knob so a deployment that sets it goes
on working, and states exactly what that costs:

> Previous name for `TS_INDEX_DUMP_WAL_GAP_BYTES`, still honoured so a deployment that sets it
> keeps working. **Read only when the current name is unset.**

The loader exported that previous name:

```python
"storage.index_dump_oplog_gap_bytes": "TS_INDEX_DUMP_OPLOG_GAP_BYTES",
```

So the value in the shipped config did not lose loudly. It lost to anything that set the
current name — **including a write from the portal, which offers exactly that variable** —
while the operator read their `1048576` in the file and had every reason to believe it applied.
The systemd units run through `with_config.sh`, so this is the deployed path, not documentation.

### The fix keeps the key

Only the variable it exports moves to the one the engine reads first, so deployed config files
keep working unchanged. Key and variable already differ elsewhere — `block_slab_target_bytes`
exports `TS_BLOCK_SEGMENT_TARGET_BYTES` — so this is the existing shape, not a new one. The
file now names the current variable and records that the old one is still honoured.

### The guard reads the engine, not a list

Superseded names come from `storage_config.rs` (`*_PREVIOUS_NAME` consts), so retiring another
knob needs no edit here. Two floors keep it from going quiet: the engine must still mark at
least one superseded name, and the mapping table must still parse (30+ entries).

### Mutation test

| mutation | result |
|---|---|
| put the old name back | **FAILED** — `storage.index_dump_oplog_gap_bytes -> TS_INDEX_DUMP_OPLOG_GAP_BYTES` |
| restored | **OK** |

### Checks

`python3 -m unittest` over every config / flag / inventory / engine / gateway / policy / launcher
guard in `tools/`: **547 tests, OK**. The generated inventory moves
`TS_INDEX_DUMP_WAL_GAP_BYTES` from "portal" to "config, portal", which is the point.
