### PR TITLE
One encoder model field, because there is one encoder model

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -347,12 +347,17 @@ SETTINGS: List[Setting] = [
             "Must end in /v1: the request is built as <base>/embeddings."),
     Setting("embedding.model", "embedding", "MATRIXARK_EMBEDDING_MODEL",
             "Embedding model", "str", "", "live",
-            "Encoder model name, e.g. paraphrase-multilingual-MiniLM-L12-v2."
+            "The encoder to use: a model name like paraphrase-multilingual-MiniLM-L12-v2, or "
+            "a path to one you have downloaded -- an in-process encoder loads either, and a hosted "
+            "provider is sent the name."
             + ENCODER_SERVER_NOTE + ENCODER_CHANGE_NOTE),
-    Setting("embedding.model_path", "embedding", "MATRIXARK_EMBEDDING_MODEL_PATH",
-            "Embedding model path", "str", "", "live",
-            "Local path to a downloaded encoder; wins over the model name when set."
-            + ENCODER_SERVER_NOTE + ENCODER_CHANGE_NOTE),
+    # MATRIXARK_EMBEDDING_MODEL_PATH was offered here as a second encoder field. It is not a
+    # second choice: the encoder reads `MODEL_PATH or MODEL`, so it only ever overrode the field
+    # above -- and only on the in-process path, because a hosted provider is sent the model NAME and
+    # never looks at the path at all. Two fields for one value, one of which silently won on one
+    # path and did nothing on the other. The variable is still honoured where a launcher sets it,
+    # and `_model_config_snapshot` says so, because a value in force that no screen shows is the
+    # thing this whole panel exists to prevent.
     Setting("embedding.api_key_env", "embedding", "MATRIXARK_EMBEDDING_API_KEY_ENV",
             "Embedding key variable", "str", "", "live",
             "Name of the environment variable holding the encoder key -- the key you enter below is "

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1709,6 +1709,20 @@ def _model_config_snapshot() -> Json:
                 "built as <base>/embeddings, so an OpenAI-compatible encoder serving "
                 "/v1/embeddings is never reached and every vector is a hash fallback."
             )
+        overriding_path = _env("MATRIXARK_EMBEDDING_MODEL_PATH")
+        if overriding_path:
+            if _gwconfig.embedding_provider_effect(embedding_provider) == "local_model":
+                warnings.append(
+                    "MATRIXARK_EMBEDDING_MODEL_PATH is set to " + overriding_path + ", and an "
+                    "in-process encoder loads it in preference to Embedding model: the model named "
+                    "above is not the one making vectors. Clear the variable, or put the path in "
+                    "Embedding model, which accepts one.")
+            else:
+                warnings.append(
+                    "MATRIXARK_EMBEDDING_MODEL_PATH is set to " + overriding_path + " and this "
+                    "provider never reads it -- a hosted encoder is sent the model NAME. It is "
+                    "doing nothing here, and would take over if the provider changed to an "
+                    "in-process encoder.")
         if not embedding["api_key_configured"]:
             warnings.append(
                 "Embedding API key is empty: the embedding call is skipped before it is "

--- a/tools/test_matrixark_both_encoder_controls_name_the_server.py
+++ b/tools/test_matrixark_both_encoder_controls_name_the_server.py
@@ -87,10 +87,16 @@ class EveryControlItReadsSaysSoTest(unittest.TestCase):
                                   % (setting.key, SERVER))
 
     def test_they_say_it_the_same_way(self) -> None:
-        """One sentence, shared. Two copies is how one of them came to carry it and the other not."""
+        """One sentence, shared. Two copies is how one of them came to carry it and the other not.
+
+        The floor was two controls, which is what the file name still refers to. It is one now:
+        `embedding.model_path` was a second field for the same value -- read only where it OVERRODE
+        the model name -- and the field that absorbed it carries the note. One is not vacuous; zero
+        would be, and that is what this guards.
+        """
         controls = controls_by_variable()
         carrying = [s for v in bound_at_import(SERVER) & set(controls) for s in controls[v]]
-        self.assertGreaterEqual(len(carrying), 2)
+        self.assertGreaterEqual(len(carrying), 1)
         for setting in carrying:
             with self.subTest(setting=setting.key):
                 self.assertIn(cfg.ENCODER_SERVER_NOTE, setting.help or "")

--- a/tools/test_matrixark_the_encoder_controls_say_what_they_cost.py
+++ b/tools/test_matrixark_the_encoder_controls_say_what_they_cost.py
@@ -33,8 +33,10 @@ sys.path.insert(0, TOOLS)
 import matrixark_gateway_config as cfg  # noqa: E402
 import matrixark_mcp_core as core  # noqa: E402
 
