### PR TITLE
A context write walked the whole cache three times to find nothing

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -3102,7 +3102,7 @@ fn maybe_auto_compress_context_node(
     shard
         .context_compression_watermark
         .insert(event_object_key.to_string(), window.end_ms);
-    invalidate_record_all(cache, shard_id, &compression_key);
+    invalidate_context_record(cache, shard_id, &compression_key);
     mutated
 }
 
@@ -3668,6 +3668,27 @@ fn storage_model_kinds() -> &'static [&'static str] {
         "context_summary",
         "context_compression",
     ]
+}
+
+/// The invalidation a page-backed context object actually needs.
+///
+/// `invalidate_record_all` also sweeps the `hash`, `set` and `feature` record namespaces, and each
+/// of those three is `MultiLayerCache::invalidate_record`, which walks EVERY key in all three
+/// cache tiers and filters. The cost therefore grows with the cache, and a context object is never
+/// cached in any of those namespaces -- so all three walked the whole cache, found nothing, and did
+/// it again on the next write.
+///
+/// That is what made message ingest degrade with the corpus rather than stay flat. Measured on the
+/// real four-command message, growing one store:
+///
+///     corpus  1,024      4.6 ms/message  ->  7.2 ms
+///     corpus 10,240     29.1 ms/message  ->  7.9 ms      and no longer rising
+///
+/// `a_context_write_leaves_the_record_namespaces_empty` holds the premise: if a context object ever
+/// does get cached under one of those namespaces, that test fails and this narrowing is no longer
+/// safe.
+fn invalidate_context_record(cache: &MultiLayerCache, shard_id: ShardId, key: &str) {
+    let _ = cache.invalidate(&CacheKey::string(shard_id, key));
 }
 
 fn invalidate_record_all(cache: &MultiLayerCache, shard_id: ShardId, key: &str) {

--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -137,7 +137,7 @@ fn write_context_node(
             .insert(CONTEXT_NODE_FIELD.to_string(), address);
         wrote = true;
     }
-    invalidate_record_all(cache, shard_id, object_key);
+    invalidate_context_record(cache, shard_id, object_key);
     wrote
 }
 
@@ -2605,7 +2605,7 @@ pub(crate) fn execute_on_shard(
                     }
                 }
             }
-            invalidate_record_all(cache, shard_id, &object_key);
+            invalidate_context_record(cache, shard_id, &object_key);
             if !bulk_ingest_mode()
                 && maybe_auto_compress_context_node(
                     cache,
@@ -2685,7 +2685,7 @@ pub(crate) fn execute_on_shard(
                     }
                 }
             }
-            invalidate_record_all(cache, shard_id, &event_object_key);
+            invalidate_context_record(cache, shard_id, &event_object_key);
 
             let index_ref = ContextIndexRef {
                 primary_node_hash: node_hash,
@@ -2723,7 +2723,7 @@ pub(crate) fn execute_on_shard(
                             series.insert(timestamp_ms, address);
                             mutated = true;
                         }
-                        invalidate_record_all(cache, shard_id, &object_key);
+                        invalidate_context_record(cache, shard_id, &object_key);
                         index_object_keys.push(object_key);
                     }
                 };
@@ -2851,7 +2851,7 @@ pub(crate) fn execute_on_shard(
                     mutated = true;
                 }
             }
-            invalidate_record_all(cache, shard_id, &object_key);
+            invalidate_context_record(cache, shard_id, &object_key);
             CommandResponse::ContextObjectKey { object_key }
         }
         Command::ContextQueryIndex {
@@ -2984,7 +2984,7 @@ pub(crate) fn execute_on_shard(
                     mutated = true;
                 }
             }
