### PR TITLE
One rule for the disk-fallback store path, instead of three

### DIFF
--- a/tools/matrixark_http.py
+++ b/tools/matrixark_http.py
@@ -336,6 +336,20 @@ def _hook_decode_value(value: Any) -> str | None:
     return str(value)
 
 
+def _namespace_and_table(args: Json) -> tuple[str, str]:
+    """Which namespace and table a backend addresses: the caller's, else the environment, else the
+    deployment defaults.
+
+    All three readers below resolved this themselves, in the same two lines, and carried their own
+    copy of both default names with them. Renaming a default would have had to be done in three
+    places and would have been right in whichever one the author happened to open.
+    """
+    return (
+        str(args.get("namespace") or os.environ.get("MATRIXARK_NAMESPACE") or "deploy_ns"),
+        str(args.get("table") or os.environ.get("MATRIXARK_TABLE") or "deploy_table"),
+    )
+
+
 class _HookStoreReader:
     name = "unknown"
 
@@ -362,8 +376,7 @@ class _HookStoreReader(_HookStoreReader):
             or repo_root / "output-ubuntu22/release/sdk/lib/libtemporalstore.so"
         )
         metaserver = str(args.get("native_metaserver") or os.environ.get("MATRIXARK_TEMPORALSTORE_METASERVER") or "127.0.0.1:18000")
-        namespace = str(args.get("namespace") or os.environ.get("MATRIXARK_NAMESPACE") or "deploy_ns")
-        table = str(args.get("table") or os.environ.get("MATRIXARK_TABLE") or "deploy_table")
+        namespace, table = _namespace_and_table(args)
         self.client = Client(
             Options(
                 metaserver_addr=metaserver,
@@ -393,8 +406,7 @@ class _RustServiceHookStoreReader(_HookStoreReader):
 
     def __init__(self, args: Json) -> None:
         self.addr = str(args.get("rust_service_addr") or os.environ.get("MATRIXARK_RUST_SERVICE_PROXY_ADDR") or "127.0.0.1:17100")
-        self.namespace = str(args.get("namespace") or os.environ.get("MATRIXARK_NAMESPACE") or "deploy_ns")
-        self.table = str(args.get("table") or os.environ.get("MATRIXARK_TABLE") or "deploy_table")
+        self.namespace, self.table = _namespace_and_table(args)
 
     def _post(self, path: str, payload: Json) -> Json | None:
         try:
@@ -426,8 +438,7 @@ class _RustLocalHookStoreReader(_HookStoreReader):
     def __init__(self, args: Json) -> None:
         repo_root = Path(__file__).resolve().parents[1]
         self.proxy_bin = str(args.get("rust_proxy_bin") or os.environ.get("MATRIXARK_RUST_PROXY_BIN") or repo_root / "target/release/matrixark_rust_proxy")
-        self.namespace = str(args.get("namespace") or os.environ.get("MATRIXARK_NAMESPACE") or "deploy_ns")
-        self.table = str(args.get("table") or os.environ.get("MATRIXARK_TABLE") or "deploy_table")
+        self.namespace, self.table = _namespace_and_table(args)
         self.cwd = str(repo_root)
 
     def _call(self, op: str, **kwargs: Any) -> Json | None:

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -511,6 +511,20 @@ def _note_full_read_fallback(where: str, reason: BaseException) -> None:
         pass
 
 
+def disk_fallback_store_path() -> str:
+    """Where a direct adapter falls back to on disk, or "" when no fallback is configured.
+
+    Two adapters set this in their constructors and a third restores it for an instance that
+    predates the attribute; all three spelled out the same read, including the strip. The strip is
+    the part worth having in one place: a path with a stray newline from a shell export is not the
+    same string as the path, and two of the three would have had to remember to remove it.
+
+    Read per call rather than captured at import, so a deployment that sets the variable after this
+    module loads still gets it.
+    """
+    return os.environ.get("MATRIXARK_TEMPORALSTORE_LOCAL_STORE", "").strip()
+
+
 class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirectBackendMixin, _TemporalDirectWriteMixin, _TemporalDirectReadMixin, _TemporalDirectRetrieveMixin):
     # The base class precedes the mixins in the MRO, so without this the buffered audit
     # implementation the __init__ prepares for (MATRIXARK_DIRECT_AUDIT_MODE, buffer, flusher)
@@ -2934,7 +2948,7 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         self._append_engine_ms_total = 0.0
         self._append_engine_count = 0
         self._disk_fallback_adapter: MatrixArkLocalAdapter | None = None
-        self._disk_fallback_path = os.environ.get("MATRIXARK_TEMPORALSTORE_LOCAL_STORE", "").strip()
+        self._disk_fallback_path = disk_fallback_store_path()
         self._disk_fallback_enabled = bool(self._disk_fallback_path)
         self._disk_fallback_recovery_enabled = bool(self._disk_fallback_path)
         self._disk_fallback_recovery_attempted = False
@@ -3076,7 +3090,7 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         if not hasattr(self, "_disk_fallback_adapter"):
             self._disk_fallback_adapter = None
         if not hasattr(self, "_disk_fallback_path"):
-            self._disk_fallback_path = os.environ.get("MATRIXARK_TEMPORALSTORE_LOCAL_STORE", "").strip()
+            self._disk_fallback_path = disk_fallback_store_path()
         if not hasattr(self, "_disk_fallback_enabled"):
             self._disk_fallback_enabled = bool(self._disk_fallback_path)
         if not hasattr(self, "_disk_fallback_recovery_enabled"):
@@ -4554,7 +4568,7 @@ class MatrixArkTemporalStoreRustAdapter(MatrixArkTemporalStoreDirectAdapter):
         self._retrieval_candidate_cache: dict[str, Json] = {}
         self._retrieval_candidate_cache_lock = threading.RLock()
         self._disk_fallback_adapter: MatrixArkLocalAdapter | None = None
-        self._disk_fallback_path = os.environ.get("MATRIXARK_TEMPORALSTORE_LOCAL_STORE", "").strip()
+        self._disk_fallback_path = disk_fallback_store_path()
         self._disk_fallback_enabled = bool(self._disk_fallback_path)
         self._disk_fallback_write_failures = 0
         self._metaserver = metaserver


### PR DESCRIPTION
Two direct adapters set the fallback path in their constructors and a third restores it for an
instance that predates the attribute. All three spelled out the same read, strip and all.

**The strip is the part worth having in one place.** A path carrying a stray space or newline from
a shell export is not the same string as the path, and two of the three would have had to remember
to remove it — with the failure showing up as a fallback that silently does not find the store it
was pointed at.

Read per call rather than captured at import, so a deployment that sets the variable after this
module loads still gets it:

```
unset            -> ''
'  /tmp/store  ' -> '/tmp/store'
after removal    -> ''
```

### This closes the seam

It is the last of the **six** identical read expressions repeated three or more times inside a
single module. What remains is deliberate and says so in the code — a module that imports nothing
from the project on purpose, and argparse defaults in standalone CLI entry points.

### Checks

Adapter tests: **53, OK**. Broader run over gateway / config / flag / retrieval / embedding /
adapter guards: **501 tests, OK**.
