### PR TITLE
Compress a WAL record by default, and name the choice where it is made

### DIFF
--- a/config/temporalstore.toml
+++ b/config/temporalstore.toml
@@ -96,6 +96,7 @@ index_dump_oplog_gap_bytes = 1048576   # TS_INDEX_DUMP_WAL_GAP_BYTES  undumped i
 [wal]
 commit_delay_us = 0                     # TS_WAL_COMMIT_DELAY_US  group-commit batch-widening delay in microseconds. 0 = pure timer-less (batch = whatever accrues during one barrier's in-flight duration); >0 deliberately widens batches under extreme load.
 wal_legacy_recovery = 0                # TS_WAL_LEGACY_RECOVERY  1 = emergency fallback to the legacy multi-barrier write path + delta-fold recovery.
+wal_compress_records = 1               # TS_WAL_COMPRESS_RECORDS  compress each record before writing it; 0 writes them uncompressed. Which encoding a record is in is recorded in the record, so this is safe to change either way on an existing log.
 # raft_wal_dir = ""                    # TS_RAFT_WAL_DIR        raft WAL directory (raft/replicated modes)
 
 

--- a/crates/temporalstore-rust/src/wal_proto.rs
+++ b/crates/temporalstore-rust/src/wal_proto.rs
@@ -78,14 +78,22 @@ const COMPRESSION_MIN_BYTES: usize = 256;
 /// Reading never consults this. A payload says what encoding it is in, so a log written across a
 /// change reads end to end and turning it off again is not a one-way door -- the same contract
 /// `TS_WAL_BINARY_RECORDS` keeps.
