### PR TITLE
The active log can be written in blocks, one per append batch

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -183,6 +183,18 @@ _DELTA_BLOCK_HEADER_BYTES = 5
 #: are 74.9% of the log and compress 11.91x.
 _SHARD_CONTAINER_MAGIC = b"MASHRD\x01"
 _SHARD_CODEC_ZLIB = b"\x01"
+#: A shard written as a STREAM of blocks rather than one compressed blob. This is the form the
+#: ACTIVE log can take: a sealed shard is finished and compresses whole, but a log is appended to,
+#: and a stream of self-describing blocks is appendable where a single deflate stream is not.
+_SHARD_CODEC_BLOCKS = b"\x02"
+#: Off by default. This is the only change in this family that alters the DURABLE SOURCE OF TRUTH
+#: rather than something derived from it, and the failure it guards against is a real one: a process
+#: appending plain JSON to a block-framed log corrupts it. The form is taken from the file on disk
+#: rather than from this flag (see _log_append_form), so turning it on affects only logs this build
+#: creates, and turning it off again leaves every existing log readable.
+LOCAL_JSONL_BLOCK_LOG = os.environ.get(
+    "MATRIXARK_LOCAL_JSONL_BLOCK_LOG", "0"
+).strip().lower() not in ("0", "false", "no", "off")
 #: On, and reversible: the reader takes either form, so a store written with this on still reads
 #: with it off, and a shard sealed once never needs unsealing.
 LOCAL_JSONL_COMPRESS_SEALED = os.environ.get(
@@ -239,6 +251,48 @@ def _encode_delta_block(records: list[Json]) -> bytes:
         LOCAL_DURABLE_READ_CACHE_COMPRESS_LEVEL,
     )
     return _DELTA_BLOCK_CODEC_ZLIB_ARRAY + len(payload).to_bytes(4, "big") + payload
+
+
+def _encode_log_block(records: list[Json]) -> bytes:
+    """One append batch as one block, its payload one document per line.
+
+    Lines rather than the array the snapshot blocks use, and the reason is this file rather than
+    that one. The log is parsed line-by-line today, so a line payload is neutral where an array
+    would be a second change measured separately; and two of the five shard readers scan for a
+    single record type with a substring test, which a line payload keeps.
+    """
+    payload = zlib.compress(
+        b"\n".join(json.dumps(record, separators=(",", ":")).encode("utf-8")
+                     for record in records),
+        LOCAL_DURABLE_READ_CACHE_COMPRESS_LEVEL,
+    )
+    return _DELTA_BLOCK_CODEC_ZLIB + len(payload).to_bytes(4, "big") + payload
+
+
+def _iter_block_stream_lines(handle):
+    """Every line of a block-stream shard, one block decompressed at a time."""
+    while True:
+        header = handle.read(_DELTA_BLOCK_HEADER_BYTES)
+        if len(header) < _DELTA_BLOCK_HEADER_BYTES:
+            return
+        codec = header[:1]
+        length = int.from_bytes(header[1:], "big")
+        body = handle.read(length)
+        if len(body) < length or codec not in (_DELTA_BLOCK_CODEC_ZLIB,
+                                               _DELTA_BLOCK_CODEC_ZLIB_ARRAY):
+            # A torn final block, or one this build does not know. Both mean the same thing here:
+            # stop, and let the caller work with what came before it -- a half-written append is
+            # exactly what a crash mid-write leaves, and dropping it is what the plain form does
+            # with a half-written line.
+            return
+        decoded = zlib.decompress(body)
+        if codec == _DELTA_BLOCK_CODEC_ZLIB_ARRAY:
+            for record in json.loads(decoded):
+                yield json.dumps(record, separators=(",", ":"))
+            continue
+        for line in decoded.split(b"\n"):
+            if line.strip():
+                yield line.decode("utf-8")
 
 
 def _iter_delta_blocks(raw: bytes):
@@ -351,6 +405,10 @@ def _iter_shard_lines(path: Path):
     with path.open("rb") as handle:
         handle.seek(len(_SHARD_CONTAINER_MAGIC))
         codec = handle.read(1)
+        if codec == _SHARD_CODEC_BLOCKS:
+            for line in _iter_block_stream_lines(handle):
+                yield line
+            return
         if codec != _SHARD_CODEC_ZLIB:
             raise ValueError("unknown sealed-shard codec %r" % codec)
         decompressor = zlib.decompressobj()
