### PR TITLE
Serve the last pack to a turn the store did not answer

### DIFF
--- a/tools/matrixark_agent_hook.py
+++ b/tools/matrixark_agent_hook.py
@@ -1404,10 +1404,13 @@ def main() -> int:
                 "hookEventName": args.event,
                 "additionalContext": additional_context,
             }
-        else:
+        elif not _pack_cache.store_answered(retrieve):
             # The store could not answer. Emitting `{}` tells the agent it has NO history, which is
             # both wrong and silent; the previous pack is stale by a turn or two, which is a much
             # smaller error. Labelled in band so nothing is passed off as fresh.
+            #
+            # A turn the store DID answer is left alone even when it renders to nothing: that is a
+            # turn with no context on purpose, and a stale pack is not an improvement on none.
             previous, age_s = _pack_cache.recover_context_pack(
                 cache_path, max_age_s=_pack_cache.pack_cache_max_age_s()
             )

--- a/tools/matrixark_codex_hook.py
+++ b/tools/matrixark_codex_hook.py
@@ -2153,7 +2153,7 @@ def codex_hook_output(
             )
             if additional_context.strip():
                 _pack_cache.remember_context_pack(_cache_path, additional_context)
-            elif not error:
+            elif not error and not _pack_cache.store_answered(retrieve):
                 _previous, _age_s = _pack_cache.recover_context_pack(
                     _cache_path, max_age_s=_pack_cache.pack_cache_max_age_s()
                 )

--- a/tools/matrixark_hook_pack_cache.py
+++ b/tools/matrixark_hook_pack_cache.py
@@ -73,6 +73,22 @@ def pack_cache_max_age_s() -> float:
         return DEFAULT_MAX_AGE_S
 
 