+/// **Default ON.** It was built off, which meant every deployment paid to store a log it had the
+/// code to shrink. Compression is applied only where it pays twice over: a payload under
+/// `COMPRESSION_MIN_BYTES` is left alone, and a payload whose compressed form is not actually
+/// smaller is written raw under its own marker.
+///
+/// The variable now opts OUT, like `TS_WAL_BINARY_RECORDS` and `TS_WAL_BINARY_FRAME` beside it --
+/// and for the same reason it is safe to flip either way: which encoding a payload is in is a
+/// property of the payload, not of this flag.
 pub(crate) fn compress_records_enabled() -> bool {
-    matches!(
+    !matches!(
         std::env::var("TS_WAL_COMPRESS_RECORDS")
             .unwrap_or_default()
             .trim()
             .to_ascii_lowercase()
             .as_str(),
-        "1" | "true" | "yes" | "on"
+        "0" | "false" | "no" | "off"
     )
 }
 
@@ -800,7 +808,9 @@ mod tests {
 
         std::env::set_var("TS_WAL_COMPRESS_RECORDS", "1");
         let compressed = encode(&record).expect("encodes with compression on");
-        std::env::remove_var("TS_WAL_COMPRESS_RECORDS");
+        // "0", not unset. Unset is ON now, and this line said "off" while meaning "default" -- the
+        // kind of test that keeps passing through exactly the change it should have caught.
+        std::env::set_var("TS_WAL_COMPRESS_RECORDS", "0");
         let plain = encode(&record).expect("encodes with compression off");
 
         assert!(
@@ -825,6 +835,40 @@ mod tests {
         // deployment that turns this off does not lose the log it already wrote.
         assert_eq!(record, decode(&compressed).expect("still decodes with the flag off"));
         assert_eq!(record, decode(&plain).expect("uncompressed decodes"));
+    }
+
+    #[test]
+    fn compression_is_on_when_nothing_says_otherwise() {
+        // The default is the whole point: a log nobody configured is the log almost every
+        // deployment writes. Asserted through `encode`, not by reading the flag, because what
+        // matters is which marker reaches the file.
+        let record = compressible_record();
+        std::env::remove_var("TS_WAL_COMPRESS_RECORDS");
+        let written = encode(&record).expect("encodes with nothing set");
+        assert!(
+            matches!(
+                written.first(),
+                Some(&COMPRESSED_RAW_PAYLOAD_MARKER) | Some(&COMPRESSED_ESCAPED_PAYLOAD_MARKER)
+            ),
+            "an unconfigured deployment should compress, got marker {:?}",
+            written.first()
+        );
+        assert_eq!(record, decode(&written).expect("and it reads back"));
+
+        // Every spelling its neighbours accept turns it off, which is what the old read did not do.
+        for spelling in ["0", "false", "no", "off", "OFF"] {
+            std::env::set_var("TS_WAL_COMPRESS_RECORDS", spelling);
+            let plain = encode(&record).expect("encodes with compression off");
+            assert!(
+                matches!(
+                    plain.first(),
+                    Some(&RAW_PAYLOAD_MARKER) | Some(&BINARY_PAYLOAD_MARKER)
+                ),
+                "{spelling:?} should turn compression off, got marker {:?}",
+                plain.first()
+            );
+        }
+        std::env::remove_var("TS_WAL_COMPRESS_RECORDS");
     }
 
     fn record_with(command: Option<Command>) -> WriteAheadLogRecord {

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -177,7 +177,7 @@ What is written, when it is flushed, and what is reclaimed. The escape hatches h
 | `TS_WAL_BINARY_FRAME` | on | launch, test, portal | 1 | — |
 | `TS_WAL_BINARY_RECORDS` | on | launch, test, portal | 1 | — |
 | `TS_WAL_COMMIT_DELAY_US` | 0 | config | 1 | — |
-| `TS_WAL_COMPRESS_RECORDS` | off | test, portal | 1 | — |
+| `TS_WAL_COMPRESS_RECORDS` | on | config, test, portal | 1 | — |
 | `TS_WAL_DATA_ONLY` | on | launch, test | 1 | — |
 | `TS_WAL_LEGACY_RECOVERY` | off | config, test | 1 | yes |
 | `TS_WAL_OUTCOME_ITEMS` | on | launch, test | 1 | — |

--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -571,11 +571,13 @@ SETTINGS: List[Setting] = [
             "length-framed log."),
     Setting("storage_engine.wal_compress_records", "storage_engine",
             "TS_WAL_COMPRESS_RECORDS",
-            "Compress log records", "bool", "0", "restart",
+            "Compress log records", "bool", "1", "restart",
             "On, a log record is zstd-compressed before it is written. Measured on one live "
             "segment -- 151 records averaging 13.5 KB -- this is 8.61x, which on a 698 MB log is "
-            "about 617 MB back. It ships OFF because it spends write CPU to buy disk, and which "
-            "of those is scarce is the deployment's answer, not this file's. Reading never "
+            "about 617 MB back. It ships ON: it spends write CPU to buy disk, and 8.61x is a large "
+            "enough return that a deployment which would rather keep the CPU is the one that "
+            "should have to say so. Turn it off where write latency is the scarce thing. Reading "
+            "never "
             "consults it: a payload says what encoding it is in, so a log written across a change "
             "reads end to end and turning it off again is not a one-way door. Records below 256 "
             "bytes, and any record the codec fails to shrink, are written uncompressed. Each "

--- a/tools/matrixark_load_config.py
+++ b/tools/matrixark_load_config.py
@@ -100,6 +100,7 @@ ENV_MAP: Dict[str, str] = {
     "storage.index_dump_oplog_gap_bytes": "TS_INDEX_DUMP_WAL_GAP_BYTES",
     # ---- [wal] --------------------------------------------------------------
     "wal.wal_legacy_recovery": "TS_WAL_LEGACY_RECOVERY",
+    "wal.wal_compress_records": "TS_WAL_COMPRESS_RECORDS",
     "wal.raft_wal_dir": "TS_RAFT_WAL_DIR",
     # ---- [replication] ------------------------------------------------------
     "replication.meta_addr": "TS_META_ADDR",

--- a/tools/test_matrixark_the_wal_compresses_a_record_by_default.py
+++ b/tools/test_matrixark_the_wal_compresses_a_record_by_default.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""WAL record compression is on, offered, and named in the shipped config.
+
+The engine has compressed durability-log records for a while. It was built **off**, so every
+deployment paid to store a log it had the code to shrink, and no surface mentioned it: not the
+portal, not `config/temporalstore.toml`, not the loader that turns that file into an environment.
+
+Its neighbours were already on -- `TS_WAL_BINARY_RECORDS` and `TS_WAL_BINARY_FRAME`, the latter of
+which is what carries the footer hint the tail scan uses -- and all three share the property that
+makes flipping safe: which encoding a record is in is a property of the RECORD, not of the flag, so
+a log written across a change reads end to end and turning it off again is not a one-way door.
+
+This file covers the surfaces. The engine's own tests cover what reaches the file.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(TOOLS)
+sys.path.insert(0, TOOLS)
+
+import matrixark_gateway_config as cfg  # noqa: E402
+import matrixark_load_config as loader  # noqa: E402
+
+SETTING = "storage_engine.wal_compress_records"
+VARIABLE = "TS_WAL_COMPRESS_RECORDS"
+PROTO = os.path.join(ROOT, "crates", "temporalstore-rust", "src", "wal_proto.rs")
+FRAMING = os.path.join(ROOT, "crates", "temporalstore-rust", "src", "log_framing.rs")
+
+
+def reader_body(path: str, function: str) -> str:
+    """The body of a Rust flag reader, so its default can be asked for rather than assumed."""
+    with open(path, encoding="utf-8") as handle:
+        source = handle.read()
+    start = source.index("fn %s() -> bool {" % function)
+    return source[start:source.index("\n}", start)]
+
+
+def defaults_on(path: str, function: str) -> bool:
+    """True when the reader OPTS OUT -- `!matches!(..., "0" | "false" | ...)`.
+
+    Read from the source rather than restated, because the whole point of this change is which way
+    round that negation goes.
+    """
+    body = reader_body(path, function)
+    return body.lstrip().startswith("!matches!") or "\n    !matches!" in body
+
+
+class TheEngineCompressesByDefaultTest(unittest.TestCase):
+
+    def test_the_reader_opts_out_rather_than_in(self) -> None:
+        self.assertTrue(defaults_on(PROTO, "compress_records_enabled"),
+                        "compression is opt-IN again; every unconfigured deployment stopped "
+                        "compressing its log")
+
+    def test_it_accepts_every_spelling_its_neighbours_accept(self) -> None:
+        """`off` and `no` turn the neighbours off. A flag that only understood `0` and `false` was
+        a real defect on the one beside this."""
+        body = reader_body(PROTO, "compress_records_enabled")
+        for spelling in ('"0"', '"false"', '"no"', '"off"'):
+            with self.subTest(spelling=spelling):
+                self.assertIn(spelling, body)
+
+    def test_its_neighbours_are_still_on_too(self) -> None:
+        """The floor, and the reason this one was the odd one out: the record encoding and the
+        frame -- which is what carries the footer hint the tail scan reads -- were already on."""
+        self.assertTrue(defaults_on(PROTO, "binary_records_enabled"))
+        self.assertTrue(defaults_on(FRAMING, "binary_frame_enabled"))
+
+    def test_compression_is_still_only_applied_where_it_pays(self) -> None:
+        """Turning it on is safe because it is not unconditional: a small record is left alone, and
+        one that does not shrink is written raw. If either check went, this became a tax."""
+        with open(PROTO, encoding="utf-8") as handle:
+            source = handle.read()
+        start = source.index("fn compress_payload(")
+        body = source[start:source.index("\n}", start)]
+        self.assertIn("COMPRESSION_MIN_BYTES", body)
+        self.assertIn("compressed.len() < encoded.len()", body)
+
+
+class ACustomerCanSeeAndChangeItTest(unittest.TestCase):
+    """It was on none of the three surfaces a deployment is configured through."""
+
+    def test_the_portal_offers_it(self) -> None:
+        self.assertIn(SETTING, cfg.SETTINGS_BY_KEY)
+        self.assertEqual(VARIABLE, cfg.SETTINGS_BY_KEY[SETTING].env)
+        self.assertEqual("bool", cfg.SETTINGS_BY_KEY[SETTING].kind)
+
+    def test_the_offered_default_is_the_engine_default(self) -> None:
+        """A portal that shows `0` beside a build that compresses is the defect this file exists to
+        prevent, one layer up."""
+        self.assertTrue(defaults_on(PROTO, "compress_records_enabled"))
+        self.assertEqual("1", cfg.SETTINGS_BY_KEY[SETTING].default)
+
+    def test_the_help_says_it_is_reversible(self) -> None:
+        """The one question an operator has about a log format: can I change my mind."""
+        help_text = cfg.SETTINGS_BY_KEY[SETTING].help
+        self.assertIn("one-way door", help_text)
+        self.assertIn("a payload says what encoding it is in", help_text)
+
+    def test_the_help_no_longer_explains_a_default_it_does_not_have(self) -> None:
+        """It said "It ships OFF because ..." -- a sentence that became false the moment the
+        default moved, and the kind a reader trusts precisely because it explains itself."""
+        help_text = cfg.SETTINGS_BY_KEY[SETTING].help
+        self.assertNotIn("ships OFF", help_text)
+        self.assertIn("ships ON", help_text)
+        self.assertIn("8.61x", help_text)
+
+    def test_the_registry_has_no_duplicate_keys(self) -> None:
+        """Added after this change introduced one: a second Setting with the same key is not an
+        error anywhere -- the dict keeps the last and the first silently stops existing, so the
+        portal shows one and a reader of the source finds the other."""
+        keys = [setting.key for setting in cfg.SETTINGS]
+        duplicated = sorted({key for key in keys if keys.count(key) > 1})
+        self.assertEqual([], duplicated)
+
+    def test_the_shipped_config_names_it(self) -> None:
+        with open(os.path.join(ROOT, "config", "temporalstore.toml"), encoding="utf-8") as handle:
+            toml = handle.read()
+        row = [line for line in toml.splitlines() if line.startswith("wal_compress_records")]
+        self.assertEqual(1, len(row), "the shipped config should name it exactly once")
+        self.assertIn(VARIABLE, row[0])
+        self.assertTrue(re.match(r"wal_compress_records\s*=\s*1\b", row[0]), row[0])
+
+    def test_the_loader_exports_it(self) -> None:
+        """Naming it in the file does nothing unless the loader turns it into an environment."""
+        self.assertEqual(VARIABLE, loader.ENV_MAP["wal.wal_compress_records"])
+
+    def test_it_sits_in_the_wal_section_with_its_neighbours(self) -> None:
+        """A WAL choice filed anywhere else is one an operator reads past."""
+        wal_keys = [k for k in loader.ENV_MAP if k.startswith("wal.")]
+        self.assertIn("wal.wal_compress_records", wal_keys)
+        self.assertIn("wal.wal_legacy_recovery", wal_keys)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The engine has compressed durability-log records for a while. It shipped **off**, so every
deployment paid to store a log it had the code to shrink.

The measurement was already written down, in the setting's own help: on one live segment — 151
records averaging 13.5 KB — compression is **8.61×**, which on a 698 MB log is about **617 MB back**.

Its neighbours were already on. `TS_WAL_BINARY_RECORDS` writes records as protobuf;
`TS_WAL_BINARY_FRAME` writes the length-prefixed frame and is what carries the **footer hint** the
tail scan walks forward from. `TS_WAL_DATA_ONLY`, `TS_WAL_OUTCOME_ITEMS` and `TS_WAL_PREALLOCATE` are
on too. Compression was the only WAL optimisation still opt-in, and it is now spelled like the rest —
the variable opts *out*.

### Why the flip is safe, and reversible

All of them share the property that makes this changeable: **which encoding a record is in is a
property of the record, not of the flag.** `decode_wal_line` dispatches on the payload's first byte
across all four markers — binary, raw, compressed-raw, compressed-escaped — so a log written across
the change reads end to end, and turning it off again is not a one-way door.

Compression is also not unconditional, which is what makes "on" a defensible default rather than a
tax: a record under `COMPRESSION_MIN_BYTES` is left alone, and a record the codec fails to shrink is
written raw under its own marker. A test asserts both checks are still there — if either went, this
would become a cost with no ceiling.

### A position I am overriding, stated plainly

The help used to say:

> It ships OFF because it spends write CPU to buy disk, and which of those is scarce is the
> deployment's answer, not this file's.

That was a considered call, and this change reverses it: 8.61× is a large enough return that the
deployment which would rather keep the CPU is the one that should have to say so. The help now says
that, and says where to turn it off — write latency being the scarce thing. The sentence explaining
the old default is gone rather than left to quietly contradict the value beside it, and a test pins
that.

### It is now on all three configuration surfaces

It was on none of them. `config/temporalstore.toml` names it in `[wal]` beside
`wal_legacy_recovery`, `matrixark_load_config` maps it so the file actually reaches the environment
(verified by `--dry-run` emitting `TS_WAL_COMPRESS_RECORDS=1`), and the portal setting's declared
default now matches what the engine does — asserted by reading the Rust reader's shape, not by
restating it.

### A mistake this change made, and the guard for it

I added a second `Setting` with a key that already existed. Nothing complained: `SETTINGS_BY_KEY` is
a dict comprehension, so the last one wins and the first silently stops existing — the portal shows
one and a reader of the source finds the other. There is now a test that the registry has no
duplicate keys.

12 Python tests. The two Rust tests — the default writes a compressed marker and reads back, and
every spelling its neighbours accept turns it off — run in CI's `cargo test` step. I did not run them
on this box: it was at load 34 from another session's build, and adding to that is the thing the
engine build guidance exists to prevent.