@@ -4960,6 +5018,69 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
     def _jsonl_rotated_path(self, index: int) -> Path:
         return self.event_log.with_name(f"{self.event_log.name}.{index}")
 
+    def _log_append_form(self) -> bytes:
+        """Which form to append in: whatever the log ALREADY is, else the configured one.
+
+        Taken from the FILE rather than from the flag. That is what keeps two forms out of one file:
+        a log written by hand -- which is how a good many fixtures are built -- stays plain and is
+        appended to as plain, and a store that crosses the flag changes form only when rotation
+        hands it a new file. Turning the flag off again leaves every existing log readable, because
+        nothing rewrites one.
+        """
+        try:
+            with self.event_log.open("rb") as handle:
+                head = handle.read(len(_SHARD_CONTAINER_MAGIC) + 1)
+        except (FileNotFoundError, OSError):
+            head = b""
+        if head[:len(_SHARD_CONTAINER_MAGIC)] == _SHARD_CONTAINER_MAGIC:
+            return head[len(_SHARD_CONTAINER_MAGIC):len(_SHARD_CONTAINER_MAGIC) + 1]
+        if head:
+            return b""
+        return _SHARD_CODEC_BLOCKS if LOCAL_JSONL_BLOCK_LOG else b""
+
+    def _append_records_to_log(self, jsonl_records: list[Json]) -> None:
+        """Append one batch to the log, in whichever form the log is written.
+
+        BOTH append paths come through here. They used to encode and write separately, which was
+        duplication while there was one form and is a correctness hazard with two -- the same shape
+        of defect the snapshot tail had when only one of its two writers knew about blocks.
+
+        The batch is the block, and that is why this costs no durability: the batch is already the
+        unit acked together, so a crash loses exactly what it loses today. Per-record blocks would
+        be durability-free too and are worth almost nothing -- 1.43x against 9.68x.
+
+        Rotation is decided on the bytes actually written, so a block log holds proportionally more
+        history before rotating. That is a behaviour change and a deliberate one: retention stays a
+        disk budget, and compressing the log spends it on more history rather than on less disk.
+
+        The form is re-read after rotation, because rotation hands back an EMPTY log -- which adopts
+        the configured form, and that need not be the form the old file had.
+        """
+        form = self._log_append_form()
+        block = _encode_log_block(jsonl_records) if form == _SHARD_CODEC_BLOCKS else None
+        lines = ([json.dumps(record, separators=(",", ":")) + "\n" for record in jsonl_records]
+                 if block is None else [])
+        size = len(block) if block is not None else sum(len(line.encode("utf-8")) for line in lines)
+        self._rotate_jsonl_if_needed_locked(size)
+
+        after = self._log_append_form()
+        if after != form:
+            form = after
+            block = _encode_log_block(jsonl_records) if form == _SHARD_CODEC_BLOCKS else None
+            lines = ([json.dumps(record, separators=(",", ":")) + "\n" for record in jsonl_records]
+                     if block is None else [])
+
+        if block is not None:
+            fresh = not self.event_log.exists() or self.event_log.stat().st_size == 0
+            with self.event_log.open("ab") as handle:
+                if fresh:
+                    handle.write(_SHARD_CONTAINER_MAGIC + _SHARD_CODEC_BLOCKS)
+                handle.write(block)
+            return
+        with self.event_log.open("a", encoding="utf-8") as handle:
+            for line in lines:
+                handle.write(line)
+
     def _seal_rotated_shard(self, path: Path) -> None:
         """Store a just-rotated shard compressed.
 
@@ -6158,12 +6279,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 # cached view covers, another writer appended in between and the cached view is
                 # missing their records -- see _update_read_cache_after_append.
                 pre_size = int(self._jsonl_cache_signature_detail().get("total_size", -1))
-                jsonl_records = self._encode_records_for_log(sanitized)
-                jsonl_lines = [json.dumps(item, separators=(",", ":")) + "\n" for item in jsonl_records]
-                self._rotate_jsonl_if_needed_locked(sum(len(line.encode("utf-8")) for line in jsonl_lines))
-                with self.event_log.open("a", encoding="utf-8") as handle:
-                    for line in jsonl_lines:
-                        handle.write(line)
+                self._append_records_to_log(self._encode_records_for_log(sanitized))
                 self._prune_jsonl_retention_locked()
         self._update_latest_entity_cache(records)
         # The read caches hold the fully-expanded (interning-free) view, so serve the sanitized
@@ -6198,12 +6314,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             with self._event_log_lock:
                 # Same interloper capture as append() -- see _update_read_cache_after_append.
                 pre_size = int(self._jsonl_cache_signature_detail().get("total_size", -1))
-                jsonl_records = self._encode_records_for_log(sanitized)
-                jsonl_lines = [json.dumps(record, separators=(",", ":")) + "\n" for record in jsonl_records]
-                self._rotate_jsonl_if_needed_locked(sum(len(line.encode("utf-8")) for line in jsonl_lines))
-                with self.event_log.open("a", encoding="utf-8") as handle:
-                    for line in jsonl_lines:
-                        handle.write(line)
+                self._append_records_to_log(self._encode_records_for_log(sanitized))
                 self._prune_jsonl_retention_locked()
         self._update_latest_entity_cache(records)
         self._update_read_cache_after_append(sanitized, pre_size=pre_size)

--- a/tools/test_matrixark_the_log_is_written_in_blocks.py
+++ b/tools/test_matrixark_the_log_is_written_in_blocks.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The active log can be written as a stream of blocks, one block per append batch.
+
+At 76 KB documents the event log is 95.3% of everything this module writes -- the snapshot, its
+tail and the rotated shards are all compressed now, and the log is the last plain-text artifact.
+Priced against the batches this code really appends (3, 5 and 284 records, recorded by spying on
+append_many):
+
+    plain JSONL (today)                     4,853,970    1.00x
+    one block per RECORD                    3,399,456    1.43x
+    one block per APPEND BATCH                501,381    9.68x
+    one block per 256 records                 485,806    9.99x
+    the whole file at once (a ceiling)        276,828   17.53x
+
+A block per append batch reaches 97% of what fixed 256-record blocks would, and costs NO durability:
+the batch is already the unit acked together, so a crash loses exactly what it loses today.
+
+OFF by default, and this one is not a formality. Every other change in this family compresses
+something DERIVED -- a snapshot, a tail, a sealed shard -- which can always be rebuilt from the log.
+This changes the log itself, and a process appending plain JSON to a block-framed log corrupts it.
+So the form is taken from the file on disk rather than from the flag: an existing log keeps its own
+form, only a fresh one adopts the configured one, and turning the flag off leaves every log readable.
+"""
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools import matrixark_mcp_local_adapter as adapter_module
+from tools.matrixark_mcp_local_adapter import (
+    _SHARD_CODEC_BLOCKS,
+    _SHARD_CONTAINER_MAGIC,
+    _encode_log_block,
+    _iter_shard_lines,
+    loads_with_interned_keys,
+    MatrixArkLocalAdapter,
+    _LOCAL_READ_CACHE,
+    _LOCAL_READ_CACHE_LOCK,
+)
+
+
+def _clear_process_read_cache() -> None:
+    with _LOCAL_READ_CACHE_LOCK:
+        _LOCAL_READ_CACHE.clear()
+
+
+def _records(start: int, count: int) -> list[dict]:
+    return [
+        {
+            "record_type": "context_event",
+            "event_id_hash": index,
+            "text": "event %d " % index + "x" * 300,
+            "nested": {"a": [1, 2, {"b": "c"}], "unicode": "中文 — dash"},
+            "updated_at_ms": 1780000000000 + index,
+        }
+        for index in range(start, start + count)
+    ]
+
+
+class LogIsWrittenInBlocksTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        self.addCleanup(self._dir.cleanup)
+        self.store = Path(self._dir.name)
+        self.log = self.store / "events.jsonl"
+        _clear_process_read_cache()
+        self.addCleanup(_clear_process_read_cache)
+        self.addCleanup(setattr, adapter_module, "LOCAL_JSONL_BLOCK_LOG",
+                        adapter_module.LOCAL_JSONL_BLOCK_LOG)
+
+    def _read_back(self, path: Path) -> list[dict]:
+        return [loads_with_interned_keys(line) for line in _iter_shard_lines(path)
+                if line.strip()]
+
+    def _appended(self, path: Path) -> list[dict]:
+        """Only the records this test appended.
+
+        `_encode_records_for_log` puts intern-dictionary sidecars in the log beside them -- a
+        storage detail, not part of the history -- so a raw line count is one or two more than what
+        was written, and an assertion on it would be measuring the interner.
+        """
+        return [record for record in self._read_back(path)
+                if record.get("record_type") == "context_event"]
+
+    def test_the_log_says_what_it_is_and_is_much_smaller(self):
+        adapter_module.LOCAL_JSONL_BLOCK_LOG = True
+        adapter = MatrixArkLocalAdapter(self.log)
+        adapter.append_many(_records(0, 200))
+        raw = self.log.read_bytes()
+        self.assertTrue(raw.startswith(_SHARD_CONTAINER_MAGIC + _SHARD_CODEC_BLOCKS),
+                        "the log does not declare the block-stream form")
+
+        plain = self.store / "plain.jsonl"
+        with plain.open("w", encoding="utf-8") as handle:
+            for record in self._read_back(self.log):
+                handle.write(json.dumps(record, separators=(",", ":")) + "\n")
+        self.assertLess(len(raw), plain.stat().st_size / 4,
+                        "the block log is not materially smaller, so it is not earning its format")
+
+    def test_the_log_holds_the_same_records_either_way(self):
+        """Checked here rather than end to end: context_index postings compact differently run to
+        run, so a served-record count moves by a dozen for reasons that have nothing to do with the
+        format -- it moved, and then moved back, while this was being written."""
+        batches = [_records(0, 3), _records(3, 5), _records(8, 284)]
+        records = [record for batch in batches for record in batch]
+
+        plain = self.store / "plain.jsonl"
+        with plain.open("w", encoding="utf-8") as handle:
+            for record in records:
+                handle.write(json.dumps(record, separators=(",", ":")) + "\n")
+
+        blocks = self.store / "blocks.jsonl"
+        with blocks.open("wb") as handle:
+            handle.write(_SHARD_CONTAINER_MAGIC + _SHARD_CODEC_BLOCKS)
+            for batch in batches:
+                handle.write(_encode_log_block(batch))
+
+        self.assertEqual(self._read_back(plain), self._read_back(blocks))
+        self.assertEqual(records, self._read_back(blocks))
+
+    def test_one_block_per_append_batch(self):
+        """The durability argument in one assertion.
+
+        A block is only free of durability cost while it is exactly what an append already acked
+        together. A writer that buffered across batches would compress better and would quietly
+        widen the window a crash can lose.
+        """
+        adapter_module.LOCAL_JSONL_BLOCK_LOG = True
+        adapter = MatrixArkLocalAdapter(self.log)
+        for batch in (_records(0, 3), _records(3, 5), _records(8, 40)):
+            adapter.append_many(batch)
+
+        raw = self.log.read_bytes()[len(_SHARD_CONTAINER_MAGIC) + 1:]
+        blocks, at = 0, 0
+        while at + 5 <= len(raw):
+            length = int.from_bytes(raw[at + 1:at + 5], "big")
+            at += 5 + length
+            blocks += 1
+        self.assertEqual(3, blocks, "the log does not hold one block per append batch")
+
+    def test_a_plain_log_already_on_disk_stays_plain(self):
+        """The form comes from the FILE, which is what keeps two forms out of one of them."""
+        adapter_module.LOCAL_JSONL_BLOCK_LOG = False
+        MatrixArkLocalAdapter(self.log).append_many(_records(0, 4))
+        self.assertTrue(self.log.read_bytes().startswith(b"{"))
+
+        adapter_module.LOCAL_JSONL_BLOCK_LOG = True
+        _clear_process_read_cache()
+        MatrixArkLocalAdapter(self.log).append_many(_records(4, 4))
+        self.assertTrue(self.log.read_bytes().startswith(b"{"),
+                        "turning the flag on converted a plain log mid-life; a reader that only "
+                        "knows the plain form would stop at the first block")
+        self.assertEqual(8, len(self._appended(self.log)))
+
+    def test_a_block_log_stays_blocks_when_the_flag_goes_off(self):
+        adapter_module.LOCAL_JSONL_BLOCK_LOG = True
+        MatrixArkLocalAdapter(self.log).append_many(_records(0, 4))
+        self.assertTrue(self.log.read_bytes().startswith(_SHARD_CONTAINER_MAGIC))
+
+        adapter_module.LOCAL_JSONL_BLOCK_LOG = False
+        _clear_process_read_cache()
+        MatrixArkLocalAdapter(self.log).append_many(_records(4, 4))
+        self.assertTrue(self.log.read_bytes().startswith(_SHARD_CONTAINER_MAGIC),
+                        "plain lines were appended onto a block log, which corrupts it")
+        self.assertEqual(8, len(self._appended(self.log)))
+
+    def test_a_torn_final_block_drops_only_its_own_records(self):
+        """The same contract a half-written line has: a crash mid-append loses that append."""
+        adapter_module.LOCAL_JSONL_BLOCK_LOG = True
+        adapter = MatrixArkLocalAdapter(self.log)
+        adapter.append_many(_records(0, 5))
+        adapter.append_many(_records(5, 5))
+        whole = self._appended(self.log)
+        self.assertEqual(10, len(whole))
+
+        raw = self.log.read_bytes()
+        self.log.write_bytes(raw[: len(raw) - 20])
+        kept = self._appended(self.log)
+        self.assertEqual(whole[:len(kept)], kept, "the survivors are not a prefix of the log")
+        self.assertLess(len(kept), len(whole))
+        self.assertGreaterEqual(len(kept), 5, "an intact earlier block was lost with the torn one")
+
+    def test_a_cold_read_serves_the_block_log(self):
+        adapter_module.LOCAL_JSONL_BLOCK_LOG = True
+        adapter = MatrixArkLocalAdapter(self.log)
+        adapter.append_many(_records(0, 40))
+        expected = adapter.read_all()
+
+        for path in list(self.store.iterdir()):
+            if "read-cache" in path.name:
+                path.unlink()
+        _clear_process_read_cache()
+        self.assertEqual(expected, MatrixArkLocalAdapter(self.log).read_all())
+
+
+    def test_a_block_log_rotates_into_a_sealed_shard_and_starts_a_fresh_one(self):
+        """Three formats meet here and none of them may swallow another.
+
+        The active log is a block stream; rotation renames it to a shard, which the sealer then
+        compresses WHOLE; and the new active log must start again with its own magic rather than
+        inherit the old file's bytes. A reader has to walk all three and return every record.
+        """
+        adapter_module.LOCAL_JSONL_BLOCK_LOG = True
+        adapter_module.LOCAL_JSONL_COMPRESS_SEALED = True
+        self.addCleanup(setattr, adapter_module, "LOCAL_JSONL_MAX_BYTES",
+                        adapter_module.LOCAL_JSONL_MAX_BYTES)
+        adapter_module.LOCAL_JSONL_MAX_BYTES = 4096
+
+        adapter = MatrixArkLocalAdapter(self.log)
+        for start in range(0, 400, 40):
+            adapter.append_many(_records(start, 40))
+
+        rotated = [path for path in sorted(self.store.iterdir())
+                   if path.name.startswith("events.jsonl.") and path.suffix.lstrip(".").isdigit()]
+        self.assertTrue(rotated, "nothing rotated, so this tests none of the seam")
+        self.assertTrue(self.log.read_bytes().startswith(_SHARD_CONTAINER_MAGIC + _SHARD_CODEC_BLOCKS),
+                        "the log after rotation is not a fresh block stream")
+
+        # In the module's own order: `.1` is the MOST RECENT rotated shard, because rotation
+        # shifts `.1` to `.2`, so reading them by filename returns history backwards.
+        seen = []
+        for path in MatrixArkLocalAdapter(self.log)._retained_jsonl_paths():
+            seen.extend(record["event_id_hash"] for record in self._appended(path))
+        retained = adapter_module.LOCAL_JSONL_RETENTION_COUNT
+        self.assertEqual(sorted(seen), seen, "records came back out of order across the shards")
+        self.assertEqual(len(set(seen)), len(seen), "a record was returned twice across the seam")
+        self.assertIn(399, seen, "the most recent record is missing from the retained shards")
+        self.assertGreaterEqual(len(rotated) + 1, 2)
+        self.assertLessEqual(len(rotated) + 1, retained)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
With the snapshot, its tail and the rotated shards all compressed, the **event log** was the last
plain-text artifact — and at 76 KB documents it is **95.3%** of everything this module writes.

