### PR TITLE
Two background rounds copied the whole proxy set before reading it

### DIFF
--- a/crates/temporalstore-rust/src/meta/failure_detector.rs
+++ b/crates/temporalstore-rust/src/meta/failure_detector.rs
@@ -653,9 +653,28 @@ impl MetaFailureDetector {
     ///
     /// A proxy carries no boot-time anchor, so it is never convicted for a
     /// restart -- only for silence.
+    /// Plan a proxy round from records the caller owns.
+    ///
+    /// Kept for callers that already hold owned records; it borrows from them
+    /// rather than copying them again. The metaserver uses
+    /// [`Self::plan_proxy_round_borrowed`], which never makes the copies.
     pub fn plan_proxy_round(
         &mut self,
         proxies: &[ProxyMetaInfo],
+        now_ms: u64,
+        policy: ConvictionPolicy,
+    ) -> ConvictionPlan {
+        self.plan_proxy_round_borrowed(&proxies.iter().collect::<Vec<_>>(), now_ms, policy)
+    }
+
+    /// Plan a proxy round without owning the proxies.
+    ///
+    /// A subject under judgement already borrows -- it holds `&str` into the
+    /// record rather than a copy of it -- so lifting the whole proxy set out of
+    /// the metadata first bought nothing.
+    pub fn plan_proxy_round_borrowed(
+        &mut self,
+        proxies: &[&ProxyMetaInfo],
         now_ms: u64,
         policy: ConvictionPolicy,
     ) -> ConvictionPlan {
@@ -666,10 +685,10 @@ impl MetaFailureDetector {
                 convict_enabled: false,
                 ..policy
             };
-            let subjects = proxy_subjects(proxies);
+            let subjects = proxy_subjects(proxies.iter().copied());
             return self.plan_subject_round(&subjects, now_ms, policy);
         }
-        let subjects = proxy_subjects(proxies);
+        let subjects = proxy_subjects(proxies.iter().copied());
         self.plan_subject_round(&subjects, now_ms, policy)
     }
 
@@ -725,9 +744,12 @@ struct ConvictionSubject<'a> {
     serving_shards: Vec<ShardId>,
 }
 
