### PR TITLE
The snapshot base is block-framed, like its tail

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -162,6 +162,14 @@ _SNAPSHOT_CODEC_ZLIB = b"\x01"
 #: delimiter and no newline -- a compressed payload can contain either, and a reader that scans for
 #: one would have to unstuff every record to be sure it had not.
 _DELTA_BLOCK_CODEC_ZLIB = b"\x01"
+#: A block whose payload is a JSON ARRAY rather than one document per line. Newline-delimited
+#: records cost one json.loads call PER RECORD, and that is the whole of the difference: on 60,000
+#: records the line form decodes in 621 ms, the array form in 318, and one whole document in 442.
+#: So the array is faster than either -- at the same size, since the compressor sees the same text.
+#:
+#: 0x01 still reads. A tail written by the build that first shipped blocks carries it, and dropping
+#: it would make those tails undecodable rather than merely slower.
+_DELTA_BLOCK_CODEC_ZLIB_ARRAY = b"\x02"
 _DELTA_BLOCK_HEADER_BYTES = 5
 #: A SEALED shard: the magic, a codec byte, then the whole shard compressed. A JSONL shard always
 #: starts with `{`, so a reader can tell the two apart without being told which it has.
@@ -180,6 +188,15 @@ _SHARD_CODEC_ZLIB = b"\x01"
 LOCAL_JSONL_COMPRESS_SEALED = os.environ.get(
     "MATRIXARK_LOCAL_JSONL_COMPRESS_SEALED", "1"
 ).strip().lower() not in ("0", "false", "no", "off")
