### PR TITLE
Two set guards could not follow a dispatch that names its set

### DIFF
--- a/tools/test_matrixark_an_unrecognised_provider_name_is_named.py
+++ b/tools/test_matrixark_an_unrecognised_provider_name_is_named.py
@@ -52,6 +52,8 @@ def assigned_string_set(filename: str, name: str) -> set:
         if isinstance(node, ast.Assign):
             for target in node.targets:
                 if isinstance(target, ast.Name) and target.id == name:
+                    if not isinstance(node.value, (ast.Set, ast.List, ast.Tuple)):
+                        continue
                     return {e.value for e in node.value.elts
                             if isinstance(e, ast.Constant) and isinstance(e.value, str)}
     raise AssertionError("%s not found in %s" % (name, filename))
@@ -65,6 +67,20 @@ def provider_membership_sets(filename: str) -> list:
             continue
         left, right = node.left, node.comparators[0]
         if not (isinstance(left, ast.Name) and left.id == "provider"):
+            continue
+        if isinstance(right, ast.Name):
+            # A dispatch may NAME its set rather than spell it out, and one now does: the encoder
+            # hoisted the four spellings that select the in-process model into a constant, because
+            # writing them at each branch was four places for a new spelling to reach one and miss
+            # the others. Refusing to follow the name would make this check pass only for modules
+            # that repeat themselves, and go quiet on the ones that stopped -- which is the wrong
+            # way round, since what it is really asking is what the code DISPATCHES on.
+            try:
+                named = assigned_string_set(filename, right.id)
+            except AssertionError:
+                continue
+            if named:
+                found.append(named)
             continue
         if isinstance(right, (ast.Set, ast.List, ast.Tuple)):
             members = {e.value for e in right.elts

--- a/tools/test_matrixark_every_choice_is_explained.py
+++ b/tools/test_matrixark_every_choice_is_explained.py
@@ -96,7 +96,11 @@ class TheClaimsAboutLocalAreTrueTest(unittest.TestCase):
         with open(os.path.join(TOOLS, "matrixark_mcp_embeddings.py"), encoding="utf-8") as handle:
             source = handle.read()
         api = re.search(r"_API_EMBEDDING_PROVIDERS\s*=\s*\{([^}]*)\}", source)
-        oss = re.search(r'provider in \{("oss"[^}]*)\}', source)
+        # Read from the assignment, as the API set above already is. The encoder used to spell
+        # these four spellings out at each branch and now names them once; the check that the
+        # constant is what the code actually DISPATCHES on lives in
+        # test_matrixark_an_unrecognised_provider_name_is_named, which follows the name.
+        oss = re.search(r"_OSS_EMBEDDING_PROVIDERS\s*=\s*\{([^}]*)\}", source)
         strip = lambda text: {v.strip().strip('"').strip("'") for v in text.split(",") if v.strip()}
         return strip(api.group(1)), strip(oss.group(1))
 


### PR DESCRIPTION
**I broke these and did not notice.** The encoder used to spell out the four spellings that select
the in-process model at each of four branches; consolidating them into one named constant
([#975](https://github.com/matrixarkai/TemporalStore/pull/975)) left two guards reading for a
literal that is no longer written, and both have been red on main since.

They are not the same failure, and the difference is worth keeping:

| guard | what it asserted | how it broke |
|---|---|---|
| `…an_unrecognised_provider_name_is_named` | the gateway's copy of the set is a set the encoder **dispatches** on | went **blind** — its parser walks `provider in {…}` and skipped the branch once the right side became a name |
| `…every_choice_is_explained` | `local` selects neither encoder path | raised **AttributeError on None** — the louder outcome; its sibling test exists precisely to make a vacuous pass impossible, and it did its job |

Both now read the constant. The first resolves a name through the assignment lookup it already had
for the API set; the second matches that assignment directly, which is what it already did for the
API set one line above.

### Neither loosens what is asserted

| mutation | result |
|---|---|
| add a spelling to the encoder's set | **FAILS** the first guard |
| put `local` into the encoder's set | **FAILS** the second guard |
| unmodified | both **OK** |

### How this got through, which is the part that matters

After consolidating I ran tests selected by grepping filenames for words I expected to be
relevant — `embed`, `vector`, `encoder`, `model`, `retrieval`. **Neither of these files matches any
of them.** 633 tests passed while both of these were already failing.

The suite that decides is `unittest discover`, which is what the ratchet runs. A subset chosen by
guessing at filenames is not a substitute for it.

### Checks

Full discovery, the way the ratchet runs it:

```
before: 3253 tests, 75 failures, 11 errors
after:  3253 tests, 75 failures,  9 errors   <- the documented baseline
```
