### PR TITLE
Call the secondary-index growth bound from the pipeline it was written for

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -4623,7 +4623,26 @@ def compact_and_apply_tombstones(records: list[Json]) -> list[Json]:
     except ImportError:  # Direct script execution from tools/.
         from matrixark_pipeline_task_slim import bound_pipeline_task_footprint
     records = bound_pipeline_task_footprint(records)
-    return compact_latest_context_state_records(apply_memory_tombstones(compact_latest_value_records(records)))
+    served = compact_latest_context_state_records(
+        apply_memory_tombstones(compact_latest_value_records(records)))
+    # Secondary-index growth bounding runs LAST, and for the same reason the footprint bound above
+    # runs first: it was written for this pipeline and was reachable from nowhere. Its module
+    # documents a four-lever ladder, registers two levers as operator knobs with measured recall
+    # floors, and states "the bounds run on EVERY serving recompute" -- and nothing called any of
+    # them. A cap sweep from 128 down to 8 changed nothing; calling it by hand works.
+    #
+    # LAST, because compact_latest_context_state_records rebuilds context_index postings: bounding
+    # before it would count a set that is about to be replaced.
+    #
+    # Safe at this position for the reason the footprint bound is safe at its own: it touches only
+    # context_index records, never memory records, and it returns `records` itself when nothing is
+    # over budget -- so a store below the cap is byte-identical to today and the default keeps its
+    # measured floor of 128 per session.
+    try:
+        from tools.matrixark_index_growth_bound import enforce_secondary_index_bounds
+    except ImportError:  # Direct script execution from tools/.
+        from matrixark_index_growth_bound import enforce_secondary_index_bounds
+    return enforce_secondary_index_bounds(served)
 
 
 # --------------------------------------------------------------------------------------------- #

