### PR TITLE
Retrieve does not narrate itself

### DIFF
--- a/crates/temporalstore-rust/src/context_workflow.rs
+++ b/crates/temporalstore-rust/src/context_workflow.rs
@@ -1893,24 +1893,6 @@ pub fn retrieve_context(
     engine: &TemporalEngine,
     request: ContextRetrieveRequest,
 ) -> ContextRetrieveReport {
-    let trace_retrieve = matches!(
-        std::env::var("MATRIXARK_CONTEXT_RETRIEVE_TRACE")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "1" | "true" | "yes" | "on"
-    );
-    let trace_started = Instant::now();
-    let trace_stage = |stage: &str| {
-        if trace_retrieve {
-            eprintln!(
-                "context_retrieve_stage={stage} elapsed_seconds={:.6}",
-                trace_started.elapsed().as_secs_f64()
-            );
-        }
-    };
-    trace_stage("start");
     let mut blocks = Vec::new();
     let mut node_count = 0usize;
     let mut event_count = 0usize;
@@ -1972,7 +1954,6 @@ pub fn retrieve_context(
             };
         }
     };
-    trace_stage("query_embedding");
     // The encoder that produced the query vector, read from the RAW request rather than the
     // normalized provider: normalisation substitutes a mock sentinel for an absent
     // embedding_model, and hashing that would conflict with everything a real ingest wrote,
@@ -2141,7 +2122,6 @@ pub fn retrieve_context(
     // node pass alone would under-report.
     fanout_plan.embedding_width_conflict_nodes = width_conflict_nodes;
     fanout_plan.embedding_model_conflict_nodes = model_conflict_nodes;
-    trace_stage("summary_embedding_lookup");
     // Hybrid lexical fallback: nodes with NO stored summary embedding used to score
     // a flat 0 here (missing-embedding -> unwrap_or_default), so a freshly
     // bulk-loaded (un-embedded) store collapsed to recency order and lost focused
@@ -2187,7 +2167,6 @@ pub fn retrieve_context(
             }
         }
     }
-    trace_stage("lexical_fallback");
     let mut summary_scores = node_hashes
         .iter()
         .map(|node_hash| {
@@ -2218,7 +2197,6 @@ pub fn retrieve_context(
             *node_hash,
         )
     });
-    trace_stage("summary_score_sort");
     let summary_node_limit = request
         .max_summary_nodes
         .max(1)
@@ -2250,7 +2228,6 @@ pub fn retrieve_context(
             _ => Vec::new(),
         }
     };
-    trace_stage("rerank_node_load");
     for node in rerank_nodes {
         let node_hash = node.node_hash;
         if let Some(score) = summary_scores
@@ -2287,7 +2264,6 @@ pub fn retrieve_context(
             *node_hash,
         )
     });
-    trace_stage("rerank_sort");
     node_hashes = summary_scores
         .iter()
         .take(summary_node_limit)
@@ -2485,7 +2461,6 @@ pub fn retrieve_context(
         }
     }
     fanout_plan.event_query_returned_count = event_query_returned_count;
-    trace_stage("event_expansion");
 
     blocks.sort_by_cached_key(|block| {
         (
@@ -2495,9 +2470,7 @@ pub fn retrieve_context(
             block.uri.clone(),
         )
     });
-    trace_stage("block_sort");
     dedupe_context_blocks_by_source_ref(&mut blocks);
-    trace_stage("block_dedupe");
     context_query_debug_finalize(
         &mut query_understanding_debug,
         &query_plan,
@@ -2505,7 +2478,6 @@ pub fn retrieve_context(
         node_count,
         tiers.as_slice(),
     );
-    trace_stage("debug_finalize");
     ContextRetrieveReport {
         status: Status::ok(),
         blocks,

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -8,7 +8,7 @@ within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 296 of them, read by 93 functions.
+There are 295 of them, read by 92 functions.
 
 Deleting unreachable code is not the lever. An earlier version of this document argued that
 by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
@@ -46,12 +46,12 @@ Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 296 |
-| booleans whose default this could read off the source | 32 |
+| total | 295 |
+| booleans whose default this could read off the source | 31 |
 | numbers whose default this could read off the source | 35 |
 | **defaulting on, and set by nothing** | 2 |
 | offered on the portal | 26 |
-| **that nothing in this repository sets** | 175 |
+| **that nothing in this repository sets** | 174 |
 | documented as keeping an older path alive | 5 |
 | reaching more than two files | 15 |
 | whose doc comment is really about another flag | 43 |
@@ -334,13 +334,12 @@ Who the caller is, not what the engine does. Supplied per request or per process
 | `TEMPORALSTORE_AGENT_NAME` | — | launch | 2 | — |
 | `MATRIXARK_SESSION_ID` | — | nothing | 1 | — |
 
-## diagnostic (5)
+## diagnostic (4)
 
 Extra evidence for someone investigating. Off by default.
 
 | flag | default | set by | files | keeps an older path |
 |---|---|---|---|---|
-| `MATRIXARK_CONTEXT_RETRIEVE_TRACE` | off | nothing | 1 | — |
 | `MATRIXARK_RUST_PROXY_SINGLE_SHOT_DEBUG` | off | script | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_REPORT_ONLY` | off | nothing | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_TRACE` | off | nothing | 1 | — |

--- a/tools/test_a_two_path_flag_says_why.py
+++ b/tools/test_a_two_path_flag_says_why.py
@@ -40,9 +40,6 @@ KNOWN_TWO_PATH_FLAGS: Dict[str, str] = {
         "retrieval does not read the ctxidx refs, so ON is write-only cost on the live path -- but "
         "ON is what the harness query-back validation reads, and the accessor calls it the escape "
         "hatch for anything still on that surface, held until a redesign gives the refs a reader",
-    "MATRIXARK_CONTEXT_RETRIEVE_TRACE":
-        "ON emits per-stage timings from retrieve_context; OFF emits none. The only way to see "
-        "where a slow retrieval spent its time",
     "TEMPORALSTORE_CONTEXT_BENCHMARK_ALL_SOURCE_REPLAY": "benchmark harness mode",
     "TEMPORALSTORE_CONTEXT_BENCHMARK_COMPACT_SOURCE_REPLAY": "benchmark harness mode",
     "TEMPORALSTORE_CONTEXT_BENCHMARK_DIRECT_SOURCE_SCORING": "benchmark harness mode",


### PR DESCRIPTION
`MATRIXARK_CONTEXT_RETRIEVE_TRACE` gated a closure that printed a stage name and an elapsed time to
stderr at **eleven points** through `retrieve_context`. Nothing shipped ever turned it on — no
launcher, no config, no portal field, and the flag inventory records it as *set by nothing*. Every
deployment ran the silent path, and the eleven calls did nothing eleven times.

The closure and its call sites are gone. One live path, and the same answer.

### The import of `Instant` stays

Removing it looked right — the only `Instant::now()` in the file was the trace clock — and the
compiler disagreed three times: `Instant` is also used as a **type** here.

Checking for one usage form rather than the bare identifier is the same mistake that nearly shipped
a `NameError` in the previous flag, one language over. Worth stating twice.

### Checks

| | |
|---|---|
| crate compiles | yes, 0 errors |
| `context_workflow` tests | **51 passed, 0 failed** |
| decision list | struck of this flag, which its own test enforces |
| engine inventory | 296 → 295 flags |
