### PR TITLE
A portal field read only as a FALLBACK must say what wins over it

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -274,10 +274,14 @@ SETTINGS: List[Setting] = [
             "immediately, with no restart."),
     Setting("extraction.timeout_sec", "extraction", "MATRIXARK_EXTRACTION_TIMEOUT_SEC",
             "Extraction timeout (s)", "float", "30", "restart",
-            "A slow endpoint that exceeds this falls back to the deterministic path silently."),
+            "A slow endpoint that exceeds this falls back to the deterministic path "
+            "silently. The Anthropic path prefers MATRIXARK_ANTHROPIC_TIMEOUT_SEC where "
+            "that is set and falls back to this."),
     Setting("extraction.max_tokens", "extraction", "MATRIXARK_EXTRACTION_MAX_TOKENS",
             "Extraction max tokens", "int", "1200", "restart",
-            "Completion cap per extraction call."),
+            "Completion cap per extraction call. The Anthropic path prefers "
+            "MATRIXARK_ANTHROPIC_MAX_TOKENS where that is set and falls back to this, so "
+            "a value there overrides this field for that provider only."),
 
     # ---- the summary model ----------------------------------------------------------------------
     # The third model a deployment runs, and the one called most: every context node gets a summary,
@@ -404,8 +408,12 @@ SETTINGS: List[Setting] = [
     Setting("retrieval.default_max_context_tokens", "retrieval",
             "MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS",
             "Default context budget (tokens)", "int", "500000", "restart",
-            "Budget applied when a caller does not name one. Callers can ask for less per request; "
-            "this is the ceiling they inherit."),
+            "Budget applied when a caller does not name one. Callers can ask for less per "
+            "request; this is the ceiling they inherit. The agent hooks are not such a "
+            "caller: they prefer MATRIXARK_HOOK_MAX_CONTEXT_TOKENS where it is set, which "
+            "the installation manual sets to 10000, and matrixark_codex_dual_hook.sh "
+            "passes its own 10000 without consulting this at all. Changing this does not "
+            "change what a hook sends."),
     Setting("retrieval.gateway_default_max_context_tokens", "retrieval",
             "MATRIXARK_GATEWAY_DEFAULT_MAX_CONTEXT_TOKENS",
             "Gateway default context budget", "int", "", "restart",

--- a/tools/test_a_setting_says_what_overrides_it.py
+++ b/tools/test_a_setting_says_what_overrides_it.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A portal field read only as a FALLBACK must say what wins over it.
+
+Several knobs are read as `get(SPECIFIC, get(GENERAL, default))` -- a deliberate hierarchy, where a
+provider-specific or path-specific name overrides a general one. The portal offers the GENERAL name
+for three of them and said nothing about the specific one, so the field promised a reach it does
+not have.
+
+`retrieval.default_max_context_tokens` is the one that matters. It offers
+`MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS` at 500000, while the agent hooks prefer
+`MATRIXARK_HOOK_MAX_CONTEXT_TOKENS` -- which the installation manual instructs operators to set to
+10000 -- and `matrixark_codex_dual_hook.sh` passes its own 10000 without consulting the portal's
+variable at all. An operator raising the portal field and expecting a hook to send more got no
+change and no explanation.
+
+The rule is narrow on purpose: only a field whose OWN variable is the second name of such a pair
+has to mention the first. It is not a demand that every setting document every neighbour.
+
+This is the same defect as the one that had the portal advertising budgets it does not apply, in a
+different disguise: a surface stating something the code will not do.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import unittest
+from typing import Dict
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(TOOLS)
+sys.path.insert(0, TOOLS)
+
+# get(SPECIFIC, get(GENERAL, ...)) -- the second name is only reached when the first is unset.
+_PAIR = re.compile(
+    r'environ\.get\(\s*["\']((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)["\']\s*,\s*'
+    r'(?:os\.)?(?:environ\.get|getenv)\(\s*["\']((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)["\']')
+
+# 10 pairs and 3 shadowed settings when this was written.
+EXPECTED_PAIR_FLOOR = 6
+EXPECTED_SHADOWED_FLOOR = 3
+
+
+def _pairs() -> Dict[str, str]:
+    """fallback name -> the name preferred over it."""
+    listed = subprocess.run(["git", "ls-files", "*.py"], cwd=REPO,
+                            capture_output=True, text=True).stdout.split()
+    found: Dict[str, str] = {}
+    for path in listed:
+        if os.path.basename(path).startswith("test_"):
+            continue
+        try:
+            with open(os.path.join(REPO, path), encoding="utf-8", errors="replace") as handle:
+                source = handle.read()
+        except OSError:
+            continue
+        for match in _PAIR.finditer(source):
+            found.setdefault(match.group(2), match.group(1))
+    return found
+
+
+def _shadowed():
+    """(setting, the name preferred over its variable) for every field read as a fallback."""
+    import matrixark_gateway_config as cfgmod
+    pairs = _pairs()
+    offered = {s.env for s in cfgmod.SETTINGS if s.env}
+    out = []
+    for setting in cfgmod.SETTINGS:
+        preferred = pairs.get(setting.env)
+        # If the portal also offers the preferred name, an operator can reach both and the
+        # precedence is visible on the page itself.
+        if preferred and preferred not in offered:
+            out.append((setting, preferred))
+    return out
+
+
+class ASettingSaysWhatOverridesItTest(unittest.TestCase):
+
+    def test_the_scan_still_finds_fallback_pairs(self) -> None:
+        pairs = _pairs()
+        self.assertGreaterEqual(
+            len(pairs), EXPECTED_PAIR_FLOOR,
+            "found %d primary/fallback pairs, expected at least %d -- if the read shape changed, "
+            "the assertion below runs on an empty set" % (len(pairs), EXPECTED_PAIR_FLOOR))
+
+    def test_the_scan_still_finds_shadowed_settings(self) -> None:
+        shadowed = _shadowed()
+        self.assertGreaterEqual(
+            len(shadowed), EXPECTED_SHADOWED_FLOOR,
+            "found %d portal fields read as a fallback, expected at least %d -- below that this "
+            "file is asserting almost nothing" % (len(shadowed), EXPECTED_SHADOWED_FLOOR))
+
+    def test_a_shadowed_field_names_what_wins_over_it(self) -> None:
+        silent = ["%s (overridden by %s)" % (setting.key, preferred)
+                  for setting, preferred in _shadowed() if preferred not in setting.help]
+        self.assertEqual(
+            [], silent,
+            "these portal fields are read only when another variable is unset, and their help "
+            "does not name it: %s\nAn operator changing one of these can get no effect and no "
+            "explanation." % silent)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Several knobs are read as `get(SPECIFIC, get(GENERAL, default))` — a deliberate hierarchy where
a provider- or path-specific name overrides a general one. The portal offers the **general** name
for three of them and said nothing about the specific one, so those fields promised a reach they
do not have.

### The one that matters

`retrieval.default_max_context_tokens` offers `MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS` at 500000.
But:

- the agent hooks prefer `MATRIXARK_HOOK_MAX_CONTEXT_TOKENS`, which
  `docs/matrixark_codex_mcp_hook_installation_manual` **instructs operators to set to 10000**;
- `tools/matrixark_codex_dual_hook.sh:42` passes its own `10000` and never consults the portal's
  variable at all;
- `tools/matrixark_local_backfill_ingester.py:627` sets it for child processes.

So an operator raising that field and expecting a hook to send more got **no change and no
explanation**.

The other two are the Anthropic extraction pair, which prefer `MATRIXARK_ANTHROPIC_MAX_TOKENS` and
`MATRIXARK_ANTHROPIC_TIMEOUT_SEC` over the extraction fields the portal offers. Nothing in the tree
sets either today, so nothing is losing right now — the help says it because the code implements
it, not because it has bitten anyone.

**No default moves and no behaviour changes.** Three help texts, and a test so a fourth cannot
arrive silently.

### The rule is deliberately narrow

Only a field whose **own** variable is the second name of such a pair must mention the first, and
only when the portal does not also offer the first — if both are on the page, the precedence is
visible there. It is not a demand that every setting document every neighbour.

### Checks

Two floors guard the scan, since all of it passes on an empty set: **6** pairs found, **3** shadowed
fields.

| mutation | result |
|---|---|
| remove the variable name from one help text | **FAILED** — `retrieval.default_max_context_tokens (overridden by MATRIXARK_HOOK_MAX_CONTEXT_TOKENS)` |
| restored | **OK** |

`python3 -m unittest` over every config / flag / inventory / engine / gateway / policy / launcher
guard in `tools/`: **554 tests, OK**.