## Priced against the batches this code really appends

Recorded by spying on `append_many`: 3 records ×60, 5 ×60, 284 ×29, 292 ×1.

| framing | bytes | ratio |
|---|---|---|
| plain JSONL (today) | 4,853,970 | 1.00× |
| one block per **record** | 3,399,456 | 1.43× |
| one block per **append batch** | 501,381 | **9.68×** |
| one block per 256 records | 485,806 | 9.99× |
| the whole file at once (a ceiling) | 276,828 | 17.53× |

A block per append batch reaches **97%** of what fixed 256-record blocks would, and it costs **no
durability**: the batch is already the unit that gets acked together, so a crash loses exactly what
it loses today. Per-record framing would be durability-free for the same reason and is worth almost
nothing — one record carries no dictionary.

## End to end

40 documents of 76 KB, same corpus, 7,224 records:

```
                                   store        B/record   vs source
before the container work     28,177,927           3,893       9.06x
container + tail + shards     14,936,207           2,068       4.80x
and the log in blocks          1,440,350             199       0.46x
```

The store is now **smaller than the text it was built from**, where it used to be nine times larger.

## Off by default, and here that is not a formality

Every other change in this family compresses something **derived** — a snapshot, a tail, a sealed
shard — which can be rebuilt from the log if it is ever unreadable. This changes the log itself, and
a process appending plain JSON to a block-framed log corrupts it.

