### PR TITLE
A wide parent hid its newest children from retrieval

### DIFF
--- a/crates/temporalstore-rust/src/engine/context.rs
+++ b/crates/temporalstore-rust/src/engine/context.rs
@@ -813,6 +813,25 @@ pub(super) fn load_context_children(
 /// The same lookup as `load_context_node`, decoding only the vector.
 ///
 /// Used where a candidate is scored and discarded, which is most of them.
+/// Children dropped by the per-parent cut BEFORE any scoring.
+///
+/// The cut is by recency, which correlates with nothing a query asked for, so anything it drops is
+/// unreachable however well it matches. Retrieval still answers from what survived, so the limit
+/// reads as ordinary imperfect recall unless something counts it. Non-zero here means a parent is
+/// wide enough that retrieval cannot see all of it.
+pub static CONTEXT_CHILDREN_DROPPED_BEFORE_SCORING: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// Children dropped before scoring since the last reset.
+pub fn context_children_dropped_before_scoring() -> u64 {
+    CONTEXT_CHILDREN_DROPPED_BEFORE_SCORING.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Reset the drop counter. For tests measuring one traversal.
+pub fn reset_context_children_dropped_before_scoring() {
+    CONTEXT_CHILDREN_DROPPED_BEFORE_SCORING.store(0, std::sync::atomic::Ordering::Relaxed);
+}
+
 pub(super) fn load_context_node_vector(
     cache: &MultiLayerCache,
     page_store: &LocalBlockStore,
@@ -1049,8 +1068,32 @@ pub(super) fn traverse_context_tree(
             let child_key = context_child_key(tenant_hash, parent.node_hash);
             let mut children =
                 load_context_children(cache, page_store, shard_id, shard, &child_key);
-            children.sort_by_key(|child_ref| (child_ref.updated_at_ms, child_ref.child_hash));
+            // NEWEST first, not oldest. This cut happens BEFORE any scoring, so whatever it
+            // drops is unreachable by any query however well it matches -- and it used to sort
+            // ascending, which kept the oldest children and made the most recently ingested the
+            // first to disappear. That is the opposite of what a store keyed on time should do.
+            //
+            // This does NOT make the selection relevance-based, and it is worth being plain
+            // about that: scoring a child costs a page read (`load_context_node_vector` reads
+            // the node's page and decodes its vector), so scoring every child of a very wide
+            // parent is not affordable, and a cap has to stay. Recency is a better proxy than
+            // age, not a substitute for relevance. A parent wide enough for this cut to bind
+            // still hides children, which is what the node hierarchy in the issue addresses.
+            children.sort_by_key(|child_ref| {
+                (
+                    std::cmp::Reverse(child_ref.updated_at_ms),
+                    child_ref.child_hash,
+                )
+            });
+            let considered = children.len();
             children.truncate(child_limit);
+            if considered > child_limit {
+                // Say it, because the failure is otherwise invisible: retrieval still returns
+                // plausible results from whatever survived, so a structural limit reads as
+                // ordinary imperfect recall.
+                CONTEXT_CHILDREN_DROPPED_BEFORE_SCORING
+                    .fetch_add((considered - child_limit) as u64, std::sync::atomic::Ordering::Relaxed);
+            }
             for child in children {
                 // Score from the vector the node itself carries. The node is addressable by
                 // the child hash already in hand; the retired separate records were not -- they

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -14847,6 +14847,135 @@ fn the_cache_namespaces_a_record_can_actually_use() {
     }
 }
 
+/// A wide parent keeps its NEWEST children for scoring, not its oldest.
+///
+/// Traversal cuts a parent's children down to a cap BEFORE scoring any of them, so whatever the
+/// cut drops is unreachable by any query however well it matches. The sort was ascending on
+/// `updated_at_ms`, so the cut kept the OLDEST children and the most recently ingested were the
+/// first to become invisible -- the opposite of what a store keyed on time should do.
+///
+/// This is not a claim that selection is now relevance-based. It is not: scoring a child costs a
+/// page read, so a cap has to stay and a wide enough parent still hides children. What this holds
+/// is that recent writes are reachable, and that the drop is counted rather than silent.
+#[test]
+fn a_wide_parent_keeps_its_newest_children_for_scoring() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        32 * 1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+
+    const TENANT: u64 = 77;
+    const PARENT: u64 = 1;
+    const CHILDREN: u64 = 16;
+    const CAP: usize = 4;
+
+    // Each child carries a vector that points along its own axis, so a query can name exactly one
+    // of them and no other child scores against it.
+    let axis = |n: u64| -> Vec<f32> {
+        let mut vector = vec![0.0f32; CHILDREN as usize + 2];
+        vector[n as usize] = 1.0;
+        vector
+    };
+
+    let upsert = |node_hash: u64, vector: Vec<f32>| Command::ContextUpsertNode {
+        tenant_hash: TENANT,
+        node: Box::new(crate::types::ContextNode {
+            node_hash,
+            parent_hash: 0,
+            kind: 1,
+            canonical_name: format!("node-{node_hash}"),
+            status: 1,
+            last_event_time_ms: 1_700_000_000_000 + node_hash,
+            raw_metadata_ref: String::new(),
+            l0: String::new(),
+            l1_ref: String::new(),
+            vector,
+            embedding_model_hash: 0,
+            embedding_updated_at_ms: 0,
+            summary_vector: Vec::new(),
+            summary_vector_valid_from_ms: 0,
+            summary_vector_model_hash: 0,
+        }),
+    };
+
+    let out = engine.execute(ExecuteRequest { shard_id: 1, command: upsert(PARENT, axis(0)) });
+    assert!(out.status.ok, "{:?}", out.status);
+
+    // Children 2..=17, each newer than the last.
+    for index in 0..CHILDREN {
+        let child_hash = index + 2;
+        let out = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: upsert(child_hash, axis(child_hash - 1)),
+        });
+        assert!(out.status.ok, "{:?}", out.status);
+        let out = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextUpsertChildRef {
+                tenant_hash: TENANT,
+                child_ref: crate::types::ContextChildRef {
+                    parent_hash: PARENT,
+                    child_hash,
+                    // Ascending: the last child written is the newest.
+                    updated_at_ms: 1_700_000_000_000 + index,
+                },
+            },
+        });
+        assert!(out.status.ok, "{:?}", out.status);
+    }
+
+    let newest = CHILDREN + 1;
+    let oldest = 2u64;
+
+    let traverse = |target: u64| -> Vec<u64> {
+        let shards = engine.shards.read().expect("shards lock poisoned");
+        let shard = shards.get(&1).expect("shard 1 loaded");
+        crate::engine::context::traverse_context_tree(
+            &engine.cache,
+            &engine.page_store,
+            1,
+            shard,
+            TENANT,
+            PARENT,
+            &axis(target - 1),
+            Some(1),
+            Some(CHILDREN as usize),
+            Some(CAP),
+            Some(CHILDREN as usize),
+            false,
+        )
+        .into_iter()
+        .map(|node| node.node_hash)
+        .collect()
+    };
+
+    crate::engine::context::reset_context_children_dropped_before_scoring();
+    let found_newest = traverse(newest);
+    let dropped = crate::engine::context::context_children_dropped_before_scoring();
+
+    assert!(
+        found_newest.contains(&newest),
+        "the newest child was not reachable: a cap of {CAP} over {CHILDREN} children scored          {found_newest:?}, so the most recently written content is invisible to retrieval"
+    );
+    assert_eq!(
+        dropped,
+        CHILDREN as u64 - CAP as u64,
+        "the children the cut dropped before scoring must be counted, or the limit is invisible"
+    );
+
+    // The other half of the same fact, and the control on the assertion above: with the cap
+    // binding, the OLDEST child is the one now out of reach. If both ends were reachable the cap
+    // would not be binding and the test would prove nothing about which end is kept.
+    assert!(
+        !traverse(oldest).contains(&oldest),
+        "both the newest and oldest children were reachable, so the cap did not bind and this          test says nothing about which end the cut keeps"
+    );
+}
+
 /// A context write leaves nothing in the `hash`, `set` or `feature` cache namespaces.
 ///
 /// This is the premise `invalidate_context_record` rests on. `invalidate_record_all` sweeps those


