### PR TITLE
Ask the classifier in the one surface that still decided for itself

### DIFF
--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -179,7 +179,7 @@ What is written, when it is flushed, and what is reclaimed. The escape hatches h
 | `TS_WAL_COMMIT_DELAY_US` | 0 | config | 1 | — |
 | `TS_WAL_COMPRESS_RECORDS` | off | test, portal | 1 | — |
 | `TS_WAL_DATA_ONLY` | on | launch, test | 1 | — |
-| `TS_WAL_LEGACY_RECOVERY` | off | config, harness, script | 1 | yes |
+| `TS_WAL_LEGACY_RECOVERY` | off | config, test | 1 | yes |
 | `TS_WAL_OUTCOME_ITEMS` | on | launch, test | 1 | — |
 | `TS_WAL_PREALLOCATE` | on | launch, test | 1 | yes |
 | `TS_WAL_PREALLOCATE_CHUNK` | — | nothing | 1 | — |
@@ -200,7 +200,7 @@ The shape of what is written. Readers generally accept both shapes, which is wha
 | `TS_NODE_SUMMARY_VECTOR` | on | test, portal | 1 | — |
 | `TS_PROXY_BINARY_VERSION` | — | nothing | 1 | — |
 | `TS_VECTOR_INT8` | off | test, portal | 1 | — |
-| `TS_VECTOR_SCALED` | on | launch, script, test, portal | 1 | — |
+| `TS_VECTOR_SCALED` | on | launch, test, portal | 1 | — |
 
 ## capacity (80)
 
@@ -309,10 +309,10 @@ The memory pipeline: what gets extracted, embedded, drained and packed. The surf
 | `MATRIXARK_CONTEXT_EVENT_SCAN_CAP` | 64 | nothing | 1 | — |
 | `MATRIXARK_CONTEXT_PACK_INCLUDE_SCORES` | off | nothing | 1 | — |
 | `MATRIXARK_CONTEXT_SECONDARY_INDEX` | off | test | 1 | — |
-| `MATRIXARK_EMBEDDING_MODEL` | — | config, script, portal | 1 | — |
+| `MATRIXARK_EMBEDDING_MODEL` | — | config, script, test, portal | 1 | — |
 | `MATRIXARK_EMBED_API_KEY_ENV` | — | nothing | 1 | — |
 | `MATRIXARK_EMBED_BASE_URL` | — | config, script | 1 | — |
-| `MATRIXARK_EMBED_DRAINER` | off | config, launch, portal | 1 | — |
+| `MATRIXARK_EMBED_DRAINER` | off | config, launch, test, portal | 1 | — |
 | `MATRIXARK_EMBED_DRAINER_BATCH` | — | config, portal | 1 | — |
 | `MATRIXARK_HOOK_ADDITIONAL_CONTEXT_CHAR_LIMIT` | 40000 | launch | 1 | — |
 | `MATRIXARK_REQUIRE_MODEL_EMBEDDINGS` | off | config, portal | 1 | — |
@@ -330,7 +330,7 @@ Who the caller is, not what the engine does. Supplied per request or per process
 | `MATRIXARK_ACCOUNT_ID` | — | launch | 2 | — |
 | `MATRIXARK_AGENT_NAME` | — | launch | 2 | — |
 | `MATRIXARK_TENANT_ID` | — | launch | 2 | — |
-| `MATRIXARK_USER_ID` | — | launch, script | 2 | — |
+| `MATRIXARK_USER_ID` | — | launch, test | 2 | — |
 | `TEMPORALSTORE_AGENT_NAME` | — | launch | 2 | — |
 | `MATRIXARK_SESSION_ID` | — | nothing | 1 | — |
 

--- a/tools/build_engine_flag_inventory.py
+++ b/tools/build_engine_flag_inventory.py
@@ -596,7 +596,13 @@ def _setters_by_name():
                 for name in CONFIG_NAME.findall(body):
                     found.setdefault(name, set()).add("config")
                 continue
