### PR TITLE
Twelve cache sweeps looked for entries nothing ever writes

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -3694,7 +3694,12 @@ fn invalidate_context_record(cache: &MultiLayerCache, shard_id: ShardId, key: &s
 fn invalidate_record_all(cache: &MultiLayerCache, shard_id: ShardId, key: &str) {
     let _ = cache.invalidate(&CacheKey::string(shard_id, key));
     let _ = cache.invalidate_record(shard_id, "hash", key);
-    let _ = cache.invalidate_record(shard_id, "set", key);
+    // A set has exactly ONE cacheable entry -- `CacheKey::set_members` fixes the selector at
+    // "members" -- so naming it is equivalent to sweeping for it, and a sweep is
+    // `invalidate_record`, which walks every key in all three cache tiers.
+    let _ = cache.invalidate(&CacheKey::set_members(shard_id, key));
+    // `hash` and `feature` keep their sweeps: a hash caches one entry per FIELD and a feature
+    // one per query window, so neither has a single key to name.
     let _ = cache.invalidate_record(shard_id, "feature", key);
 }
 

--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -713,7 +713,7 @@ pub(crate) fn execute_on_shard(
                     .insert(member.clone(), address);
                 mutated = true;
             }
-            let _ = cache.invalidate_record(shard_id, "set", &key);
+            let _ = cache.invalidate(&CacheKey::set_members(shard_id, &key));
             CommandResponse::Empty
         }
         Command::ZSetAdd { key, member, score } => {
@@ -764,7 +764,6 @@ pub(crate) fn execute_on_shard(
                     .insert(member.clone(), (biased, address));
                 mutated = true;
             }
-            let _ = cache.invalidate_record(shard_id, "zset", &key);
             CommandResponse::Integer {
                 value: i64::from(existed.is_none()),
             }
@@ -772,7 +771,6 @@ pub(crate) fn execute_on_shard(
         Command::ZSetScore { key, member } => {
             if remove_if_expired(shard, &key) {
                 mutated = true;
-                let _ = cache.invalidate_record(shard_id, "zset", &key);
                 return ExecuteOutcome {
                     response: CommandResponse::Bytes { value: None },
                     mutated,
@@ -800,7 +798,6 @@ pub(crate) fn execute_on_shard(
                     if shard.zsets.get(&key).is_some_and(BTreeMap::is_empty) {
                         shard.zsets.remove(&key);
                     }
-                    let _ = cache.invalidate_record(shard_id, "zset", &key);
                     CommandResponse::Integer { value: 1 }
                 }
             }
@@ -808,7 +805,6 @@ pub(crate) fn execute_on_shard(
         Command::ZSetCard { key } => {
             if remove_if_expired(shard, &key) {
                 mutated = true;
-                let _ = cache.invalidate_record(shard_id, "zset", &key);
                 return ExecuteOutcome {
                     response: CommandResponse::Integer { value: 0 },
                     mutated,
@@ -1051,7 +1047,6 @@ pub(crate) fn execute_on_shard(
                 );
                 mutated = true;
             }
-            let _ = cache.invalidate_record(shard_id, "zset", &key);
             CommandResponse::Bytes {
                 value: Some(zset_score_string(biased).into_bytes()),
             }
@@ -1059,7 +1054,6 @@ pub(crate) fn execute_on_shard(
         Command::ZSetPop { key, min, count } => {
             if remove_if_expired(shard, &key) {
                 mutated = true;
-                let _ = cache.invalidate_record(shard_id, "zset", &key);
                 return ExecuteOutcome {
                     response: CommandResponse::Members {
                         members: Vec::new(),
@@ -1087,7 +1081,6 @@ pub(crate) fn execute_on_shard(
                 shard.zsets.remove(&key);
             }
             if mutated {
-                let _ = cache.invalidate_record(shard_id, "zset", &key);
             }
             CommandResponse::Members { members }
         }
@@ -1167,14 +1160,12 @@ pub(crate) fn execute_on_shard(
                     .insert(seq, address);
                 mutated = true;
             }
-            let _ = cache.invalidate_record(shard_id, "list", &key);
             let length = shard.lists.get(&key).map_or(0, BTreeMap::len) as i64;
             CommandResponse::Integer { value: length }
         }
         Command::ListPop { key, left } => {
             if remove_if_expired(shard, &key) {
                 mutated = true;
-                let _ = cache.invalidate_record(shard_id, "list", &key);
                 return ExecuteOutcome {
                     response: CommandResponse::Bytes { value: None },
                     mutated,
@@ -1197,7 +1188,6 @@ pub(crate) fn execute_on_shard(
                     if shard.lists.get(&key).is_some_and(BTreeMap::is_empty) {
                         shard.lists.remove(&key);
                     }
-                    let _ = cache.invalidate_record(shard_id, "list", &key);
                     CommandResponse::Bytes {
                         value: read_page_bytes(cache, page_store, shard_id, &address),
                     }
@@ -1207,7 +1197,6 @@ pub(crate) fn execute_on_shard(
         Command::ListRange { key, start, stop } => {
             if remove_if_expired(shard, &key) {
                 mutated = true;
-                let _ = cache.invalidate_record(shard_id, "list", &key);
                 return ExecuteOutcome {
                     response: CommandResponse::Members {
                         members: Vec::new(),
@@ -1259,7 +1248,6 @@ pub(crate) fn execute_on_shard(
         Command::ListLen { key } => {
             if remove_if_expired(shard, &key) {
                 mutated = true;
-                let _ = cache.invalidate_record(shard_id, "list", &key);
                 return ExecuteOutcome {
                     response: CommandResponse::Integer { value: 0 },
                     mutated,
@@ -1272,7 +1260,7 @@ pub(crate) fn execute_on_shard(
         Command::SetMembers { key } => {
             if remove_if_expired(shard, &key) {
                 mutated = true;
-                let _ = cache.invalidate_record(shard_id, "set", &key);
+                let _ = cache.invalidate(&CacheKey::set_members(shard_id, &key));
                 return ExecuteOutcome {
                     response: CommandResponse::Members {
                         members: Vec::new(),
@@ -1302,7 +1290,7 @@ pub(crate) fn execute_on_shard(
             if let Some(set) = shard.sets.get_mut(&key) {
                 mutated |= set.remove(&member).is_some();
             }
-            let _ = cache.invalidate_record(shard_id, "set", &key);
+            let _ = cache.invalidate(&CacheKey::set_members(shard_id, &key));
             CommandResponse::Empty
         }
         Command::FeatureAppend { key, points } => {

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -14751,6 +14751,102 @@ fn a_no_page_command_in_a_batch_does_not_rebuild_the_index() {
     );
 }
 
+/// Which cache namespaces a record can actually end up in.
+///
+/// `invalidate_record` walks EVERY key in all three cache tiers and filters, so each call costs
+/// more as the cache fills. Three of the namespaces it was being called for did not need a walk:
+///
+/// - `list` and `zset` have no `CacheKey` constructor at all, so nothing ever puts an entry in
+///   them and every sweep for one walked the whole cache to match nothing. Those calls are gone.
+/// - `set` has exactly one possible entry per record -- `CacheKey::set_members` fixes the selector
+///   at `members` -- so naming that key is equivalent to sweeping for it, and O(1) instead.
+///
+/// `hash` and `feature` keep their sweeps: a hash caches one entry per field and a feature one per
+/// query window, so neither has a single key to name.
+///
+/// This holds those premises. If a `list` or `zset` entry ever appears, the removed invalidations
+/// were load bearing after all; if a `set` entry ever appears under another selector, the narrowed
+/// one stops being equivalent.
+#[test]
+fn the_cache_namespaces_a_record_can_actually_use() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        32 * 1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+
+    // Write and then READ each collection kind: a read is what populates the record caches, so
+    // writing alone would leave every namespace empty and prove nothing.
+    for command in [
+        Command::ListPush { key: "l".to_string(), member: b"a".to_vec(), left: false },
+        Command::ListRange { key: "l".to_string(), start: 0, stop: -1 },
+        Command::ListLen { key: "l".to_string() },
+        Command::ZSetAdd { key: "z".to_string(), member: b"m".to_vec(), score: 1.0 },
+        Command::ZSetScore { key: "z".to_string(), member: b"m".to_vec() },
+        Command::ZSetCard { key: "z".to_string() },
+        Command::SetAdd { key: "s".to_string(), member: b"m".to_vec() },
+        Command::SetMembers { key: "s".to_string() },
+        Command::HashSet { key: "h".to_string(), field: "f".to_string(), value: b"v".to_vec() },
+        Command::HashGet { key: "h".to_string(), field: "f".to_string() },
+    ] {
+        let out = engine.execute(ExecuteRequest { shard_id: 1, command });
+        assert!(out.status.ok, "{:?}", out.status);
+    }
+
+    let entries = engine.cache.entries_for_shard(1);
+    let in_namespace = |name: &str| -> Vec<String> {
+        entries
+            .iter()
+            .filter(|entry| entry.namespace == name)
+            .map(|entry| format!("{}/{}", entry.record_key, entry.selector))
+            .collect()
+    };
+
+    // The positive control comes FIRST, because everything below is an emptiness claim and an
+    // empty view would satisfy all of them at once.
+    assert!(
+        !in_namespace("hash").is_empty(),
+        "no hash entry was cached, so this view cannot show that list and zset are empty"
+    );
+
+    assert!(
+        in_namespace("list").is_empty(),
+        "a list entry reached the cache, so removing the list invalidations leaves it stale: {:?}",
+        in_namespace("list")
+    );
+    assert!(
+        in_namespace("zset").is_empty(),
+        "a zset entry reached the cache, so removing the zset invalidations leaves it stale: {:?}",
+        in_namespace("zset")
+    );
+
+    // A set caches exactly one entry, under one selector, which is what makes naming it
+    // equivalent to sweeping for it.
+    let sets = in_namespace("set");
+    assert!(
+        sets.iter().all(|entry| entry.ends_with("/members")),
+        "a set cached an entry under a selector other than `members`, so naming one key no          longer covers the record: {sets:?}"
+    );
+
+    // And the narrowed call really does remove it.
+    if !sets.is_empty() {
+        let _ = engine
+            .cache
+            .invalidate(&matrixcache::CacheKey::set_members(1, "s"));
+        assert!(
+            engine
+                .cache
+                .entries_for_shard(1)
+                .iter()
+                .all(|entry| entry.namespace != "set"),
+            "invalidating the one set key left a set entry behind"
+        );
+    }
+}
+
 /// A context write leaves nothing in the `hash`, `set` or `feature` cache namespaces.
 ///
 /// This is the premise `invalidate_context_record` rests on. `invalidate_record_all` sweeps those


### PR DESCRIPTION
`MultiLayerCache::invalidate_record` walks **every key in all three cache tiers** and filters, so each call costs more as the cache fills. Three of the namespaces it was being called for did not need a walk at all.

## `list` and `zset`: 12 sweeps that can never match

The cache's `CacheKey` constructors produce `string`, `hash`, `set`, `feature` and `page` — **there is no `list` or `zset` constructor**, so an entry in those namespaces cannot exist. The twelve calls sweeping for one walked the whole cache, matched nothing, and did it again on the next command.

Seven are on write paths: `ListPush`, `ZSetAdd`, `ZSetRemove`, `ZSetIncrBy`, `ZSetPop`. (The others sit behind `remove_if_expired`, so they only fired on an expiry.) Removed.

## `set`: 4 sweeps that had exactly one thing to find

`CacheKey::set_members` fixes the selector at `members`, so a set has exactly one cacheable entry per record. Naming that key is equivalent to sweeping for it, and is a hash lookup instead of a walk. Narrowed — including the call inside `invalidate_record_all`, which every generic invalidation goes through.

## What is deliberately left alone

`hash` and `feature` keep their sweeps: a hash caches one entry per **field** and a feature one per **query window**, so neither has a single key to name. Fixing those needs an index inside the cache itself, which is a change to MatrixCache rather than here.

## The test holds the premises, not the conclusion

`the_cache_namespaces_a_record_can_actually_use` exercises every collection kind and **reads each back** — a read is what populates a record cache, so writing alone would leave every namespace empty and prove nothing. It asserts a hash entry exists **first**, because everything after it is an emptiness claim and an empty view would satisfy all of them at once.

If a `list` or `zset` entry ever appears, the removed invalidations were load bearing after all. If a `set` entry appears under another selector, the narrowed one stops being equivalent. Either way the test says so.

Found by asking the question #970 raised: which namespaces can a record actually be cached in?