### PR TITLE
A heartbeat is not a turn the store failed to answer

### DIFF
--- a/tools/matrixark_codex_hook.py
+++ b/tools/matrixark_codex_hook.py
@@ -2151,9 +2151,20 @@ def codex_hook_output(
             _cache_path = _pack_cache.context_pack_cache_path(
                 "codex", str(agent_context.get("workspace_root") or "")
             )
+            # A pack that arrived and rendered to nothing is not a pack that never arrived.
+            # A heartbeat-only pack is exactly that: the store answered, and every line it sent
+            # was filtered out as hook noise. Serving the previous pack there injects another
+            # query's context into a turn that correctly carries none -- which is the thing the
+            # heartbeat invariant exists to prevent, and it reached the agent labelled as
+            # "prior context" from a query it never asked.
+            _answered_then_filtered = bool(
+                isinstance(retrieve, dict)
+                and str(retrieve.get("context") or "").strip()
+                and not rendered_context
+            )
             if additional_context.strip():
                 _pack_cache.remember_context_pack(_cache_path, additional_context)
-            elif not error:
+            elif not error and not _answered_then_filtered:
                 _previous, _age_s = _pack_cache.recover_context_pack(
                     _cache_path, max_age_s=_pack_cache.pack_cache_max_age_s()
                 )


### PR DESCRIPTION
main's ratchet has been red since #988 on
`test_heartbeat_only_rendered_context_does_not_emit_additional_context`, which
requires that a prompt whose retrieved pack is nothing but hook heartbeat text
emits no additional context at all.

#988 serves the last good pack when a turn cannot build one, which is right: a
turn that emits `{}` tells the agent it has NO history, and that is both wrong
and silent. But the condition it fires on is "this turn produced no context and
there was no error", and a heartbeat-only pack satisfies it. So the fallback ran
on a turn that correctly carries no context and injected the previous pack --
from an unrelated query -- labelled to the agent as prior context:

    context_pack_source: previous_pack
    additionalContext: "[prior context: the store did not answer this turn ...]
                        Query: grouped refs ..."

The store did answer. It sent a heartbeat, and the hook filtered every line of it
as noise, which is what the heartbeat handling is for. A pack that arrived and
rendered to nothing is not a pack that never arrived, so the fallback now
declines that case and only that case: the retrieve carried content, and nothing
survived rendering.

Scope checked rather than assumed. The two hooks each own a copy of this
fallback, and the comment above the Codex one says why -- a fallback added to one
entry point leaves the other silently unprotected. Here the exposure is Codex
only: heartbeat filtering appears 13 times in matrixark_codex_hook.py and not
once in matrixark_agent_hook.py, so the Claude hook cannot reach this case and is
left alone.

The feature itself is untouched: all 8 tests in
test_a_turn_that_cannot_build_a_pack_serves_the_last_one still pass, including
the fail-open contract that nothing is served when nothing was stored, and the
two that keep one agent or workspace from serving another its context. The
composer goes from 13 failures to 12, and the name that leaves is this one.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>