So **the form is taken from the file, not from the flag**. An existing log keeps its own form, only a
fresh one adopts the configured one, and turning the flag off again leaves every log readable because
nothing rewrites one. That also means a log written by hand — which is how a good many fixtures are
built — stays plain and keeps working untouched.

## Lines, not the array the snapshot uses

Deliberately different, and the reason is this file rather than that one. The log is parsed
line-by-line *today*, so a line payload is neutral where an array would be a second change to measure
separately; and two of the five shard readers scan for a single record type with a substring test,
which a line payload keeps and an array payload would turn into parsing every record.

## One writer

Both append paths go through `_append_records_to_log`. They used to encode and write separately —
duplication while there was one form, and the same hazard the snapshot tail had in #939 when only one
of its two writers knew about blocks.

Rotation is decided on the bytes actually written, so a block log holds proportionally more history
before rotating. Deliberate: retention stays a disk budget, and compressing the log spends it on more
history rather than on less disk.

## Where losslessness is checked

On a **round trip**, not end to end. A served-record count moves by a dozen between runs because
`context_index` postings compact differently — it moved, and then moved back, while this was being
written — so an end-to-end count would have been reading the compactor, not the format. The raw log
records are identical in both arms (2,919, identical histograms).

## Why not a shared dictionary

Per-batch blocks reach 9.69x where compressing the whole file at once reaches 17.55x, and the obvious
explanation is that every block pays to rediscover the same record shape. zlib takes a `zdict` that a
file could carry once in its header, so this was measured rather than assumed:

