### PR TITLE
One place for the shared hook-store default, instead of three

### DIFF
--- a/tools/matrixark_local_backfill_ingester.py
+++ b/tools/matrixark_local_backfill_ingester.py
@@ -57,6 +57,20 @@ AGENTS = {
 }
 
 
+def shared_hook_store_base() -> str:
+    """Where an agent's hook store lives when nothing names one for that agent specifically.
+
+    The path was written out at all three branches below. Three places to correct it in is two
+    places to miss, and a store root that disagrees with itself sends a backfill somewhere the
+    realtime hook is not writing -- which looks like missing data, not like a wrong constant.
+
+    Read per call rather than captured at import, for the same reason every other setting here is:
+    a value resolved once could not be changed by anything that sets it later.
+    """
+    return os.environ.get(
+        "MATRIXARK_SHARED_HOOK_STORE_BASE", "/root/.matrixark/temporalstore-hooks/shared")
+
+
 def agent_root(agent: str) -> str:
     """Resolve the durable Rust hook root for a backfilled agent.
 
@@ -75,7 +89,7 @@ def agent_root(agent: str) -> str:
         return os.path.join(
             os.environ.get(
                 "MATRIXARK_CLAUDE_HOOK_STORE_BASE",
-                os.environ.get("MATRIXARK_SHARED_HOOK_STORE_BASE", "/root/.matrixark/temporalstore-hooks/shared"),
+                shared_hook_store_base(),
             ),
             "rust",
         )
@@ -89,12 +103,12 @@ def agent_root(agent: str) -> str:
         return os.path.join(
             os.environ.get(
                 "MATRIXARK_CODEX_HOOK_STORE_BASE",
-                os.environ.get("MATRIXARK_SHARED_HOOK_STORE_BASE", "/root/.matrixark/temporalstore-hooks/shared"),
+                shared_hook_store_base(),
             ),
             "rust",
         )
     return os.path.join(
-        os.environ.get("MATRIXARK_SHARED_HOOK_STORE_BASE", "/root/.matrixark/temporalstore-hooks/shared"),
+        shared_hook_store_base(),
         "rust",
     )
 


### PR DESCRIPTION
`agent_root` resolves where a backfilled agent's Rust hook store lives. Its three branches each
wrote out the same fallback:

```python
os.environ.get("MATRIXARK_SHARED_HOOK_STORE_BASE", "/root/.matrixark/temporalstore-hooks/shared")
```

Three places to correct that path in is two places to miss — and a store root that disagrees with
itself does not look like a wrong constant. It looks like **missing data**: a backfill lands
somewhere the realtime hook is not writing, and both halves report success.

The accessor reads per call rather than being captured at import, like everything else here — a
value resolved once could not be changed by anything that sets it later.

```
claude / codex / other  -> /root/.matrixark/temporalstore-hooks/shared/rust   (unchanged)
after a live write      -> /tmp/elsewhere/rust                                (all three move)
after removal           -> /root/.matrixark/temporalstore-hooks/shared/rust
```

The module docstring still spells the path out twice, and should: it describes what an operator
will find on disk rather than resolving it.

### Checks

Behaviour identical. The suite covering this file fails **15** tests and errors **1** both with and
without the change — the codex-hook cluster, which is intended and stays exactly as it is.