+            # A test that sets a flag is a TEST, not a launcher configuring a deployment. The
+            # script pattern matches a Python test's os.environ assignment identically, so without
+            # this every flag a unit test touches was reported as one a script sets -- and adding a
+            # test that names a flag rewrote this document with a claim about deployments.
+            is_test = path.name.startswith("test_") or "tests" in path.parts
             for label, pattern in SETTERS:
+                label = "test" if is_test else label
                 for name in pattern.findall(body):
                     found.setdefault(name, set()).add(label)
     return found

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -2870,15 +2870,27 @@ def _encoder_summary() -> Json:
     zero pending would otherwise read as "all done".
     """
     provider = os.environ.get("MATRIXARK_EMBEDDING_PROVIDER", "deterministic").strip()
-    deterministic = provider.lower() in ("", "deterministic")
+    # Asked of the classifier, not decided here. The pair this replaced -- ("", "deterministic") --
+    # was the last hand-written copy of that question in this file, and it was the incomplete kind:
+    # "local" is a synonym for the hash fallback and a misspelt provider name falls through to it,
+    # and both were reported as a working semantic encoder with nothing waiting to be said.
+    effect = _gwconfig.embedding_provider_effect(provider)
+    if effect == "hash" and _gwconfig.provider_is_unrecognised("embedding", provider):
+        note = ("The embedding provider is set to " + repr(provider) + ", which nothing "
+                "recognises, so every vector is a hash fallback and nothing is waiting to be "
+                "encoded.")
+    elif effect == "hash":
+        note = ("No encoder is configured, so nothing is waiting to be encoded and nothing ever "
+                "will be: every vector is a hash fallback.")
+    else:
+        note = ""
     return {
         "provider": provider,
         "model": os.environ.get("MATRIXARK_EMBEDDING_MODEL", "").strip(),
-        "semantic": not deterministic,
+        "semantic": effect != "hash",
         "drainer_enabled": os.environ.get("MATRIXARK_EMBED_DRAINER", "").strip().lower()
         in ("1", "true", "yes", "on"),
-        "note": ("No encoder is configured, so nothing is waiting to be encoded and nothing ever "
-                 "will be: every vector is a hash fallback.") if deterministic else "",
+        "note": note,
     }
 
 

--- a/tools/test_matrixark_engine_flag_inventory.py
+++ b/tools/test_matrixark_engine_flag_inventory.py
@@ -105,6 +105,19 @@ def _regenerate_into(directory: str) -> str:
 
 ROOT_PATH = pathlib.Path(ROOT)
 
+def _rows() -> dict:
+    """{flag: its row} from the generated inventory table."""
+    with open(DOC, encoding="utf-8") as handle:
+        text = handle.read()
+    found = {}
+    for line in text.splitlines():
+        if not line.startswith("| `"):
+            continue
+        name = line.split("`")[1]
+        found[name] = line
+    return found
+
+
 class TheInventoryMatchesTheEngineTest(unittest.TestCase):
 
     def test_the_document_exists(self) -> None:
@@ -335,6 +348,30 @@ class TheInventoryKnowsWhatTheCustomerCanSeeTest(unittest.TestCase):
     Checked against `matrixark_gateway_config.SETTINGS`, which is what the portal renders, rather
     than against the built HTML -- the page is generated from that list, so the list is the claim.
     """
