### PR TITLE
An entity upsert files its own page instead of rebuilding the whole index

### DIFF
--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1111,6 +1111,27 @@ pub(super) fn sync_context_pages_for_object(
                 vec![address.clone()],
             ));
         }
+    } else if let Some((collection_key, entity_hash)) = split_context_entity_key(object_key) {
+        // A PERSISTED per-entity key names one entity inside a node's collection, and that is
+        // what an entity write reports as its object key. The index groups entities under the
+        // COLLECTION key, so the lookup above finds nothing, the object reports as uncovered,
+        // and the caller rebuilds the whole bucket index -- on every entity upsert. Measured at
+        // 4.27 MB per upsert into a 3,200-entity store, 99.8% of the write, all of it the
+        // rebuild and its flag refresh.
+        //
+        // File the ONE page this key names. The composed key above is
+        // `{collection_key}:{entity_hash}`, which IS this key, so both paths file the same shape.
+        if let Some(address) = shard
+            .context_entities
+            .get(&collection_key)
+            .and_then(|series| series.get(&entity_hash))
+        {
+            groups.push((
+                "context_entity",
+                object_key.to_string(),
+                vec![address.clone()],
+            ));
+        }
     }
 
     // A context node's page lives in `shard.hashes` under a single field, so the rebuild derives

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -16477,3 +16477,82 @@ fn what_the_string_family_costs_against_the_store() {
     assert!(scaling > 3.0, "the scaling control reported {scaling:.2}x -- probe cannot see growth");
     println!("  A string is one page per key, so declaring or not should not matter here.");
 }
+
+#[test]
+fn an_entity_upsert_does_not_report_its_page_uncovered() {
+    // An entity write reports the PERSISTED per-entity key `ctx:entity:{t}:{n}:{e}`, but the index
+    // groups entities under the node's COLLECTION key `ctx:entity:{t}:{n}`. Maintenance looked the
+    // per-entity key up directly, always missed, and reported the object uncovered -- which sends
+    // the caller into a FULL bucket-index rebuild plus a full flag refresh on EVERY upsert.
+    // Measured at 4,270,101 allocated bytes per upsert into a 3,200-entity store -- 99.8% of the
+    // write, and rising with the store -- against 9,599 and flat once the key resolves.
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        8 * 1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    let entity_at = |i: u64| -> crate::types::ContextEntity {
+        crate::types::ContextEntity {
+            entity_hash: 7_000 + i,
+            node_hash: 42,
+            entity_type: 1,
+            name: format!("entity_{i:06}"),
+            value: "approved".to_string(),
+            updated_at_ms: 1_000 + i,
+            valid_from_ms: 1_000,
+            confidence: 0.97,
+            source_event_hashes: vec![5],
+            vector: Vec::new(),
+        }
+    };
+    // The first write creates the node's collection; the second is the one under test.
+    let first = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextUpsertEntity { tenant_hash: 1, entity: entity_at(0) },
+    });
+    assert!(first.status.ok, "seed upsert refused: {:?}", first.status);
+
+    crate::engine::uncovered_maintenance::reset();
+    let second = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextUpsertEntity { tenant_hash: 1, entity: entity_at(1) },
+    });
+    assert!(second.status.ok, "upsert refused: {:?}", second.status);
+    let after_upsert = crate::engine::uncovered_maintenance::snapshot();
+
+    // Positive control, in THIS test: a key the shard holds nothing for must report uncovered.
+    // Without it, a tally that silently stopped recording would let the assertion below pass
+    // while the defect it guards was fully present.
+    let absent_key = "ctx:node:1:999999".to_string();
+    {
+        let mut shards = engine.shards.write().expect("shards lock poisoned");
+        let shard = shards.get_mut(&1).expect("shard 1 loaded");
+        let covered = crate::engine::storage_bucket_internals::sync_context_pages_for_object(
+            shard,
+            1,
+            &absent_key,
+        );
+        assert!(
+            !covered,
+            "a key the shard holds nothing for must report UNCOVERED, or the tally proves nothing"
+        );
+    }
+    assert!(
+        crate::engine::uncovered_maintenance::snapshot()
+            .iter()
+            .any(|key| key == &absent_key),
+        "the uncovered tally is not recording, so the entity assertion below would pass vacuously"
+    );
+
+    let stray: Vec<&String> = after_upsert
+        .iter()
+        .filter(|key| key.starts_with("ctx:entity:"))
+        .collect();
+    assert!(
+        stray.is_empty(),
+        "an entity upsert reported its own page uncovered, so every entity write rebuilds the          whole bucket index: {stray:?}"
+    );
+}


### PR DESCRIPTION
`ContextUpsertEntity` reports the persisted per-entity key `ctx:entity:{tenant}:{node}:{entity}`
as its object key, which is right: the page is addressed and routed by that key.

But the index groups entities under the node's collection key `ctx:entity:{tenant}:{node}`. So
`sync_context_pages_for_object` looked up a key `context_entities` never holds, found nothing, and
reported the object uncovered -- and an uncovered object sends the post-command path into
`rebuild_bucket_first_index` plus a full `refresh_bucket_runtime_flags`, both O(store), on every
single upsert.

`ContextUpsertNode` reports a key that does match its map, which is why it has always measured
flat while the entity write grew with the corpus.

The engine already carries the resolver for exactly this split: `split_context_entity_key`,
documented as turning a persisted per-entity key back into (collection key, entity hash).
Maintenance now calls it and files the one page that key names.

## Measured

Allocated bytes per upsert, same store, 20 writes:

| entities in store | before | after |
|---|---|---|
| 200 | 288,036 | 9,597 |
| 3,200 | 4,270,101 | 9,599 |

14.82x -> 1.00x: the write no longer scales with the store. The probe's own 3,200-entity fill fell
from 336s to 105s, because that fill was itself quadratic.

Located with a checkpoint sweep -- read a running allocation counter at eight points across
`execute()`, attribute each delta to the region before it. The two hot regions were
`rebuild_bucket_first_index` (3,575,515 bytes, 83.7%) and `refresh_bucket_runtime_flags` (687,047,
16.1%); every other region totalled under 2,500. Both are absent for SetAdd and FeatureAppend,
which is what pinned the cost to this command.

## Test

The test asserts no `ctx:entity:` key is reported uncovered after an upsert. Because that is an
assertion of absence -- which passes hardest when the mechanism is dead -- the same test first
feeds the maintenance path a key the shard holds nothing for and asserts that one IS recorded, so
a tally that stopped recording cannot make it pass vacuously.

Verified to fail on the current code, naming the key: `["ctx:entity:1:42:7001"]`.
