### PR TITLE
Packed vectors become the default; the block log does not

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -189,11 +189,17 @@ _SHARD_CODEC_ZLIB = b"\x01"
 #: ACTIVE log can take: a sealed shard is finished and compresses whole, but a log is appended to,
 #: and a stream of self-describing blocks is appendable where a single deflate stream is not.
 _SHARD_CODEC_BLOCKS = b"\x02"
-#: Off by default. This is the only change in this family that alters the DURABLE SOURCE OF TRUTH
-#: rather than something derived from it, and the failure it guards against is a real one: a process
-#: appending plain JSON to a block-framed log corrupts it. The form is taken from the file on disk
-#: rather than from this flag (see _log_append_form), so turning it on affects only logs this build
-#: creates, and turning it off again leaves every existing log readable.
+#: Off, and it stays off -- the hazard is demonstrated rather than argued. Turning it on breaks
+#: `test_a_writer_in_another_process_does_not_corrupt_the_view` and
+#: `test_both_append_paths_write_the_same_tail`: both append raw JSON lines to a log this module
+#: created, which is what a writer that is NOT this module does, and a plain append onto a
+#: block-framed log corrupts it. A store this build creates has to remain appendable by something
+#: that writes plain JSONL, and defaulting this on takes that away.
+#:
+#: Everything else about it is safe and measured -- an existing plain log stays plain because the
+#: form is read from the FILE, and a store written with this on reads byte-identically with it off
+#: (144 records, 82 vectors, same digest). It is a per-deployment choice for anyone who knows their
+#: log has a single writer, not a default.
 LOCAL_JSONL_BLOCK_LOG = os.environ.get(
     "MATRIXARK_LOCAL_JSONL_BLOCK_LOG", "0"
 ).strip().lower() not in ("0", "false", "no", "off")
@@ -1478,11 +1484,16 @@ def _copy_interned_value(value: Any) -> Any:
 #: The packed vector field. A separate key rather than a re-typed ``vector`` so a record is either
 #: one form or the other and a reader can tell which by looking, not by guessing.
 VECTOR_F32_KEY = "vector_f32"
-#: Off by default: a reader from before this change finds no ``vector`` on a packed record and
-#: carries on without one, which is lost recall and no error. Every other switch in this family
-#: degrades to re-deriving from the log; this one degrades to a quietly worse answer.
+#: ON. A 384-dimension vector costs 20.96 bytes a dimension as JSON digits and 5.33 packed, which is
+#: 2.28x after block compression -- and f32 is exact, so there is no recall question to answer.
+#:
+#: It shipped off because a reader from before this change finds no ``vector`` on a packed record and
+#: carries on without one: lost recall, no error. That hazard is a mixed-version deployment rather
+#: than an upgrade. Within a build the round trip is measured byte-identical, unpacking is
+#: unconditional, and a JSON float array already on disk keeps being read beside packed ones, per
+#: record -- so a store crossing this flag is a mixture and reads correctly either way.
 LOCAL_BINARY_VECTORS = os.environ.get(
-    "MATRIXARK_LOCAL_BINARY_VECTORS", "0"
+    "MATRIXARK_LOCAL_BINARY_VECTORS", "1"
 ).strip().lower() not in ("0", "false", "no", "off")
 
 

--- a/tools/test_intern_record_metadata.py
+++ b/tools/test_intern_record_metadata.py
@@ -279,7 +279,12 @@ class InterningCase(_FlagGuard):
             # (expansion is a no-op when nothing is interned).
             A.INTERN_RECORD_METADATA = True
             reloaded = mcp.MatrixArkLocalAdapter(path)._read_raw_records()
-            self.assertEqual(raw, reloaded)
+            # `_read_raw_records` expands interned fields AND unpacks the vector storage form, while
+            # `_raw_disk_records` is the durable bytes and does neither. Those were the same thing
+            # while expansion had one job; with a packed vector the disk record carries
+            # `vector_f32` and the expanded one carries `vector`. Both sides go through the same
+            # unpacking so this stays a test about interning, which is its subject.
+            self.assertEqual(A.unpack_record_vectors(raw), reloaded)
 
     def test_retrieve_delete_get_all_work_with_interning(self):
         """The mem0 surface behaves identically with interning ON: recall, then delete leaves nothing."""


### PR DESCRIPTION
Two binary storage forms shipped **off**, both because they change the *durable* form where every
other change in this family compresses something derived. Turning both on and running the suites
separated them — and that separation is the point of this change.

## Vectors default on

A 384-dimension vector costs **20.96 bytes a dimension** as JSON digits and **5.33** packed — 2.28×
after block compression — and f32 is **exact**, so there is no recall question to answer.

Verified with no environment variable set:

```
default:                     115 stored lines packed, 0 JSON arrays
MATRIXARK_LOCAL_BINARY_VECTORS=0:  0 packed, 115 JSON arrays
served vector digest:        4e4060d978c11458  — identical both ways
```

The identical digest is what makes it a representation rather than a codec.

## The block log stays off, and the reason is demonstrated

Turning it on breaks two tests:

- `test_a_writer_in_another_process_does_not_corrupt_the_view`
- `test_both_append_paths_write_the_same_tail`

Both append raw JSON lines to a log **this module created** — which is exactly what a writer that is
not this module does — and a plain append onto a block-framed log corrupts it. **A store this build
creates has to stay appendable by something that writes plain JSONL**, and defaulting blocks on takes
that away.

Six other failures were fixture arithmetic (a 10× smaller log stops reaching a byte-threshold
rotation) and would have been fair to fix. This one is not, so the flag keeps its default and the
comment now carries the two test names as the reason.

It remains a per-deployment choice for anyone who knows their log has a single writer.

## The reversibility both rely on is measured

Same store, read twice with the reader flag flipped:

```
store written   log head            records  vectors digest
on, read on     4d41534852440102        144       82 a642e26d7c8579ab
on, read off    4d41534852440102        144       82 a642e26d7c8579ab
off, read on    7b227265636f7264        144       82 3ce90d635ad1ac73
off, read off   7b227265636f7264        144       82 3ce90d635ad1ac73
```

Byte-identical both ways, in both directions — the flag chooses what to **write** and never what can
be read.

> An earlier version of that check compared four **separate** stores and produced four different
> digests, which proved nothing: every store derives its own identities, so only reading the *same*
> bytes twice answers the question.

Nothing on disk is converted either way. A JSON float array keeps being read beside packed ones, per
record, so a store crossing this flag is a mixture and reads correctly.