+
+    def test_a_flag_only_a_test_sets_is_not_credited_to_a_script(self) -> None:
+        """The "set by" column exists to answer whether anyone throws the switch. A Python test's
+        `os.environ["X"] = ...` matches the script pattern exactly, so a flag no deployment
+        configures was reported as one a script sets -- and TS_WAL_LEGACY_RECOVERY, a flag whose
+        whole question is whether anything still needs it, read as script-configured.
+
+        The consequence beyond the wrong answer: adding any test that names a flag rewrote this
+        generated document with a claim about deployments.
+        """
+        rows = _rows()
+        row = rows.get("TS_WAL_LEGACY_RECOVERY")
+        self.assertIsNotNone(row, "the flag this is about is no longer listed")
+        surfaces = {s.strip() for s in row.split("|")[3].split(",") if s.strip()}
+        self.assertIn("test", surfaces)
+        self.assertNotIn("script", surfaces)
+
+    def test_a_flag_a_real_script_sets_is_still_credited(self) -> None:
+        """The floor. If nothing were ever labelled "script" any more, the assertion above would
+        pass on a document that had lost the distinction entirely."""
+        rows = _rows()
+        scripted = [name for name, row in rows.items()
+                    if "script" in {s.strip() for s in row.split("|")[3].split(",")}]
+        self.assertTrue(scripted, "no flag is credited to a script at all")
 
     def test_every_offered_engine_flag_is_marked_portal(self) -> None:
         sys.path.insert(0, TOOLS)