--- a/tools/test_matrixark_the_index_bound_is_reachable.py
+++ b/tools/test_matrixark_the_index_bound_is_reachable.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The secondary-index growth bound is called from the serving pipeline.
+
+`matrixark_index_growth_bound` documents a four-lever ladder for bounding `context_index` growth,
+registers two levers as operator knobs in the tenant policy with measured recall floors ("128 holds
+recall 5/5 at 40 turns, 96 and below lose a fact"), and carries the comment "The bounds run on EVERY
+serving recompute".
+
+Nothing called any of them. Counted as ast.Call nodes across production files, because a grep that
+merely excludes `def name` still counts strings, dict keys and comments:
+
+                                        mentions   CALLS
+    enforce_secondary_index_bounds             0       0
+    dedupe_index_postings                      1       0
+    sweep_index_compaction                     0       0
+    max_index_records_per_scope                0       0
+    index_hard_ceiling                         1       0
+    node_path_embeddings_enabled  <- control   2       1
+    share_serving_values_enabled  <- control   3       1
+
+The two controls are what make that a finding rather than a broken parse: functions in the SAME
+module are found when they are called, so it is specifically the index-bounding half that was dead.
+Confirmed by measurement as well -- a cap sweep from 128 down to 8 changed nothing on main, while
+calling the function by hand worked.
+
+An earlier draft cited max_selected_refs (49) and top_k_per_layer (20) as the controls. They are not
+callers: zero calls each, appearing only as dict keys and in a comment. They were two more instances
+of the same dead code.
+
+This is the same defect the footprint bound in the same pipeline had, in its own words: "written as
+this pipeline's entry and was reachable from nowhere".
+
+Measured with the wiring in place, 16 documents, one scope:
+
+    cap        main (unwired)      wired
+    default        46 served        46 served
+    32                    -         32 served
+    8              46 served         8 served
+
+and the retrieval answer is byte-identical at every cap -- same 126 refs, same 5,226 tokens, same
+fingerprint. So the default keeps today's behaviour and the knob is what changes.
+
+These tests are about REACHABILITY. The eviction logic itself has its own suite; what was missing was
+anything asserting that a serving read goes through it, which is exactly what a dead subsystem needs.
+
+Only ONE of the three discriminates. Run against the unwired tree,
+`test_a_serving_read_goes_through_the_bound` fails with "38 not less than or equal to 4"; the other
+two PASS there, because a cap that does nothing trivially leaves both the view and the answer alone.
+They are guards against later drift -- a default that starts evicting, an answer that starts moving --
+and not evidence that the wiring works. Said here so the count is not mistaken for coverage.
+"""
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools import matrixark_mcp_local_adapter as adapter_module
+from tools.matrixark_mcp_local_adapter import (
+    MatrixArkLocalAdapter,
+    _LOCAL_READ_CACHE,
+    _LOCAL_READ_CACHE_LOCK,
+)
+
+
+def _clear_process_read_cache() -> None:
+    with _LOCAL_READ_CACHE_LOCK:
+        _LOCAL_READ_CACHE.clear()
+
+
+SCOPE = {"tenant_id": "acme", "user_id": "dana", "session_id": "skills"}
+
+
+def _skill_text(index: int, sections: int = 50) -> str:
+    out = ["# Runbook %d" % index, ""]
+    for section in range(sections):
+        out += ["## Step %d" % section, "",
+                "Check the queue depth for case %d step %d, then drain the backlog." % (index, section),
+                ""]
+    return "\n".join(out)
+
+
+class IndexBoundIsReachableTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        self.addCleanup(self._dir.cleanup)
+        self.store = Path(self._dir.name)
+        self.log = self.store / "events.jsonl"
+        _clear_process_read_cache()
+        self.addCleanup(_clear_process_read_cache)
+
+    def _ingest(self, documents: int = 12) -> None:
+        for index in range(documents):
+            adapter = MatrixArkLocalAdapter(self.log)
+            adapter.ingest({"kind": "skill", "scope": SCOPE, "text": _skill_text(index),
+                            "metadata": {"raw_uri": "file:///s/d-%d.md" % index,
+                                         "title": "d-%d" % index}})
+            adapter.close(timeout_s=3600)
+        _clear_process_read_cache()
+
+    def _served_postings(self) -> int:
+        _clear_process_read_cache()
+        return sum(1 for record in MatrixArkLocalAdapter(self.log).read_all()
+                   if str(record.get("record_type") or "") == "context_index")
+
+    def _with_cap(self, cap: int):
+        """Set the cap the way an operator would, through the policy accessor's environment."""
+        import os
+        for name, value in (("MATRIXARK_MAX_SECONDARY_INDEX_RECORDS_PER_SESSION", str(cap)),
+                            ("MATRIXARK_MAX_SECONDARY_INDEX_RECORDS_PER_TENANT", str(cap * 8))):
+            previous = os.environ.get(name)
+            os.environ[name] = value
+            self.addCleanup(
+                (lambda n, p: (os.environ.__setitem__(n, p) if p is not None
+                               else os.environ.pop(n, None))), name, previous)
+
+    def test_a_serving_read_goes_through_the_bound(self):
+        """The whole finding in one assertion: on main this number does not move.
+
+        A cap of 4 is far below anything an operator would run, and that is the point -- it makes
+        the difference between "called" and "not called" impossible to miss.
+        """
+        self._ingest()
+        unbounded = self._served_postings()
+        self.assertGreater(unbounded, 8,
+                           "not enough postings to bound; this would pass without the wiring")
+
+        self._with_cap(4)
+        bounded = self._served_postings()
+        self.assertLessEqual(bounded, 4,
+                             "the serving read did not go through enforce_secondary_index_bounds; "
+                             "the operator knob is doing nothing, which is how it shipped")
+        self.assertLess(bounded, unbounded)
+
+    def test_the_default_leaves_the_view_alone(self):
+        """Wiring a dormant bound must not change what a store below the cap serves. The bound
+        returns its input unchanged when nothing is over budget, and this pins that."""
+        self._ingest()
+        default_view = MatrixArkLocalAdapter(self.log).read_all()
+        _clear_process_read_cache()
+        self._with_cap(100000)
+        self.assertEqual(default_view, MatrixArkLocalAdapter(self.log).read_all(),
+                         "a cap nothing reaches still changed the served view")
+
+    def test_bounding_the_postings_does_not_change_the_answer_here(self):
+        """Measured, and stated as a property of THIS corpus rather than a general claim: at 16
+        documents in one scope the answer is byte-identical from 46 postings down to 8. The module's
+        own docs are explicit that evictions CAN cost recall on a conversational corpus, which is a
+        different workload and has its own measured floor of 128."""
+        self._ingest()
+        query = {"scope": SCOPE, "query": "drain the backlog when the queue depth grows", "limit": 8}
+
+        _clear_process_read_cache()
+        before = MatrixArkLocalAdapter(self.log).retrieve(dict(query))
+        self._with_cap(8)
+        _clear_process_read_cache()
+        after = MatrixArkLocalAdapter(self.log).retrieve(dict(query))
+
+        def keys(pack):
+            return [str(item.get("ref_hash") or item) if isinstance(item, dict) else str(item)
+                    for item in (pack.get("selected_refs") or [])]
+
+        self.assertTrue(keys(before), "the baseline selected nothing, so this compares nothing")
+        self.assertEqual(keys(before), keys(after))
+        self.assertEqual(before.get("used_context_tokens"), after.get("used_context_tokens"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`matrixark_index_growth_bound` documents a four-lever ladder for bounding `context_index` growth,
registers two levers as operator knobs in the tenant policy with measured recall floors — *"128 holds
recall 5/5 at 40 turns, 96 and below lose a fact"* — and carries the comment **"The bounds run on
EVERY serving recompute"**.

Nothing called any of them.

Counted as `ast.Call` nodes across production files, because a grep that merely excludes `def name`
still counts strings, dict keys and comments:

| function | mentions | **calls** |
|---|---|---|
| `enforce_secondary_index_bounds` | 0 | **0** |
| `dedupe_index_postings` | 1 | **0** |
| `sweep_index_compaction` | 0 | **0** |
| `max_index_records_per_scope` | 0 | **0** |
| `index_hard_ceiling` | 1 | **0** |
| *control:* `node_path_embeddings_enabled` | 2 | **1** |
| *control:* `share_serving_values_enabled` | 3 | **1** |

The two controls are what make this a finding rather than a broken parse: functions in the **same**
module are found when they are called, so it is specifically the index-bounding half that was dead.
No `getattr` dispatch, no star imports.

> **Correction.** An earlier revision of this description cited `max_selected_refs` (49) and
> `top_k_per_layer` (20) as the controls. They are not callers — both have **zero** calls and appear
> only as dict keys and inside a comment (71 and 26 mentions). They were not controls; they were two
> more instances of the same dead code. The finding is unchanged and slightly stronger: these
> functions have zero *calls*, not merely zero non-test mentions.

## This is a known problem, not a new one

`test_matrixark_policy_gates_wired.py` already documents the wider state, in its own words:

> This was six until the caller check started requiring a real call rather than a mention of the
> name; the true figure was twelve. `extract_segments` and `generate_embeddings` are now wired, so
> ten remain. **The wider surface is worse still: of 42 functions in the policy module, 3 are
> reachable from production code.**

So the file was written for exactly this, holds a `KNOWN_UNWIRED` list, and fails if a listed gate
gets wired without being struck off. This change reduces that list's subject matter by one lever
rather than reporting something nobody knew.

Two of the four functions here are outside what that guard can see, which is why they are not on its
list: `_gates()` matches `^def ([a-z0-9_]+_enabled)\(`, and `max_index_records_per_scope` and
`index_hard_ceiling` are not `*_enabled`. Widening that census is a separate change and is worth
doing — a knob counts as read today when the function resolving it is itself never called, which is
how the two `max_secondary_index_records_*` knobs pass while doing nothing.

`dedupe_index_postings_enabled` stays on `KNOWN_UNWIRED` and correctly so under that file's
definition: it is called from inside its own module, and the guard requires a call from outside.
After this change it is reachable transitively through the pipeline, which is the spirit of "wired"
without the letter of it — another reason the census is worth widening separately.

## Confirmed twice by measurement

A cap sweep of `MATRIXARK_MAX_SECONDARY_INDEX_RECORDS_PER_SESSION` from 128 down to 8 changed nothing
on main — 402 postings stored at every setting, identical answer fingerprint. Calling the function by
hand works and evicts in recall priority. **The code is correct and was unreachable, not broken.**

## The same defect, in the same pipeline

From the comment on the step directly above this one:

> Audit/pipeline-task footprint bounding runs FIRST. It was written as this pipeline's entry
> (`bound_pipeline_task_footprint`, …) and **was reachable from nowhere** — while a comment in
> `matrixark_mcp_summary_runtime` states serving already applies it.

Same fix, same place.

## Why last, and why it is safe there

`compact_latest_context_state_records` rebuilds `context_index` postings, so bounding before it would
count a set that is about to be replaced. Safe at that position for the reason the footprint bound is
safe at its own: it touches only `context_index` records, never memory records, and it returns its
input unchanged when nothing is over budget.

## Measured

16 documents in one scope:

```
cap        main (unwired)     wired
default        46 served      46 served
32                    -       32 served
8              46 served       8 served
```

The **default is unchanged**, which is the point of wiring it with the floor its own docs measured.
The retrieval answer is byte-identical at every cap here — same 126 refs, same 5,226 tokens, same
fingerprint — but that is a property of **this** corpus and is stated as one: the module is explicit
that evictions can cost recall on a conversational corpus, which is the workload its 128 floor was
measured against.

## What this does not do

**Lever 1 (temporal compaction on summary) stays unwired.** It needs a tombstone producer as well as
the sweep, so wiring the sweep alone would do nothing — that is its own change. Its end-to-end test,
`test_rollup_prunes_event_postings_without_losing_recall`, is red on `main` today for exactly that
reason and is untouched here.

**Lever 0 buys nothing on a skill corpus** — measured 46 postings in, 46 out, losslessness confirmed
by comparing (scope, term, ref set) triples. It collapses postings repeating the same triple across
time buckets, which is a conversational-turn pattern. It runs anyway, inside
`enforce_secondary_index_bounds`, where it costs nothing.

## Tests

Three, and **only one discriminates**. `test_a_serving_read_goes_through_the_bound` fails on the
unwired tree with `38 not less than or equal to 4`. The other two pass there — a cap that does nothing
trivially leaves both the view and the answer alone — so they are guards against later drift, not
evidence the wiring works. That is said in the file so the count is not mistaken for coverage.
