### PR TITLE
The decision guard asked the wrong source who selects a flag

### DIFF
--- a/tools/test_a_two_path_flag_says_why.py
+++ b/tools/test_a_two_path_flag_says_why.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import os
 import re
+import subprocess
 import unittest
 from typing import Dict, List, Tuple
 
@@ -40,12 +41,6 @@ KNOWN_TWO_PATH_FLAGS: Dict[str, str] = {
         "retrieval does not read the ctxidx refs, so ON is write-only cost on the live path -- but "
         "ON is what the harness query-back validation reads, and the accessor calls it the escape "
         "hatch for anything still on that surface, held until a redesign gives the refs a reader",
-    "TEMPORALSTORE_CONTEXT_BENCHMARK_ALL_SOURCE_REPLAY": "benchmark harness mode",
-    "TEMPORALSTORE_CONTEXT_BENCHMARK_COMPACT_SOURCE_REPLAY": "benchmark harness mode",
-    "TEMPORALSTORE_CONTEXT_BENCHMARK_DIRECT_SOURCE_SCORING": "benchmark harness mode",
-    "TEMPORALSTORE_CONTEXT_BENCHMARK_EXTERNAL_ONLY": "benchmark harness mode",
-    "TEMPORALSTORE_CONTEXT_BENCHMARK_REPORT_ONLY": "benchmark harness mode",
-    "TEMPORALSTORE_CONTEXT_BENCHMARK_SOURCE_ORDER_RANKING": "benchmark harness mode",
     "TEMPORALSTORE_CONTEXT_BENCHMARK_STORED_RECORD_SCORING": "benchmark harness mode",
     "TEMPORALSTORE_CONTEXT_BENCHMARK_TRACE": "benchmark harness mode",
 }
@@ -84,10 +79,54 @@ def _rows() -> List[Tuple[str, str, str]]:
     return rows
 
 
+def _selected_anywhere() -> set:
+    """Every flag name a tracked file ASSIGNS, anywhere in the repository.
+
+    The inventory's own `set by` column cannot answer this: it is built from engine sources, so a
+    flag a Python harness or a shell script sets reads there as selected by nothing. Six of the
+    eight benchmark flags were listed that way, and `tools/run_locomo_rust_harness.py` sets them --
+    four to their non-default arm. A list that says "nothing selects this" about a flag something
+    selects is worse than no list, because it licenses a removal.
+    """
+    listed = subprocess.run(["git", "ls-files"], cwd=REPO,
+                            capture_output=True, text=True).stdout.split()
+    assign = re.compile(
+        r'"((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)"\s*:'                 # a dict entry
+        r'|export\s+((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)='            # a shell export
+        r'|environ\[\s*"((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)"\s*\]\s*='  # a python set
+        r'|set_var\(\s*"((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)"')      # a rust set
+    found = set()
+    for path in listed:
+        if os.path.splitext(path)[1] not in (".py", ".sh", ".rs", ".toml", ".json", ".yaml"):
+            continue
+        base = os.path.basename(path)
+        # This file lists the flag names it has decided about, in a dict. Reading itself would
+        # make every decision look like a selector and empty the list -- the same self-reference
+        # that made an earlier guard feed on its own output.
+        if base == os.path.basename(__file__):
+            continue
+        # A test exercising the other arm is not a SHIPPED selector; that is the distinction the
+        # list is about, and the inventory column already reports it separately.
+        if (base.startswith("test_") or base in ("tests.rs", "tests.py")
+                or "/tests/" in path or "/tests." in path):
+            continue
+        try:
+            with open(os.path.join(REPO, path), encoding="utf-8", errors="replace") as handle:
+                source = handle.read()
+        except OSError:
+            continue
+        for match in assign.finditer(source):
+            found.add(next(group for group in match.groups() if group))
+    return found
+
+
 def _unselected() -> List[str]:
-    """Booleans whose other arm nothing ships a selector for."""
+    """Booleans whose other arm nothing ships a selector for, asked of the whole tree."""
+    selected = _selected_anywhere()
     out = []
     for name, _default, set_by in _rows():
+        if name in selected:
+            continue
         if set_by == "nothing" or set(part.strip() for part in set_by.split(",")) <= {
                 "test", "harness"}:
             out.append(name)


### PR DESCRIPTION
The guard read the inventory's `set by` column, which is built from **engine sources only**. So a
flag that a Python harness or a shell script sets reads there as *selected by nothing* — and the
guard then invited a decision about removing an arm something already chooses.

### Six of the eight benchmark flags are selected by a shipped script

`tools/run_locomo_rust_harness.py` sets them, four to their **non-default** arm:

```
TEMPORALSTORE_CONTEXT_BENCHMARK_EXTERNAL_ONLY        = 1   (default off)
TEMPORALSTORE_CONTEXT_BENCHMARK_REPORT_ONLY          = 1   (default off)
TEMPORALSTORE_CONTEXT_BENCHMARK_ALL_SOURCE_REPLAY    = 1   (default off)
TEMPORALSTORE_CONTEXT_BENCHMARK_SOURCE_ORDER_RANKING = 1   (default off)
TEMPORALSTORE_CONTEXT_BENCHMARK_DIRECT_SOURCE_SCORING = 0
TEMPORALSTORE_CONTEXT_BENCHMARK_COMPACT_SOURCE_REPLAY = 1
```

Those six have two reachable arms on purpose. They are struck from the list, because the premise
that put them there was false.

### The guard now asks the whole tree

Every tracked file is swept for an assignment — a shell export, a Python `environ` write, a dict
entry, a Rust `set_var` — and only what nothing selects is put up for a decision.

Two exclusions, both learned while writing it:

- **this file lists the flag names it has decided about, in a dict.** Reading itself made every
  decision look like a selector and emptied the list — the same self-inclusion that made an earlier
  guard feed on its own output;
- **a test setting a value is not a shipped selector**, and one of them lives in a file called
  `tests.rs` rather than under a `tests/` directory, which a check for the directory missed.

### Result

The list goes from nine entries to **three**: `CONTEXT_SECONDARY_INDEX` and the two benchmark modes
no script sets. Nine became three, and the difference was never a judgement — it was asking the
whole tree instead of one column.

### Mutation test

Deleting one selector from the harness script makes the guard ask for a decision about that flag
again.
