### PR TITLE
One rule for reading the embedding provider, instead of six copies of it

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -3484,7 +3484,9 @@ def compact_embedding_vector(vector: list[float]) -> list[float]:
 
 
 def embedding_model_name() -> str:
-    provider = os.environ.get("MATRIXARK_EMBEDDING_PROVIDER", "deterministic").strip().lower()
+    from matrixark_mcp_embeddings import embedding_provider_name
+
+    provider = embedding_provider_name()
     if provider in {"oss", "open_source", "sentence_transformers", "sentence-transformers"}:
         return os.environ.get("MATRIXARK_EMBEDDING_MODEL_PATH") or os.environ.get(
             "MATRIXARK_EMBEDDING_MODEL",
@@ -3497,7 +3499,9 @@ def embedding_model_name() -> str:
 
 
 def embedding_execution_mode_name() -> str:
-    provider = os.environ.get("MATRIXARK_EMBEDDING_PROVIDER", "deterministic").strip().lower()
+    from matrixark_mcp_embeddings import embedding_provider_name
+
+    provider = embedding_provider_name()
     if embedding_fallback_used():
         return "local_hash_embedding_fallback"
     if provider in {"oss", "open_source", "sentence_transformers", "sentence-transformers"}:

--- a/tools/matrixark_mcp_embeddings.py
+++ b/tools/matrixark_mcp_embeddings.py
@@ -148,8 +148,8 @@ def embedding_for_text(text: str, role: str = "passage") -> list[float]:
         cached = _cache_get(cache_key)
         if cached is not None:
             return list(cached)
-    provider = os.environ.get("MATRIXARK_EMBEDDING_PROVIDER", "deterministic").strip().lower()
-    if provider in {"oss", "open_source", "sentence_transformers", "sentence-transformers"}:
+    provider = embedding_provider_name()
+    if provider in _OSS_EMBEDDING_PROVIDERS:
         vector = truncate_embedding(oss_embedding_for_text(text))
         with _EMBEDDING_VECTOR_CACHE_LOCK:
             _cache_put(cache_key, vector)
@@ -191,7 +191,7 @@ def embeddings_for_texts(texts: list[str], role: str = "passage") -> list[list[f
                 missing.append((index, text))
             else:
                 results.append(list(cached))
-    provider = os.environ.get("MATRIXARK_EMBEDDING_PROVIDER", "deterministic").strip().lower()
+    provider = embedding_provider_name()
     if missing and provider in _API_EMBEDDING_PROVIDERS:
         vectors = api_embedding_for_texts([text for _index, text in missing], provider)
         with _EMBEDDING_VECTOR_CACHE_LOCK:
@@ -199,7 +199,7 @@ def embeddings_for_texts(texts: list[str], role: str = "passage") -> list[list[f
                 materialized = truncate_embedding([round(float(value), 6) for value in vector])
                 _cache_put((model, text), materialized)
                 results[index] = materialized
-    elif missing and provider in {"oss", "open_source", "sentence_transformers", "sentence-transformers"}:
+    elif missing and provider in _OSS_EMBEDDING_PROVIDERS:
         model_ref = os.environ.get("MATRIXARK_EMBEDDING_MODEL_PATH") or os.environ.get(
             "MATRIXARK_EMBEDDING_MODEL",
             "intfloat/multilingual-e5-large",
@@ -227,8 +227,8 @@ def embeddings_for_texts(texts: list[str], role: str = "passage") -> list[list[f
 
 
 def embedding_model_name() -> str:
-    provider = os.environ.get("MATRIXARK_EMBEDDING_PROVIDER", "deterministic").strip().lower()
-    if provider in {"oss", "open_source", "sentence_transformers", "sentence-transformers"}:
+    provider = embedding_provider_name()
+    if provider in _OSS_EMBEDDING_PROVIDERS:
         return os.environ.get("MATRIXARK_EMBEDDING_MODEL_PATH") or os.environ.get(
             "MATRIXARK_EMBEDDING_MODEL",
             "intfloat/multilingual-e5-large",
@@ -240,10 +240,10 @@ def embedding_model_name() -> str:
 
 
 def embedding_execution_mode_name() -> str:
-    provider = os.environ.get("MATRIXARK_EMBEDDING_PROVIDER", "deterministic").strip().lower()
+    provider = embedding_provider_name()
     if embedding_fallback_used():
         return "local_hash_embedding_fallback"
-    if provider in {"oss", "open_source", "sentence_transformers", "sentence-transformers"}:
+    if provider in _OSS_EMBEDDING_PROVIDERS:
         return "oss_embedding_model"
     if provider in _API_EMBEDDING_PROVIDERS:
         return "voyage_embedding_api" if provider == "voyage" else "openai_embedding_api"
@@ -262,6 +262,27 @@ def embedding_fallback_used() -> bool:
 # no embeddings API, so API embeddings are OpenAI/Voyage (or any OpenAI-compatible server, incl. a
 # local vLLM/Ollama endpoint via MATRIXARK_EMBEDDING_API_BASE). No new dependency: stdlib urllib only.
 _API_EMBEDDING_PROVIDERS = {"openai", "openai_compatible", "openai-compatible", "azure_openai", "voyage", "api"}
+#: The spellings that select the in-process sentence-transformers encoder. Written out at three
+#: dispatch sites before, which is three chances for one of them to learn a new spelling and the
+#: others not to.
+_OSS_EMBEDDING_PROVIDERS = {"oss", "open_source", "sentence_transformers", "sentence-transformers"}
+
+
+def embedding_provider_name() -> str:
+    """The configured embedding provider, normalised the way every dispatch site needs it.
+
+    Read per call, never captured into a module constant: a constant is resolved once at import and
+    a later write to the environment could not reach it, which is the difference between a setting
+    the portal calls live and one that only looks live.
+
+    Six sites spelled this out identically, each repeating the default. A seventh would have had to
+    remember it, and a default that is written down six times is a default that disagrees with
+    itself eventually -- which is exactly what the numeric-default check exists to catch one layer
+    up. Sites that deliberately report the RAW configured string, rather than dispatch on it, still
+    read the variable directly and should: they are answering "what is set", not "what will run".
+    """
+    return os.environ.get("MATRIXARK_EMBEDDING_PROVIDER", "deterministic").strip().lower()
+
 
 
 def _deterministic_embedding_for_text(text: str) -> list[float]:


### PR DESCRIPTION
`MATRIXARK_EMBEDDING_PROVIDER` is read at thirteen places. **Six of them dispatch on it** and
spelled out the same expression character for character, each repeating the default:

```python
os.environ.get("MATRIXARK_EMBEDDING_PROVIDER", "deterministic").strip().lower()
```

A seventh would have had to remember all of it, and a default written down six times is one that
disagrees with itself eventually — the drift the numeric-default check exists to catch one layer
up. Now there is one accessor and the six sites call it.

The four spellings that select the in-process encoder (`oss`, `open_source`,
`sentence_transformers`, `sentence-transformers`) were also written out **four times in the same
module**, so a new spelling could reach one dispatch and miss the others. They are a named set now.

### Read per call, never a module constant

A constant resolves once at import and a later write to the environment cannot reach it — the
difference between a setting the portal calls live and one that only looks live. Verified both
ways:

```
default            -> deterministic
after a live write -> voyage      ("  VOYAGE  " normalises)
after removal      -> deterministic
```

### The seven sites left alone are left alone deliberately

- **three** report the *raw* configured string rather than dispatching on it — they answer "what is
  set", not "what will run";
- **two** save and restore the variable around a temporary override;
- **two** normalise with `.strip()` alone.

Folding those into the dispatch rule would change what they do.

### And what is not touched

`embedding_model_name()` exists in **both** modules with different default models
(`all-MiniLM-L6-v2` vs `multilingual-e5-large`). That is an open question needing a backfill
decision, not something to tidy up in passing — so core also keeps its own copy of the provider
set rather than importing a private name from the module it lazily imports.

### Checks

Behaviour is identical: no default moves, no value changes.

| | |
|---|---|
| embedding / vector / encoder / model / retrieval / pack / gateway / config guards | **633 tests, OK** |
| mutation: drop `.strip().lower()` from the new accessor | **FAILED** — so the centralised behaviour is covered, not merely moved |