-# The controls that change which encoder makes a vector.
-ENCODER_CONTROLS = ("embedding.provider", "embedding.model", "embedding.model_path")
+# The controls that change which encoder makes a vector. There were three: `embedding.model_path`
+# was a second field for the same value, read only where it OVERRODE the model name, so it is gone
+# and the note it carried belongs to the field that absorbed it.
+ENCODER_CONTROLS = ("embedding.provider", "embedding.model")
 
 
 class TheControlsCarryTheNoteTest(unittest.TestCase):
@@ -72,8 +74,9 @@ class TheControlsCarryTheNoteTest(unittest.TestCase):
         self.assertIn("hash vectors", cfg.SETTINGS_BY_KEY["embedding.provider"].help)
         self.assertIn("co-located encoder server",
                       cfg.SETTINGS_BY_KEY["embedding.model"].help)
-        self.assertIn("wins over the model name",
-                      cfg.SETTINGS_BY_KEY["embedding.model_path"].help)
+        # What the retired path field used to say, now said by the field that took its place.
+        self.assertIn("or a path to one you have downloaded",
+                      cfg.SETTINGS_BY_KEY["embedding.model"].help)
 
     def test_settings_that_do_not_change_the_encoder_are_left_alone(self) -> None:
         """A note on every control is a note nobody reads."""