| framing | bytes | ratio |
|---|---|---|
| per batch, no dictionary | 500,920 | 9.69x |
| per batch, `zdict` = batch 0 | 480,615 | 10.10x |
| per batch, `zdict` = 32 KB sample | 504,075 | **9.63x** |
| per batch, level 9 | 482,968 | 10.05x |
| the whole file at once (a ceiling) | 276,633 | 17.55x |

**At most 4.2%, and the bigger dictionary is worse than none** — the 32 KB sample costs more carried
in the file than it saves. The distance to the ceiling is not the dictionary: the large batches are 284
records and build a perfectly good window of their own, and what a single stream exploits is
redundancy ACROSS batches, which no per-block dictionary can reach without giving up the property
that makes this free. Level 9 buys 3.7% for more CPU on every append.

So no dictionary, and level 6 — this is within 4% of what a durability-free design can do.

## Tests

`test_matrixark_the_log_is_written_in_blocks.py` — the log says what it is and is much smaller, holds
the same records either way, writes one block per append batch, a plain log already on disk stays
plain, a block log stays blocks when the flag goes off, a torn final block drops only its own records
while the prefix survives, and a cold read serves the block log.

Four mutations, four caught: the form taken from the flag instead of the file, one block per record
instead of per batch, a torn final block raising instead of stopping, and the magic never written.
