### PR TITLE
Serve the last context pack when a turn cannot build one

### DIFF
--- a/tools/matrixark_agent_hook.py
+++ b/tools/matrixark_agent_hook.py
@@ -13,6 +13,10 @@ from __future__ import annotations
 
 import argparse
 import json
+try:
+    from tools import matrixark_hook_pack_cache as _pack_cache
+except ImportError:  # running from inside tools/, as the hooks do
+    import matrixark_hook_pack_cache as _pack_cache
 import os
 import subprocess
 import sys
@@ -1138,7 +1142,37 @@ def call_write_tool(
         return {}
 
 
+def call_retrieve_tool(
+    server: Any,
+    tool: str,
+    tool_args: Json,
+    *,
+    failures: list[Json],
+) -> Json:
+    """Call the retrieve tool, recording a failure instead of ending the turn.
+
+    A raise here used to kill main() before the last-good-pack fallback below could run, so a
+    retrieval that failed LOUDLY and one that failed silently both ended as `{}`. Returning {} lets
+    the fallback serve the previous pack while `retrieve_error` says what actually went wrong --
+    which matters most when the failure is a policy error (native ContextPack required but not
+    produced), because that is precisely what an operator needs told rather than left to infer.
+    """
+    try:
+        return call_tool(server, tool, tool_args)
+    except Exception as retrieve_error:  # noqa: BLE001 - the turn must survive to serve a pack.
+        failures.append(
+            {
+                "tool": tool,
+                "error": f"{retrieve_error.__class__.__name__}: {retrieve_error}"[:500],
+            }
+        )
+        return {}
+
+
 def main() -> int:
+    # Declared before the FIRST retrieve: main() calls retrieve twice, hundreds of lines
+    # apart, and the earlier call precedes every other collector in this function.
+    retrieve_failures: list[Json] = []
     args = parse_args()
     validate_hook_backend_policy(args.backend)
     payload = read_stdin_payload()
@@ -1191,7 +1225,9 @@ def main() -> int:
             retrieve_metadata=retrieve_metadata,
             local_context=local_context if isinstance(local_context, list) else [],
         )
-        retrieve = call_tool(server, "matrixark_retrieve", retrieve_args)
+        retrieve = call_retrieve_tool(
+            server, "matrixark_retrieve", retrieve_args, failures=retrieve_failures
+        )
     base_metadata: Json = {
         "source": f"{args.agent}_hook",
         "agent": args.agent,
@@ -1275,7 +1311,9 @@ def main() -> int:
             retrieve_metadata=retrieve_metadata,
             local_context=local_context if isinstance(local_context, list) else [],
         )
-        retrieve = call_tool(server, "matrixark_retrieve", retrieve_args)
+        retrieve = call_retrieve_tool(
+            server, "matrixark_retrieve", retrieve_args, failures=retrieve_failures
+        )
 
     commit: Json = {}
     if should_commit(args.event):
@@ -1349,6 +1387,7 @@ def main() -> int:
         "retrieved": retrieved_summary,
         "committed": session_commit_summary(commit),
         "write_failures": write_failures,
+        "retrieve_error": retrieve_failures,
     }
     # Emit the Claude Code hook contract so retrieved memory actually reaches the
     # model. The wrapper (matrixark_claude_hook.sh) passes through
@@ -1356,11 +1395,29 @@ def main() -> int:
     # pack is retrieved but never injected.
     if should_retrieve(args.event) or args.query:
         additional_context = additional_context_from_retrieve(retrieve)
+        cache_path = _pack_cache.context_pack_cache_path(
+            args.agent, str(agent_context.get("workspace_root") or "")
+        )
         if additional_context.strip():
+            _pack_cache.remember_context_pack(cache_path, additional_context)
             output["hookSpecificOutput"] = {
                 "hookEventName": args.event,
                 "additionalContext": additional_context,
             }
