### PR TITLE
A batch asks for its piece's length once, not once per record

### DIFF
--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -1341,6 +1341,7 @@ impl LocalWriteAheadLogStore {
             let batch_path = active_wal_path(&mut inner, shard_id);
             let prealloc = wal_preallocate_enabled();
             WAL_FILE_OPENS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let mut batch_physical: u64 = 0;
             let mut batch_file = if prealloc {
                 OpenOptions::new()
                     .create(true)
@@ -1375,7 +1376,7 @@ impl LocalWriteAheadLogStore {
                     &rec,
                     false,
                     None,
-                    Some(&mut batch_file),
+                    Some((&mut batch_file, &mut batch_physical)),
                 )?;
                 inner.stats.last_sequence = report.current_sequence;
                 batch_end = Some(report.persistent_bytes);
@@ -2988,6 +2989,19 @@ fn shard_uses_blocks(
 /// shows up as a count rather than as a timing that this machine cannot resolve.
 static WAL_FILE_OPENS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
+/// How many times an append asks the filesystem for the piece's physical length.
+///
+/// Under preallocation every record used to `fstat` to find out whether the reservation still had
+/// room. Within a batch nothing else can change that length -- the append lock and the `inner`
+/// lock are both held -- so the batch reads it once and carries it, growing its own copy when it
+/// grows the file.
+static WAL_FILE_STATS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Physical-length stats of the active piece since the last reset.
+pub fn wal_file_stats() -> u64 {
+    WAL_FILE_STATS.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 /// Opens of the active piece since the last reset.
 pub fn wal_file_opens() -> u64 {
     WAL_FILE_OPENS.load(std::sync::atomic::Ordering::Relaxed)
@@ -2996,6 +3010,7 @@ pub fn wal_file_opens() -> u64 {
 /// Reset the open counter. For tests measuring one append path's syscall volume.
 pub fn reset_wal_file_opens() {
     WAL_FILE_OPENS.store(0, std::sync::atomic::Ordering::Relaxed);
+    WAL_FILE_STATS.store(0, std::sync::atomic::Ordering::Relaxed);
 }
 
 fn append_record_locked(
@@ -3018,7 +3033,7 @@ fn append_record_locked_on(
     record: &WriteAheadLogRecord,
     sync: bool,
     known_offset: Option<u64>,
-    reuse: Option<&mut std::fs::File>,
+    reuse: Option<(&mut std::fs::File, &mut u64)>,
 ) -> Result<WriteAheadLogAppendReport, WriteAheadLogError> {
     let path = active_wal_path(inner, record.shard_id);
     // The caller has usually just measured this under the same append lock, so taking its answer
@@ -3140,8 +3155,12 @@ fn append_record_locked_on(
     }
     let prealloc = wal_preallocate_enabled();
     let mut opened;
+    let mut carried_physical: Option<&mut u64> = None;
     let file: &mut std::fs::File = match reuse {
-        Some(handle) => handle,
+        Some((handle, physical)) => {
+            carried_physical = Some(physical);
+            handle
+        }
         None => {
             WAL_FILE_OPENS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             opened = if prealloc {
@@ -3156,7 +3175,17 @@ fn append_record_locked_on(
     };
     if prealloc {
         let needed = offset.saturating_add(bytes.len() as u64);
-        let physical = file.metadata()?.len();
+        // The batch carries the length it already knows. Nothing else can change it while the
+        // append lock and the `inner` lock are both held, and the batch updates its copy below
+        // whenever it grows the file -- so asking the filesystem again would be a syscall to
+        // learn a number already in hand.
+        let physical = match carried_physical.as_deref() {
+            Some(&known) if known > 0 => known,
+            _ => {
+                WAL_FILE_STATS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                file.metadata()?.len()
+            }
+        };
         // Carried rather than re-read. The length after this block is either the one just read or
         // the one just set, so asking the filesystem again is a second stat a write to learn a
         // number already in hand.
@@ -3174,6 +3203,9 @@ fn append_record_locked_on(
         } else {
             physical
         };
+        if let Some(known) = carried_physical.as_deref_mut() {
+            *known = physical;
+        }
         inner
             .prealloc_physical_by_shard
             .insert(record.shard_id, physical);
@@ -5264,6 +5296,57 @@ mod tests {
     /// No `alloc-probe` feature here -- it counts calls, not allocations. An earlier version of
     /// this probe inherited that cfg from the test it was pasted above and vanished from the
     /// build entirely.
+    /// A batch that outgrows its reservation several times still reads back whole.
+    ///
+    /// 512 records of 4 KiB is ~2 MiB against a 256 KiB chunk, so the reservation is grown
+    /// roughly eight times inside one batch -- the case a single-chunk batch never reaches.
+    ///
+    /// What the carried physical length can and cannot break, since the distinction decides what
+    /// this test is worth: the carried number gates GROWTH only. The write offset comes from
+    /// `verified_len_by_shard`, not from the file's physical length, so a stale carried value
+    /// causes a redundant `set_len` and never a misplaced record. Checked by control -- refusing
+    /// to update it after a growth leaves this test passing and only the syscall count moving.
+    ///
+    /// So this is an end-to-end check that a multi-growth batch survives, not the discriminating
+    /// test for the carried length: `a_batch_opens_the_piece_once_not_once_per_record` is that.
+    #[test]
+    fn a_batch_that_outgrows_its_reservation_reads_back_whole() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalWriteAheadLogStore::new(dir.path());
+        let commands: Vec<Command> = (0..512)
+            .map(|index| Command::StringSet {
+                key: format!("grown-{index:05}"),
+                value: vec![(index % 251) as u8; 4096],
+            })
+            .collect();
+
+        let written = store
+            .append_batch_atomic(1, commands, true)
+            .expect("the batch appends");
+        assert_eq!(written.len(), 512);
+
+        let read = store
+            .scan(1, 0, u64::MAX, u64::MAX)
+            .expect("the log scans back");
+        assert_eq!(
+            read.len(),
+            512,
+            "the batch wrote 512 records and the log reads back {}; a carried physical length              that missed a growth puts records at the wrong offset",
+            read.len()
+        );
+
+        // Sequences are contiguous and in order -- a record landing at a wrong offset shows up
+        // here before it shows up anywhere a user would look.
+        let sequences: Vec<u64> = written.iter().map(|record| record.sequence).collect();
+        let mut expected = sequences.clone();
+        expected.sort_unstable();
+        expected.dedup();
+        assert_eq!(
+            sequences, expected,
+            "the batch produced out-of-order or duplicate sequences"
+        );
+    }
+
     /// A batch opens the active piece ONCE, not once per record.
     ///
     /// A batch is one crash-atomic group under one durability barrier, and that barrier is the
@@ -5292,12 +5375,14 @@ mod tests {
         super::reset_wal_file_opens();
         store.append_batch_atomic(1, commands.clone(), true).unwrap();
         let batched = super::wal_file_opens();
+        let batched_stats = super::wal_file_stats();
 
         super::reset_wal_file_opens();
         for command in commands {
             store.append_with_sync(1, command, true).unwrap();
         }
         let one_at_a_time = super::wal_file_opens();
+        let one_at_a_time_stats = super::wal_file_stats();
 
         assert!(
             one_at_a_time >= 64,
@@ -5306,6 +5391,19 @@ mod tests {
         assert_eq!(
             batched, 1,
             "a batch of 64 records opened the piece {batched} times; it holds the append lock and              the inner lock across the whole loop and rolls only afterwards, so one open covers it"
+        );
+
+        // The same argument covers the physical length. Under preallocation each record asked the
+        // filesystem whether the reservation still had room; nothing else can change that length
+        // while both locks are held, so the batch reads it once and carries it, growing its own
+        // copy when it grows the file.
+        assert!(
+            one_at_a_time_stats >= 1,
+            "the control never asked for the physical length ({one_at_a_time_stats}), so the              batch figure below is not measuring anything"
+        );
+        assert_eq!(
+            batched_stats, 1,
+            "a batch of 64 records asked for the piece's physical length {batched_stats} times"
         );
     }
 


### PR DESCRIPTION
Follows #983, which stopped a batch reopening the active piece per record. Under preallocation each record **also** asked the filesystem for the piece's physical length, to find out whether the reservation still had room.

Nothing else can change that length while the batch runs — it holds the append lock and the `inner` lock across its whole loop — so the batch reads it once and carries it, updating its copy whenever it grows the file.

| a 64-record batch | opens | length checks |
|---|---|---|
| before #983 | 65 | 64 |
| after #983 | 1 | 64 |
| now | **1** | **1** |

## What a stale carried value could actually do

Worth stating, because it decides how much care this needs. The carried number **gates growth only** — the write offset comes from `verified_len_by_shard`, not from the file's physical length. So a stale value costs a redundant `set_len` and **cannot misplace a record**.

Established by control rather than by reading: refusing to update it after a growth leaves the read-back test passing and moves only the syscall count.

## That control corrected my own test

The new read-back test originally claimed a stale length would put a record at the wrong offset. It would not. The test still earns its place — 512 records of 4 KiB against a 256 KiB chunk grows the reservation about eight times inside one batch, which no single-chunk batch reaches — but it is an **end-to-end** check, and the syscall count is the discriminating one. The doc comment now says that instead of claiming a cause it does not test.

## Scope

The remaining per-record syscall is the write itself; buffering the batch into one write is the other option #306 records. Verified against 95 wal tests plus the crash-recovery, restart, batch and recovery suites.