### PR TITLE
A rolled-up event drops the postings the summary replaced

### DIFF
--- a/tools/matrixark_local_adapter_summaries.py
+++ b/tools/matrixark_local_adapter_summaries.py
@@ -982,6 +982,29 @@ class _LocalAdapterSummariesMixin:
                     "updated_at_ms": refreshed_at_ms,
                 }
                 self.append(summary_record)
+                # Lever 1. The events this summary rolls up no longer need postings of their own:
+                # the summary carries its own, and those are the surviving recall path. The
+                # tombstone names exactly the events covered, and the serving sweep drops their
+                # postings.
+                #
+                # `index_compaction_tombstone` returns None when there is nothing to compact, so a
+                # summary with no source events appends nothing and the log stays byte-identical to
+                # what it was before this.
+                try:
+                    from tools.matrixark_index_growth_bound import (
+                        index_compact_on_summary_enabled, index_compaction_tombstone)
+                except ImportError:  # Direct script execution from tools/.
+                    from matrixark_index_growth_bound import (
+                        index_compact_on_summary_enabled, index_compaction_tombstone)
+                summary_scope = summary_record.get("scope")
+                if index_compact_on_summary_enabled(summary_scope):
+                    compaction = index_compaction_tombstone(
+                        source_event_ids=source_event_ids,
+                        scope=summary_scope if isinstance(summary_scope, dict) else None,
+                        summary_hash=summary_hash,
+                    )
+                    if compaction is not None:
+                        self.append(compaction)
                 for index_name in candidate_index_terms(summary_record, {}, {}):
                     self.append(
                         context_index_posting_record(

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -4728,8 +4728,17 @@ def compact_and_apply_tombstones(records: list[Json]) -> list[Json]:
     except ImportError:  # Direct script execution from tools/.
         from matrixark_pipeline_task_slim import bound_pipeline_task_footprint
     records = bound_pipeline_task_footprint(records)
+    # The compaction sweep runs on the log's own order, BEFORE the posting rebuild below.
+    # `sweep_index_compaction` drops a posting only when a tombstone that FOLLOWS it covers every
+    # ref, and `compact_latest_context_state_records` rebuilds postings -- so sweeping afterwards
+    # hands it fresh rows positioned after the tombstones, which it cannot match. Measured: 4 of 60
+    # event postings survived that way.
+    try:
+        from tools.matrixark_index_growth_bound import sweep_index_compaction
+    except ImportError:  # Direct script execution from tools/.
+        from matrixark_index_growth_bound import sweep_index_compaction
     served = compact_latest_context_state_records(
-        apply_memory_tombstones(compact_latest_value_records(records)))
+        apply_memory_tombstones(compact_latest_value_records(sweep_index_compaction(records))))
     # Secondary-index growth bounding runs LAST, and for the same reason the footprint bound above
     # runs first: it was written for this pipeline and was reachable from nowhere. Its module
     # documents a four-lever ladder, registers two levers as operator knobs with measured recall
@@ -4747,6 +4756,12 @@ def compact_and_apply_tombstones(records: list[Json]) -> list[Json]:
         from tools.matrixark_index_growth_bound import enforce_secondary_index_bounds
     except ImportError:  # Direct script execution from tools/.
         from matrixark_index_growth_bound import enforce_secondary_index_bounds
+    # Lever 1 before the budget, which is the module's own order: "Lever 1 has already removed every
+    # posting that was purely redundant, so whatever a cap evicts on top of it is a live lookup
+    # path." Bounding first would spend the budget evicting postings the sweep removes for free.
+    #
+    # Identity when the log carries no compaction tombstone, so a store that has never rolled up a
+    # summary is byte-identical to before.
     return enforce_secondary_index_bounds(served)
 
 

--- a/tools/test_matrixark_policy_gates_wired.py
+++ b/tools/test_matrixark_policy_gates_wired.py
@@ -33,14 +33,13 @@ GATES_MODULE = os.path.join(TOOLS, "matrixark_index_growth_bound.py")
 # wired -- the test fails if you forget to.
 #
 # This was six until the caller check started requiring a real call rather than a mention of the
-# name; the true figure was twelve. `extract_segments` and `generate_embeddings` are now wired, so
-# ten remain. The wider surface is worse still: of 42 functions in the policy module, 3 are
-# reachable from production code.
+# name; the true figure was twelve. `extract_segments` and `generate_embeddings` are now wired, and
+# `index_compact_on_summary` with the rollup sweep, so nine remain. The wider surface is worse
+# still: of 42 functions in the policy module, 3 are reachable from production code.
 KNOWN_UNWIRED: Set[str] = {
     "dedupe_index_postings_enabled",
     "embed_node_path_prefix_enabled",
     "generate_l1_summaries_enabled",
-    "index_compact_on_summary_enabled",
     # `return_all_candidates` is NOT a wiring job, and calling it one would mislead whoever picks
     # it up. It means "return every candidate, no prefilter and no scoring", and no such bypass
     # exists in `retrieve()` -- nor does anything read its companion knob


### PR DESCRIPTION
Lever 1 of the index growth bound is the principled one: once an event has been rolled up into a
summary, its per-event postings are redundant with the summary's own, so the summary emits an
`index_compact` tombstone naming exactly the events it covers and the serving sweep drops those
postings. The index stays dense for recent turns and sparse-summarized for old ones, and old content
stays retrievable through its summary.

**Both halves existed and neither was called.** Each is identity without the other, so wiring one
alone would have changed nothing while looking like a fix: `index_compaction_tombstone` returns
`None` when there is nothing to compact, and `sweep_index_compaction` returns its input unchanged
when the log carries no tombstone. A store that has never rolled up a summary is byte-identical
either way.

## It fixes a test that is red on main

`test_rollup_prunes_event_postings_without_losing_recall` asserts this end to end: with compaction
on, every rolled-up event's postings must be gone, the summary postings must survive, and **not one
fact may be lost**. It has been red on `main` (`4 != 0`). It passes here.

Measured on that test's own corpus — 15 turns over 5 facts:

```
event postings in the raw log      60
event postings served, before       4   (sweep in the wrong place)
event postings served, after        0
```

## Order, twice — both found by measurement, not reasoning

**The sweep runs before the posting rebuild.** `sweep_index_compaction` drops a posting only when a
tombstone that *follows* it covers every ref — "a tombstone only removes records that PRECEDE it" —
and `compact_latest_context_state_records` **rebuilds** `context_index` postings. Sweeping after it
hands the sweep fresh rows positioned after the tombstones, which it cannot match: **4 of 60
survived** that way, every one with its ref already covered. That looked like a coverage bug and was
an ordering bug.

**The sweep runs before the budget**, which is the module's own order:

> Lever 1 has already removed every posting that was purely redundant, so whatever a cap evicts on
> top of it is a live lookup path.

Bounding first would spend the budget evicting postings the sweep removes for free.

## Where the tombstone is emitted

Where the summary is written — the only place that knows both the summary hash and the events it
covers, and the record already carries `source_event_ids`. It is scoped by the summary's own scope,
so a tombstone in one scope cannot drop another scope's postings.

## Scope

Two files, 39 lines. No new test file: the behaviour already had an end-to-end test, and it was red.
Adding a second test asserting the same thing would not have made it more true.

Follows #1002, which wired levers 0, 2 and 3 from the same module.
