### PR TITLE
Read the provider sets by name, not by the shape of the dispatch

### DIFF
--- a/tools/test_matrixark_an_unrecognised_provider_name_is_named.py
+++ b/tools/test_matrixark_an_unrecognised_provider_name_is_named.py
@@ -71,6 +71,21 @@ def provider_membership_sets(filename: str) -> list:
                        if isinstance(e, ast.Constant) and isinstance(e.value, str)}
             if members:
                 found.append(members)
+        elif isinstance(right, ast.Name):
+            # `provider in _OSS_EMBEDDING_PROVIDERS` is the same dispatch as `provider in {...}`,
+            # and naming the set is what a reader should prefer. Resolving the name keeps this
+            # reading the dispatch rather than the spelling: the literal form went away when six
+            # copies of the check became one, and every branch's ratchet went red on it.
+            # Only a set this module ASSIGNS. A name imported from elsewhere is declared in
+            # another file, and this scan is per-file by design -- `assigned_string_set` is meant
+            # to fail loudly when a caller names a set that should be here, so it is not the right
+            # lookup for a walk that meets every comparison in the module.
+            try:
+                members = assigned_string_set(filename, right.id)
+            except AssertionError:
+                continue
+            if members:
+                found.append(members)
     return found
 
 

--- a/tools/test_matrixark_every_choice_is_explained.py
+++ b/tools/test_matrixark_every_choice_is_explained.py
@@ -96,7 +96,11 @@ class TheClaimsAboutLocalAreTrueTest(unittest.TestCase):
         with open(os.path.join(TOOLS, "matrixark_mcp_embeddings.py"), encoding="utf-8") as handle:
             source = handle.read()
         api = re.search(r"_API_EMBEDDING_PROVIDERS\s*=\s*\{([^}]*)\}", source)
-        oss = re.search(r'provider in \{("oss"[^}]*)\}', source)
+        # The OSS set is read where it is DECLARED, like the API set above it. It used to be read
+        # off a `provider in {...}` dispatch site, which stopped existing when six copies of that
+        # check became one -- so this was asserting on the spelling of the dispatch rather than on
+        # the set, and went red for a refactor that changed neither the set nor the behaviour.
+        oss = re.search(r"_OSS_EMBEDDING_PROVIDERS\s*=\s*\{([^}]*)\}", source)
         strip = lambda text: {v.strip().strip('"').strip("'") for v in text.split(",") if v.strip()}
         return strip(api.group(1)), strip(oss.group(1))
 


### PR DESCRIPTION
Three tests have been red on `main` since the six copies of the provider check became one, and the
ratchet reports them as **new failures on every branch opened since** — they are not caused by the
branches that report them. I verified the same three fail on a clean `matrixark/main` archive with
identical messages.

```
test_local_selects_neither_encoder_path                      branch=1  main=1
test_the_in_process_set_is_a_dispatch_set_in_the_encoder     branch=1  main=1
test_the_two_that_do_run_an_encoder_still_do                 branch=1  main=1

AssertionError: {'sentence-transformers', 'sentence_transformers', 'open_source', 'oss'}
                not found in []
```

## What they assert, and how they assert it

Something true and worth asserting: **the sets the encoder dispatches on are the sets the config
declares.** But they assert it by matching `provider in {"oss", ...}` as a *set literal* — one by
regex, one by walking the AST for a literal comparator.

Consolidating the check replaced those literals with a name:

```python
if provider in _OSS_EMBEDDING_PROVIDERS:      # was: provider in {"oss", ...}
```

So the AST scan returns `[]` and the regex finds nothing. **The sets did not move. The behaviour did
not change. Only the spelling did.**

## The fix

The helpers learn to resolve a name to the module-level set it refers to — which is what they were
always trying to read — and the regex reads the OSS set where it is **declared**, exactly as the API
set on the line above it already did. Both are strictly more robust: they survive naming a set, which
is the refactor that broke them.

A name the module does not *assign* is skipped rather than raising. `assigned_string_set` is meant to
fail loudly when a caller names a set that should be there, which makes it the wrong lookup for a walk
that meets every comparison in a file — `matrixark_mcp_core.py` compares against a set it imports, and
that is not this scan's business.

## Making a scan permissive is how a test turns vacuous

So the check is not that these pass. It is that they still **fail when the sets are wrong**. Four
controls on the source the tests read, four caught:

| control | caught by |
|---|---|
| `local` added to the in-process set | `test_local_selects_neither_encoder_path`, `test_the_in_process_set_is_a_dispatch_set_in_the_encoder` |
| `local` added to the API set | `test_every_api_provider_is_called_api`, `test_local_selects_neither_encoder_path` |
| `voyage` dropped from the API set | `test_the_api_set_is_the_encoders`, `test_the_two_that_do_run_an_encoder_still_do` |
| the encoder stops dispatching on the named set (all 4 sites) | `test_the_in_process_set_is_a_dispatch_set_in_the_encoder` |

## Scope

Test-only, two files, 20 lines. No production code is touched — the consolidation it adapts to is
correct, and this is the tests catching up to it.

The membership scan exists in **two** files. Only the one that broke is changed: the other module
still writes its sets as literals, so it is green, and its copy is noted in the code rather than
edited here. Two copies of one helper is worth removing on its own, not inside a fix for a red gate.

Opened because a red `main` puts three failures on every other branch's ratchet. Flagged on #975 with
this diagnosis first; picking it up since nothing was in flight for it.