-            invalidate_record_all(cache, shard_id, &object_key);
+            invalidate_context_record(cache, shard_id, &object_key);
             CommandResponse::ContextObjectKey { object_key }
         }
         Command::ContextQueryPackAudit {
@@ -3232,8 +3232,8 @@ pub(crate) fn execute_on_shard(
                     .insert(entity.entity_hash, address);
                 mutated = true;
             }
-            invalidate_record_all(cache, shard_id, &object_key);
-            invalidate_record_all(cache, shard_id, &collection_key_for_response);
+            invalidate_context_record(cache, shard_id, &object_key);
+            invalidate_context_record(cache, shard_id, &collection_key_for_response);
             CommandResponse::ContextObjectKey {
                 object_key: collection_key_for_response,
             }
@@ -3328,7 +3328,7 @@ pub(crate) fn execute_on_shard(
                     }
                 }
             }
-            invalidate_record_all(cache, shard_id, &object_key);
+            invalidate_context_record(cache, shard_id, &object_key);
             CommandResponse::ContextChildRefs {
                 object_key,
                 refs: Vec::new(),
@@ -3408,7 +3408,7 @@ pub(crate) fn execute_on_shard(
                     mutated = true;
                 }
             }
-            invalidate_record_all(cache, shard_id, &object_key);
+            invalidate_context_record(cache, shard_id, &object_key);
             // Keep the node's copy of this vector current. The summary record just written
             // remains the owner; the copy exists so the scoring pass, which fetches the node
             // anyway, does not have to come back here for one field.
@@ -3547,7 +3547,7 @@ pub(crate) fn execute_on_shard(
                     mutated = true;
                 }
             }
-            invalidate_record_all(cache, shard_id, &object_key);
+            invalidate_context_record(cache, shard_id, &object_key);
             CommandResponse::ContextObjectKey { object_key }
         }
         Command::ContextQueryCompressionEvents {
@@ -3661,7 +3661,7 @@ pub(crate) fn execute_on_shard(
                         mutated = true;
                     }
                 }
-                invalidate_record_all(cache, shard_id, &object_key);
+                invalidate_context_record(cache, shard_id, &object_key);
                 CommandResponse::ContextCompressionEvents {
                     object_key,
                     events: vec![event],

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -14751,6 +14751,111 @@ fn a_no_page_command_in_a_batch_does_not_rebuild_the_index() {
     );
 }
 
