### PR TITLE
A log record can be compressed, and by default is not

### DIFF
--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -114,6 +114,8 @@ pub fn decode_wal_line(line: &[u8]) -> Result<WriteAheadLogRecord, WriteAheadLog
     // written across a flag change still reads end to end.
     if payload.first() == Some(&crate::wal_proto::BINARY_PAYLOAD_MARKER)
         || payload.first() == Some(&crate::wal_proto::RAW_PAYLOAD_MARKER)
+        || payload.first() == Some(&crate::wal_proto::COMPRESSED_RAW_PAYLOAD_MARKER)
+        || payload.first() == Some(&crate::wal_proto::COMPRESSED_ESCAPED_PAYLOAD_MARKER)
     {
         return crate::wal_proto::decode(payload).map_err(|err| {
             WriteAheadLogError::Corruption(format!("engine wal record decode failed: {err}"))
@@ -2994,7 +2996,12 @@ fn append_record_locked(
     // different marker to say so. Fusing on `binary_records` alone wrote raw bytes into a line
     // frame, and a value containing a newline then split into two unreadable records --
     // `what_each_frame_costs_on_disk` toggles the frame flag precisely to catch that, and did.
-    if crate::wal_proto::binary_records_enabled() && crate::log_framing::binary_frame_enabled() {
+    // Compression is excluded from the borrowing writer deliberately: it reserves
+    // the frame from a length the payload does not have yet. See `encode`.
+    if crate::wal_proto::binary_records_enabled()
+        && crate::log_framing::binary_frame_enabled()
+        && !crate::wal_proto::compress_records_enabled()
+    {
         // The payload lands directly in the frame. Building it separately meant carrying the
         // record twice -- once into its own buffer and once into this one -- and at a four
         // kilobyte value the second copy was four kilobytes of pure duplication.

--- a/crates/temporalstore-rust/src/wal_proto.rs
+++ b/crates/temporalstore-rust/src/wal_proto.rs
@@ -42,6 +42,66 @@ pub(crate) const BINARY_PAYLOAD_MARKER: u8 = 0xB7;
 /// reading halfway through.
 pub(crate) const RAW_PAYLOAD_MARKER: u8 = 0xB8;
 
+/// Marker for a protobuf payload that is zstd-compressed and carries no escaping.
+///
+/// A record's payload is the largest thing this log writes and the most repetitive: the same
+/// field names, scope keys and policy blocks over and over. Measured on one live segment of the
+/// hook store -- 151 records, 13.5 KB each -- zstd at level 3 takes 2,038,147 bytes to 236,714,
+/// which is 8.61x, and projects to 617 MB off a 698 MB log.
+///
+/// Compressing the whole SEGMENT instead reaches 22.28x, and is not available here: a log id is a
+/// byte position, page references point at those positions, and a block that has to be inflated
+/// before any record inside it can be found does not have them. Per record keeps every record
+/// independently addressable, which is the property the log is built on.
+pub(crate) const COMPRESSED_RAW_PAYLOAD_MARKER: u8 = 0xB9;
+
+/// The same, for a delimited frame, where the compressed bytes still have to be escaped.
+///
+/// Two markers rather than one plus a flag, for the reason the pair above gives: which encoding a
+/// payload is in has to be a property of the payload, or a log written across a configuration
+/// change stops reading halfway through.
+pub(crate) const COMPRESSED_ESCAPED_PAYLOAD_MARKER: u8 = 0xBA;
+
+/// Compression level. The same level the index already compresses at, so the log and the index
+/// make the same trade rather than two unexplained ones.
+const COMPRESSION_LEVEL: i32 = 3;
+
+/// Below this many bytes a payload is written uncompressed.
+///
+/// Not a guess: the page store measured this exact question and found a 1-byte floor worse than
+/// no compression at all -- the saving stopped while the median write rose, because a tiny
+/// payload costs more to compress than it gives back. 256 is the floor that measurement chose.
+const COMPRESSION_MIN_BYTES: usize = 256;
+
+/// Whether new records are written compressed. DEFAULT OFF.
+///
+/// Reading never consults this. A payload says what encoding it is in, so a log written across a
+/// change reads end to end and turning it off again is not a one-way door -- the same contract
+/// `TS_WAL_BINARY_RECORDS` keeps.
+pub(crate) fn compress_records_enabled() -> bool {
+    matches!(
+        std::env::var("TS_WAL_COMPRESS_RECORDS")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+/// Compress `encoded` if it is worth compressing, returning None when it is not.
+///
+/// None for a payload under the floor, and None when the compressed form is not actually smaller.
+/// The second check is the page store's: compression that does not pay is written uncompressed
+/// rather than trusted to pay on average.
+fn compress_payload(encoded: &[u8]) -> Option<Vec<u8>> {
+    if encoded.len() < COMPRESSION_MIN_BYTES {
+        return None;
+    }
+    let compressed = zstd::stream::encode_all(encoded, COMPRESSION_LEVEL).ok()?;
+    (compressed.len() < encoded.len()).then_some(compressed)
+}
+
 /// Escapes a newline out of an encoded payload.
 ///
 /// The log is read with `reader.lines()`. A JSON payload can never contain a raw newline, so that
@@ -487,6 +547,31 @@ pub(crate) fn prepare(record: &WriteAheadLogRecord) -> Result<PreparedRecord<'_>
 /// Encode a record as protobuf, marker byte first.
 pub(crate) fn encode(record: &WriteAheadLogRecord) -> Result<Vec<u8>, String> {
     let parts = record_parts(record)?;
+    if compress_records_enabled() {
+        // Compression cannot use the borrowing writer above: that path reserves the frame from
+        // `payload_len()` before the payload exists, and how long a compressed payload will be is
+        // not knowable until it has been compressed. So this arm builds the payload first and the
+        // frame around it, which is what the escaping arm below has always done.
+        let mut encoded = Vec::with_capacity(parts.len);
+        parts.put(record, &mut encoded)?;
+        if let Some(compressed) = compress_payload(&encoded) {
+            let escaping = !crate::log_framing::binary_frame_enabled();
+            let mut out = Vec::with_capacity(compressed.len() + 8);
+            out.push(if escaping {
+                COMPRESSED_ESCAPED_PAYLOAD_MARKER
+            } else {
+                COMPRESSED_RAW_PAYLOAD_MARKER
+            });
+            if escaping {
+                out.extend_from_slice(&escape_newlines(&compressed));
+            } else {
+                out.extend_from_slice(&compressed);
+            }
+            return Ok(out);
+        }
+        // Not worth compressing. Fall through and write it the way it would have been written
+        // anyway, under its own marker -- a reader cannot tell that this record was considered.
+    }
     if crate::log_framing::binary_frame_enabled() {
         // The frame declares its own length, so the payload is written as produced -- which means
         // the marker can go in FIRST and the message encode straight after it. `encode` appends,
@@ -509,12 +594,25 @@ pub(crate) fn encode(record: &WriteAheadLogRecord) -> Result<Vec<u8>, String> {
 /// Decode a payload this module wrote. The caller has already checked the marker byte.
 pub(crate) fn decode(payload: &[u8]) -> Result<WriteAheadLogRecord, String> {
     let body = &payload[1..];
+    let marker = payload.first().copied();
+    let escaped = marker == Some(BINARY_PAYLOAD_MARKER)
+        || marker == Some(COMPRESSED_ESCAPED_PAYLOAD_MARKER);
+    let compressed = marker == Some(COMPRESSED_RAW_PAYLOAD_MARKER)
+        || marker == Some(COMPRESSED_ESCAPED_PAYLOAD_MARKER);
     let unescaped;
-    let bytes: &[u8] = if payload.first() == Some(&RAW_PAYLOAD_MARKER) {
-        body
-    } else {
+    let framed: &[u8] = if escaped {
         unescaped = unescape_newlines(body)?;
         unescaped.as_slice()
+    } else {
+        body
+    };
+    let inflated;
+    let bytes: &[u8] = if compressed {
+        inflated = zstd::stream::decode_all(framed)
+            .map_err(|err| format!("compressed wal payload did not inflate: {err}"))?;
+        inflated.as_slice()
+    } else {
+        framed
     };
     let message = v1::EngineWalRecord::decode(bytes).map_err(|err| err.to_string())?;
     // Absent is a legitimate record now, not a malformed one: it carries results instead.
@@ -581,6 +679,152 @@ mod tests {
         let mut encoded = Vec::with_capacity(message.encoded_len());
         message.encode(&mut encoded).unwrap();
         encoded
+    }
+
+    /// A record big and repetitive enough to be worth compressing, which most real ones are.
+    fn compressible_record() -> WriteAheadLogRecord {
+        let mut record = record_with(Some(Command::StringSet {
+            key: "compressible".to_string(),
+            // Repetition is the point: a real record repeats field names, scope keys and policy
+            // blocks, and a payload of one byte over and over would flatter the codec in a way
+            // those do not. This alternates, so it is compressible without being trivial.
+            value: (0..4096u32).map(|index| (index % 7) as u8).collect(),
+        }));
+        record.outcomes = vec![crate::wal::WalOutcomeItem {
+            kind: "page".to_string(),
+            object_key: "tenant/1/object/9".to_string(),
+            component: Some("body".to_string()),
+            object_id: 9,
+            routing_bucket: 8539,
+            address: None,
+            value: Some(vec![3; 512]),
+            ttl: Some(60_000),
+            deleted: false,
+            meta: false,
+        }];
+        record
+    }
+
+    /// Build the compressed payload by hand, so decoding is tested without touching the
+    /// environment: what a reader must accept is a property of the bytes, not of a flag.
+    fn compressed_payload(record: &WriteAheadLogRecord, escaping: bool) -> Vec<u8> {
+        let mut encoded = Vec::new();
+        record_parts(record).unwrap().put(record, &mut encoded).unwrap();
+        let compressed = zstd::stream::encode_all(encoded.as_slice(), COMPRESSION_LEVEL).unwrap();
+        let mut out = Vec::new();
+        if escaping {
+            out.push(COMPRESSED_ESCAPED_PAYLOAD_MARKER);
+            out.extend_from_slice(&escape_newlines(&compressed));
+        } else {
+            out.push(COMPRESSED_RAW_PAYLOAD_MARKER);
+            out.extend_from_slice(&compressed);
+        }
+        out
+    }
+
+    #[test]
+    fn a_compressed_payload_decodes_to_the_record_that_made_it() {
+        let record = compressible_record();
+        for escaping in [false, true] {
+            let payload = compressed_payload(&record, escaping);
+            let back = decode(&payload).expect("compressed payload decodes");
+            assert_eq!(record, back, "escaping={escaping}");
+        }
+    }
+
+    #[test]
+    fn a_log_holding_every_encoding_reads_end_to_end() {
+        // What a log looks like across a configuration change: records written under different
+        // settings, sitting next to each other, all of which must still read.
+        let record = compressible_record();
+        let mut encoded = Vec::new();
+        record_parts(&record).unwrap().put(&record, &mut encoded).unwrap();
+
+        let mut raw = vec![RAW_PAYLOAD_MARKER];
+        raw.extend_from_slice(&encoded);
+        let mut escaped = vec![BINARY_PAYLOAD_MARKER];
+        escaped.extend_from_slice(&escape_newlines(&encoded));
+
+        for payload in [
+            raw,
+            escaped,
+            compressed_payload(&record, false),
+            compressed_payload(&record, true),
+        ] {
+            assert_eq!(record, decode(&payload).expect("payload decodes"));
+        }
+    }
+
+    #[test]
+    fn a_payload_under_the_floor_is_left_alone() {
+        // Compressing a tiny payload costs more than it gives back; the page store measured that
+        // and chose this floor, so the check is that the floor is honoured, not that it is right.
+        let tiny = vec![1u8; COMPRESSION_MIN_BYTES - 1];
+        assert!(compress_payload(&tiny).is_none());
+    }
+
+    #[test]
+    fn a_payload_that_would_not_shrink_is_left_alone() {
+        // Random bytes do not compress. Writing them "compressed" would add a frame header to a
+        // payload that got no smaller, so the encoder declines.
+        let mut incompressible = Vec::with_capacity(4096);
+        let mut state = 0x2545_F491_4F6C_DD1Du64;
+        for _ in 0..4096 {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            incompressible.push((state >> 24) as u8);
+        }
+        assert!(compress_payload(&incompressible).is_none());
+    }
+
+    #[test]
+    fn compression_is_worth_doing_on_a_record_shaped_like_a_real_one() {
+        let record = compressible_record();
+        let mut encoded = Vec::new();
+        record_parts(&record).unwrap().put(&record, &mut encoded).unwrap();
+        let compressed = compress_payload(&encoded).expect("a repetitive record compresses");
+        assert!(
+            compressed.len() * 2 < encoded.len(),
+            "expected better than 2x, got {} -> {}",
+            encoded.len(),
+            compressed.len()
+        );
+    }
+
+    #[test]
+    fn the_flag_decides_what_is_written_and_never_what_is_read() {
+        // One test rather than several: these set a process-wide variable, and separate tests
+        // would race each other inside the same binary.
+        let record = compressible_record();
+
+        std::env::set_var("TS_WAL_COMPRESS_RECORDS", "1");
+        let compressed = encode(&record).expect("encodes with compression on");
+        std::env::remove_var("TS_WAL_COMPRESS_RECORDS");
+        let plain = encode(&record).expect("encodes with compression off");
+
+        assert!(
+            matches!(
+                compressed.first(),
+                Some(&COMPRESSED_RAW_PAYLOAD_MARKER) | Some(&COMPRESSED_ESCAPED_PAYLOAD_MARKER)
+            ),
+            "compression on should write a compressed marker, got {:?}",
+            compressed.first()
+        );
+        assert!(
+            matches!(
+                plain.first(),
+                Some(&RAW_PAYLOAD_MARKER) | Some(&BINARY_PAYLOAD_MARKER)
+            ),
+            "compression off should write an uncompressed marker, got {:?}",
+            plain.first()
+        );
+        assert!(compressed.len() < plain.len());
+
+        // The flag is off now, and the compressed record still reads. That is the contract: a
+        // deployment that turns this off does not lose the log it already wrote.
+        assert_eq!(record, decode(&compressed).expect("still decodes with the flag off"));
+        assert_eq!(record, decode(&plain).expect("uncompressed decodes"));
     }
 
     fn record_with(command: Option<Command>) -> WriteAheadLogRecord {

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -8,7 +8,7 @@ within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 296 of them, read by 94 functions.
+There are 297 of them, read by 95 functions.
 
 Deleting unreachable code is not the lever. An earlier version of this document argued that
 by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
@@ -46,11 +46,11 @@ Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 296 |
-| booleans whose default this could read off the source | 33 |
+| total | 297 |
+| booleans whose default this could read off the source | 34 |
 | numbers whose default this could read off the source | 35 |
 | **defaulting on, and set by nothing** | 2 |
-| offered on the portal | 25 |
+| offered on the portal | 26 |
 | **that nothing in this repository sets** | 175 |
 | documented as keeping an older path alive | 5 |
 | reaching more than two files | 15 |
@@ -159,7 +159,7 @@ Secrets. Never a form field, never in a launch artifact.
 | `TS_API_AUTH_TOKEN` | — | nothing | 1 | — |
 | `TS_META_ADMIN_TOKEN` | — | nothing | 1 | — |
 
-## durability (22)
+## durability (23)
 
 What is written, when it is flushed, and what is reclaimed. The escape hatches here trade throughput for a more conservative barrier.
 
@@ -177,6 +177,7 @@ What is written, when it is flushed, and what is reclaimed. The escape hatches h
 | `TS_WAL_BINARY_FRAME` | on | launch, test, portal | 1 | — |
 | `TS_WAL_BINARY_RECORDS` | on | launch, test, portal | 1 | — |
 | `TS_WAL_COMMIT_DELAY_US` | 0 | config | 1 | — |
+| `TS_WAL_COMPRESS_RECORDS` | off | test, portal | 1 | — |
 | `TS_WAL_DATA_ONLY` | on | launch, test | 1 | — |
 | `TS_WAL_LEGACY_RECOVERY` | off | config, harness, script | 1 | yes |
 | `TS_WAL_OUTCOME_ITEMS` | on | launch, test | 1 | — |

--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -560,6 +560,18 @@ SETTINGS: List[Setting] = [
             "length frames is NOT supported: finding the tail of the log follows this setting, and "
             "off it searches backwards for a newline, which is not a record boundary in a "
             "length-framed log."),
+    Setting("storage_engine.wal_compress_records", "storage_engine",
+            "TS_WAL_COMPRESS_RECORDS",
+            "Compress log records", "bool", "0", "restart",
+            "On, a log record is zstd-compressed before it is written. Measured on one live "
+            "segment -- 151 records averaging 13.5 KB -- this is 8.61x, which on a 698 MB log is "
+            "about 617 MB back. It ships OFF because it spends write CPU to buy disk, and which "
+            "of those is scarce is the deployment's answer, not this file's. Reading never "
+            "consults it: a payload says what encoding it is in, so a log written across a change "
+            "reads end to end and turning it off again is not a one-way door. Records below 256 "
+            "bytes, and any record the codec fails to shrink, are written uncompressed. Each "
+            "record is compressed on its own rather than the log in blocks: blocks reach 22.28x "
+            "and would end record-level addressing, which page references depend on."),
     Setting("storage_engine.vector_scaled", "storage_engine",
             "TS_VECTOR_SCALED",
             "Store vectors in the scaled form", "bool", "1", "live",


### PR DESCRIPTION
The write-ahead log is **44% of what this store holds** — 698 MB on the box these numbers come
from — and it is the most repetitive thing written: the same field names, scope keys and policy
blocks, over and over. Nothing compressed it. The index already does, at zstd level 3, and the
crate has depended on `zstd` all along.

Measured read-only on one live segment, **151 records averaging 13.5 KB**, before any of this was
written:

| | bytes | ratio |
|---|---:|---:|
| as written today | 2,038,147 | — |
| zstd-3, per record | 236,714 | **8.61×** |
| zstd-3, whole segment | 91,461 | 22.28× |

On the live log that is about **617 MB back**.

### Per record, not in blocks — the design constraint

Blocks reach 22.28× and cannot be used here. A log id **is a byte position**, stored page addresses point
at those positions, and a block that must be inflated before any record inside it can be found no
longer has them. Per record keeps every record independently addressable.

### Default OFF

It spends write CPU to buy disk, and which of those is scarce is a deployment's answer, not this
file's. What this builds is the capability. Turning it on anywhere is a separate decision — and on
a live store, an operator's.

### Reading never consults the flag

Two new markers say what a payload is — compressed-raw for a length frame, compressed-escaped for a
delimited one — so a log written across a change reads end to end and turning it off again is not a
one-way door. That is the contract the two existing markers already keep, and the reason there are
two new ones rather than one marker plus a flag.

Two refusals are built in, both borrowed from the page store, which measured this question already:
a payload under **256 bytes** is left alone, and a payload the codec fails to actually shrink is
written as it was rather than trusting compression to pay on average.

### One structural note

Compression cannot use the borrowing writer the length-framed path uses: that reserves the frame
from a `payload_len()` the payload does not have until it has been compressed. The compressed arm
builds its payload first — which is what the escaping arm has always done — and the guard in
`wal.rs` says so where it excludes compression from the zero-copy path.

### Checks

Six new tests, **five touching no environment at all** — what a reader must accept is a property of
the bytes, not of a flag:

- a hand-built compressed payload decodes, in both framings;
- a log holding all four encodings side by side reads end to end;
- the 256-byte floor is honoured;
- an incompressible payload is left alone;
- a record shaped like a real one compresses better than 2×.

The sixth covers the flag in a single test rather than several, because separate ones would race
each other for a process-wide variable.

**Mutation test:** making `decode` ignore the compressed marker fails four tests.

**The suite is unchanged.** In parallel the crate fails 10 on main and 10 here, with 6 more
passing — and the failing *set* differs between runs of identical code, because these tests race
through the process environment. Run single-threaded, which removes that:

```
branch: 93 passed; 0 failed
main:   93 passed; 0 failed
```
