### PR TITLE
Offer encoders the provider can serve, without touching the measurement

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1494,6 +1494,23 @@ _STORE_SENTINELS = {"", "local", "none", "standalone", "off"}
 # These are measurements on ONE corpus of technical documentation with English and Chinese queries.
 # They rank these models on that corpus; they do not promise the same ranking on a different one,
 # which is why the portal presents them as evidence rather than as a recommendation to apply blindly.
+# Encoders a HOSTED provider serves. Deliberately not rows in _ENCODER_CATALOG: every entry there
+# carries hit@1 and throughput measured by encoding a real corpus on this machine, which is only
+# possible for a model we run. Giving these numbers they do not have would put invented figures in
+# the comparison table, sorted and marked "best" against measured ones -- so they are named here and
+# offered as choices, and the table stays what it is.
+#
+# Each name is one the code already uses: the encoder's own default for that provider, or a preset.
+_HOSTED_ENCODERS = [
+    {"model": "voyage-3", "serves": "voyage", "dim": 1024,
+     "note": "Voyage's general encoder, and what this build asks for when the provider is Voyage."},
+    {"model": "text-embedding-3-small", "serves": "openai", "dim": 1536,
+     "note": "OpenAI's cheaper encoder; what the OpenAI preset configures."},
+    {"model": "text-embedding-3-large", "serves": "openai", "dim": 3072,
+     "note": "OpenAI's stronger encoder, and what this build asks for on an OpenAI-compatible "
+             "endpoint that names no model."},
+]
+
 _ENCODER_CATALOG = [
     {
         "id": "intfloat/multilingual-e5-large",
@@ -1561,6 +1578,38 @@ def encoder_catalog() -> list:
     return out
 
 
+def _encoder_applies(provider: str) -> bool:
+    """Whether a SELF-HOSTED encoder is something this provider could run.
+
+    An OpenAI-compatible endpoint is the one value covering two worlds -- OpenAI itself and a local
+    server behind the same protocol, which is what the MiniLM preset configures -- so it keeps them.
+    A hosted-only provider cannot serve a repository id at all.
+    """
+    effect = _gwconfig.embedding_provider_effect(provider)
+    if effect == "hash":
+        return True  # nothing chosen yet; narrowing towards nothing helps no one
+    if effect == "local_model":
+        return True
+    return (provider or "").strip().lower() != "voyage"
+
+
+def _hosted_encoders_for(provider: str) -> List[Json]:
+    """Encoders the provider serves itself, with no measurement to show for them.
+
+    An in-process encoder gets NONE: it loads a model rather than calling one, so a hosted name is
+    not a thing it could be pointed at. Nothing chosen yet gets all of them, because narrowing
+    towards nothing helps no one.
+    """
+    name = (provider or "").strip().lower()
+    effect = _gwconfig.embedding_provider_effect(name)
+    if effect == "local_model":
+        return []
+    if effect != "api":
+        return [dict(row) for row in _HOSTED_ENCODERS]
+    wanted = "voyage" if name == "voyage" else "openai"
+    return [dict(row) for row in _HOSTED_ENCODERS if row["serves"] == wanted]
+
+
 def _model_picker_body(target: str) -> Json:
     """The part of /v1/admin/models that needs no network: which setting a pick belongs in, what is
     in that setting now, and the suggestions for the selected provider.
@@ -1575,13 +1624,23 @@ def _model_picker_body(target: str) -> Json:
     """
     setting_key = ("embedding.model" if target == "embedding"
                    else _gwconfig.extraction_model_setting())
-    return {
+    body: Json = {
         "target": target,
         "key": setting_key,
         "catalogue": (embedding_picker_catalogue() if target == "embedding"
                       else _gwconfig.model_catalogue(target)),
         "current": os.environ.get(_gwconfig.SETTINGS_BY_KEY[setting_key].env, "").strip(),
     }
+    if target == "embedding":
+        # `applicable` narrows what is OFFERED without narrowing what is SHOWN. The measured table
+        # is evidence -- a deployment on Voyage is still entitled to see what self-hosting would
+        # score -- but offering it five models it cannot serve, and none it can, is the defect.
+        provider = os.environ.get("MATRIXARK_EMBEDDING_PROVIDER", "")
+        applies = _encoder_applies(provider)
+        for row in body["catalogue"]:
+            row["applicable"] = applies
+        body["provider_models"] = _hosted_encoders_for(provider)
+    return body
 
 
 def _model_config_snapshot() -> Json:

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -1622,7 +1622,16 @@ SETUP_JS = r"""
     ((d.discovered || {}).models || []).forEach(function (m) {
       push(m, "offered by the configured endpoint");
     });
+    /* What the provider serves itself. These carry no measurement and never will -- the numbers
+       in the table come from encoding a corpus on this machine -- so they are listed as choices
+       with their note, and stay out of the comparison. */
+    (d.provider_models || []).forEach(function (c) {
+      push(c.model, c.note || (c.dim ? c.dim + " dimensions" : ""));
+    });
     (d.catalogue || []).forEach(function (c) {
+      /* Shown in the table, not offered in the dropdown: a deployment on a hosted encoder cannot
+         serve a self-hosted one, and picking it would configure a model that is never reached. */
+      if (c.applicable === false) { return; }
       /* The width collision belongs in the option text, not in a footnote: it is the reason a
          switch that looks harmless is not. Two encoders of the same width raise no error. */
       var same = (c.same_width_as || []).length

--- a/tools/portal/encoder_options_harness.js
+++ b/tools/portal/encoder_options_harness.js
@@ -1,0 +1,109 @@
+/* Run the setup page's modelOptions and see which encoders it OFFERS.
+ *
+ * The measured catalogue is five self-hosted models, and the numbers beside them come from encoding
+ * a real corpus on the machine that runs them. A deployment on Voyage cannot serve any of them, and
+ * was offered all five and none of the ones it can.
+ *
+ * The fix is a split, not a filter on one list: `applicable` narrows what is OFFERED without
+ * narrowing what is SHOWN, so the comparison table still answers "what would self-hosting score".
+ * That distinction only exists in the dropdown builder, so it is pulled out of the BUILT page and
+ * executed here.
+ *
+ * Usage: node encoder_options_harness.js <setup_portal.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+const start = page.indexOf("function modelOptions(target) {");
+if (start < 0) { console.log("FAIL modelOptions is not on the page"); process.exit(1); }
+const end = page.indexOf("\n  }", start);
+if (end < 0) { console.log("FAIL no end for modelOptions"); process.exit(1); }
+const source = page.slice(start, end + 4);
+
+function options(routeBody) {
+  const modelData = { embedding: routeBody };
+  const scope = new Proxy({}, {
+    has: () => true,
+    get: (_t, name) => {
+      if (name === Symbol.unscopables) { return undefined; }
+      if (name === "modelData") { return modelData; }
+      if (name in globalThis) { return globalThis[name]; }
+      return () => "";
+    }
+  });
+  const NL = String.fromCharCode(10);
+  const body = "return function build() {" + NL + source + NL +
+    "return modelOptions('embedding');" + NL + "};";
+  return new Function("scope", "with (scope) { " + body + " }")(scope)();
+}
+
+const MEASURED = [
+  { model: "intfloat/multilingual-e5-large", dim: 512, hit_at_1: 76.2, texts_per_s: 1.7,
+    note: "best measured", same_width_as: [] },
+  { model: "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2", dim: 384, hit_at_1: 59.4,
+    texts_per_s: 31.7, note: "fastest", same_width_as: [] }
+];
+
+/* 1. Voyage: the measured rows are not offered, and what Voyage serves is. */
+let names = options({
+  current: "", catalogue: MEASURED.map((m) => Object.assign({}, m, { applicable: false })),
+  provider_models: [{ model: "voyage-3", note: "Voyage's general encoder." }]
+}).map((o) => o.model);
+ok("a self-hosted encoder is not offered to a hosted provider",
+   !names.some((n) => n.indexOf("/") >= 0), JSON.stringify(names));
+ok("what the provider serves is offered", names.indexOf("voyage-3") >= 0, JSON.stringify(names));
+
+/* 2. The note survives, because a name with nothing beside it is a guess. */
+let entries = options({
+  current: "", catalogue: [],
+  provider_models: [{ model: "voyage-3", note: "Voyage's general encoder." }]
+});
+ok("a hosted encoder carries its note",
+   entries.length === 1 && /Voyage's general encoder/.test(entries[0].note),
+   JSON.stringify(entries));
+
+/* 3. An OpenAI-compatible endpoint keeps both worlds. */
+names = options({
+  current: "", catalogue: MEASURED.map((m) => Object.assign({}, m, { applicable: true })),
+  provider_models: [{ model: "text-embedding-3-small", note: "cheaper" }]
+}).map((o) => o.model);
+ok("a self-hosted encoder is still offered where it can run",
+   names.filter((n) => n.indexOf("/") >= 0).length === 2, JSON.stringify(names));
+ok("and the hosted one alongside it", names.indexOf("text-embedding-3-small") >= 0,
+   JSON.stringify(names));
+
+/* 4. The floor. A build that offered nothing would pass every "is not offered" check above. */
+names = options({ current: "", catalogue: MEASURED, provider_models: [] }).map((o) => o.model);
+ok("a route that says nothing about applicability offers everything", names.length === 2,
+   JSON.stringify(names));
+
+/* 5. The configured model is always offered, even when its provider would not list it -- a
+      deployment already pointed at something must be able to see what that is. */
+entries = options({
+  current: "intfloat/multilingual-e5-large",
+  catalogue: MEASURED.map((m) => Object.assign({}, m, { applicable: false })),
+  provider_models: [{ model: "voyage-3", note: "" }]
+});
+ok("the model in use is still listed",
+   entries.some((o) => o.model === "intfloat/multilingual-e5-large"),
+   JSON.stringify(entries.map((o) => o.model)));
+
+/* 6. What the endpoint itself reported is not filtered: it comes from asking the live provider,
+      so it is by definition something that provider serves. */
+names = options({
+  current: "", catalogue: [], provider_models: [],
+  discovered: { models: ["voyage-3-lite"] }
+}).map((o) => o.model);
+ok("a model the endpoint reported is offered", names.indexOf("voyage-3-lite") >= 0,
+   JSON.stringify(names));
+
+console.log(failures ? "\n" + failures + " failure(s)" : "\nall ok");
+process.exit(failures ? 1 : 0);

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -1337,7 +1337,16 @@ function liveStream(options) {
     ((d.discovered || {}).models || []).forEach(function (m) {
       push(m, "offered by the configured endpoint");
     });
+    /* What the provider serves itself. These carry no measurement and never will -- the numbers
+       in the table come from encoding a corpus on this machine -- so they are listed as choices
+       with their note, and stay out of the comparison. */
+    (d.provider_models || []).forEach(function (c) {
+      push(c.model, c.note || (c.dim ? c.dim + " dimensions" : ""));
+    });
     (d.catalogue || []).forEach(function (c) {
+      /* Shown in the table, not offered in the dropdown: a deployment on a hosted encoder cannot
+         serve a self-hosted one, and picking it would configure a model that is never reached. */
+      if (c.applicable === false) { return; }
       /* The width collision belongs in the option text, not in a footnote: it is the reason a
          switch that looks harmless is not. Two encoders of the same width raise no error. */
       var same = (c.same_width_as || []).length

--- a/tools/test_matrixark_the_encoder_picker_offers_what_the_provider_serves.py
+++ b/tools/test_matrixark_the_encoder_picker_offers_what_the_provider_serves.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The encoder picker offers encoders the selected provider can actually serve.
+
+Every entry in the measured catalogue is a model the deployment RUNS -- the hit@1 and throughput
+figures come from encoding a real corpus on the machine that runs it, which is only possible for a
+model we host. A deployment on Voyage was offered all five of them and none of the ones Voyage
+serves.
+
+The fix is a split rather than a filter on one list, because the obvious shape breaks a deliberate
+rule. `test_matrixark_models` requires that the picker serves the MEASURED catalogue and nothing
+else, and that every row in it carries the numbers a choice is made on -- a rule that exists because
+a hand-written list beside the measured one drifted, omitting the whole e5 family and recommending
+the encoder fifteen points of hit@1 behind. Adding unmeasured rows to `catalogue` would have relaxed
+that; giving them invented numbers would have been worse, because the comparison table sorts and
+marks a "best" column.
+
+So `catalogue` is untouched -- it is evidence, and a deployment on a hosted encoder is still
+entitled to see what self-hosting would score. `applicable` narrows what is OFFERED, and
+`provider_models` carries what the provider serves instead, with notes and no measurements. Which of
+those the dropdown shows is decided in the page, so `portal/encoder_options_harness.js` runs that
+code out of the built page.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+
+try:
+    from tools import matrixark_v1_gateway as gw  # type: ignore
+except ImportError:
+    import matrixark_v1_gateway as gw  # type: ignore
+
+cfg = gw._gwconfig
+
+PARTICIPATING = ("MATRIXARK_EMBEDDING_PROVIDER", "MATRIXARK_EMBEDDING_MODEL",
+                 "MATRIXARK_EMBEDDING_API_BASE")
+
+
+class Case(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self._saved = {n: os.environ.get(n) for n in PARTICIPATING}
+        for name in PARTICIPATING:
+            os.environ.pop(name, None)
+
+    def tearDown(self) -> None:
+        for name, value in self._saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+    def body(self, provider: str) -> dict:
+        os.environ["MATRIXARK_EMBEDDING_PROVIDER"] = provider
+        return gw._model_picker_body("embedding")
+
+    def offered(self, provider: str) -> list:
+        return [row["model"] for row in self.body(provider)["catalogue"]
+                if row.get("applicable") is not False]
+
+    def hosted(self, provider: str) -> list:
+        return [row["model"] for row in self.body(provider)["provider_models"]]
+
+
+class TheMeasuredCatalogueIsUntouchedTest(Case):
+    """The rule this change had to work within, asserted here so a later simplification that folds
+    the two lists together fails against the reason rather than against a style preference."""
+
+    def test_every_row_still_carries_its_measurement(self) -> None:
+        for provider in ("voyage", "openai_compatible", "deterministic"):
+            for row in self.body(provider)["catalogue"]:
+                with self.subTest(provider=provider, model=row["model"]):
+                    self.assertIsInstance(row["hit_at_1"], (int, float))
+                    self.assertGreater(row["hit_at_1"], 0)
+
+    def test_the_evidence_is_shown_even_where_it_cannot_be_used(self) -> None:
+        """A deployment on Voyage is still entitled to see what self-hosting would score."""
+        self.assertEqual(len(self.body("openai_compatible")["catalogue"]),
+                         len(self.body("voyage")["catalogue"]))
+
+    def test_no_hosted_encoder_carries_a_measurement(self) -> None:
+        """Invented numbers would be sorted and marked "best" against measured ones."""
+        for row in gw._HOSTED_ENCODERS:
+            for field in ("hit_at_1", "hit_at_5", "texts_per_s", "vectors_mb_per_doc"):
+                with self.subTest(model=row["model"], field=field):
+                    self.assertNotIn(field, row)
+
+
+class TheOfferMatchesWhatTheProviderCanServeTest(Case):
+
+    def test_a_hosted_provider_is_not_offered_a_self_hosted_encoder(self) -> None:
+        self.assertEqual([], [name for name in self.offered("voyage") if "/" in name])
+
+    def test_it_is_offered_what_that_provider_serves(self) -> None:
+        self.assertEqual(["voyage-3"], self.hosted("voyage"))
+
+    def test_an_openai_compatible_endpoint_keeps_both_worlds(self) -> None:
+        """One provider value covers OpenAI itself and a local server behind the same protocol,
+        which is what the MiniLM preset configures. Narrowing to either would be wrong."""
+        self.assertTrue([name for name in self.offered("openai_compatible") if "/" in name])
+        self.assertIn("text-embedding-3-small", self.hosted("openai_compatible"))
+        self.assertNotIn("voyage-3", self.hosted("openai_compatible"))
+
+    def test_an_in_process_encoder_is_offered_no_hosted_name(self) -> None:
+        """It loads a model rather than calling one, so a hosted name is not something it could be
+        pointed at."""
+        self.assertEqual([], self.hosted("oss"))
+        self.assertTrue([name for name in self.offered("oss") if "/" in name])
+
+    def test_nothing_chosen_yet_narrows_nothing(self) -> None:
+        for provider in ("deterministic", "cohere", ""):
+            with self.subTest(provider=provider):
+                self.assertTrue([name for name in self.offered(provider) if "/" in name])
+                self.assertEqual(len(gw._HOSTED_ENCODERS), len(self.hosted(provider)))
+
+    def test_every_hosted_name_is_one_the_code_already_uses(self) -> None:
+        """Not written from general knowledge: each is the encoder's own default for that provider,
+        or a preset. An invented name is a model nobody can check."""
+        with open(os.path.join(TOOLS, "matrixark_mcp_embeddings.py"), encoding="utf-8") as handle:
+            encoder = handle.read()
+        preset_models = {str(preset["values"].get("embedding.model", ""))
+                         for preset in cfg.PRESETS.values()}
+        for row in gw._HOSTED_ENCODERS:
+            with self.subTest(model=row["model"]):
+                self.assertTrue(row["model"] in encoder or row["model"] in preset_models,
+                                "%s is named nowhere in the code" % row["model"])
+
+    def test_the_extraction_side_gains_neither_field(self) -> None:
+        """These two only mean something for encoders; carrying them on the other target would be a
+        field the page has to learn to ignore."""
+        body = gw._model_picker_body("extraction")
+        self.assertNotIn("provider_models", body)
+        self.assertTrue(all("applicable" not in row for row in body["catalogue"]))
+
+
+class ThePageOffersWhatTheRouteMarkedTest(unittest.TestCase):
+    """`applicable` only means anything if the dropdown reads it, and that is page code."""
+
+    def test_the_harness_passes(self) -> None:
+        node = shutil.which("node")
+        if node is None:
+            self.skipTest("node is not available")
+        result = subprocess.run(
+            [node, os.path.join(PORTAL, "encoder_options_harness.js"),
+             os.path.join(PORTAL, "setup_portal.html")],
+            capture_output=True, text=True, timeout=120)
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertIn("all ok", result.stdout)
+
+    def test_the_built_page_carries_the_change(self) -> None:
+        """The page is generated; a change made only to the generator ships nothing."""
+        with open(os.path.join(PORTAL, "setup_portal.html"), encoding="utf-8") as handle:
+            page = handle.read()
+        self.assertIn("d.provider_models", page)
+        self.assertIn("c.applicable === false", page)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Every entry in the measured encoder catalogue is a model the deployment **runs** — the hit@1 and
throughput figures come from encoding a real corpus on the machine that runs it, which is only
possible for a model we host.

A deployment on Voyage was offered all five of them, and none of the ones Voyage serves.

### Why this is a split and not a filter

The obvious shape — add `voyage-3` and the OpenAI encoders to `catalogue` — breaks a deliberate rule
in `test_matrixark_models`:

> the picker serves the MEASURED catalogue, not a second list … every encoder carries the numbers a
> choice is made on

That rule exists because a hand-written list beside the measured one drifted: it omitted the whole
e5 family — the models that scored best — and recommended the encoder the measurement puts fifteen
points of hit@1 behind. Relaxing it would reopen exactly that. Giving the hosted encoders invented
numbers would be worse: the comparison table sorts on hit@1 and marks a "best" column, so a made-up
figure would be ranked against measured ones.

So the measured catalogue is untouched. It is **evidence**, and a deployment on a hosted encoder is
still entitled to see what self-hosting would score.

- `applicable` narrows what is **offered** without narrowing what is **shown**.
- `provider_models` carries what the provider serves instead — with notes, and no measurements.

An in-process encoder (`oss`) gets none of the hosted names: it loads a model rather than calling
one, so a hosted name is not something it could be pointed at. A provider that encodes nothing yet
gets everything — narrowing towards nothing helps no one.

```
the shipped bug: nothing is marked inapplicable              -> FAIL 1
the provider's own encoders are not offered                  -> FAIL 5
voyage is told it can run a self-hosted encoder              -> FAIL 1
an in-process encoder is offered hosted names                -> FAIL 1
an openai-compatible endpoint loses the models it can run    -> FAIL 1
a hosted entry is given a measurement it does not have       -> FAIL 4
a hosted entry is invented rather than taken from the code   -> FAIL 2
the catalogue is FILTERED instead of marked                  -> FAIL 1
the page offers what the route marked inapplicable           -> FAIL 2
the page ignores what the provider serves                    -> FAIL 2
```

The eighth is the one that matters: filtering `catalogue` instead of marking it is the shape this
change deliberately avoided, and it fails.

Each hosted name is one the code already uses — the encoder's own default for that provider, or a
preset — so none of them is a model nobody can check.

Which of the two lists the dropdown shows is page code, so `portal/encoder_options_harness.js` pulls
`modelOptions` **out of the built page** and runs it, including the cases that would be easy to get
subtly wrong: the model currently in use is still listed even when its provider would not offer it,
and what the endpoint itself reported is never filtered — it came from asking the live provider, so
by definition that provider serves it.

12 tests here, plus the 32 in `test_matrixark_models` that the design had to keep passing.
Neighbours: the derived list of every suite touching the catalogue, the models route, the built page
or the harnesses — 54, all green — plus all portal- (166), gateway- (258) and config-named (90)
suites, and the 15 siblings that write these environment variables in one process (305 tests).