--- a/tools/test_matrixark_the_encoder_summary_asks_the_classifier.py
+++ b/tools/test_matrixark_the_encoder_summary_asks_the_classifier.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""No surface in the gateway classifies a provider by hand.
+
+"Is this provider deterministic?" was answered separately in four places, each with its own literal.
+Three were consolidated when a misspelt provider name turned out to be reported as configured. The
+fourth survived, because it is written as a **tuple** rather than a set and the sweep that found the
+others looked for ``deterministic = {...}``:
+
+    deterministic = provider.lower() in ("", "deterministic")
+
+It is the incomplete kind, and it feeds the encoder summary served beside the backlog counts. On
+``local`` -- a synonym for the hash fallback -- and on any misspelt provider name, it reported
+``semantic: true`` and an empty note, so a deployment making nothing but hash vectors read as a
+working semantic encoder with nothing to say about it.
+
+The guard below is the point of this change: it fails on ANY collection literal in the gateway that
+classifies a provider by name, so a fifth copy cannot be added quietly. Finding these one at a time
+is how the fourth survived three rounds of fixing the same defect.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+try:
+    from tools import matrixark_v1_gateway as gw  # type: ignore
+except ImportError:
+    import matrixark_v1_gateway as gw  # type: ignore
+
+cfg = gw._gwconfig
+
+# Names that only appear in a collection because something is deciding what a provider IS.
+PROVIDER_NAMES = {"deterministic", "openai_compatible", "openai_compatible_llm", "anthropic",
+                  "voyage", "oss", "open_source", "sentence_transformers", "claude"}
+# The classifier's own sets, which are the one place this may be written.
+CLASSIFIER_SETS = {"_OPENAI_EXTRACTION_PROVIDERS", "_ANTHROPIC_EXTRACTION_PROVIDERS",
+                   "_API_EMBEDDING_PROVIDERS", "_OSS_EMBEDDING_PROVIDERS",
+                   "_DELIBERATE_FALLBACK_PROVIDERS"}
+PARTICIPATING = ("MATRIXARK_EMBEDDING_PROVIDER", "MATRIXARK_EMBEDDING_MODEL",
+                 "MATRIXARK_EMBED_DRAINER")
+
+
+def classifying_literals(filename: str, allow_assigned_to=frozenset()) -> list:
+    """Collection literals holding provider names, other than the ones allowed by name.
+
+    A `choices=[...]` on a Setting is not a classification -- it is the list a customer picks from --
+    so a literal that is an argument to Setting() is skipped.
+    """
+    path = os.path.join(TOOLS, filename)
+    with open(path, encoding="utf-8") as handle:
+        tree = ast.parse(handle.read(), filename=filename)
+
+    allowed_nodes = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id in allow_assigned_to:
+                    allowed_nodes.add(id(node.value))
+        # The offered choices, not a classification of what a provider does.
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) \
+                and node.func.id == "Setting":
+            for argument in list(node.args) + [k.value for k in node.keywords]:
+                allowed_nodes.add(id(argument))
+
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Set, ast.Tuple, ast.List)) or id(node) in allowed_nodes:
+            continue
+        members = {e.value for e in node.elts
+                   if isinstance(e, ast.Constant) and isinstance(e.value, str)}
+        if members & PROVIDER_NAMES:
+            found.append((node.lineno, sorted(members)))
+    return found
+
+
+class Case(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self._saved = {n: os.environ.get(n) for n in PARTICIPATING}
+        for name in PARTICIPATING:
+            os.environ.pop(name, None)
+
+    def tearDown(self) -> None:
+        for name, value in self._saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+    def summary(self, provider: str) -> dict:
+        os.environ["MATRIXARK_EMBEDDING_PROVIDER"] = provider
+        return gw._encoder_summary()
+
+
+class NoSurfaceClassifiesAProviderByHandTest(unittest.TestCase):
+    """The guard. Four copies of one question were found one at a time, over three changes; this
+    fails on the fifth before it ships."""
+
+    def test_the_gateway_carries_none(self) -> None:
+        self.assertEqual([], classifying_literals("matrixark_v1_gateway.py"))
+
+    def test_the_registry_carries_only_the_classifier_and_its_choices(self) -> None:
+        self.assertEqual([], classifying_literals("matrixark_gateway_config.py",
+                                                  allow_assigned_to=CLASSIFIER_SETS))
+
+    def test_the_detector_would_notice_one(self) -> None:
+        """The floor. If this stopped recognising a classification, both assertions above would pass
+        on a file full of them."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "sample.py")
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write('x = provider in ("", "deterministic")\n')
+            saved, sys.modules_dir = TOOLS, None
+            try:
+                globals()["TOOLS"] = directory
+                self.assertEqual(1, len(classifying_literals("sample.py")))
+            finally:
+                globals()["TOOLS"] = saved
+
+    def test_the_classifier_sets_are_still_there_to_be_allowed(self) -> None:
+        """If they were renamed, the allow-list would silently stop matching and the registry test
+        would fail for the wrong reason -- or worse, pass because they moved out of reach."""
+        for name in CLASSIFIER_SETS:
+            with self.subTest(constant=name):
+                self.assertTrue(getattr(cfg, name), name + " is missing or empty")
+
+
+class TheEncoderSummaryReportsWhatIsHappeningTest(Case):
+
+    def test_a_working_encoder_is_semantic(self) -> None:
+        for provider in ("openai_compatible", "voyage", "oss"):
+            with self.subTest(provider=provider):
+                summary = self.summary(provider)
+                self.assertTrue(summary["semantic"])
+                self.assertEqual("", summary["note"])
+
+    def test_the_hash_fallback_is_not_semantic(self) -> None:
+        """`local` is the case the old pair missed: a synonym for the fallback, reported as a
+        working encoder."""
+        for provider in ("deterministic", "local", ""):
+            with self.subTest(provider=provider):
+                summary = self.summary(provider)
+                self.assertFalse(summary["semantic"])
+                self.assertIn("hash fallback", summary["note"])
+
+    def test_a_name_nothing_recognises_is_named(self) -> None:
+        summary = self.summary("openai_compatibl")
+        self.assertFalse(summary["semantic"])
+        self.assertIn("openai_compatibl", summary["note"])
+        self.assertIn("nothing recognises", summary["note"])
+
+    def test_a_deliberate_choice_is_not_called_a_mistake(self) -> None:
+        self.assertNotIn("nothing recognises", self.summary("local")["note"])
+
+    def test_it_agrees_with_the_classifier_for_every_offered_choice(self) -> None:
+        """One answer, so the backlog panel and the warnings cannot disagree about the same
+        deployment."""
+        for choice in cfg.SETTINGS_BY_KEY["embedding.provider"].choices:
+            with self.subTest(provider=choice):
+                self.assertEqual(cfg.embedding_provider_effect(choice) != "hash",
+                                 self.summary(choice)["semantic"])
+
+    def test_the_rest_of_the_summary_is_unchanged(self) -> None:
+        """The floor: everything beside `semantic` and `note` still reports what it did."""
+        os.environ["MATRIXARK_EMBEDDING_MODEL"] = "voyage-3"
+        os.environ["MATRIXARK_EMBED_DRAINER"] = "1"
+        summary = self.summary("voyage")
+        self.assertEqual("voyage", summary["provider"])
+        self.assertEqual("voyage-3", summary["model"])
+        self.assertTrue(summary["drainer_enabled"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
"Is this provider deterministic?" was answered separately in four places, each with its own literal.
Three were consolidated when a misspelt provider name turned out to be reported as configured. The
fourth survived — because it is written as a **tuple**, and the sweep that found the others looked
for `deterministic = {...}`:

```python
deterministic = provider.lower() in ("", "deterministic")
```

It is the incomplete kind, and it feeds `_encoder_summary` — the encoder panel served beside the
backlog counts:

```
provider            reported semantic   note
openai_compatibl    YES                 (none)     <- one character missing
local               YES                 (none)     <- a synonym for the hash fallback
cohere              YES                 (none)     <- unsupported
```

A deployment making nothing but hash vectors read as a working semantic encoder, with nothing to say
about it — and this panel exists precisely so that a backlog of zero is not misread as "all done".

It now asks the classifier, and distinguishes the two cases the way the warnings already do:
`deterministic` keeps its own explanation, an unrecognised value names the value.

### The guard is the point

Finding these one at a time is how the fourth survived three rounds of fixing the same defect. A test
now fails on **any** collection literal in the gateway that classifies a provider by name, and on any
in the settings registry that is not one of the five classifier sets. A `choices=[…]` on a `Setting`
is excluded by *shape* — it is a list a customer picks from, not a decision about what a provider
does — rather than by being named in an exemption list.

```
the shipped bug: the pair comes back                    -> FAIL 4 (incl. the guard)
semantic is decided the old way                         -> FAIL 4 (incl. the guard)
a misspelt name loses its note                          -> FAIL 1
a deliberate choice is called a mistake                 -> FAIL 1
the note disappears entirely                            -> FAIL 4
the rest of the summary stops reporting                 -> FAIL 1
a classifier set is renamed out from under the allow-list -> FAIL 1
```

The last one matters: if a classifier set were renamed, the allow-list would silently stop matching,
so a test asserts the five are still there to be allowed. And the detector has its own floor — it is
run against a file containing exactly the literal this change removed, so it cannot pass by having
stopped recognising one.

### One clean negative worth recording

While looking for other surfaces reading a variable nothing consumes, `ingestion.embed_drainer`
appeared to have no reader. It does: `crates/temporalstore-rust/src/context_workflow/embed_drainer.rs`,
via `server.rs`. The audit only scanned `tools/`. The control is real and nothing needed changing.

10 tests here, plus 2 added to the flag-inventory suite (18 there in total). Neighbours: the derived
list of every suite touching the encoder summary, the classifier or the settings registry — 45, all
green — plus all portal- (178), gateway- (258) and config-named (90) suites, and the 11 siblings that
write these variables in one process (220 tests).

### One more, surfaced by the test above

Adding a test that sets `MATRIXARK_EMBED_DRAINER` rewrote the generated flag inventory — because a
Python test's `os.environ["X"] = …` matches the generator's **script** pattern exactly. That column
exists to answer "is this a switch anyone actually throws", and the generator has a `test` label
already; a Python test was simply landing in the wrong one.

```
- | `TS_WAL_LEGACY_RECOVERY` | off | config, harness, script | 1 | yes |
+ | `TS_WAL_LEGACY_RECOVERY` | off | config, test           | 1 | yes |
```

That is the row that matters: a legacy flag whose whole question is whether anything still needs it
read as script-configured, when only tests set it. Five rows move, all in that direction. Guarded
both ways — a flag only a test sets must not say "script", and some flag must still say "script", or
the column has lost the distinction rather than gained accuracy.
