### PR TITLE
One extraction model, and the summary uses it

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -246,18 +246,22 @@ SETTINGS: List[Setting] = [
             "Extraction base URL", "str", "", "restart",
             "OpenAI-compatible base, including /v1. DeepSeek: https://api.deepseek.com/v1. "
             "anthropic ignores this and uses Anthropic base URL below."),
-    Setting("extraction.model", "extraction", "MATRIXARK_EXTRACTION_MODEL",
+    # No fixed variable: `_env_name` sends this to whichever one the selected provider reads,
+    # the same way the API key is routed. An empty `env` is how the registry says "dynamic", and it
+    # is what keeps the declared-default sweep from comparing one blank against two fallbacks.
+    Setting("extraction.model", "extraction", "",
             "Extraction model", "str", "", "restart",
-            "Model name sent to the endpoint, e.g. deepseek-chat. anthropic ignores this and "
-            "uses Anthropic model below."),
-    # anthropic does not read the two fields above. Its model and endpoint have their own
-    # variables and no fallback, so without these a customer who chose anthropic could type a model
-    # and watch a different one be called. Max tokens and timeout are not repeated here because
+            "The model extraction calls, sent to whichever provider is selected above -- Anthropic "
+            "reads its own variable and this field follows, so there is nothing to keep in step by "
+            "hand. Blank means the provider's own default: claude-sonnet-5 on Anthropic, "
+            "qwen2.5:1.5b on an OpenAI-compatible endpoint."),
+    # anthropic does not read the BASE URL above: its endpoint has its own variable and no
+    # fallback, so without this a customer who chose anthropic could fill in a base URL and watch a
+    # different endpoint be called. The MODEL is no longer repeated here -- Extraction model above
+    # writes to whichever variable the selected provider reads -- because two fields for one value
+    # meant one of them was always inert, and which one depended on a dropdown three rows up.
+    # Max tokens and timeout are not repeated here because
     # those DO fall back to the extraction controls.