--- a/tools/test_matrixark_the_encoder_has_one_model_field.py
+++ b/tools/test_matrixark_the_encoder_has_one_model_field.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The portal offers one encoder model field, because there is one encoder model.
+
+There were two: ``embedding.model`` and ``embedding.model_path``. They are not two choices. The
+encoder reads ``MODEL_PATH or MODEL``, so the path only ever **overrode** the name -- and only on the
+in-process path, because a hosted provider is sent the model NAME and never looks at the path at all:
+
+    in-process   model_ref = MODEL_PATH or MODEL or "intfloat/multilingual-e5-large"
+    hosted       model     = MODEL
+
+So one of the two fields silently won on one path and did nothing on the other, and a customer had
+to know which encoder they were on to know which field they were filling in. A model name and a
+local path are both just "the encoder to load", and the field takes either, because the encoder does.
+
+The variable is still honoured where a launcher sets it -- that is not the portal's to clear -- and
+the panel says so, with the consequence spelled out per provider. A value in force that no screen
+shows is the thing that panel exists to prevent.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+try:
+    from tools import matrixark_v1_gateway as gw  # type: ignore
+except ImportError:
+    import matrixark_v1_gateway as gw  # type: ignore
+
+try:
+    from tools import matrixark_mcp_embeddings as encoder  # type: ignore
+except ImportError:
+    import matrixark_mcp_embeddings as encoder  # type: ignore
+
+cfg = gw._gwconfig
+ENCODER = "matrixark_mcp_embeddings.py"
+PATH_VARIABLE = "MATRIXARK_EMBEDDING_MODEL_PATH"
+NAME_VARIABLE = "MATRIXARK_EMBEDDING_MODEL"
+PARTICIPATING = ("MATRIXARK_EMBEDDING_PROVIDER", NAME_VARIABLE, PATH_VARIABLE,
+                 "MATRIXARK_EMBEDDING_API_BASE", "MATRIXARK_REQUIRE_MODEL_EMBEDDINGS")
+
+
+def in_process_resolutions() -> list:
+    """Every ``a or b or "<the in-process default>"`` chain in the encoder, as its variable names.
+
+    Identified by the DEFAULT it ends in rather than by the variable it starts with, so a read site
+    that stopped consulting the path is still found -- which is the whole point: a site that resolves
+    an in-process model and does not prefer the path makes the panel's warning wrong.
+    """
+    with open(os.path.join(TOOLS, ENCODER), encoding="utf-8") as handle:
+        tree = ast.parse(handle.read(), filename=ENCODER)
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.BoolOp) or not isinstance(node.op, ast.Or):
+            continue
+        literals = [c.value for c in ast.walk(node)
+                    if isinstance(c, ast.Constant) and isinstance(c.value, str)]
+        names = []
+        for value in node.values:
+            for sub in ast.walk(value):
+                if (isinstance(sub, ast.Call) and sub.args
+                        and isinstance(sub.args[0], ast.Constant)
+                        and isinstance(sub.args[0].value, str)):
+                    names.append(sub.args[0].value)
+                    break
+        if literals and names:
+            found.append((names, literals[-1]))
+    return found
+
+
+class Case(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self._saved = {n: os.environ.get(n) for n in PARTICIPATING}
+        for name in PARTICIPATING:
+            os.environ.pop(name, None)
+
+    def tearDown(self) -> None:
+        for name, value in self._saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+    def on(self, provider: str, **environment) -> None:
+        os.environ["MATRIXARK_EMBEDDING_PROVIDER"] = provider
+        for name, value in environment.items():
+            os.environ[name] = value
+
+    def warnings_about_the_path(self, provider: str, path: str = "") -> list:
+        os.environ["MATRIXARK_EMBEDDING_PROVIDER"] = provider
+        if path:
+            os.environ[PATH_VARIABLE] = path
+        return [w for w in gw._model_config_snapshot()["warnings"] if PATH_VARIABLE in w]
+
+
+class ThePremiseIsStillTrueTest(Case):
+    """Everything here rests on what the encoder DOES with the two variables, so it is asked rather
+    than read. An earlier version of this parsed the source for `PATH or NAME`; a mutation that
+    flipped one of the three read sites left the parse counting two chains against two mentions and
+    passing. Behaviour does not have that hole."""
+
+    def test_every_in_process_resolution_prefers_the_path(self) -> None:
+        """Found by the default each chain ends in, not by the variable it starts with -- a site
+        that quietly stopped consulting the path would otherwise leave the count matching and the
+        panel's warning wrong. `embedding_model_name` supplies the default, so this cannot drift
+        from the encoder either."""
+        self.on("oss")
+        os.environ.pop(NAME_VARIABLE, None)
+        os.environ.pop(PATH_VARIABLE, None)
+        default = encoder.embedding_model_name()
+        chains = [names for names, literal in in_process_resolutions() if literal == default]
+        self.assertTrue(chains, "no chain ends in the in-process default %r" % default)
+        for names in chains:
+            with self.subTest(chain=names):
+                self.assertEqual(PATH_VARIABLE, names[0])
+                self.assertIn(NAME_VARIABLE, names)
+
+    def test_an_in_process_encoder_prefers_the_path(self) -> None:
+        self.on("oss", **{NAME_VARIABLE: "a-name", PATH_VARIABLE: "/a/path"})
+        self.assertEqual("/a/path", encoder.embedding_model_name())
+
+    def test_an_in_process_encoder_uses_the_name_when_no_path_is_set(self) -> None:
+        """Which is what lets one field carry both: a name reaches the in-process encoder too."""
+        self.on("oss", **{NAME_VARIABLE: "a-name"})
+        self.assertEqual("a-name", encoder.embedding_model_name())
+
+    def test_a_hosted_encoder_ignores_the_path_entirely(self) -> None:
+        self.on("voyage", **{NAME_VARIABLE: "voyage-3", PATH_VARIABLE: "/a/path"})
+        self.assertEqual("voyage-3", encoder.embedding_model_name())
+
+    def test_the_two_answers_really_do_differ(self) -> None:
+        """The floor. If this function returned the same thing everywhere, the three assertions
+        above would agree with each other and say nothing."""
+        self.on("oss", **{NAME_VARIABLE: "a-name", PATH_VARIABLE: "/a/path"})
+        in_process = encoder.embedding_model_name()
+        self.on("voyage", **{NAME_VARIABLE: "voyage-3", PATH_VARIABLE: "/a/path"})
+        self.assertNotEqual(in_process, encoder.embedding_model_name())
+
+
+class ThePortalOffersOneFieldTest(unittest.TestCase):
+
+    def test_the_second_field_is_gone(self) -> None:
+        self.assertNotIn("embedding.model_path", cfg.SETTINGS_BY_KEY)
+
+    def test_exactly_one_setting_names_an_encoder_model(self) -> None:
+        """Counted rather than asserted about one key, so a third field cannot appear beside it."""
+        naming = [key for key, setting in cfg.SETTINGS_BY_KEY.items()
+                  if setting.group == "embedding" and "model" in key
+                  and key != "embedding.require_model_embeddings"]
+        self.assertEqual(["embedding.model"], naming)
+
+    def test_the_field_says_it_takes_either_spelling(self) -> None:
+        """A customer should not have to know which encoder path they are on to know what to type."""
+        help_text = cfg.SETTINGS_BY_KEY["embedding.model"].help
+        self.assertIn("a path to one you have downloaded", help_text)
+        self.assertIn("hosted provider is sent the name", help_text)
+
+    def test_a_stored_value_for_the_retired_field_is_no_longer_applied(self) -> None:
+        """`apply_boot` walks the registry, so a key that left it stops reaching the environment --
+        which is what makes "one field decides" true rather than aspirational."""
+        os.environ.pop(PATH_VARIABLE, None)
+        seeded = cfg.apply_boot({"values": {"embedding.model_path": "/models/left-behind",
+                                            "embedding.model": "e5-small"}})
+        self.assertNotIn(PATH_VARIABLE, seeded)
+        self.assertIsNone(os.environ.get(PATH_VARIABLE))
+
+    def test_the_field_that_remains_is_still_applied(self) -> None:
+        """The floor: if apply_boot seeded nothing, the assertion above would pass on a build that
+        had stopped applying settings altogether."""
+        seeded = cfg.apply_boot({"values": {"embedding.model": "e5-small"}})
+        self.assertIn(NAME_VARIABLE, seeded)
+
+
+class ALauncherSetPathIsReportedTest(Case):
+    """The portal cannot clear a variable the launcher set, so it has to say what it is doing."""
+
+    def test_an_in_process_encoder_is_told_the_field_is_overridden(self) -> None:
+        warning = self.warnings_about_the_path("oss", "/models/e5-large")
+        self.assertEqual(1, len(warning))
+        self.assertIn("/models/e5-large", warning[0])
+        self.assertIn("not the one making vectors", warning[0])
+
+    def test_a_hosted_provider_is_told_it_does_nothing(self) -> None:
+        """Two different consequences. Reporting the in-process wording here would send someone
+        looking for a problem that is not affecting them."""
+        for provider in ("openai_compatible", "voyage"):
+            with self.subTest(provider=provider):
+                warning = self.warnings_about_the_path(provider, "/models/e5-large")
+                self.assertEqual(1, len(warning))
+                self.assertIn("never reads it", warning[0])
+                self.assertNotIn("not the one making vectors", warning[0])
+
+    def test_it_says_where_to_put_the_path_instead(self) -> None:
+        warning = self.warnings_about_the_path("oss", "/models/e5-large")[0]
+        self.assertIn("Embedding model", warning)
+
+    def test_nothing_is_said_when_nothing_is_set(self) -> None:
+        for provider in ("oss", "openai_compatible", "deterministic"):
+            with self.subTest(provider=provider):
+                self.assertEqual([], self.warnings_about_the_path(provider))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The portal offered two encoder model fields. They were never two choices.

```
in-process   model_ref = MODEL_PATH or MODEL or "intfloat/multilingual-e5-large"
hosted       model     = MODEL
```

`MATRIXARK_EMBEDDING_MODEL_PATH` only ever **overrode** the model name — and only on the in-process
path. A hosted provider is sent the model *name* and never looks at the path at all. So one of the
two fields silently won on one encoder and did nothing on the other, and a customer had to know
which encoder they were on to know which field they were filling in.

A model name and a local path are both just *the encoder to load*. One field takes either, because
the encoder does: with no path set, the name reaches the in-process encoder unchanged — that is what
makes the merge possible rather than a guess.

### The variable does not disappear

A launcher can still set it, and that is not the portal's to clear. So the panel says what it is
doing, and the two consequences are different enough to be worth separate wording:

> **in-process** — `MATRIXARK_EMBEDDING_MODEL_PATH` is set to `/models/e5-large`, and an in-process
> encoder loads it in preference to Embedding model: the model named above is not the one making
> vectors. Clear the variable, or put the path in Embedding model, which accepts one.

> **hosted** — `MATRIXARK_EMBEDDING_MODEL_PATH` is set to `/models/e5-large` and this provider never
> reads it — a hosted encoder is sent the model NAME. It is doing nothing here, and would take over
> if the provider changed to an in-process encoder.

A value in force that no screen shows is the thing that panel exists to prevent.

### The premise is tested by asking the encoder, not by reading it

```
the shipped state: a second encoder model field comes back    -> FAIL 3
the field stops saying it takes a path                        -> FAIL 1
a launcher-set path is no longer reported                     -> FAIL 4
both providers are told the same thing                        -> FAIL 2
the hosted case is told the in-process story                  -> FAIL 2
the encoder stops preferring the path                         -> FAIL 1
the hosted request starts reading the path                    -> FAIL 2
```

The sixth took three attempts and is worth the note. I first asserted the source contained
`PATH or NAME`; a mutation that flipped **one of the three** read sites left the parse counting two
chains against two mentions and passing. Asking `embedding_model_name()` instead was stronger but
still missed it, because that function is not the site the mutation changed. What catches it is
finding every chain **by the in-process default it ends in** — so a site that quietly stops
consulting the path is still found, which is exactly the case that would make the panel's warning
wrong.

`apply_boot` walks the registry, so a value stored against the retired key simply stops reaching the
environment — that is what makes "one field decides" true rather than aspirational, and it is
asserted, alongside a floor that the field which remains *is* still applied.

14 tests. Two neighbour suites move with their reasons: both asserted the encoder notes across the
three controls and then the two, and the retired field's help is now carried by the field that
absorbed it. The floor in `..._both_encoder_controls_name_the_server` becomes one control rather
than two — still not vacuous, which is what it guards. Neighbours: 48 suites, 3 failing with the
known `No module named 'tools'` standalone-import limit; all portal- (178), gateway- (258) and
config-named (90) suites green, and 15 siblings in one process (307 tests).
