### PR TITLE
One list of the fields a default serving ref omits, instead of two that had drifted

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -7171,33 +7171,18 @@ mod tests {
             .get("selected_refs")
             .and_then(Value::as_array)
             .expect("selected refs");
-        for field in [
-            "ref_hash",
-            "node_hash",
-            "node_path",
-            "token_estimate",
-            "score",
-            "continuity_boost",
-            "cross_session_rerank_boost",
-            "continuity_reason",
-            "selection_reason",
-            "source_session_ids",
-            "source_entity_hashes",
-            "source_entity_types",
-            "source_roles",
-            "source_role_counts",
-            "budget_source_roles",
-            "budget_source_role_counts",
-            "source_hook_types",
-            "source_hook_type_counts",
-            "source_codex_events",
-            "source_codex_event_counts",
-            "source_memory_scopes",
-            "source_session_continuities",
-            "source_extraction_phases",
-            "source_profile_promotion_policies",
-            "source_profile_promotion_blockers",
-        ] {
+        // Walking the production lists means a field ADDED to them is covered here without
+        // anyone remembering to add it -- which is the drift that left the old hand-written copy
+        // checking 25 of 26. It cannot, on its own, notice a field REMOVED from them: the loop
+        // would simply stop asking about it. So the extent is pinned too, and a shrinking list
+        // fails here rather than quietly starting to leak.
+        assert_eq!(
+            LINEAGE_ONLY_FIELDS.len(),
+            22,
+            "the lineage list changed size; if a field was deliberately dropped, say so and              update this number, because dropping one is how a served ref starts carrying it"
+        );
+        assert_eq!(SCORE_ONLY_FIELDS.len(), 4, "the score list changed size");
+        for field in LINEAGE_ONLY_FIELDS.iter().chain(SCORE_ONLY_FIELDS.iter()) {
             assert!(
                 selected_refs.iter().all(|value| value.get(field).is_none()),
                 "default serving ref leaked {field}"

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl/native_serving.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl/native_serving.rs
@@ -4,6 +4,50 @@
 // native serving / memory-inventory / layer-budget helpers, split from matrixark_rust_proxy_impl.rs (textually include!d;
 // shares parent use-imports + flat scope; no use-statements or mod wrapper).
 
+/// What a served ref carries only when lineage is asked for.
+///
+/// A constant rather than an inline list because the test that proves a default ref does
+/// not leak these had its own hand-written copy, and the copies had already drifted: it
+/// checked 25 of the 26 fields, missing `source_ref`. A field added to production and not
+/// to that list would have leaked with the test still green, because the assertion only
+/// ever looked for the names written into it.
+pub(crate) const LINEAGE_ONLY_FIELDS: [&str; 22] = [
+    "ref_hash",
+    "node_hash",
+    "node_path",
+    "continuity_reason",
+    "selection_reason",
+    "source_session_ids",
+    "source_entity_hashes",
+    "source_entity_types",
+    "source_roles",
+    "source_role_counts",
+    "budget_source_roles",
+    "budget_source_role_counts",
+    "source_hook_types",
+    "source_hook_type_counts",
+    "source_codex_events",
+    "source_codex_event_counts",
+    "source_memory_scopes",
+    "source_session_continuities",
+    "source_extraction_phases",
+    "source_profile_promotion_policies",
+    "source_profile_promotion_blockers",
+    "source_ref",
+];
+
+/// What a served ref carries only when scores are asked for.
+///
+/// Separate from the lineage list, and it has to stay separate: the two answer different
+/// questions, and folding them together would make someone debugging a score take 22
+/// provenance fields they did not ask for.
+pub(crate) const SCORE_ONLY_FIELDS: [&str; 4] = [
+    "token_estimate",
+    "score",
+    "continuity_boost",
+    "cross_session_rerank_boost",
+];
+
 fn context_pack_debug_lineage_enabled() -> bool {
     env::var("MATRIXARK_CONTEXT_PACK_DEBUG_LINEAGE")
         .ok()
@@ -23,40 +67,12 @@ fn native_serving_ref(mut item: Value) -> Value {
     let include_scores = context_pack_include_scores_enabled();
     if let Some(object) = item.as_object_mut() {
         if !include_lineage {
-            for field in [
-                "ref_hash",
-                "node_hash",
-                "node_path",
-                "continuity_reason",
-                "selection_reason",
-                "source_session_ids",
-                "source_entity_hashes",
-                "source_entity_types",
-                "source_roles",
-                "source_role_counts",
-                "budget_source_roles",
-                "budget_source_role_counts",
-                "source_hook_types",
-                "source_hook_type_counts",
-                "source_codex_events",
-                "source_codex_event_counts",
-                "source_memory_scopes",
-                "source_session_continuities",
-                "source_extraction_phases",
-                "source_profile_promotion_policies",
-                "source_profile_promotion_blockers",
-                "source_ref",
-            ] {
+            for field in LINEAGE_ONLY_FIELDS {
                 object.remove(field);
             }
         }
         if !include_scores {
-            for field in [
-                "token_estimate",
-                "score",
-                "continuity_boost",
-                "cross_session_rerank_boost",
-            ] {
+            for field in SCORE_ONLY_FIELDS {
                 object.remove(field);
             }
         }


### PR DESCRIPTION
A served ref carries lineage and scores only when asked for; by default those fields are stripped.
The list of them existed **twice** — inline in `native_serving_ref`, and hand-written again in the
test that proves a default ref does not leak them.

**The copies had already parted company.**

| | fields |
|---|---|
| production strips | **26** (22 lineage + 4 score) |
| the test checked | **25** |
| missing | `source_ref` |

So if anything had stopped stripping `source_ref`, it would have gone out in every served pack with
that test still green — its assertion only ever looked for the names written into it.

### One list, walked by both

The lists now live where the stripping happens and the test walks them. That covers a field
**added** to production without anyone remembering a second place — the drift that caused this.

### But deriving alone would have been weaker

It does not cover a field **removed**: the loop would simply stop asking about it. That would be a
worse test than the hand-written copy it replaces. So the extent is pinned beside the loop — the
lists are asserted 22 and 4 long, and a shrinking list fails saying that dropping one is how a
served ref starts carrying it.

### Both directions mutation-tested

| mutation | result |
|---|---|
| drop `ref_hash` from the list | **FAILED** — "the lineage list changed size…" |
| leave the list intact, skip the removal of `source_ref` | **FAILED** — `default serving ref leaked source_ref` |
| unmodified | **OK** |

That second one is the failure that **was not possible before**, and is the hole this closes.

The two lists stay separate from each other: they answer different questions, and folding them
together would make someone debugging a score take 22 provenance fields they did not ask for.

### One note for whoever runs these next

`matrixark_rust_proxy_impl.rs` is `include!`d by the binaries rather than compiled into the lib, so
**its tests do not run under `cargo test --lib` at all** — they need `--bin matrixark_rust_proxy`.

Full binary suite: **52 passed, 0 failed.**
