### PR TITLE
Read a cached answer without building it one byte at a time

### DIFF
--- a/crates/temporalstore-rust/src/engine/command_validation.rs
+++ b/crates/temporalstore-rust/src/engine/command_validation.rs
@@ -943,17 +943,74 @@ pub(super) fn validate_command_preconditions(
 /// contained to the pair of functions here. A stored entry that does not decode is dropped and
 /// recomputed, which is what the JSON path already did -- so an entry written by an older build
 /// in the same process costs one recompute, not an error.
-fn encode_cached_response(response: &CommandResponse) -> Option<Vec<u8>> {
+/// Reading a cached answer without building it one byte at a time.
+///
+/// `CommandResponse` is an internally tagged enum (`#[serde(tag = "kind")]`). Serde cannot pick the
+/// variant until it has read the tag, so reading one back buffers the whole content first, and a
+/// `Vec<u8>` buffers as one element per BYTE at 32 bytes each. Measured on a hit, decoding a stored
+/// answer for a 4,096-byte value allocated 135,296 bytes, of which 131,072 is exactly 4,096 x 32.
+/// That was 97% of everything a warm read allocated.
+///
+/// None of it shows in what is stored: the same answer packs into 4,117 bytes, a 1.005x encoding.
+/// The cost is entirely on the read side.
+///
+/// So the tag is read on its own first, and the payload is then read into a plain struct that
+/// carries no tag and so needs no buffering. What is STORED does not change at all -- these are the
+/// same bytes the encoder already wrote -- which matters because the cache admits and evicts by
+/// size, and an entry of a different size lives a different life.
+#[derive(serde::Deserialize)]
+struct CachedKind {
+    kind: String,
+}
+
+#[derive(serde::Deserialize)]
+struct CachedBytes {
+    value: Option<Vec<u8>>,
+}
+
+#[derive(serde::Deserialize)]
+struct CachedMembers {
+    members: Vec<Vec<u8>>,
+}
+
+#[derive(serde::Deserialize)]
+struct CachedValues {
+    values: Vec<Option<Vec<u8>>>,
+}
+
+/// Encode a cached response.
+///
+/// Nothing on disk depends on this being msgpack rather than anything else, but it does depend on
+/// it staying the SAME: these entries are sized by the cache, so changing the encoding changes
+/// which of them survive pressure. This writes what it has always written.
+pub(super) fn encode_cached_response(response: &CommandResponse) -> Option<Vec<u8>> {
     let mut packed = Vec::new();
     let mut serializer = rmp_serde::Serializer::new(&mut packed).with_struct_map();
-    // struct-as-MAP: `CommandResponse` is internally tagged (`#[serde(tag = "kind")]`), which
-    // needs the field names present to read back. The array form would drop them.
+    // struct-as-MAP: the internal tag needs the field names present to read back. The array form
+    // would drop them.
     serde::Serialize::serialize(response, &mut serializer).ok()?;
     Some(packed)
 }
 
-fn decode_cached_response(bytes: &[u8]) -> Option<CommandResponse> {
-    rmp_serde::from_slice::<CommandResponse>(bytes).ok()
+pub(super) fn decode_cached_response(bytes: &[u8]) -> Option<CommandResponse> {
+    // Reading the tag on its own steps over the payload instead of building it: the fields this
+    // struct does not name are skipped, not materialised.
+    let kind = rmp_serde::from_slice::<CachedKind>(bytes).ok()?.kind;
+    match kind.as_str() {
+        "bytes" => Some(CommandResponse::Bytes {
+            value: rmp_serde::from_slice::<CachedBytes>(bytes).ok()?.value,
+        }),
+        "members" => Some(CommandResponse::Members {
+            members: rmp_serde::from_slice::<CachedMembers>(bytes).ok()?.members,
+        }),
+        "values" => Some(CommandResponse::Values {
+            values: rmp_serde::from_slice::<CachedValues>(bytes).ok()?.values,
+        }),
+        // Every other shape carries no bulk payload, so the buffering costs nothing worth avoiding
+        // and the whole enum reads back as itself. A variant added later lands here: slower than it
+        // could be, never wrong.
+        _ => rmp_serde::from_slice::<CommandResponse>(bytes).ok(),
+    }
 }
 
 pub(super) fn cached_response(

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -191,6 +191,177 @@ fn what_the_read_cache_codec_costs() {
     }
 }
 
+/// Where a warm read's remaining allocations go.
+///
+/// Caching the answer packed rather than as text took a warm read from 15 allocations to 8. The
+/// convenient story about the rest is that it all lives inside the cache crate -- convenient
+/// because that crate is a pinned dependency. Worth splitting rather than assuming: anything on
+/// this side of the boundary is ours.
+///
+/// Decodes a stored answer directly, which is the same call a hit makes, and compares that against
+/// the whole read. What is left over is the plumbing around the codec.
+#[test]
+#[ignore]
+#[cfg(feature = "alloc-probe")]
+fn where_a_warm_reads_allocations_go() {
+    for value_len in [64usize, 4096] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            64 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+
+        let keys = 200usize;
+        let names: Vec<String> =
+            (0..keys).map(|index| format!("tenant/7/object/{index:09}")).collect();
+        for name in &names {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet { key: name.clone(), value: vec![118u8; value_len] },
+            });
+        }
+        // Warm the cache, so what follows measures hits.
+        for name in &names {
+            let _ = engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringGet { key: name.clone() },
+            });
+        }
+
+        // What one stored answer costs to decode: the same shape the cache stores.
+        let stored = crate::engine::command_validation::encode_cached_response(
+            &crate::types::CommandResponse::Bytes { value: Some(vec![118u8; value_len]) },
+        )
+        .expect("encode");
+
+        let probe = crate::alloc_probe::Probe::start();
+        for _ in 0..keys {
+            std::hint::black_box(crate::engine::command_validation::decode_cached_response(
+                &stored,
+            ));
+        }
+        let decoding = probe.stop();
+
+        // The whole read, key building and cache lookup included.
+        let probe = crate::alloc_probe::Probe::start();
+        for name in &names {
+            std::hint::black_box(engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringGet { key: name.clone() },
+            }));
+        }
+        let whole = probe.stop();
+
+        let split = |counts: &crate::alloc_probe::AllocCounts| {
+            (counts.allocs as f64 / keys as f64, counts.alloc_bytes as f64 / keys as f64)
+        };
+        let (da, db) = split(&decoding);
+        let (wa, wb) = split(&whole);
+        println!(
+            "  SPLITREAD value {value_len:>5}B | stored {:>6} B | decode {da:>5.1} allocs {db:>8.0} B | whole read {wa:>5.1} allocs {wb:>8.0} B | everything else {:>5.1} allocs {:>8.0} B ({:>4.0}% of allocs)",
+            stored.len(),
+            wa - da,
+            wb - db,
+            if wa > 0.0 { (wa - da) / wa * 100.0 } else { 0.0 },
+        );
+
+        assert!(whole.allocs > 0, "the probe must observe the reads at {value_len}B");
+    }
+}
+
+/// A cached answer reads back as itself, whichever shape it is.
+///
+/// The read cache writes the three payload-carrying shapes as their bytes and everything else
+/// through msgpack. Both halves are exercised here, along with the shapes that have an easy
+/// off-by-one in them -- an absent value, an empty payload, an empty collection, and a `Values`
+/// run that mixes present and absent -- because the framing is hand-written.
+#[test]
+fn a_cached_answer_reads_back_as_itself() {
+    use crate::engine::command_validation::{decode_cached_response, encode_cached_response};
+    use crate::types::CommandResponse;
+
+    let cases = vec![
+        ("bytes absent", CommandResponse::Bytes { value: None }),
+        ("bytes empty", CommandResponse::Bytes { value: Some(Vec::new()) }),
+        ("bytes small", CommandResponse::Bytes { value: Some(b"a value".to_vec()) }),
+        ("bytes large", CommandResponse::Bytes { value: Some(vec![118u8; 8192]) }),
+        ("bytes with a tag byte in it", CommandResponse::Bytes { value: Some(vec![0, 1, 2, 3, 4]) }),
+        ("members none", CommandResponse::Members { members: Vec::new() }),
+        (
+            "members several",
+            CommandResponse::Members {
+                members: vec![Vec::new(), b"one".to_vec(), vec![7u8; 4096]],
+            },
+        ),
+        ("values none", CommandResponse::Values { values: Vec::new() }),
+        (
+            "values mixed",
+            CommandResponse::Values {
+                values: vec![None, Some(Vec::new()), Some(b"three".to_vec()), None],
+            },
+        ),
+        ("empty", CommandResponse::Empty),
+        ("integer", CommandResponse::Integer { value: -9_007_199_254_740_993 }),
+        (
+            "hash entries, through the packed fallback",
+            CommandResponse::HashEntries {
+                entries: vec![("field".to_string(), vec![9u8; 32])],
+            },
+        ),
+    ];
+
+    for (label, response) in cases {
+        let encoded = encode_cached_response(&response).unwrap_or_else(|| {
+            panic!("{label} must encode");
+        });
+        let decoded = decode_cached_response(&encoded)
+            .unwrap_or_else(|| panic!("{label} must decode back"));
+        assert_eq!(
+            format!("{decoded:?}"),
+            format!("{response:?}"),
+            "{label} did not survive the cache codec"
+        );
+
+        // A truncated entry is a miss, not a panic and not a different answer. The cache drops
+        // whatever fails to decode and recomputes, so this is the path an interrupted entry takes.
+        for cut in [0usize, 1, encoded.len().saturating_sub(1)] {
+            if cut < encoded.len() {
+                let short = decode_cached_response(&encoded[..cut]);
+                if let Some(short) = short {
+                    assert_ne!(
+                        format!("{short:?}"),
+                        format!("{response:?}"),
+                        "{label} cut to {cut} bytes must not read back as the whole answer"
+                    );
+                }
+            }
+        }
+    }
+
+    // Bytes that are not a stored answer read as a miss rather than as a wrong answer.
+    assert!(decode_cached_response(&[]).is_none(), "an empty entry must not decode");
+    assert!(decode_cached_response(&[0xc1, 0xff, 0x00]).is_none(), "junk must not decode");
+
+    // What is STORED must not drift. The cache admits and evicts these entries by size, so an
+    // encoding change is a behaviour change: it decides which answers survive pressure, not just
+    // how they are written. Four tests around eviction and refill turn on exactly that.
+    let response = CommandResponse::Bytes { value: Some(b"a value".to_vec()) };
+    let packed_directly = {
+        let mut packed = Vec::new();
+        let mut serializer = rmp_serde::Serializer::new(&mut packed).with_struct_map();
+        serde::Serialize::serialize(&response, &mut serializer).expect("pack");
+        packed
+    };
+    assert_eq!(
+        encode_cached_response(&response).expect("encode"),
+        packed_directly,
+        "a stored answer must stay the bytes it has always been"
+    );
+}
+
 #[test]
 fn object_manager_runtime_report_tracks_residency_layout_and_tombstones() {
     let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
`CommandResponse` is an internally tagged enum (`#[serde(tag = "kind")]`). Serde cannot pick the
variant until it has read the tag, so reading one back buffers the whole content first, and a
`Vec<u8>` buffers as one element per BYTE at 32 bytes each.

Measured on a cache hit, decoding a stored answer:

| value | stored | decode allocations | decode bytes |
|---|---:|---:|---:|
| 64 B | 85 B | 3 | 2,240 B |
| 4,096 B | 4,117 B | 3 | 135,296 B |

135,296 - 4,224 = 131,072, which is exactly 4,096 x 32. That was 97% of everything a warm read
allocated; the cache lookup and the rest of the plumbing came to 4,248 B.

None of this shows in what is stored: the answer packs into 4,117 bytes for a 4,096-byte value, a
1.005x encoding. The cost is entirely on the read side, so measuring what is stored says the
encoding is fine while every hit pays 33x.

So the tag is read on its own first, and the payload is then read into a plain struct that carries
no tag and needs no buffering. Per warm read:

| value | before | after |
|---|---|---|
| 64 B | 11 allocations, 2,456 B | 10 allocations, 285 B |
| 4,096 B | 11 allocations, 139,544 B | 10 allocations, 8,349 B |

What is STORED does not change: these are the same bytes the encoder already wrote. That turned out
to matter more than it looks. The first version of this change also replaced the encoding with a
tag byte and the raw payload, which is smaller and faster still -- and it failed four eviction and
refill tests that pass on main. The cache admits and evicts by size, so a smaller entry survives
pressure that the larger one did not, and a read those tests expect to reach the page store was
served from cache instead. The answers were correct; the residency was not the one the tests
describe. An encoding change here is a behaviour change, so this one leaves the bytes alone, and a
test now asserts they stay what they have always been.

The round-trip test covers the shapes with an easy off-by-one in them -- an absent value, an empty
payload, an empty collection, and a `Values` run mixing present and absent -- plus the shapes that
take the fallback, and checks that truncated or unrelated bytes read as a miss rather than as a
different answer. Three deliberate breakages of the payload handling each fail it.