-    Setting("extraction.anthropic_model", "extraction", "MATRIXARK_ANTHROPIC_MODEL",
-            "Anthropic model", "str", "claude-sonnet-5", "restart",
-            "Used when Extraction provider is anthropic, which does not read Extraction model. "
-            "Leave it alone on any other provider."),
     Setting("extraction.anthropic_base_url", "extraction", "MATRIXARK_ANTHROPIC_API_BASE",
             "Anthropic base URL", "str", "https://api.anthropic.com", "restart",
             "Used when Extraction provider is anthropic, which does not read Extraction base URL. "
@@ -304,12 +308,12 @@ SETTINGS: List[Setting] = [
             "here. The choice itself takes effect on the next summary; the model below waits for a "
             "restart.",
             ["", "deterministic", "openai_compatible"]),
-    Setting("summary.model", "extraction", "MATRIXARK_SUMMARY_MODEL",
-            "Summary model", "str", "", "restart",
-            "Model for node summaries, sent to the extraction endpoint above with the same key. "
-            "Blank uses the extraction model. Naming a smaller one here is the point of the "
-            "setting: every node gets a summary, so this call is made far more often than an "
-            "extraction."),
+    # summary.model was here. Node summaries are made by the extraction endpoint with the
+    # extraction key, so a separate model was a second name for the same call -- and the two could
+    # be set to models the same endpoint does not both serve. The summary uses the extraction model,
+    # and MATRIXARK_SUMMARY_MODEL is no longer read; `_model_config_snapshot` says so if a launcher
+    # has one set, because a variable that silently stopped mattering is worse than one that never
+    # existed.
     Setting("summary.max_tokens", "extraction", "MATRIXARK_SUMMARY_MAX_TOKENS",
             "Summary max tokens", "int", "900", "restart",
             "Completion cap per summary call, separate from the extraction cap because a summary is "
@@ -841,7 +845,6 @@ _EXPLICIT_BUILD_DEFAULT = {
     # to be misconfigured -- a cloud provider selected, endpoint never filled in -- was described
     # as having no endpoint at all rather than as pointed at a local port.
     "extraction.base_url": ("EXTRACTION_LLM_BASE_URL", "matrixark_mcp_extraction_provider"),
-    "extraction.model": ("EXTRACTION_LLM_MODEL", "matrixark_mcp_extraction_provider"),
 }
 
 
@@ -1001,7 +1004,7 @@ PRESETS: Dict[str, Json] = {
         "values": {
             "extraction.provider": "anthropic",
             "extraction.anthropic_base_url": "https://api.anthropic.com",
-            "extraction.anthropic_model": "claude-sonnet-5",
+            "extraction.model": "claude-sonnet-5",
         },
     },
     "ollama": {
@@ -1134,16 +1137,24 @@ def discover_models(target: str, timeout: float = 8.0) -> Json:
             "count": len(set(models))}
 
 
-def extraction_model_setting(provider: Optional[str] = None) -> str:
-    """Which setting holds the model the selected extraction provider actually READS.
+# What each provider's own code falls back to when no model is named. Read from that code, for
+# the reason the budgets are: a number re-typed here is the second copy this file refuses to keep.
+_EXTRACTION_MODEL_DEFAULT = {
+    "anthropic": ("ANTHROPIC_LLM_MODEL", "matrixark_mcp_core"),
+    "openai": ("EXTRACTION_LLM_MODEL", "matrixark_mcp_extraction_provider"),
+}
 
-    The Anthropic path reads MATRIXARK_ANTHROPIC_MODEL and ignores MATRIXARK_EXTRACTION_MODEL
-    entirely, so writing a pick into `extraction.model` on that deployment changed nothing at all.
+
+def extraction_model_default(provider: Optional[str] = None) -> str:
+    """The model the selected provider calls when the field is blank.
+
+    One field is offered, so the portal has to be able to say what blank means on the provider in
+    use -- and the two providers do not agree, which is why the field declares no default of its own.
     """
     resolved = provider if provider is not None else _configured_extraction_provider()
-    if extraction_provider_effect(resolved) == "anthropic":
-        return "extraction.anthropic_model"
-    return "extraction.model"
+    effect = extraction_provider_effect(resolved)
+    named = _EXTRACTION_MODEL_DEFAULT.get(effect if effect == "anthropic" else "openai")
+    return _build_constant(*named) or ""
 
 
 def model_catalogue(target: str, provider: Optional[str] = None) -> List[Json]:
@@ -1254,6 +1265,16 @@ def _env_name(setting: Setting, values: Dict[str, str]) -> str:
     decision at all. Every other provider-dependent field here already defaults to empty for the
     same reason; these two used to pin one provider's name.
     """
+    if setting.key == "extraction.model":
+        # The same reason the key below is routed: the value a customer types has to reach the code
+        # that reads it, and which variable that is is not the customer's problem. Anthropic reads
+        # MATRIXARK_ANTHROPIC_MODEL and ignores MATRIXARK_EXTRACTION_MODEL entirely, so a model
+        # typed into one field on that deployment configured nothing and said nothing.
+        provider = (values.get("extraction.provider")
+                    or _configured_extraction_provider())
+        if extraction_provider_effect(provider) == "anthropic":
+            return "MATRIXARK_ANTHROPIC_MODEL"
+        return "MATRIXARK_EXTRACTION_MODEL"
     if setting.key not in _PROVIDER_KEY_VARIABLE:
         return setting.env
     group = setting.key.rsplit(".", 1)[0]
@@ -1845,7 +1866,7 @@ def probe(targets: Optional[List[str]] = None, timeout: float = 10.0) -> Json:
             else:
                 results.append(_probe(
                     "extraction_anthropic", f"{anthropic_base}/v1/messages",
-                    {"model": anthropic_model or SETTINGS_BY_KEY["extraction.anthropic_model"].default,
+                    {"model": anthropic_model or extraction_model_default("anthropic"),
                      "max_tokens": 1, "messages": [{"role": "user", "content": "ping"}]},
                     {"x-api-key": key, "anthropic-version": version}, timeout))
         elif provider not in _OPENAI_EXTRACTION_PROVIDERS:

--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -290,7 +290,10 @@ SUMMARY_LLM_PROVIDER = os.environ.get(
     "MATRIXARK_SUMMARY_PROVIDER",
     os.environ.get("MATRIXARK_UNDERSTANDING_PROVIDER", os.environ.get("MATRIXARK_EXTRACTION_PROVIDER", "deterministic")),
 ).strip().lower().replace("-", "_")
-SUMMARY_LLM_MODEL = os.environ.get("MATRIXARK_SUMMARY_MODEL", EXTRACTION_LLM_MODEL)
+# The summary IS the extraction model. It used to be `get(MATRIXARK_SUMMARY_MODEL, ...)`, a
+# second name for a call made against the extraction endpoint with the extraction key -- so the two
+# could name models that endpoint does not both serve, and the portal offered no way to see that.
+SUMMARY_LLM_MODEL = EXTRACTION_LLM_MODEL
 SUMMARY_LLM_MAX_TOKENS = int(os.environ.get("MATRIXARK_SUMMARY_MAX_TOKENS", "900"))
 ENABLE_LLM_MERGE_OPERATOR = os.environ.get("MATRIXARK_ENABLE_LLM_MERGE_OPERATOR", "").strip().lower() in {"1", "true", "yes"}
 DEFAULT_ENTITY_MERGE_OPERATOR = os.environ.get("MATRIXARK_ENTITY_MERGE_OPERATOR", "EUA_MERGE").strip().upper() or "EUA_MERGE"

--- a/tools/matrixark_mcp_summaries.py
+++ b/tools/matrixark_mcp_summaries.py
@@ -38,7 +38,10 @@ SUMMARY_LLM_PROVIDER = os.environ.get(
 # said "qwen2.5:1.5b". Both modules send `model=SUMMARY_LLM_MODEL` to the endpoint, so a
 # deployment that chose a provider and named no model asked for a different model depending
 # on which of them did the summarising.
-SUMMARY_LLM_MODEL = os.environ.get("MATRIXARK_SUMMARY_MODEL", os.environ.get("MATRIXARK_EXTRACTION_MODEL", os.environ.get("OPENAI_MODEL", "qwen2.5:1.5b")))
+# The summary IS the extraction model; see the note beside the same constant in
+# matrixark_mcp_core. Spelled out rather than imported because these two modules deliberately do not
+# depend on each other, and a test pins that they still resolve to the same thing.
+SUMMARY_LLM_MODEL = os.environ.get("MATRIXARK_EXTRACTION_MODEL", os.environ.get("OPENAI_MODEL", "qwen2.5:1.5b"))
 SUMMARY_LLM_MAX_TOKENS = int(os.environ.get("MATRIXARK_SUMMARY_MAX_TOKENS", "900"))
 
 

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1622,14 +1622,18 @@ def _model_picker_body(target: str) -> Json:
     tested twice and shipped once, which is exactly what a mutation of the route proved: the route
     could report the wrong field with every assertion still green.
     """
-    setting_key = ("embedding.model" if target == "embedding"
-                   else _gwconfig.extraction_model_setting())
+    # One extraction field now, and it routes itself: `_env_name` sends it to the variable the
+    # selected provider reads. There is nothing left for this to choose between.
+    setting_key = "embedding.model" if target == "embedding" else "extraction.model"
     body: Json = {
         "target": target,
         "key": setting_key,
         "catalogue": (embedding_picker_catalogue() if target == "embedding"
                       else _gwconfig.model_catalogue(target)),
-        "current": os.environ.get(_gwconfig.SETTINGS_BY_KEY[setting_key].env, "").strip(),
+        # Resolved, not read off `.env`: the extraction model has no fixed variable any more, so
+        # `.env` is empty for it and this read would answer "" for every deployment.
+        "current": os.environ.get(
+            _gwconfig._env_name(_gwconfig.SETTINGS_BY_KEY[setting_key], {}), "").strip(),
     }
     if target == "embedding":
         # `applicable` narrows what is OFFERED without narrowing what is SHOWN. The measured table
@@ -1683,7 +1687,10 @@ def _model_config_snapshot() -> Json:
     extraction: Json = {
         "provider": extraction_provider,
         "base_url": _env("MATRIXARK_EXTRACTION_BASE_URL"),
-        "model": _env("MATRIXARK_EXTRACTION_MODEL"),
+        # The model the SELECTED provider reads, not one variable's value: Anthropic reads its
+        # own, so a panel hardcoding the OpenAI one showed a field the deployment never sends.
+        "model": _env(_gwconfig._env_name(
+            _gwconfig.SETTINGS_BY_KEY["extraction.model"], {})),
         "timeout_sec": _env("MATRIXARK_EXTRACTION_TIMEOUT_SEC", "30"),
         "max_tokens": _env("MATRIXARK_EXTRACTION_MAX_TOKENS"),
         **_key_state(extraction_key_env),
@@ -1715,6 +1722,13 @@ def _model_config_snapshot() -> Json:
             "out-of-the-box default so the API works with no configuration. Set "
             "MATRIXARK_REQUIRE_AUTH=1 and MATRIXARK_ACCESS_MODE=enforced, then restart."
         )
+    _retired_summary_model = _env("MATRIXARK_SUMMARY_MODEL")
+    if _retired_summary_model:
+        warnings.append(
+            "MATRIXARK_SUMMARY_MODEL is set to " + _retired_summary_model + " and is no longer "
+            "read: node summaries are made by the extraction endpoint with the extraction key, so "
+            "they use Extraction model. Clear the variable, or set Extraction model to the one you "
+            "want.")
     def _unrecognised(group: str, provider: str) -> str:
         """The warning for a value nothing matches. It names the value, because the whole failure is
         that the value looks configured -- and lists what would have worked."""

--- a/tools/test_matrixark_models.py
+++ b/tools/test_matrixark_models.py
@@ -219,6 +219,9 @@ class ModelsRouteTest(_ModelTest):
         self.assertIn("re-encode", warning)
 
     def test_it_reports_what_is_configured_now(self) -> None:
+        # Which variable holds "the extraction model" follows the provider, so the provider is named
+        # here rather than left to whatever a sibling test happened to set.
+        os.environ["MATRIXARK_UNDERSTANDING_PROVIDER"] = "openai_compatible"
         os.environ["MATRIXARK_EXTRACTION_MODEL"] = "deepseek-chat"
         status, body = self.get("/v1/admin/models?target=extraction&probe=0")
         self.assertEqual("deepseek-chat", body["current"])

--- a/tools/test_matrixark_one_answer_for_the_summary_model.py
+++ b/tools/test_matrixark_one_answer_for_the_summary_model.py
@@ -10,6 +10,11 @@ and it used to end in a different literal::
     core       MATRIXARK_SUMMARY_MODEL -> MATRIXARK_EXTRACTION_MODEL -> OPENAI_MODEL -> qwen2.5:1.5b
     summaries  MATRIXARK_SUMMARY_MODEL -> MATRIXARK_EXTRACTION_MODEL -> OPENAI_MODEL -> gpt-4o-mini
 
+The first link is gone now. A node summary is made by the extraction endpoint with the extraction
+key, so a separate summary model was a second name for the same call -- two names that could be set
+to models one endpoint does not both serve. The summary IS the extraction model, and that is
+asserted below rather than left to the two chains happening to agree.
+
 Both modules **use** it: each sends ``model=SUMMARY_LLM_MODEL`` to the configured endpoint. So a
 deployment that chose a summary provider and named no model asked for a different model depending on
 which of them happened to summarise, and nothing anywhere said so. On an OpenAI endpoint one of
@@ -50,7 +55,9 @@ CASES = {
     "a provider chosen, no model named": {"MATRIXARK_SUMMARY_PROVIDER": "openai_compatible"},
     "only OPENAI_MODEL": {"OPENAI_MODEL": "gpt-4o"},
     "an extraction model named": {"MATRIXARK_EXTRACTION_MODEL": "deepseek-chat"},
-    "a summary model named": {"MATRIXARK_SUMMARY_MODEL": "something-cheap"},
+    # Retired: nothing reads it. Kept as a case because the two modules must ignore it the SAME
+    # way -- one of them still honouring it would be the old divergence with a new cause.
+    "the retired summary model still set": {"MATRIXARK_SUMMARY_MODEL": "something-cheap"},
     "extraction named and OPENAI_MODEL set": {"MATRIXARK_EXTRACTION_MODEL": "deepseek-chat",
                                               "OPENAI_MODEL": "gpt-4o"},
 }
@@ -110,6 +117,31 @@ class TheValueIsActuallySentTest(unittest.TestCase):
             with self.subTest(module=name):
                 self.assertIn("model=SUMMARY_LLM_MODEL", self._source(name),
                               "%s resolves a summary model and never sends it" % name)
+
+
+class TheSummaryModelIsTheExtractionModelTest(unittest.TestCase):
+    """The rule the first link's removal is FOR. Both chains agreeing is not enough: they could
+    agree on a third thing."""
+
+    def test_it_follows_the_extraction_model(self) -> None:
+        resolved = _resolve({"MATRIXARK_EXTRACTION_MODEL": "deepseek-chat"})
+        self.assertEqual("deepseek-chat", resolved["core"])
+        self.assertEqual("deepseek-chat", resolved["summaries"])
+
+    def test_the_retired_variable_no_longer_wins(self) -> None:
+        """What this change is: a deployment with both set gets the extraction model, in both
+        modules, rather than a summary model neither the portal nor the endpoint agreed to."""
+        resolved = _resolve({"MATRIXARK_EXTRACTION_MODEL": "deepseek-chat",
+                             "MATRIXARK_SUMMARY_MODEL": "something-cheap"})
+        self.assertEqual("deepseek-chat", resolved["core"])
+        self.assertEqual("deepseek-chat", resolved["summaries"])
+
+    def test_it_tracks_a_change_to_the_extraction_model(self) -> None:
+        """The floor: if both constants had been frozen to a literal, the two above would pass on a
+        build where the summary followed nothing at all."""
+        first = _resolve({"MATRIXARK_EXTRACTION_MODEL": "deepseek-chat"})["core"]
+        second = _resolve({"MATRIXARK_EXTRACTION_MODEL": "gpt-4o-mini"})["core"]
+        self.assertNotEqual(first, second)
 
 
 if __name__ == "__main__":

--- a/tools/test_matrixark_the_anthropic_model_is_selectable.py
+++ b/tools/test_matrixark_the_anthropic_model_is_selectable.py
@@ -35,7 +35,12 @@ sys.path.insert(0, TOOLS)
 
 import matrixark_gateway_config as cfg  # noqa: E402
 
-ANTHROPIC_CONTROLS = ("extraction.anthropic_model", "extraction.anthropic_base_url")
+# The model is no longer among these. Extraction model writes to whichever variable the selected
+# provider reads, so Anthropic's model is selectable through the one field rather than a second one
+# beside it -- which is the same guarantee this file was written to protect, with the failure mode
+# removed instead of documented. The ENDPOINT still needs its own control: it has no fallback, and
+# nothing routes it.
+ANTHROPIC_CONTROLS = ("extraction.anthropic_base_url",)
 
 PROBE = """
 import json, sys
@@ -70,7 +75,7 @@ def started_with(**overrides):
 
 class TheControlsExistTest(unittest.TestCase):
 
-    def test_both_are_offered(self) -> None:
+    def test_the_endpoint_control_is_offered(self) -> None:
         for key in ANTHROPIC_CONTROLS:
             with self.subTest(setting=key):
                 self.assertIn(key, cfg.SETTINGS_BY_KEY)
@@ -90,8 +95,9 @@ class TheDeclaredDefaultsAreTheRealOnesTest(unittest.TestCase):
     what the deployment is doing."""
 
     def test_the_model_default_is_what_the_code_uses(self) -> None:
-        self.assertEqual(started_with()["model"],
-                         cfg.SETTINGS_BY_KEY["extraction.anthropic_model"].default)
+        """The field declares no default of its own -- the two providers disagree about it -- so the
+        portal asks the provider's code instead, and that answer has to be the real one."""
+        self.assertEqual(started_with()["model"], cfg.extraction_model_default("anthropic"))
 
     def test_the_base_default_is_what_the_code_uses(self) -> None:
         self.assertEqual(started_with()["base"],
@@ -109,8 +115,21 @@ class TheControlsActuallySelectTheModelTest(unittest.TestCase):
         return cfg._env_name(cfg.SETTINGS_BY_KEY[key], {})
 
     def test_naming_a_model_changes_what_is_called(self) -> None:
-        got = started_with(**{self.variable("extraction.anthropic_model"): "claude-opus-4"})
+        """Driven through the variable the ONE model field resolves to on this provider. Writing
+        MATRIXARK_ANTHROPIC_MODEL out here would pass even if the field routed somewhere else --
+        which is exactly the failure this change removes."""
+        variable = cfg._env_name(cfg.SETTINGS_BY_KEY["extraction.model"],
+                                 {"extraction.provider": "anthropic"})
+        got = started_with(**{variable: "claude-opus-4"})
         self.assertEqual("claude-opus-4", got["model"])
+
+    def test_the_same_field_on_another_provider_does_not_reach_anthropic(self) -> None:
+        """The floor for the test above: if the field wrote one variable whatever the provider, both
+        would pass and the routing would be untested."""
+        variable = cfg._env_name(cfg.SETTINGS_BY_KEY["extraction.model"],
+                                 {"extraction.provider": "openai_compatible"})
+        got = started_with(**{variable: "gpt-4o-mini"})
+        self.assertNotEqual("gpt-4o-mini", got["model"])
 
     def test_naming_an_endpoint_changes_where_it_is_called(self) -> None:
         got = started_with(**{self.variable("extraction.anthropic_base_url"): "https://proxy.example"})
@@ -141,16 +160,18 @@ class TheAsymmetryThatExplainsTheScopeTest(unittest.TestCase):
 class TheOtherTwoControlsSayTheyAreIgnoredTest(unittest.TestCase):
     """A customer on anthropic reads Extraction model first; it has to say it is not the one."""
 
-    def test_the_model_control_says_so(self) -> None:
-        self.assertIn("anthropic ignores this",
-                      cfg.SETTINGS_BY_KEY["extraction.model"].help)
+    def test_the_model_control_says_it_follows_the_provider(self) -> None:
+        """It used to have to say "anthropic ignores this". It does not ignore it any more."""
+        help_text = cfg.SETTINGS_BY_KEY["extraction.model"].help
+        self.assertIn("whichever provider is selected", help_text)
+        self.assertNotIn("anthropic ignores this", help_text)
 
     def test_the_base_url_control_says_so(self) -> None:
         self.assertIn("anthropic ignores this",
                       cfg.SETTINGS_BY_KEY["extraction.base_url"].help)
 
-    def test_each_points_at_the_one_that_is_used(self) -> None:
-        self.assertIn("Anthropic model", cfg.SETTINGS_BY_KEY["extraction.model"].help)
+    def test_the_base_url_still_points_at_the_one_that_is_used(self) -> None:
+        """Only the endpoint is left to point at: the model field IS the one that is used."""
         self.assertIn("Anthropic base URL", cfg.SETTINGS_BY_KEY["extraction.base_url"].help)
 
 

--- a/tools/test_matrixark_the_extraction_has_one_model_field.py
+++ b/tools/test_matrixark_the_extraction_has_one_model_field.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The portal offers one extraction model field, and it lands where the provider reads it.
+
+There were two: ``extraction.model`` and ``extraction.anthropic_model``. A deployment uses one
+provider at a time, so one of the two fields was always inert -- and which one was inert depended on
+a dropdown three rows above it. The Anthropic path reads ``MATRIXARK_ANTHROPIC_MODEL`` and ignores
+``MATRIXARK_EXTRACTION_MODEL`` entirely, so a customer on Anthropic who filled in "Extraction model"
+had configured nothing at all.
+
+One field now, whose variable follows the selected provider -- the same mechanism the API key uses,
+for the same reason: the value a customer types has to reach the code that reads it, and which
+variable that is is not the customer's problem.
+
+Blank means the provider's own default, which differs per provider, so the field declares no default
+of its own. That is the honest state for a value with more than one fallback, and the help names
+both so nobody has to read the source to find out what is running.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+try:
+    from tools import matrixark_v1_gateway as gw  # type: ignore
+except ImportError:
+    import matrixark_v1_gateway as gw  # type: ignore
+
+cfg = gw._gwconfig
+
+OPENAI_VARIABLE = "MATRIXARK_EXTRACTION_MODEL"
+ANTHROPIC_VARIABLE = "MATRIXARK_ANTHROPIC_MODEL"
+SUMMARY_VARIABLE = "MATRIXARK_SUMMARY_MODEL"
+PARTICIPATING = ("MATRIXARK_UNDERSTANDING_PROVIDER", "MATRIXARK_EXTRACTION_PROVIDER",
+                 OPENAI_VARIABLE, ANTHROPIC_VARIABLE, SUMMARY_VARIABLE,
+                 "MATRIXARK_EXTRACTION_BASE_URL", "MATRIXARK_ANTHROPIC_API_BASE", "OPENAI_MODEL")
+
+
+class Case(unittest.TestCase):
+    """Resolution reads the process environment, so it is controlled here -- a sibling suite leaving
+    a provider set is the difference between passing alone and failing the full run."""
+
+    def setUp(self) -> None:
+        self._saved = {n: os.environ.get(n) for n in PARTICIPATING}
+        for name in PARTICIPATING:
+            os.environ.pop(name, None)
+
+    def tearDown(self) -> None:
+        for name, value in self._saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+    def variable_for(self, provider: str) -> str:
+        return cfg._env_name(cfg.SETTINGS_BY_KEY["extraction.model"],
+                             {"extraction.provider": provider})
+
+    def on(self, provider: str, **environment) -> None:
+        os.environ["MATRIXARK_UNDERSTANDING_PROVIDER"] = provider
+        for name, value in environment.items():
+            os.environ[name] = value
+
+
+class ThePortalOffersOneFieldTest(unittest.TestCase):
+
+    def test_the_second_field_is_gone(self) -> None:
+        self.assertNotIn("extraction.anthropic_model", cfg.SETTINGS_BY_KEY)
+
+    def test_exactly_one_setting_names_an_extraction_model(self) -> None:
+        """Counted, so a third cannot appear beside it the next time a provider is added."""
+        naming = [key for key, setting in cfg.SETTINGS_BY_KEY.items()
+                  if setting.group == "extraction" and key.endswith("model")]
+        self.assertEqual(["extraction.model"], naming)
+
+    def test_it_declares_no_default_of_its_own(self) -> None:
+        """The build's fallback differs per provider, so naming one here would be wrong for the
+        other -- and `export_settings` writes a declared default to a clone as an explicit value."""
+        self.assertEqual("", cfg.SETTINGS_BY_KEY["extraction.model"].default)
+
+    def test_blank_means_a_different_model_on_each_provider(self) -> None:
+        """The reason the field declares no default: the two answers differ, and the one it gives
+        has to be the one the help names. A single answer for both would satisfy the help test on
+        its own, which is how a mutation collapsing this survived a first pass."""
+        anthropic = cfg.extraction_model_default("anthropic")
+        openai = cfg.extraction_model_default("openai_compatible")
+        self.assertNotEqual(anthropic, openai)
+        help_text = cfg.SETTINGS_BY_KEY["extraction.model"].help
+        self.assertIn(anthropic, help_text)
+        self.assertIn(openai, help_text)
+
+    def test_the_help_names_what_blank_means_on_each_provider(self) -> None:
+        help_text = cfg.SETTINGS_BY_KEY["extraction.model"].help
+        self.assertIn("claude-sonnet-5", help_text)
+        self.assertIn("qwen2.5:1.5b", help_text)
+
+
+class TheValueLandsWhereTheProviderReadsItTest(Case):
+
+    def test_anthropic_gets_its_own_variable(self) -> None:
+        self.assertEqual(ANTHROPIC_VARIABLE, self.variable_for("anthropic"))
+
+    def test_everything_else_gets_the_general_one(self) -> None:
+        for provider in ("openai_compatible", "deterministic", "", "typo_provider"):
+            with self.subTest(provider=provider):
+                self.assertEqual(OPENAI_VARIABLE, self.variable_for(provider))
+
+    def test_the_provider_may_come_from_the_launcher(self) -> None:
+        """A deployment that sets the provider in the environment and the model in the portal is the
+        mixed case, and it has to resolve the same way."""
+        os.environ["MATRIXARK_UNDERSTANDING_PROVIDER"] = "anthropic"
+        self.assertEqual(ANTHROPIC_VARIABLE,
+                         cfg._env_name(cfg.SETTINGS_BY_KEY["extraction.model"], {}))
+
+    def test_a_write_reaches_the_variable_the_provider_reads(self) -> None:
+        """The whole point, end to end: apply the stored value and see where it lands."""
+        seeded = cfg.apply_boot({"values": {"extraction.provider": "anthropic",
+                                            "extraction.model": "claude-opus-5"}})
+        self.assertIn(ANTHROPIC_VARIABLE, seeded)
+        self.assertEqual("claude-opus-5", os.environ.get(ANTHROPIC_VARIABLE))
+        self.assertIsNone(os.environ.get(OPENAI_VARIABLE))
+
+    def test_the_same_write_on_the_other_provider_lands_elsewhere(self) -> None:
+        """The floor: if it always wrote one variable, the assertion above would pass by accident."""
+        seeded = cfg.apply_boot({"values": {"extraction.provider": "openai_compatible",
+                                            "extraction.model": "gpt-4o-mini"}})
+        self.assertIn(OPENAI_VARIABLE, seeded)
+        self.assertEqual("gpt-4o-mini", os.environ.get(OPENAI_VARIABLE))
+        self.assertIsNone(os.environ.get(ANTHROPIC_VARIABLE))
+
+
+class ThePanelAndTheProbeFollowItTest(Case):
+
+    def test_the_panel_reports_the_model_in_use(self) -> None:
+        self.on("anthropic", **{ANTHROPIC_VARIABLE: "claude-opus-5",
+                                OPENAI_VARIABLE: "gpt-4o"})
+        self.assertEqual("claude-opus-5",
+                         gw._model_config_snapshot()["extraction"]["model"])
+
+    def test_the_other_provider_reports_the_other_one(self) -> None:
+        self.on("openai_compatible", **{ANTHROPIC_VARIABLE: "claude-opus-5",
+                                        OPENAI_VARIABLE: "gpt-4o"})
+        self.assertEqual("gpt-4o", gw._model_config_snapshot()["extraction"]["model"])
+
+    def test_the_picker_writes_the_one_field(self) -> None:
+        """It used to choose between two keys. There is one, so there is nothing to choose."""
+        self.on("anthropic")
+        self.assertEqual("extraction.model", gw._model_picker_body("extraction")["key"])
+        self.on("openai_compatible")
+        self.assertEqual("extraction.model", gw._model_picker_body("extraction")["key"])
+
+
+class TheSummaryHasNoModelOfItsOwnTest(Case):
+    """A node summary is made by the extraction endpoint with the extraction key. A separate model
+    was a second name for the same call, and the two could name models one endpoint does not both
+    serve -- with no screen showing the pair."""
+
+    def test_the_control_is_gone(self) -> None:
+        self.assertNotIn("summary.model", cfg.SETTINGS_BY_KEY)
+
+    def test_what_is_left_of_the_summary_group_is_not_a_model(self) -> None:
+        """provider and max_tokens stay: they are choices about the summary, not a second model."""
+        remaining = sorted(k for k in cfg.SETTINGS_BY_KEY if k.startswith("summary."))
+        self.assertEqual(["summary.max_tokens", "summary.provider"], remaining)
+
+    def test_a_launcher_that_still_sets_it_is_told(self) -> None:
+        """It stopped mattering rather than never existing, which is the worse of the two to leave
+        silent."""
+        self.on("openai_compatible", **{SUMMARY_VARIABLE: "something-cheap"})
+        named = [w for w in gw._model_config_snapshot()["warnings"]
+                 if SUMMARY_VARIABLE in w]
+        self.assertEqual(1, len(named))
+        self.assertIn("something-cheap", named[0])
+        self.assertIn("no longer read", named[0])
+
+    def test_it_says_which_field_decides_now(self) -> None:
+        self.on("openai_compatible", **{SUMMARY_VARIABLE: "something-cheap"})
+        named = [w for w in gw._model_config_snapshot()["warnings"] if SUMMARY_VARIABLE in w][0]
+        self.assertIn("Extraction model", named)
+
+    def test_nothing_is_said_when_it_is_not_set(self) -> None:
+        self.on("openai_compatible")
+        self.assertEqual([], [w for w in gw._model_config_snapshot()["warnings"]
+                              if SUMMARY_VARIABLE in w])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_the_model_picker_writes_the_field_the_provider_reads.py
+++ b/tools/test_matrixark_the_model_picker_writes_the_field_the_provider_reads.py
@@ -102,7 +102,7 @@ class TheSuggestionsAreOnesTheProviderServesTest(Case):
         disagrees with the field beside it."""
         self.on("anthropic")
         models = [entry["model"] for entry in cfg.model_catalogue("extraction")]
-        self.assertIn(cfg.SETTINGS_BY_KEY["extraction.anthropic_model"].default, models)
+        self.assertIn(cfg.extraction_model_default("anthropic"), models)
 
     def test_embeddings_are_still_refused_here(self) -> None:
         """Encoders come from the measured catalogue in the gateway. A second hand-written list is
@@ -113,25 +113,27 @@ class TheSuggestionsAreOnesTheProviderServesTest(Case):
 
 class ThePickGoesIntoTheFieldTheProviderReadsTest(Case):
 
-    def test_anthropic_writes_its_own_model_setting(self) -> None:
-        self.on("anthropic")
-        self.assertEqual("extraction.anthropic_model", cfg.extraction_model_setting())
+    def variable(self, provider: str) -> str:
+        return cfg._env_name(cfg.SETTINGS_BY_KEY["extraction.model"],
+                             {"extraction.provider": provider})
+
+    def test_anthropic_writes_its_own_variable(self) -> None:
+        """There is one model field now, so there is no key to choose between -- the field itself
+        lands in the variable the provider reads."""
+        self.assertEqual("MATRIXARK_ANTHROPIC_MODEL", self.variable("anthropic"))
 
     def test_everything_else_writes_the_general_one(self) -> None:
         for provider in ("openai_compatible", "deterministic", "", "typo_provider"):
             with self.subTest(provider=provider):
-                self.on(provider)
-                self.assertEqual("extraction.model", cfg.extraction_model_setting())
+                self.assertEqual("MATRIXARK_EXTRACTION_MODEL", self.variable(provider))
 
-    def test_the_setting_it_names_exists_and_is_the_one_the_code_reads(self) -> None:
+    def test_the_key_it_names_is_on_the_form(self) -> None:
         """A key that is not in the registry would reach the page and query a field that is not on
         the form, which the page reports as 'not loaded' -- a dead end rather than an error."""
-        for provider, variable in (("anthropic", "MATRIXARK_ANTHROPIC_MODEL"),
-                                   ("openai_compatible", "MATRIXARK_EXTRACTION_MODEL")):
+        for provider in ("anthropic", "openai_compatible"):
             with self.subTest(provider=provider):
                 self.on(provider)
-                setting = cfg.SETTINGS_BY_KEY[cfg.extraction_model_setting()]
-                self.assertEqual(variable, setting.env)
+                self.assertIn(gw._model_picker_body("extraction")["key"], cfg.SETTINGS_BY_KEY)
 
 
 class TheRouteAnswersWithBothTest(Case):
@@ -142,14 +144,14 @@ class TheRouteAnswersWithBothTest(Case):
         assertion below while the route reported the wrong field -- a mutation proved it."""
         return gw._model_picker_body(target)
 
-    def test_current_is_read_from_the_field_that_is_in_use(self) -> None:
+    def test_current_is_read_from_the_variable_that_is_in_use(self) -> None:
         self.on("anthropic")
         os.environ["MATRIXARK_ANTHROPIC_MODEL"] = "claude-opus-5"
         os.environ["MATRIXARK_EXTRACTION_MODEL"] = "gpt-4o"
         body = self.body()
-        self.assertEqual("extraction.anthropic_model", body["key"])
+        self.assertEqual("extraction.model", body["key"])
         self.assertEqual("claude-opus-5", body["current"],
-                         "the panel showed the field this provider does not read")
+                         "the panel showed the variable this provider does not read")
 
     def test_the_other_field_is_not_what_is_reported(self) -> None:
         self.on("openai_compatible")

--- a/tools/test_matrixark_the_portal_declares_the_budget_the_build_runs.py
+++ b/tools/test_matrixark_the_portal_declares_the_budget_the_build_runs.py
@@ -148,10 +148,16 @@ class TheParseFoundSomethingTest(unittest.TestCase):
 
     def test_it_finds_the_chain_that_makes_a_summary_follow_extraction(self) -> None:
         """The shape the first exemption rests on, named once, so a parser change that stops seeing
-        it fails here rather than turning into a false disagreement."""
+        it fails here rather than turning into a false disagreement.
+
+        It used to be the summary MODEL following the extraction model. There is no summary model
+        any more -- a node summary is made by the extraction endpoint, so it uses the extraction
+        model and nothing else -- and the summary PROVIDER follows the extraction provider the same
+        way, which is the shape this rule is about.
+        """
         _literals, follows = read_shapes()
-        self.assertIn("MATRIXARK_EXTRACTION_MODEL",
-                      follows.get("MATRIXARK_SUMMARY_MODEL", set()))
+        self.assertIn("MATRIXARK_UNDERSTANDING_PROVIDER",
+                      follows.get("MATRIXARK_SUMMARY_PROVIDER", set()))
 
     def test_it_finds_a_variable_read_differently_per_provider(self) -> None:
         """The shape the second exemption rests on."""

--- a/tools/test_matrixark_the_portal_offers_the_summary_model.py
+++ b/tools/test_matrixark_the_portal_offers_the_summary_model.py
@@ -34,7 +34,11 @@ sys.path.insert(0, TOOLS)
 
 import matrixark_gateway_config as cfg  # noqa: E402
 
-SUMMARY_CONTROLS = ("summary.provider", "summary.model", "summary.max_tokens")
+# summary.model was here. A node summary is made by the extraction endpoint with the extraction
+# key, so a separate model was a second name for the same call -- and the pair could be set to models
+# one endpoint does not both serve, with no screen showing both. The summary uses the extraction
+# model; what is left are choices ABOUT the summary rather than a second model.
+SUMMARY_CONTROLS = ("summary.provider", "summary.max_tokens")
 
 PROBE = """
 import json, sys
@@ -65,7 +69,7 @@ def started_with(**overrides):
 
 class TheControlsExistTest(unittest.TestCase):
 
-    def test_all_three_are_offered(self) -> None:
+    def test_both_are_offered(self) -> None:
         for key in SUMMARY_CONTROLS:
             with self.subTest(setting=key):
                 self.assertIn(key, cfg.SETTINGS_BY_KEY)
@@ -102,7 +106,6 @@ class AddingThemChangesNothingTest(unittest.TestCase):
         """A blank is not seeded into the environment, so the reader's fallback chain is untouched
         for a deployment that never opens the page."""
         self.assertEqual("", cfg.SETTINGS_BY_KEY["summary.provider"].default)
-        self.assertEqual("", cfg.SETTINGS_BY_KEY["summary.model"].default)
 
     def test_the_budget_default_is_the_one_the_code_uses(self) -> None:
         self.assertEqual(900, started_with()["max_tokens"])
@@ -124,10 +127,10 @@ class AddingThemChangesNothingTest(unittest.TestCase):
         for name in CLEAR:
             os.environ.pop(name, None)
 
-        cfg.update({"summary.provider": "", "summary.model": ""}, actor="test")
+        cfg.update({"summary.provider": "", "summary.max_tokens": ""}, actor="test")
         cfg.apply_boot()
         self.assertIsNone(os.environ.get("MATRIXARK_SUMMARY_PROVIDER"))
-        self.assertIsNone(os.environ.get("MATRIXARK_SUMMARY_MODEL"))
+        self.assertIsNone(os.environ.get("MATRIXARK_SUMMARY_MAX_TOKENS"))
 
 
 class TheHelpTextIsTrueTest(unittest.TestCase):
@@ -139,13 +142,17 @@ class TheHelpTextIsTrueTest(unittest.TestCase):
         self.assertEqual("openai_compatible", got["provider"])
         self.assertEqual("deepseek-chat", got["model"])
 
-    def test_a_named_summary_model_wins(self) -> None:
-        """The reason to offer the control: a smaller model for the call made most often."""
+    def test_a_named_summary_model_no_longer_wins(self) -> None:
+        """This used to be the reason to offer the control: a smaller model for the call made most
+        often. The call is made against the extraction endpoint with the extraction key, so the two
+        names could be models one endpoint does not both serve -- and no screen showed the pair. The
+        summary uses the extraction model; the token cap, which IS a property of the summary, still
+        applies."""
         got = started_with(MATRIXARK_UNDERSTANDING_PROVIDER="openai_compatible",
                            MATRIXARK_EXTRACTION_MODEL="deepseek-chat",
                            MATRIXARK_SUMMARY_MODEL="deepseek-chat-lite",
                            MATRIXARK_SUMMARY_MAX_TOKENS="400")
-        self.assertEqual("deepseek-chat-lite", got["model"])
+        self.assertEqual("deepseek-chat", got["model"])
         self.assertEqual(400, got["max_tokens"])
 
     def test_anthropic_extraction_leaves_summaries_deterministic(self) -> None:
@@ -165,9 +172,10 @@ class TheHelpTextIsTrueTest(unittest.TestCase):
         provider_help = cfg.SETTINGS_BY_KEY["summary.provider"].help
         self.assertIn("Blank follows the extraction provider", provider_help)
         self.assertIn("anthropic", provider_help)
-        model_help = cfg.SETTINGS_BY_KEY["summary.model"].help
-        self.assertIn("extraction endpoint above with the same key", model_help)
-        self.assertIn("Blank uses the extraction model", model_help)
+        # There is no summary model control to describe. What remains is a cap on a call whose
+        # model is the extraction model, and the cap says why it is separate.
+        tokens_help = cfg.SETTINGS_BY_KEY["summary.max_tokens"].help
+        self.assertIn("summary", tokens_help.lower())
 
 
 @unittest.skipUnless(__import__("shutil").which("node"),


### PR DESCRIPTION
The portal offered two extraction model fields. A deployment uses one provider at a time, so one of
them was always inert — and which one depended on a dropdown three rows above it.

Measured on `main` before this change: pick **anthropic**, type `claude-opus-5` into *Extraction
model*, save.

```
MATRIXARK_EXTRACTION_MODEL = 'claude-opus-5'     <- where the value landed
MATRIXARK_ANTHROPIC_MODEL  = None
the model the Anthropic call sends: 'claude-sonnet-5'
```

The customer changed nothing, and nothing said so.

### One field, routed

`_env_name` now sends *Extraction model* to whichever variable the selected provider reads — the same
mechanism the API key already uses, for the same reason: the value a customer types has to reach the
code that reads it, and which variable that is is not the customer's problem.

The field declares no default of its own, because the two providers disagree about what blank means.
The portal asks each provider's own code (`ANTHROPIC_LLM_MODEL`, `EXTRACTION_LLM_MODEL`) rather than
re-typing a number this file refuses to keep a second copy of, and the help names both. A test pins
that the two answers actually differ — a mutation collapsing them to one satisfied the help test on
its own.

### The summary loses its model too

A node summary is made by **the extraction endpoint with the extraction key**. A separate summary
model was therefore a second name for the same call — and the pair could name models one endpoint
does not both serve, with no screen showing both. `SUMMARY_LLM_MODEL` is the extraction model in both
modules that send one, and `MATRIXARK_SUMMARY_MODEL` is no longer read. The panel says so if a
launcher still sets it: a variable that silently stopped mattering is worse than one that never
existed.

*Summary provider* and *max tokens* stay. They are choices **about** the summary — the token cap in
particular is a property of a call made on every node — rather than a second model.

```
the shipped bug: a second anthropic model field returns   -> FAIL 2
the field stops following the provider                    -> FAIL 4
it always writes the anthropic variable instead           -> FAIL 6
the provider set by the launcher is ignored               -> FAIL 2
the help stops naming what blank means                    -> FAIL 1
blank is answered with one provider's default for both    -> FAIL 1
the panel goes back to one hardcoded variable             -> FAIL 1
the summary model control comes back                      -> FAIL 3
the summary reads its own variable again in core          -> FAIL 2
only ONE of the two modules keeps following extraction    -> FAIL 2
the retired variable is no longer reported                -> FAIL 2
```

### Five neighbour suites move, each with its reason written where it changed

Two were built around the controls this retires:

- **the Anthropic suite** keeps its endpoint control — that genuinely has no fallback and nothing
  routes it — and now drives the model through the variable the one field resolves to. Its own
  docstring documented this defect with the *previous* fix (a second control); the failure mode is
  removed now rather than described. A floor was added: the same field on another provider must
  **not** reach Anthropic, or the routing would be untested.
- **the summary suite** keeps the two controls that are not a model, and its "a named summary model
  wins" case becomes "no longer wins" — that is the behaviour change, stated rather than deleted.

The picker no longer chooses between two keys because there is one. Its `current` is now resolved
through `_env_name` rather than read off a fixed `env` name — with a dynamic variable that read
answered `""` for every deployment, which the picker's own tests caught.

18 tests in the new suite, 3 added to the summary-agreement suite. Neighbours: the derived list of
every suite touching the retired settings, the picker or the registry — 43, all green — plus all
portal- (180), gateway- (258) and config-named (90) suites. The generated portal page and flag
inventory are unchanged, which is expected: settings are served to the page at runtime.

Follows [#1001](https://github.com/matrixarkai/TemporalStore/pull/1001), which did the same for the
encoder: one model field there too.
