### PR TITLE
Say what the binary-records flag is worth, with the number that was measured

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -544,8 +544,12 @@ SETTINGS: List[Setting] = [
             "On, a write-ahead log record is protobuf rather than JSON. Reading never consults "
             "this: a payload is decoded by what its first byte says it is, so a log written "
             "across a change reads end to end and turning it back off is not a one-way door. "
-            "Measured on a live store, text records and their frames are the larger part of what "
-            "the store holds."),
+            "Worth about 1.5x on the records themselves, measured over 2,000 identical "
+            "writes: 787,433 bytes of text against 524,735 binary. Not more than that, and "
+            "it is worth knowing why before turning it on expecting a store to halve: the "
+            "encoding gives a numeric code only to the field kinds common enough to earn "
+            "one and keeps the string otherwise, so the repeated field names that make a "
+            "log compress well survive it."),
     Setting("storage_engine.wal_binary_frame", "storage_engine",
             "TS_WAL_BINARY_FRAME",
             "Frame log records by length", "bool", "1", "restart",


### PR DESCRIPTION
The field said:

> Measured on a live store, text records and their frames are the larger part of what the store
> holds.

True, and it reads as a promise the flag does not keep. An operator turning it on to halve a store
gets about a third off the records and no explanation of why.

**The number exists.** Over 2,000 identical writes: **787,433 bytes of text against 524,735
binary** — 1.5× on the records themselves. The help now says that, and says why it is not more:
`wal_proto` gives a numeric code only to the field kinds common enough to earn one and keeps the
string otherwise, so the repeated field names survive the encoding. That is also why the same bytes
compress far better than they encode — compression works across records and a per-record encoding
cannot.

No default moves and no behaviour changes.

### The frame setting beside it is left alone

It already says "about seven bytes" against "about twenty". Measuring the live log today gives
**8.7** and **21.1** bytes per record, so it is accurate as written.

### Measured today on the live WAL

Taken read-only while checking the above; none of it changes any setting.

| | |
|---|---|
| WAL | 692 MB, 54,575 records, 12.8 KB per record |
| zlib-6 block compression (32 MB sample) | **17.0×** (zlib-9: 18.97×) |
| compressing each record on its own | 6.5× |
| text frame overhead | 21.1 B/record |
| binary frame overhead | 8.7 B/record |

So the frame flag is worth ~12 bytes a record, about 0.1% of the WAL — a consistency decision, not
a size one.

### Checks

`python3 -m unittest` over every config / gateway / flag / policy guard in `tools/`: **506 tests,
OK**.