-fn proxy_subjects(proxies: &[ProxyMetaInfo]) -> Vec<ConvictionSubject<'_>> {
+fn proxy_subjects<'a, I>(proxies: I) -> Vec<ConvictionSubject<'a>>
+where
+    I: IntoIterator<Item = &'a ProxyMetaInfo>,
+{
     proxies
-        .iter()
+        .into_iter()
         .map(|proxy| ConvictionSubject {
             addr: proxy.proxy_addr.as_str(),
             location: proxy.location.as_str(),
@@ -865,11 +887,14 @@ impl SingleNodeMeta {
         safe_mode: SafeModePolicy,
     ) -> AdaptiveConvictionReport {
         let now = now_ms();
-        let proxies = {
+        // Held across the round: the subjects borrow from the metadata rather
+        // than from a copy of it, so the read lock stays for the planning and
+        // the freezing below happens after it is dropped.
+        let plan = {
             let state = self.inner.read().expect("meta lock poisoned");
-            state.proxies.values().cloned().collect::<Vec<_>>()
+            let proxies = state.proxies.values().collect::<Vec<_>>();
+            detector.plan_proxy_round_borrowed(&proxies, now, policy)
         };
-        let plan = detector.plan_proxy_round(&proxies, now, policy);
         let detector_paused = !detector.is_active(now);
 
         let mut frozen_proxies = Vec::new();

--- a/crates/temporalstore-rust/src/meta/proxy_groups.rs
+++ b/crates/temporalstore-rust/src/meta/proxy_groups.rs
@@ -185,9 +185,31 @@ fn is_idle_candidate(proxy: &ProxyMetaInfo) -> bool {
 /// the same round — that would attach a proxy the caller has not detached yet.
 /// It becomes available on the next round instead, which keeps each round's
 /// plan independently applicable.
+/// Plan a calibration round from records the caller owns.
+///
+/// Kept so callers holding owned records still have something to call; it
+/// borrows from them rather than copying them again. The metaserver itself uses
+/// [`plan_proxy_calibration_borrowed`], which never makes the owned copies at
+/// all.
 pub fn plan_proxy_calibration(
     groups: &[ProxyGroupInfo],
     proxies: &[ProxyMetaInfo],
+    options: ProxyCalibrationOptions,
+) -> ProxyCalibrationPlan {
+    let groups = groups.iter().collect::<Vec<_>>();
+    let proxies = proxies.iter().collect::<Vec<_>>();
+    plan_proxy_calibration_borrowed(&groups, &proxies, options)
+}
+
+/// Plan a calibration round without owning anything.
+///
+/// A round reads four fields of a proxy's fifteen -- its address, its group,
+/// its location and its state -- so copying the record to read them copies ten
+/// fields nobody looks at, two of them Strings, for every proxy in the cluster,
+/// every round.
+pub fn plan_proxy_calibration_borrowed(
+    groups: &[&ProxyGroupInfo],
+    proxies: &[&ProxyMetaInfo],
     options: ProxyCalibrationOptions,
 ) -> ProxyCalibrationPlan {
     let mut plan = ProxyCalibrationPlan::default();
@@ -478,9 +500,12 @@ impl SingleNodeMeta {
         options: ProxyCalibrationOptions,
     ) -> ProxyCalibrationPlan {
         let state = self.inner.read().expect("meta lock poisoned");
-        let groups = state.proxy_groups.values().cloned().collect::<Vec<_>>();
-        let proxies = state.proxies.values().cloned().collect::<Vec<_>>();
-        plan_proxy_calibration(&groups, &proxies, options)
+        // Pointers, not records: the plan is computed while this lock is held
+        // and applied after it is dropped, so the planner can read the metadata
+        // where it already is.
+        let groups = state.proxy_groups.values().collect::<Vec<_>>();
+        let proxies = state.proxies.values().collect::<Vec<_>>();
+        plan_proxy_calibration_borrowed(&groups, &proxies, options)
     }
 
     /// Run one calibration round: fill every group to its target from the idle


### PR DESCRIPTION
Calibration and proxy conviction both run on a timer, and both lifted every proxy -- and calibration every group as well -- out of the metadata before looking at them.

Calibration reads four fields of a proxy's fifteen: its address, its group, its location and its state. The other eleven are copied and never read, two of them Strings.

Conviction does not need to own anything at all. A subject under judgement already borrows -- it holds `&str` into the record rather than a copy of it -- so the copy one step earlier bought nothing.

Both now borrow instead, so a round reads the metadata where it already is.

## Measured

Calibration, four arms interleaved:

| proxies | before | after |
|---|---|---|
| 256 | 81.7us | 25.6us |
| 1024 | 342.0us | 107.6us |

and again with the box more loaded, which moved both arms together:

| proxies | before | after |
|---|---|---|
| 256 | 221.6us | 99.7us |
| 1024 | 662.3us | 318.8us |

Between two and three times. The ratio is what to trust here: the absolute numbers moved by a factor of two between pairs as other work arrived on the machine, which is why the arms are interleaved and each measured twice.

## What is preserved

Each keeps its owning entry point, which callers outside this crate may hold. Those now borrow from the caller's records rather than copying them again, so nothing that compiles today stops compiling.

The read lock is now held across conviction planning, where before it was taken, released, and the copy judged afterwards. The freezing that follows still happens after the lock is dropped.

## Not changed, and why

Three other places in the metaserver clone a whole collection. Two are not worth touching: `list_servers` and `list_proxies` clone because the clone is the product, and `shard_locations` has no callers at all. The rebalance loop looked like a fourth but reads `serving_shard_owners` instead, so it never touches that clone.

## Testing

368 metadata tests, 52 metaserver binary tests, 248 consensus tests, 28 conviction and 40 detector tests, 25 proxy group tests. `cargo check --all-targets` clean.