### PR DESCRIPTION
Traversal cuts a parent's children down to a cap **before scoring any of them**, so whatever the cut drops is unreachable by any query however well it matches. The sort was ascending on `updated_at_ms` — so the cut kept the **oldest** children, and the most recently ingested were the first to disappear. That is the opposite of what a store keyed on time should do.

Demonstrated: 16 children, a cap of 4, a query naming the newest one. Traversal returned **nothing at all**. With the order flipped it returns that child.

## Two things this does not do

**It does not make selection relevance-based.** #494 proposes scoring all children so the cap bounds what is *returned* rather than what is *considered*. That does not work as written: scoring a child costs a **page read** — `load_context_node_vector` reads the node's page and decodes its vector — so scoring every child of the very wide parent the issue is about is exactly what is unaffordable. A cap has to stay. Recency is a better proxy than age, not a substitute for relevance.

**It does not stop a wide parent hiding children.** A parent wide enough for the cut to bind still hides them; what changes is which end goes missing. Bounding fanout by construction — the node hierarchy in #494's direction 2 — is the fix for that, and it is a product decision rather than something to change quietly here.

## So the cut is now counted

`context_children_dropped_before_scoring` reports what it dropped. The failure is otherwise invisible: retrieval keeps answering plausibly from whatever survived, which makes a structural limit look like ordinary imperfect recall.

## Test

16 children, cap 4. It asserts the newest is reachable, that the drop count equals what the cut discarded, and — as its own control — that the oldest is *not* reachable, because if both ends were reachable the cap would not be binding and the test would say nothing about which end is kept.

Reverting the sort fails it: the newest child scores `[]`.

Part of #494.