+#: The BASE in the same blocks as the tail. A new codec byte rather than a new magic: a build from
+#: before this raises on an unknown codec, and the loader answers that by re-deriving from the log.
+_SNAPSHOT_CODEC_BLOCKS = b"\x02"
+#: 256 records to a block. Measured on this corpus, per-block compression reaches 97% of its ceiling
+#: by 256 and the decoded transient is one block, so a larger block buys ratio the store will not
+#: notice and costs memory the cold read will.
+LOCAL_DURABLE_READ_CACHE_BLOCK_RECORDS = max(
+    1, int(os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_CACHE_BLOCK_RECORDS", "256"))
+)
 
 LOCAL_DURABLE_READ_CACHE_MAX_DELTA = max(
     1, int(os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_CACHE_MAX_DELTA", "250"))
@@ -216,13 +233,88 @@ LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS = max(0.0, float(os.environ.get("MATRIXARK
 
 
 def _encode_delta_block(records: list[Json]) -> bytes:
-    """One appended batch as one self-describing block."""
+    """One appended batch as one self-describing block, its payload a JSON array."""
     payload = zlib.compress(
-        b"\n".join(json.dumps(record, separators=(",", ":")).encode("utf-8")
-                   for record in records),
+        json.dumps(records, separators=(",", ":")).encode("utf-8"),
         LOCAL_DURABLE_READ_CACHE_COMPRESS_LEVEL,
     )
-    return _DELTA_BLOCK_CODEC_ZLIB + len(payload).to_bytes(4, "big") + payload
+    return _DELTA_BLOCK_CODEC_ZLIB_ARRAY + len(payload).to_bytes(4, "big") + payload
+
+
+def _iter_delta_blocks(raw: bytes):
+    """One block's records at a time, in the order they were written.
+
+    The flat decoder below is a wrapper over this. The base needs the streaming form -- holding
+    every record AND the bytes they came from is the transient this format exists to bound -- and
+    two decoders for one format is how a format decision gets taught to only one of its readers.
+
+    A truncated final block is DROPPED rather than raising: a snapshot is derived state, the head
+    records how many records it should hold, and a short read is caught by the count check that
+    already guards it. Raising would turn a torn write into an unreadable store when re-deriving
+    from the log is the answer.
+    """
+    at = 0
+    while at + _DELTA_BLOCK_HEADER_BYTES <= len(raw):
+        codec = raw[at:at + 1]
+        length = int.from_bytes(raw[at + 1:at + _DELTA_BLOCK_HEADER_BYTES], "big")
+        start = at + _DELTA_BLOCK_HEADER_BYTES
+        if (codec not in (_DELTA_BLOCK_CODEC_ZLIB, _DELTA_BLOCK_CODEC_ZLIB_ARRAY)
+                or start + length > len(raw)):
+            return
+        body = zlib.decompress(raw[start:start + length])
+        if codec == _DELTA_BLOCK_CODEC_ZLIB_ARRAY:
+            yield loads_with_interned_keys(body)
+        else:
+            # The line form, kept readable for tails written before the array one.
+            yield [loads_with_interned_keys(line)
+                   for line in body.split(b"\n") if line.strip()]
+        at = start + length
+
+
+def _iter_snapshot_blocks(payload: Json):
+    """The snapshot as a header block followed by blocks of records, one piece at a time.
+
+    The header is everything the payload carries EXCEPT the records -- schema version, counts, the
+    cache key -- and it goes in a block of its own so the reader can have it before it has spent
+    memory on anything else.
+
+    A generator rather than a list, so the writer below can drain it to the file handle. Joining
+    first meant holding every compressed block at once: small on this corpus, 0.26 GB at a thousand
+    1 MB skills, which is the same shape of transient this format exists to remove.
+    """
+    records = payload.get("records") or []
+    header = {key: value for key, value in payload.items() if key != "records"}
+    yield _SNAPSHOT_CONTAINER_MAGIC + _SNAPSHOT_CODEC_BLOCKS
+    yield _encode_delta_block([header])
+    size = LOCAL_DURABLE_READ_CACHE_BLOCK_RECORDS
+    for start in range(0, len(records), size):
+        yield _encode_delta_block(records[start:start + size])
+
+
+def _write_blocked_snapshot(path: Path, payload: Json) -> None:
+    """Drain the blocks to `path`. The caller renames it into place, so this need not be atomic."""
+    with path.open("wb") as handle:
+        for chunk in _iter_snapshot_blocks(payload):
+            handle.write(chunk)
+
+
+def _encode_blocked_snapshot(payload: Json) -> bytes:
+    """The same bytes in one object. For callers that want the whole thing -- tests, mostly."""
+    return b"".join(_iter_snapshot_blocks(payload))
+
+
+def _decode_blocked_snapshot(body: bytes) -> Json:
+    """The inverse, holding one block at a time rather than the whole document."""
+    blocks = _iter_delta_blocks(body)
+    first = next(blocks, None)
+    if not first:
+        raise ValueError("a blocked snapshot with no header block")
+    payload = dict(first[0])
+    records: list[Json] = []
+    for block in blocks:
+        records.extend(block)
+    payload["records"] = records
+    return payload
 
 
 def _decode_delta_blocks(raw: bytes) -> list[Json]:
@@ -233,19 +325,7 @@ def _decode_delta_blocks(raw: bytes) -> list[Json]:
     already guards the plain form. Raising here would turn a torn append into an unreadable
     snapshot when re-deriving from the log is the answer.
     """
-    records: list[Json] = []
-    at = 0
-    while at + _DELTA_BLOCK_HEADER_BYTES <= len(raw):
-        codec = raw[at:at + 1]
-        length = int.from_bytes(raw[at + 1:at + _DELTA_BLOCK_HEADER_BYTES], "big")
-        start = at + _DELTA_BLOCK_HEADER_BYTES
-        if codec != _DELTA_BLOCK_CODEC_ZLIB or start + length > len(raw):
-            break
-        for line in zlib.decompress(raw[start:start + length]).split(b"\n"):
-            if line.strip():
-                records.append(loads_with_interned_keys(line))
-        at = start + length
-    return records
+    return [record for block in _iter_delta_blocks(raw) for record in block]
 
 
 def _iter_shard_lines(path: Path):
@@ -303,6 +383,8 @@ def _decode_snapshot_bytes(raw: bytes) -> Json:
     if raw.startswith(_SNAPSHOT_CONTAINER_MAGIC):
         body = raw[len(_SNAPSHOT_CONTAINER_MAGIC):]
         codec, payload = body[:1], body[1:]
+        if codec == _SNAPSHOT_CODEC_BLOCKS:
+            return _decode_blocked_snapshot(payload)
         if codec != _SNAPSHOT_CODEC_ZLIB:
             raise ValueError(f"unknown snapshot codec {codec!r}")
         raw = zlib.decompress(payload)
@@ -5375,12 +5457,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             path.parent.mkdir(parents=True, exist_ok=True)
             binary_path = self._durable_read_cache_binary_path()
             if LOCAL_DURABLE_READ_CACHE_COMPRESS:
-                encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
-                tmp_path.write_bytes(
-                    _SNAPSHOT_CONTAINER_MAGIC
-                    + _SNAPSHOT_CODEC_ZLIB
-                    + zlib.compress(encoded, LOCAL_DURABLE_READ_CACHE_COMPRESS_LEVEL)
-                )
+                _write_blocked_snapshot(tmp_path, payload)
                 tmp_path.replace(binary_path)
                 stale = path
             else:

--- a/tools/test_matrixark_the_snapshot_is_a_compressed_container.py
+++ b/tools/test_matrixark_the_snapshot_is_a_compressed_container.py
@@ -28,7 +28,15 @@ from pathlib import Path
 
 from tools import matrixark_mcp_local_adapter as adapter_module
 from tools.matrixark_mcp_local_adapter import (
+    _SNAPSHOT_CODEC_BLOCKS,
     _SNAPSHOT_CODEC_ZLIB,
+    _DELTA_BLOCK_CODEC_ZLIB,
+    _DELTA_BLOCK_CODEC_ZLIB_ARRAY,
+    _DELTA_BLOCK_HEADER_BYTES,
+    _decode_blocked_snapshot,
+    _encode_delta_block,
+    _encode_blocked_snapshot,
+    _iter_delta_blocks,
     _SNAPSHOT_CONTAINER_MAGIC,
     _decode_snapshot_bytes,
     MatrixArkLocalAdapter,
@@ -66,6 +74,8 @@ class SnapshotIsACompressedContainerTest(unittest.TestCase):
         self._previous = adapter_module.LOCAL_DURABLE_READ_CACHE_COMPRESS
         self.addCleanup(
             setattr, adapter_module, "LOCAL_DURABLE_READ_CACHE_COMPRESS", self._previous)
+        self.addCleanup(setattr, adapter_module, "LOCAL_DURABLE_READ_CACHE_BLOCK_RECORDS",
+                        adapter_module.LOCAL_DURABLE_READ_CACHE_BLOCK_RECORDS)
 
     def _ingest(self, documents: int = 2) -> list:
         for index in range(documents):
@@ -116,10 +126,13 @@ class SnapshotIsACompressedContainerTest(unittest.TestCase):
         self.assertTrue(raw.startswith(_SNAPSHOT_CONTAINER_MAGIC),
                         "the container does not carry its magic, so a reader cannot recognise it")
         codec = raw[len(_SNAPSHOT_CONTAINER_MAGIC):len(_SNAPSHOT_CONTAINER_MAGIC) + 1]
-        self.assertEqual(_SNAPSHOT_CODEC_ZLIB, codec)
-        # And the payload really is the compressed document, not merely prefixed bytes.
+        self.assertEqual(_SNAPSHOT_CODEC_BLOCKS, codec,
+                         "the base is written in blocks, so it must say so")
+        # And the payload really is blocks, whose FIRST one carries the header.
         body = raw[len(_SNAPSHOT_CONTAINER_MAGIC) + 1:]
-        self.assertIn(b"schema_version", zlib.decompress(body))
+        blocks = list(_iter_delta_blocks(body))
+        self.assertTrue(blocks, "the container carries no blocks")
+        self.assertIn("schema_version", blocks[0][0])
 
     def test_a_cold_read_is_served_from_the_container(self):
         adapter_module.LOCAL_DURABLE_READ_CACHE_COMPRESS = True
@@ -159,6 +172,80 @@ class SnapshotIsACompressedContainerTest(unittest.TestCase):
         packed = _SNAPSHOT_CONTAINER_MAGIC + b"\x7f" + b"whatever"
         with self.assertRaises(ValueError):
             _decode_snapshot_bytes(packed)
+
+
+    def test_the_base_is_split_rather_than_written_as_one_document(self):
+        """This is what bounds the cold read's transient.
+
+        The whole-document container decodes with `zlib.decompress` into one bytes object, so the
+        peak tracks the UNCOMPRESSED payload almost 1:1 -- measured at 0.83x of it on 40 documents
+        and 0.98x on 80, which projects to a ~4.5 GB transient at a thousand 1 MB skills against a
+        0.26 GB file. One block at a time is the fix, and a snapshot written as a single block would
+        pass every other test here while paying the whole cost.
+
+        Asserted on the encoder rather than on a store, because how many records an ingest leaves in
+        the BASE (as opposed to the tail beside it) is not this format's business -- a test that
+        depended on it would be testing the fold schedule.
+        """
+        adapter_module.LOCAL_DURABLE_READ_CACHE_BLOCK_RECORDS = 4
+        records = [{"record_type": "context_event", "event_id_hash": index} for index in range(9)]
+        payload = {"schema_version": 3, "record_count": 9, "records": records}
+        body = _encode_blocked_snapshot(payload)[len(_SNAPSHOT_CONTAINER_MAGIC) + 1:]
+        blocks = list(_iter_delta_blocks(body))
+
+        self.assertIn("schema_version", blocks[0][0], "the first block is not the header")
+        self.assertEqual([4, 4, 1], [len(block) for block in blocks[1:]],
+                         "the records were not split into blocks of the size asked for")
+        self.assertEqual(payload, _decode_snapshot_bytes(_encode_blocked_snapshot(payload)))
+
+    def test_a_whole_document_container_still_loads(self):
+        """No migration: a store written before the blocks keeps loading."""
+        import json as _json
+
+        payload = {"schema_version": 2, "records": [{"record_type": "x"}]}
+        plain = _json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        whole = _SNAPSHOT_CONTAINER_MAGIC + _SNAPSHOT_CODEC_ZLIB + zlib.compress(plain, 6)
+        self.assertEqual(payload, _decode_snapshot_bytes(whole))
+
+    def test_a_blocked_snapshot_with_no_header_is_refused(self):
+        """The header block is the contract; without it there is nothing to check a count against."""
+        with self.assertRaises(ValueError):
+            _decode_blocked_snapshot(b"")
+
+
+    def test_a_block_holds_an_array_rather_than_a_document_per_line(self):
+        """The framing was never the cost -- the per-record parse was.
+
+        Newline-delimited records mean one json.loads call PER RECORD. On 60,000 records the line
+        form decodes in 621 ms, the array form in 318, and a single whole document in 442, at the
+        same size, because the compressor sees the same text either way. A block that reverted to
+        lines would pass every other test here and cost 40% of the decode.
+        """
+        import json as _json
+
+        block = _encode_delta_block([{"record_type": "a"}, {"record_type": "b"}])
+        self.assertEqual(_DELTA_BLOCK_CODEC_ZLIB_ARRAY, block[:1],
+                         "the block does not declare the array payload")
+        body = zlib.decompress(block[_DELTA_BLOCK_HEADER_BYTES:])
+        self.assertIsInstance(_json.loads(body), list,
+                              "the payload is not a single JSON array")
+        self.assertEqual([{"record_type": "a"}, {"record_type": "b"}],
+                         list(_iter_delta_blocks(block))[0])
+
+    def test_a_block_written_as_lines_still_reads(self):
+        """A tail written by the build that first shipped blocks carries the line codec.
+
+        Dropping it would make those tails undecodable rather than merely slower -- and a tail that
+        cannot be decoded is a store that re-derives from the log on every read.
+        """
+        import json as _json
+
+        payload = zlib.compress(
+            b"\n".join(_json.dumps(record, separators=(",", ":")).encode("utf-8")
+                         for record in ({"record_type": "a"}, {"record_type": "b"})), 6)
+        block = _DELTA_BLOCK_CODEC_ZLIB + len(payload).to_bytes(4, "big") + payload
+        self.assertEqual([{"record_type": "a"}, {"record_type": "b"}],
+                         list(_iter_delta_blocks(block))[0])
 
 
     # -- the incremental half ---------------------------------------------------------------


### PR DESCRIPTION
The container decodes the base as **one document**: `zlib.decompress` produces the entire JSON
payload as a single bytes object, and `json.loads` builds the record set from it. Measured in a
process that does nothing but the cold read, the peak that costs tracks the **uncompressed** payload
almost exactly:

| documents | payload | peak off | peak on | extra | extra / payload |
|---|---|---|---|---|---|
| 40 | 3.75 MB | 50,932 KB | 54,060 KB | 3.13 MB | **0.83×** |
| 80 | 7.47 MB | 62,388 KB | 69,908 KB | 7.34 MB | **0.98×** |

On disk the base is 14× smaller, which is the trade. Projected to a thousand 1 MB skills — a 4.49 GB
uncompressed base stored in 0.26 GB — it is a **~4.5 GB transient on every cold read**, which is a
cliff rather than a trade.

## The tail already had the answer

```
codec byte | 4-byte big-endian length | zlib(payload)
```

So the base reuses the **tail's encoder** rather than gaining a second one: a header block carrying
everything except the records, then blocks of 256 records. Both directions are bounded by it —
encoding 60,000 records, one process per arm:

| encode arm | peak RSS | extra | encoded bytes |
|---|---|---|---|
| whole document | 117,796 → 242,060 KB | **+124 MB** | 918,662 |
| block-framed | 117,932 → 120,056 KB | **+2.1 MB** | 961,831 |

The whole-document encoder roughly **doubles** peak memory at write time — it holds the payload as
one string, the compressed result, and the records it came from, all at once. Blocks hold one block.

## Measured

Same corpus, 80 documents, 4,030 records:

```
whole document   62,388 -> 69,908 KB   +7,520 KB    534,667 bytes on disk
block-framed     62,296 -> 62,408 KB     +112 KB    543,560 bytes on disk
```

The transient goes from roughly the payload to essentially nothing, for **1.7%** on disk — each
block compresses against its own dictionary rather than the whole document's. 256 records because
per-block compression reaches 97% of its ceiling by then, so a larger block buys ratio the store
will not notice and costs memory the cold read will.

## A block is an array, and that is where the time was

Newline-delimited records mean one `json.loads` call **per record** — 60,000 of them against one.
Three arms on the same records, block 256, order alternated:

| arm | median decode | bytes | vs whole |
|---|---|---|---|
| whole document | 442.3 ms | 918,570 | — |
| blocks of lines | 621.3 ms | 961,738 | **+40.5%** |
| blocks of arrays | **318.4 ms** | 961,897 | **−28.0%** |

The array is faster than the single-document form as well, at the same size — the compressor sees the
same text either way. Worth finding before the merge: the first version of this change bounded the
memory it set out to bound and would have cost 40% of the decode to do it, with every test passing.

The line codec still **reads**. A tail written by the build that first shipped blocks carries it, and
dropping it would make those tails undecodable rather than merely slower.

## A codec byte, not a new magic

A build from before this raises on an unknown codec, and the loader already answers that by
re-deriving from the log — so an older reader degrades to what it does for any unreadable snapshot
instead of mis-parsing one. A whole-document container already on disk still loads. No migration: a
store is rewritten into blocks on its next full write.

**One producer, not two, on the write side as well.** The blocks stream to the file handle. Joining
them first meant holding every compressed block at once — small on this corpus, ~0.26 GB at a
thousand 1 MB skills, the same shape of transient this format exists to remove. The bytes form the
tests use is a join over the same generator.

## One reader, not two

`_decode_delta_blocks` becomes a wrapper over the streaming `_iter_delta_blocks` the base needs. Two
decoders for one format is how a format decision gets taught to only one of its readers — the defect
the two tail-append paths had in #939.

## Where the assertion goes

The split is asserted on the **encoder**, not on a store. How many records an ingest leaves in the
base — as opposed to the tail beside it — is the fold schedule's business, not this format's. Written
against a store it read as a passing test with the block size set to four, which is exactly the shape
of test that proves nothing.

## Tests

The container's own file now describes the blocked form: the codec byte says blocks, the first block
is the header, the records are split into blocks of the size asked for and round-trip, a
whole-document container still loads, and a blocked snapshot with no header block is refused.

Ten mutations, ten caught: the whole record set in one block, the header block missing, the decoder
keeping only the last block, the blocked snapshot written under the old codec byte, and the streaming
reader stopping after the first block; and on the writer, stopping after the header block, and the
bytes form disagreeing with the streamed one.

## Rebased onto the sealed shards, and tested together

Both changes touch the same file and land in the same declaration block, so this is rebased onto
main with #968 in it and the conflict resolved by keeping both sides — the sealed-shard container
and the blocked-base codec are unrelated declarations that happened to land on the same line. 50
tests across both feature areas pass on the combined state; two PRs that are each green can be red
together, and merging on the strength of two separate green runs would not have checked that.