+        else:
+            # The store could not answer. Emitting `{}` tells the agent it has NO history, which is
+            # both wrong and silent; the previous pack is stale by a turn or two, which is a much
+            # smaller error. Labelled in band so nothing is passed off as fresh.
+            previous, age_s = _pack_cache.recover_context_pack(
+                cache_path, max_age_s=_pack_cache.pack_cache_max_age_s()
+            )
+            if previous.strip():
+                output["hookSpecificOutput"] = {
+                    "hookEventName": args.event,
+                    "additionalContext": _pack_cache.label_previous_pack(previous, age_s),
+                }
+                output["context_pack_source"] = "previous_pack"
+                output["context_pack_age_s"] = round(age_s, 1)
     require_retrieval_coverage = args.require_retrieval_memory_coverage or require_retrieval_memory_coverage(
         os.environ.get("MATRIXARK_REQUIRE_RETRIEVAL_MEMORY_COVERAGE")
     )

--- a/tools/matrixark_codex_hook.py
+++ b/tools/matrixark_codex_hook.py
@@ -6,6 +6,10 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+try:
+    from tools import matrixark_hook_pack_cache as _pack_cache
+except ImportError:  # running from inside tools/, as the hooks do
+    import matrixark_hook_pack_cache as _pack_cache
 import os
 import re
 import subprocess
@@ -2140,6 +2144,25 @@ def codex_hook_output(
             )
         else:
             additional_context = ""