+def store_answered(retrieve: object) -> bool:
+    """Whether the store returned a pack for this turn, whatever was rendered from it.
+
+    This is the question the fallback needs, and it is not "did anything get rendered". A turn whose
+    retrieved pack contains only the hook's own heartbeat renders to nothing on purpose -- there was
+    an answer, and it had nothing in it worth showing. Serving the previous pack there injects
+    stale context into a turn that deliberately has none, which is the opposite of the fallback's
+    reason for existing: emitting {} when the store COULD NOT answer tells the agent it has no
+    history, which is both wrong and silent.
+    """
+    if not isinstance(retrieve, dict) or retrieve.get("_hook_tool_timeout"):
+        return False
+    return any(bool(retrieve.get(key)) for key in
+               ("pack_id", "context_pack_id", "context", "refs", "selected_refs"))
+
+
 def label_previous_pack(previous: str, age_s: float) -> str:
     """Mark a served pack as prior context, in band, with its age.
 

--- a/tools/test_matrixark_the_previous_pack_is_for_a_turn_that_got_no_answer.py
+++ b/tools/test_matrixark_the_previous_pack_is_for_a_turn_that_got_no_answer.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The last-good-pack fallback is for a turn the store did not answer.
+
+Emitting ``{}`` when the store could not answer tells the agent it has no history -- wrong, and
+silent -- so a turn that cannot build a pack serves the previous one, labelled in band. The
+condition it fired on was "nothing was rendered", and that is a different question.
+
+A **heartbeat** turn renders nothing on purpose: the retrieved pack contains only the hook's own
+heartbeat line, which is filtered out, so nothing is left to show. There was an answer; it had
+nothing in it. Serving the previous pack there injects stale context into a turn that deliberately
+has none -- the opposite of the fallback's reason for existing.
+
+The rule now lives in the module both hooks already share, and both ask it. A fallback added to one
+entry point and not the other is a shape this codebase has been bitten by before: Codex runs a
+separate entry point from Claude, which is why the fallback had to be added twice in the first
+place.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+try:
+    from tools import matrixark_hook_pack_cache as pack_cache  # type: ignore
+except ImportError:
+    import matrixark_hook_pack_cache as pack_cache  # type: ignore
+
+
+class TheQuestionIsWhetherTheStoreAnsweredTest(unittest.TestCase):
+    """Not whether anything was rendered. Those differ exactly where this went wrong."""
+
+    def test_a_pack_that_rendered_to_nothing_still_counts_as_an_answer(self) -> None:
+        """The heartbeat case: a pack came back and its only line was filtered out."""
+        self.assertTrue(pack_cache.store_answered(
+            {"pack_id": "pack-heartbeat-only", "context": "user: hook heartbeat"}))
+
+    def test_a_pack_with_refs_counts(self) -> None:
+        self.assertTrue(pack_cache.store_answered({"refs": [{"ref": "x"}]}))
+        self.assertTrue(pack_cache.store_answered({"context_pack_id": "pack-1"}))
+
+    def test_no_answer_is_no_answer(self) -> None:
+        for retrieve in ({}, None, "", {"pack_id": ""}, {"context": ""}):
+            with self.subTest(retrieve=retrieve):
+                self.assertFalse(pack_cache.store_answered(retrieve))
+
+    def test_a_timed_out_tool_call_is_not_an_answer(self) -> None:
+        """The tell the hooks already use: a pack that arrived after the deadline is not a pack."""
+        self.assertFalse(pack_cache.store_answered(
+            {"pack_id": "pack-1", "context": "something", "_hook_tool_timeout": True}))
+
+    def test_a_shape_it_does_not_understand_is_not_an_answer(self) -> None:
+        """Defaulting to "answered" would silently disable the fallback; defaulting to "not
+        answered" only serves a stale pack, which is the smaller error and the one this whole
+        mechanism already chose."""
+        self.assertFalse(pack_cache.store_answered(["refs"]))
+        self.assertFalse(pack_cache.store_answered(42))
+
+
+class BothHooksAskItTest(unittest.TestCase):
+    """Codex runs a separate entry point from Claude. The fallback had to be added twice; the
+    condition on it has to be right twice."""
+
+    def _source(self, filename: str) -> str:
+        with open(os.path.join(TOOLS, filename), encoding="utf-8") as handle:
+            return handle.read()
+
+    def test_the_codex_hook_asks(self) -> None:
+        self.assertIn("store_answered(retrieve)", self._source("matrixark_codex_hook.py"))
+
+    def test_the_claude_hook_asks(self) -> None:
+        self.assertIn("store_answered(retrieve)", self._source("matrixark_agent_hook.py"))
+
+    def test_neither_decides_it_alone(self) -> None:
+        """One rule. A second copy is how the two entry points drift, which is the reason this
+        module exists at all."""
+        for filename in ("matrixark_codex_hook.py", "matrixark_agent_hook.py"):
+            with self.subTest(hook=filename):
+                self.assertNotIn("def store_answered", self._source(filename))
+
+
+class WhereEachSideIsCoveredTest(unittest.TestCase):
+    """Said out loud, because the asymmetry is the reason this was visible on one side only.
+
+    The Codex hook builds its output in a function a test can call, so the heartbeat case has a real
+    end-to-end test there -- it is the test that went red when the fallback landed. The Claude hook
+    builds the same output inside ``main()``, which reads stdin, parses arguments and calls the
+    backend; there is no seam to drive, so the same defect on that side showed nothing. That is the
+    whole reason the rule is asserted directly and both call sites are pinned, rather than trusting
+    one end-to-end test to cover a decision made in two places.
+    """
+
+    def test_the_codex_side_has_the_end_to_end_case(self) -> None:
+        with open(os.path.join(TOOLS, "test_codex_hook_output_part2.py"), encoding="utf-8") as f:
+            self.assertIn("test_heartbeat_only_rendered_context_does_not_emit_additional_context",
+                          f.read())
+
+    def test_the_claude_side_fallback_is_still_inside_main(self) -> None:
+        """If it ever gains a seam, this fails -- and the end-to-end test that could not be written
+        becomes writable. That is a prompt, not a rule against refactoring."""
+        with open(os.path.join(TOOLS, "matrixark_agent_hook.py"), encoding="utf-8") as f:
+            lines = f.read().splitlines()
+        fallback = next(i for i, line in enumerate(lines)
+                        if "store_answered(retrieve)" in line)
+        enclosing = [line for line in lines[:fallback] if line.startswith("def ")][-1]
+        self.assertEqual("def main() -> int:", enclosing,
+                         "the Claude-side fallback moved out of main(); an end-to-end heartbeat "
+                         "test is now possible and should replace this note")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`test_heartbeat_only_rendered_context_does_not_emit_additional_context` is red on main, and it is
right to be.

[#988](https://github.com/matrixarkai/TemporalStore/pull/988) gave both hooks a last-good-pack
fallback: emitting `{}` when the store could not answer tells the agent it has **no history**, which
is both wrong and silent, so a turn that cannot build a pack serves the previous one, labelled in
band. Good change. The condition it fires on is *"nothing was rendered"* — and that is a different
question from *"the store did not answer"*.

A **heartbeat** turn renders nothing on purpose. The retrieved pack contains only the hook's own
heartbeat line, which is filtered out, so nothing is left to show:

```
retrieve = {"pack_id": "pack-heartbeat-only", "context": "user: Codex hook heartbeat …"}
   ->  rendered_context_chars: 0, selected_ref_count: 0
   ->  fallback fires, and a pack from a previous turn is injected
```

There *was* an answer; it had nothing in it. Serving the previous pack there pushes stale context
into a turn that deliberately has none — the opposite of the fallback's reason for existing.

The condition is now `store_answered(retrieve)`: did the store return a pack for this turn, whatever
ended up being rendered from it. A timed-out tool call is not an answer — the same tell the hooks
already use — and a shape the rule does not understand is treated as *not* answered, so an unknown
retrieve serves a stale pack rather than silently disabling the fallback. That is the smaller error,
and the one this mechanism already chose.

### Both hooks, one rule

Codex runs a separate entry point from Claude, which is why the fallback had to be added twice. The
condition on it has to be right twice, so it lives in the module they already share and a test pins
that neither reimplements it.

```
the shipped bug: codex falls back whenever nothing rendered  -> FAIL 14, incl. the end-to-end case
the claude hook goes back to deciding for itself             -> FAIL 2
a pack that rendered to nothing stops counting as an answer  -> FAIL 15
everything counts as an answer, disabling the fallback       -> FAIL 7
a timed-out tool call counts as an answer                    -> FAIL 1
```

### Where each side is covered, said out loud

The Codex hook builds its output in a function a test can call, so the heartbeat case has a real
end-to-end test there — the one that went red. The Claude hook builds the same output inside
`main()`, which reads stdin, parses arguments and calls the backend; there is no seam to drive, so
the identical defect on that side showed **nothing**. That asymmetry is why the rule is asserted
directly and both call sites are pinned rather than trusting one end-to-end test to cover a decision
made in two places. A test also fails if the Claude-side fallback ever moves out of `main()` — a
prompt to write the end-to-end case that cannot be written today, not a rule against refactoring.

10 tests here. `test_matrixark_codex_hook_output` goes from 13 failures to 12 — exactly the heartbeat
test, nothing else moved — and #988's own suite, `test_a_turn_that_cannot_build_a_pack_serves_the_last_one`,
still passes all 8, so the fallback still fires where it should. The 12 that remain are red on main
and unrelated to this.