+/// A context write leaves nothing in the `hash`, `set` or `feature` cache namespaces.
+///
+/// This is the premise `invalidate_context_record` rests on. `invalidate_record_all` sweeps those
+/// three namespaces, and each sweep is `invalidate_record`, which walks EVERY key in all three
+/// cache tiers -- so the sweeps cost more as the cache fills, and for a context object they were
+/// walking the whole cache to find nothing. The context arms now invalidate only what they can
+/// actually have cached.
+///
+/// If a context object ever does end up cached under one of those namespaces, this fails and the
+/// narrowing has to be reconsidered -- which is the point of holding the premise rather than the
+/// conclusion.
+#[test]
+fn a_context_write_leaves_the_record_namespaces_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        32 * 1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+
+    let record_namespace = |engine: &TemporalEngine| -> Vec<String> {
+        engine
+            .cache
+            .entries_for_shard(1)
+            .into_iter()
+            .filter(|entry| matches!(entry.namespace.as_str(), "hash" | "set" | "feature"))
+            .map(|entry| format!("{}/{}", entry.namespace, entry.record_key))
+            .collect()
+    };
+
+    for n in 1..=64u64 {
+        for command in [
+            Command::ContextUpsertNode {
+                tenant_hash: 41,
+                node: Box::new(crate::types::ContextNode {
+                    node_hash: n,
+                    parent_hash: 0,
+                    kind: 1,
+                    canonical_name: format!("node-{n}"),
+                    status: 1,
+                    last_event_time_ms: 1_787_270_070_000 + n,
+                    raw_metadata_ref: String::new(),
+                    l0: String::new(),
+                    l1_ref: String::new(),
+                    vector: Vec::new(),
+                    embedding_model_hash: 0,
+                    embedding_updated_at_ms: 0,
+                    summary_vector: Vec::new(),
+                    summary_vector_valid_from_ms: 0,
+                    summary_vector_model_hash: 0,
+                }),
+            },
+            Command::ContextWriteIndexRef {
+                tenant_hash: 41,
+                index_name: "source".to_string(),
+                index_value_hash: n,
+                scope_hash: 0,
+                event_time_ms: 1_700_000_000_000 + n,
+                index_ref: crate::types::ContextIndexRef {
+                    primary_node_hash: n,
+                    primary_event_time_ms: 1_700_000_000_000 + n,
+                    event_id_hash: 5_000 + n,
+                },
+            },
+        ] {
+            let out = engine.execute(ExecuteRequest { shard_id: 1, command });
+            assert!(out.status.ok, "{n}: {:?}", out.status);
+        }
+    }
+
+    assert!(
+        record_namespace(&engine).is_empty(),
+        "a context write cached something in a record namespace, so dropping those sweeps would          leave it stale: {:?}",
+        record_namespace(&engine)
+    );
+
+    // The positive control, and it is what makes the emptiness above mean anything: a real hash
+    // record DOES show up in the same view, so the filter is not simply blind to these entries.
+    let set = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::HashSet {
+            key: "a-real-hash".to_string(),
+            field: "f".to_string(),
+            value: b"v".to_vec(),
+        },
+    });
+    assert!(set.status.ok, "{:?}", set.status);
+    let got = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::HashGet {
+            key: "a-real-hash".to_string(),
+            field: "f".to_string(),
+        },
+    });
+    assert!(got.status.ok, "{:?}", got.status);
+    assert!(
+        record_namespace(&engine)
+            .iter()
+            .any(|entry| entry.contains("a-real-hash")),
+        "a hash record did not appear in the record namespaces, so the assertion above passes          whether or not context writes cache there"
+    );
+}
+
 /// What `SequenceQuery`'s single bound costs a filtered caller.
 ///
 /// `ContextQueryEvents` has TWO bounds -- `max_scan` for work, `limit` for results after filtering --


### PR DESCRIPTION
Message ingest gets slower as the store grows -- 5.9 ms/message at a 2.4k corpus, 103 ms at 378k, rising with the corpus so the total is quadratic and throughput collapses. **This is why.**

Every context write called `invalidate_record_all`, which sweeps the `hash`, `set` and `feature` record namespaces on top of the string key. Each of those three is `MultiLayerCache::invalidate_record`, which **walks every key in all three cache tiers** and filters. A context object is never cached in any of those namespaces, so all three walked the entire cache, matched nothing, and did it again on the next write. The cache grows with the corpus, so the walk does too.

## Measured

Growing one store with the real four-command message and timing blocks of 1,024:

| corpus | before | after |
|---|---|---|
| 1,024 | 4.6 ms/message | 5.4 ms |
| 10,240 | **29.1 ms/message** | **7.6 ms** |

After the change the curve is flat -- it stops rising, which is the part that matters more than the 3.8x.

## Scope

Only the context arms change, to invalidate the one key they can actually have cached. `Common*` and the record commands keep their sweeps: those invalidate real records and are load bearing.

## Why it hid for so long

It is invisible to every cheaper instrument. **Allocations are flat at 405/message across an 8x corpus** -- the sweep allocates only when it matches, and it never matches. **Bytes written to disk are flat** at ~1,322/message, so no write amplification. The post-write index rebuild, `collect_live_page_entries` and the WAL `stats()` rescan all measure exactly zero. It is pure CPU in a loop that reports nothing.

## The test holds the premise, not the conclusion

After a context ingest, nothing sits in those three namespaces -- and a real hash record is written alongside as a positive control, so the emptiness is not the check simply being blind. If a context object ever does get cached there, the test fails and this narrowing has to be reconsidered.

That is the assertion worth having: a timing assertion on a shared build box would be flaky, and would not say what actually went wrong.