+        # Remember a pack that loaded; serve the last one when this turn could not build any.
+        # Codex runs a separate entry point from Claude, so a fallback added to the other hook
+        # leaves this one silently unprotected -- which is exactly what was measured.
+        try:
+            _cache_path = _pack_cache.context_pack_cache_path(
+                "codex", str(agent_context.get("workspace_root") or "")
+            )
+            if additional_context.strip():
+                _pack_cache.remember_context_pack(_cache_path, additional_context)
+            elif not error:
+                _previous, _age_s = _pack_cache.recover_context_pack(
+                    _cache_path, max_age_s=_pack_cache.pack_cache_max_age_s()
+                )
+                if _previous.strip():
+                    additional_context = _pack_cache.label_previous_pack(_previous, _age_s)
+                    output["retrieve"]["context_pack_source"] = "previous_pack"
+                    output["retrieve"]["context_pack_age_s"] = round(_age_s, 1)
+        except Exception:  # noqa: BLE001 - the cache must never cost a turn its real answer.
+            pass
         if additional_context:
             output["hookSpecificOutput"] = {
                 "hookEventName": "UserPromptSubmit",

--- a/tools/matrixark_hook_pack_cache.py
+++ b/tools/matrixark_hook_pack_cache.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The last context pack that loaded, kept so a turn that cannot build one still has something.
+
+Emitting nothing tells an agent it has NO history -- wrongly, and silently. Context that is a turn
+or two old is a far smaller error, so each pack that loads is remembered and served back when a
+later turn comes up empty.
+
+Shared by both hooks on purpose. Claude and Codex run entirely separate entry points
+(`matrixark_agent_hook.py` and `matrixark_codex_hook.py`), and a fix applied to one leaves the
+other silently broken -- which is exactly what happened: Claude turns were protected while every
+Codex turn still returned `{}`. Two copies of a cache-key scheme would also be free to drift until
+one agent served the other's pack.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import time
+from pathlib import Path
+
+DEFAULT_MAX_AGE_S = 86400.0
+
+
+def context_pack_cache_path(agent: str, workspace_root: str) -> Path:
+    """Where the last pack that loaded is kept, per agent and per workspace.
+
+    Keyed by BOTH so one project's context can never surface in another and Claude can never be
+    served Codex's pack: a stale pack is a small error, the wrong pack is a large one.
+    """
+    root = os.environ.get("MATRIXARK_HOOK_PACK_CACHE_DIR") or str(
+        Path.home() / ".matrixark" / "hook-pack-cache"
+    )
+    stamp = hashlib.sha256((workspace_root or "-").encode("utf-8")).hexdigest()[:16]
+    return Path(root) / f"{agent}-{stamp}.txt"
+
+
+def remember_context_pack(path: Path, text: str) -> None:
+    """Keep this pack, so a later turn that cannot reach the store still has something true."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Write-then-rename: a turn that dies mid-write must not leave a torn pack behind for the
+        # next one to serve.
+        temporary = path.with_suffix(".tmp")
+        temporary.write_text(text, encoding="utf-8")
+        temporary.replace(path)
+    except OSError:
+        pass
+
+
+def recover_context_pack(path: Path, *, max_age_s: float) -> tuple[str, float]:
+    """The last pack that loaded, if it is recent enough to still be worth serving.
+
+    Returns ("", 0.0) when there is nothing usable, so callers keep the fail-open contract and
+    never invent context.
+    """
+    try:
+        age_s = time.time() - path.stat().st_mtime
+        if age_s > max_age_s:
+            return "", 0.0
+        return path.read_text(encoding="utf-8"), age_s
+    except OSError:
+        return "", 0.0
+
+
+def pack_cache_max_age_s() -> float:
+    """How old a pack may be and still be served. Past this, nothing is better than stale."""
+    raw = os.environ.get("MATRIXARK_HOOK_PACK_CACHE_MAX_AGE_S", str(int(DEFAULT_MAX_AGE_S)))
+    try:
+        return max(0.0, float(str(raw).strip()))
+    except ValueError:
+        return DEFAULT_MAX_AGE_S
+
+
+def label_previous_pack(previous: str, age_s: float) -> str:
+    """Mark a served pack as prior context, in band, with its age.
+
+    The label is not decoration: without it the model cannot tell a stale pack from a fresh one,
+    and silently passing off old context as current is the failure this whole path exists to avoid.
+    """
+    return (
+        f"[prior context: the store did not answer this turn; this is the last pack that loaded, "
+        f"{age_s / 60.0:.0f} min ago]\n{previous}"
+    )

--- a/tools/matrixark_rust_proxy_daemon.py
+++ b/tools/matrixark_rust_proxy_daemon.py
@@ -27,6 +27,53 @@ from typing import Any
 Json = dict[str, Any]
 
 
+_ARENA_TRIM_THRESHOLD_BYTES = max(
+    0, int(os.environ.get("MATRIXARK_PROXY_DAEMON_TRIM_BYTES", str(8 * 1024 * 1024)) or 0)
+)
+_LIBC_FOR_TRIM: Any = None
+_LIBC_LOOKED_UP = False
+
+
+def _libc_for_trim() -> Any:
+    """glibc handle used to hand freed arenas back to the OS, or None where that is not a thing."""
+    global _LIBC_FOR_TRIM, _LIBC_LOOKED_UP
+    if not _LIBC_LOOKED_UP:
+        _LIBC_LOOKED_UP = True
+        try:
+            import ctypes
+
+            candidate = ctypes.CDLL("libc.so.6")
+            candidate.malloc_trim  # raises AttributeError off glibc
+            _LIBC_FOR_TRIM = candidate
+        except Exception:  # noqa: BLE001 - trimming is an optimisation, never a requirement.
+            _LIBC_FOR_TRIM = None
+    return _LIBC_FOR_TRIM
+
+
+def release_arenas_after_large_payload(payload_bytes: int) -> bool:
+    """Return freed heap to the OS after a big request or response.
+
+    This process is a bridge that stores nothing, yet it was observed holding 2.9 GB while the
+    engine it fronts held 1.1 GB. A whole payload is encoded and decoded here, so a large one
+    leaves arenas CPython has freed but never returns -- measured at 124 MB resident from a 105 MB
+    document, falling to 12 MB after malloc_trim(0).
+
+    Bounded to large payloads on purpose: malloc_trim walks the arenas, so running it for every
+    small request would spend time on the hot path reclaiming nothing.
+    """
+    if _ARENA_TRIM_THRESHOLD_BYTES == 0 or payload_bytes < _ARENA_TRIM_THRESHOLD_BYTES:
+        return False
+    libc = _libc_for_trim()
+    if libc is None:
+        return False
+    try:
+        libc.malloc_trim(0)
+        return True
+    except Exception:  # noqa: BLE001 - never let housekeeping break a served request.
+        return False
+
+
+
 class RustProxyDaemon:
     def __init__(self, *, proxy_path: Path, socket_path: Path, log_path: Path) -> None:
         self.proxy_path = proxy_path
@@ -274,6 +321,9 @@ class RustProxyDaemon:
                 return
             response = self._call_proxy(request)
             self._send(file, response)
+            # Both payloads are finished with here. Hand the arenas back before the next caller
+            # arrives, rather than carrying this one's high-water mark for the process lifetime.
+            release_arenas_after_large_payload(len(line))
 
     def _call_proxy(self, request: Json) -> Json:
         started = time.monotonic()

--- a/tools/test_a_retrieve_that_raises_is_recorded_not_fatal.py
+++ b/tools/test_a_retrieve_that_raises_is_recorded_not_fatal.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A retrieve that raises is recorded, not fatal.
+
+Retrieve used to be left unwrapped on the reasoning that a failed read IS the failure. That held
+only while there was nothing better to serve. Now the hook keeps the last pack that loaded, so a
+raise that kills main() throws away a usable answer -- and, worse, makes a LOUD policy error
+(native ContextPack required but not produced) end in exactly the same `{}` as a silent one.
+
+These tests pin the two halves that matter: the turn survives, and the reason is not swallowed.
+"""
+import unittest
+
+import matrixark_agent_hook as hook
+
+
+class RetrieveFailureIsSurvivableTest(unittest.TestCase):
+    def setUp(self):
+        self._real_call_tool = hook.call_tool
+
+    def tearDown(self):
+        hook.call_tool = self._real_call_tool
+
+    def test_a_raising_retrieve_returns_empty_and_is_recorded(self):
+        def boom(server, tool, tool_args):
+            raise RuntimeError(
+                "backend-native ContextPack assembly is required for TemporalStore serving"
+            )
+
+        hook.call_tool = boom
+        failures: list = []
+        result = hook.call_retrieve_tool(None, "matrixark_retrieve", {}, failures=failures)
+
+        self.assertEqual(result, {}, "a failed retrieve must return {} so the turn can continue")
+        self.assertEqual(len(failures), 1, "the failure must be recorded, not swallowed")
+        self.assertEqual(failures[0]["tool"], "matrixark_retrieve")
+        self.assertIn(
+            "ContextPack assembly is required",
+            failures[0]["error"],
+            "the recorded error must carry the REASON -- a policy error is the case an operator "
+            "most needs told rather than left to infer",
+        )
+        self.assertIn("RuntimeError", failures[0]["error"], "the error type must survive too")
+
+    def test_a_successful_retrieve_passes_straight_through(self):
+        """The control: without this, returning {} unconditionally would pass the test above."""
+        pack = {"context_pack_id": "rust-native-123-4", "groups": [{"items": [{"text": "hi"}]}]}
+        hook.call_tool = lambda server, tool, tool_args: pack
+        failures: list = []
+
+        self.assertEqual(
+            hook.call_retrieve_tool(None, "matrixark_retrieve", {}, failures=failures), pack
+        )
+        self.assertEqual(failures, [], "a retrieve that worked must record no failure")
+
+    def test_the_recorded_error_is_bounded(self):
+        """An adapter error can carry a whole request; the report must not become the payload."""
+        hook.call_tool = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("x" * 5000))
+        failures: list = []
+        hook.call_retrieve_tool(None, "matrixark_retrieve", {}, failures=failures)
+        self.assertLessEqual(len(failures[0]["error"]), 500)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_a_turn_that_cannot_build_a_pack_serves_the_last_one.py
+++ b/tools/test_a_turn_that_cannot_build_a_pack_serves_the_last_one.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A turn that cannot build a pack serves the last one that loaded, and says so.
+
+Measured on a live one-box under its normal load: agent turns returned NO context at all -- the
+retrieve completed, reported `deadline_exceeded: false`, and selected zero refs. The hook then
+emitted `{}`, which tells the agent it has no history. That is both wrong and silent, and it is a
+worse answer than context that is a turn or two old.
+
+Both hooks share this module rather than keeping a copy each, because Claude and Codex run
+entirely separate entry points: a fix applied to one leaves the other silently broken (measured:
+Claude 0 empty, Codex 3 of 4 empty, same store and same minute), and two copies of a cache-key
+scheme are free to drift until one agent serves the other's pack. These tests cover the cache
+directly -- the failure they guard against is not "the store was slow" but "the hook had something
+true and served nothing".
+"""
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+import matrixark_hook_pack_cache as pack_cache
+
+
+class LastGoodPackTest(unittest.TestCase):
+    def setUp(self):
+        self._dir = tempfile.TemporaryDirectory()
+        self._prev = os.environ.get("MATRIXARK_HOOK_PACK_CACHE_DIR")
+        os.environ["MATRIXARK_HOOK_PACK_CACHE_DIR"] = self._dir.name
+
+    def tearDown(self):
+        if self._prev is None:
+            os.environ.pop("MATRIXARK_HOOK_PACK_CACHE_DIR", None)
+        else:
+            os.environ["MATRIXARK_HOOK_PACK_CACHE_DIR"] = self._prev
+        self._dir.cleanup()
+
+    def test_a_remembered_pack_comes_back(self):
+        path = pack_cache.context_pack_cache_path("claude", "/work/project")
+        pack_cache.remember_context_pack(path, "the pack that loaded")
+        text, age = pack_cache.recover_context_pack(path, max_age_s=3600)
+        self.assertEqual(text, "the pack that loaded")
+        self.assertLess(age, 60, "a pack just written should read back as fresh")
+
+    def test_nothing_is_served_when_nothing_was_ever_stored(self):
+        """The fail-open contract: with no cache, the hook must emit nothing rather than invent
+        context."""
+        path = pack_cache.context_pack_cache_path("claude", "/never/seen")
+        self.assertEqual(pack_cache.recover_context_pack(path, max_age_s=3600), ("", 0.0))
+
+    def test_a_stale_pack_is_refused(self):
+        """Past the age bound, nothing is better than stale."""
+        path = pack_cache.context_pack_cache_path("claude", "/work/project")
+        pack_cache.remember_context_pack(path, "yesterday's pack")
+        old = time.time() - 7200
+        os.utime(path, (old, old))
+        self.assertEqual(
+            pack_cache.recover_context_pack(path, max_age_s=3600)[0],
+            "",
+            "a pack older than the bound must not be served",
+        )
+        self.assertTrue(
+            pack_cache.recover_context_pack(path, max_age_s=10800)[0],
+            "the same pack inside a wider bound must still be served",
+        )
+
+    def test_one_workspace_cannot_serve_another_its_context(self):
+        """A stale pack is a small error; the WRONG PROJECT's pack is a large one."""
+        a = pack_cache.context_pack_cache_path("claude", "/work/alpha")
+        b = pack_cache.context_pack_cache_path("claude", "/work/beta")
+        self.assertNotEqual(a, b, "different workspaces must not share a cache file")
+        pack_cache.remember_context_pack(a, "alpha context")
+        self.assertEqual(pack_cache.recover_context_pack(b, max_age_s=3600)[0], "")
+
+    def test_one_agent_cannot_serve_another_its_context(self):
+        """The two hooks share this module; they must not share a FILE."""
+        claude = pack_cache.context_pack_cache_path("claude", "/work/project")
+        codex = pack_cache.context_pack_cache_path("codex", "/work/project")
+        self.assertNotEqual(claude, codex, "agents must not share a cache file")
+        pack_cache.remember_context_pack(claude, "claude context")
+        self.assertEqual(pack_cache.recover_context_pack(codex, max_age_s=3600)[0], "")
+
+    def test_a_torn_write_cannot_be_served(self):
+        """Written via rename, so a turn that dies mid-write leaves the previous pack intact
+        rather than a truncated one."""
+        path = pack_cache.context_pack_cache_path("claude", "/work/project")
+        pack_cache.remember_context_pack(path, "first pack")
+        pack_cache.remember_context_pack(path, "second pack, longer than the first")
+        self.assertEqual(
+            pack_cache.recover_context_pack(path, max_age_s=3600)[0],
+            "second pack, longer than the first",
+        )
+        self.assertEqual(
+            list(Path(self._dir.name).glob("*.tmp")),
+            [],
+            "no temporary file should survive a completed write",
+        )
+
+    def test_the_age_bound_is_configurable_and_survives_nonsense(self):
+        prev = os.environ.get("MATRIXARK_HOOK_PACK_CACHE_MAX_AGE_S")
+        try:
+            os.environ["MATRIXARK_HOOK_PACK_CACHE_MAX_AGE_S"] = "120"
+            self.assertEqual(pack_cache.pack_cache_max_age_s(), 120.0)
+            os.environ["MATRIXARK_HOOK_PACK_CACHE_MAX_AGE_S"] = "not-a-number"
+            self.assertEqual(
+                pack_cache.pack_cache_max_age_s(),
+                pack_cache.DEFAULT_MAX_AGE_S,
+                "an unparseable bound must fall back, not crash the hook",
+            )
+        finally:
+            if prev is None:
+                os.environ.pop("MATRIXARK_HOOK_PACK_CACHE_MAX_AGE_S", None)
+            else:
+                os.environ["MATRIXARK_HOOK_PACK_CACHE_MAX_AGE_S"] = prev
+
+    def test_a_served_pack_is_labelled_as_prior_context(self):
+        """Unlabelled, the model cannot tell a stale pack from a fresh one -- and silently passing
+        off old context as current is the failure this path exists to avoid."""
+        labelled = pack_cache.label_previous_pack("BODY", 372.0)
+        self.assertIn("prior context", labelled)
+        self.assertIn("6 min ago", labelled)
+        self.assertTrue(labelled.endswith("BODY"), "the pack itself must survive the label")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_freed_arenas_go_back_to_the_os.py
+++ b/tools/test_freed_arenas_go_back_to_the_os.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Freed arenas go back to the OS after a large payload, and only then.
+
+The proxy daemon stores nothing yet sat at 2.9 GB RSS while the engine it fronts held 1.1 GB.
+Every request and response is encoded and decoded whole in this process, and CPython keeps the
+arenas after freeing them -- measured here at 124 MB left resident from a 105 MB document, falling
+to 12 MB after malloc_trim(0).
+
+Trimming walks the arenas, so doing it per request would spend CPU on the hot path to reclaim
+nothing. These tests pin the bound rather than the byte count: they assert WHEN the trim runs,
+which is deterministic, instead of asserting an RSS number, which is not.
+"""
+import os
+import unittest
+
+import matrixark_rust_proxy_daemon as daemon
+
+
+class _FakeLibc:
+    def __init__(self):
+        self.calls = 0
+
+    def malloc_trim(self, _pad):
+        self.calls += 1
+        return 1
+
+
+class ArenaTrimTest(unittest.TestCase):
+    def setUp(self):
+        self._real_libc = daemon._LIBC_FOR_TRIM
+        self._real_looked_up = daemon._LIBC_LOOKED_UP
+        self._real_threshold = daemon._ARENA_TRIM_THRESHOLD_BYTES
+        self.fake = _FakeLibc()
+        daemon._LIBC_FOR_TRIM = self.fake
+        daemon._LIBC_LOOKED_UP = True
+        daemon._ARENA_TRIM_THRESHOLD_BYTES = 1024
+
+    def tearDown(self):
+        daemon._LIBC_FOR_TRIM = self._real_libc
+        daemon._LIBC_LOOKED_UP = self._real_looked_up
+        daemon._ARENA_TRIM_THRESHOLD_BYTES = self._real_threshold
+
+    def test_a_large_payload_returns_its_arenas(self):
+        self.assertTrue(daemon.release_arenas_after_large_payload(4096))
+        self.assertEqual(self.fake.calls, 1)
+
+    def test_a_small_payload_does_not_pay_for_a_trim(self):
+        """The control. Trimming per request would put arena walking on the hot path."""
+        self.assertFalse(daemon.release_arenas_after_large_payload(64))
+        self.assertEqual(self.fake.calls, 0, "a small payload must not trigger a trim")
+
+    def test_the_boundary_is_inclusive_upward(self):
+        self.assertFalse(daemon.release_arenas_after_large_payload(1023))
+        self.assertTrue(daemon.release_arenas_after_large_payload(1024))
+
+    def test_a_zero_threshold_disables_trimming_entirely(self):
+        """An operator must be able to turn it off without patching the daemon."""
+        daemon._ARENA_TRIM_THRESHOLD_BYTES = 0
+        self.assertFalse(daemon.release_arenas_after_large_payload(10 * 1024 * 1024))
+        self.assertEqual(self.fake.calls, 0)
+
+    def test_no_glibc_is_survivable(self):
+        """Housekeeping must never break a served request on a platform without malloc_trim."""
+        daemon._LIBC_FOR_TRIM = None
+        self.assertFalse(daemon.release_arenas_after_large_payload(10 * 1024 * 1024))
+
+    def test_a_raising_libc_is_survivable(self):
+        class _Angry:
+            def malloc_trim(self, _pad):
+                raise OSError("no")
+
+        daemon._LIBC_FOR_TRIM = _Angry()
+        self.assertFalse(daemon.release_arenas_after_large_payload(10 * 1024 * 1024))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Three problems measured on a live one-box, all of which ended the same way: the agent was told it
has **no history**.

### A turn that could not build a pack emitted `{}`

`{}` is indistinguishable from "there genuinely is no context", so an agent proceeded as though it
had none — wrongly, and silently. Both hooks now remember each pack that loads and serve the last
good one when a turn would otherwise return nothing, labelled in band:

```
[prior context: the store did not answer this turn; this is the last pack that loaded, 6 min ago]
```

and recorded as `context_pack_source: "previous_pack"` with `context_pack_age_s`. A run of
`previous_pack` in the reports is an alarm that retrieval is failing — it is mitigation, not a cure.

### A retrieve that raised killed the turn before the fallback could run

Retrieve was left unwrapped on the reasoning that a failed read *is* the failure. That held only
while there was nothing better to serve. The effect was perverse: a **loud** policy error
("backend-native ContextPack assembly is required…") produced exactly the same useless `{}` as a
silent one, because `main()` died before reaching the emission path. The failure is now recorded
under `retrieve_error` and the turn continues.

### Codex was protected by neither, because it runs a separate entry point

```
matrixark_claude_hook.sh       -> tools/matrixark_agent_hook.py
matrixark_codex_onebox_hook.sh -> ... -> tools/matrixark_codex_hook.py
```

Measured over 8 turns on one box, same store, same minute: **Claude 0 empty, Codex 3 of 4 empty.**
A fix to one hook covers one agent. Both now share `tools/matrixark_hook_pack_cache.py` rather than
keeping a copy each, so two cache-key schemes cannot drift until one agent serves the other's pack.

### The proxy daemon was holding 2.9 GB

A bridge that stores nothing sat at 2.9 GB RSS while the engine it fronts held 1.1 GB — one thread,
ten fds, no accumulating containers. Every payload is encoded and decoded whole in that process, so
a large one leaves arenas CPython has freed but never returns. Measured with a 105 MB document:

| stage | RSS |
|---|---|
| peak | 345 MB |
| after `del` + `gc.collect()` | 124 MB |
| after `malloc_trim(0)` | 12 MB |

The daemon now returns arenas after a large payload, bounded to payloads above
`MATRIXARK_PROXY_DAEMON_TRIM_BYTES` (default 8 MiB, `0` disables) because `malloc_trim` walks the
arenas and doing it per request would spend time on the hot path reclaiming nothing.

### Measured effect

Live box, one soak, split at the moment the Codex fixes landed:

| | before | after |
|---|---|---|
| all agents | 38% turns with no context (3/8) | **0% (0/17)** |
| codex | 75% (3/4) | **0% (0/8)** |

Daemon RSS, compared at the same process age: **2,929 MB → 745 MB**, oscillating in a 400–1,000 MB
band instead of climbing.

Latency also improved (p50 181.8 s → 92.9 s) but box load fell over the same window, so that is
**not** attributed to this change.

### Tests

- `test_a_turn_that_cannot_build_a_pack_serves_the_last_one.py` — round trip, stale refused,
  nothing-cached refused (must not invent context), workspace isolation, agent isolation, no torn
  write, unparseable age bound falls back rather than crashing the hook, label carries the age
- `test_a_retrieve_that_raises_is_recorded_not_fatal.py` — the turn survives and the reason is
  recorded, with a control proving a working retrieve still passes straight through
- `test_freed_arenas_go_back_to_the_os.py` — trims above the threshold and **not** below it,
  boundary, disable switch, no glibc, raising libc

The controls are deliberate: without them, "return `{}` always" and "trim always" would pass.
