### PR TITLE
Two benchmark knobs nothing selects

### DIFF
--- a/crates/temporalstore-rust/src/bin/context_workflow_harness.rs
+++ b/crates/temporalstore-rust/src/bin/context_workflow_harness.rs
@@ -1225,10 +1225,6 @@ fn run_external_context_benchmark(engine: &TemporalEngine) -> ExternalContextBen
         std::env::var("TEMPORALSTORE_CONTEXT_BENCHMARK_SOURCE_ORDER_RANKING")
             .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
             .unwrap_or(false);
-    let stored_record_scoring =
-        std::env::var("TEMPORALSTORE_CONTEXT_BENCHMARK_STORED_RECORD_SCORING")
-            .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
-            .unwrap_or(true);
     let compact_source_replay =
         std::env::var("TEMPORALSTORE_CONTEXT_BENCHMARK_COMPACT_SOURCE_REPLAY")
             .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
@@ -1240,14 +1236,6 @@ fn run_external_context_benchmark(engine: &TemporalEngine) -> ExternalContextBen
         if case.unsupported_reason.is_some() {
             unsupported_benchmark_case_ids.push(case.query_id.clone());
             continue;
-        }
-        let trace_enabled = external_benchmark_trace_enabled();
-        if trace_enabled {
-            eprintln!(
-                "external_context_benchmark case={} sources={}",
-                case.query_id,
-                case.sources.len()
-            );
         }
         *dataset_counts.entry(case.dataset.clone()).or_insert(0usize) += 1;
         *category_counts
@@ -1311,13 +1299,6 @@ fn run_external_context_benchmark(engine: &TemporalEngine) -> ExternalContextBen
                             Some(hashes) => node_hashes = hashes,
                             None => ingest_ok = false,
                         }
-                        if trace_enabled {
-                            eprintln!(
-                                "external_context_benchmark case={} ingest_all_sources_ms={}",
-                                case.query_id,
-                                started.elapsed().as_millis()
-                            );
-                        }
                     } else {
                         for chunk in sources.chunks(ingest_chunk_size) {
                             let started = Instant::now();
@@ -1339,14 +1320,6 @@ fn run_external_context_benchmark(engine: &TemporalEngine) -> ExternalContextBen
                                 break;
                             }
                             node_hashes.extend(ingest.node_hashes);
-                            if trace_enabled {
-                                eprintln!(
-                                    "external_context_benchmark case={} ingest_chunk_sources={} ingest_ms={}",
-                                    case.query_id,
-                                    chunk.len(),
-                                    started.elapsed().as_millis()
-                                );
-                            }
                         }
                     }
                     if !ingest_ok {
@@ -1357,46 +1330,14 @@ fn run_external_context_benchmark(engine: &TemporalEngine) -> ExternalContextBen
                     }
                 };
                 let retrieve_started = Instant::now();
-                let blocks = if stored_record_scoring {
-                    external_stored_source_blocks(
+                let blocks = external_stored_source_blocks(
                         engine,
                         tenant_hash,
                         &node_hashes,
                         case,
                         case_max_events,
-                    )
-                } else {
-                    let retrieve = retrieve_context(
-                        engine,
-                        ContextRetrieveRequest {
-                            shard_id: 1,
-                            tenant_hash,
-                            node_hashes,
-                            query: case.query.clone(),
-                            start_time_ms: 0,
-                            end_time_ms: 10_000,
-                            max_events: case_max_events,
-                            min_confidence: 0.0,
-                            min_importance: 0.0,
-                            tiers: vec![ContextTier::L0, ContextTier::L1, ContextTier::L2],
-                            max_summary_nodes: case_max_events,
-                            max_event_nodes: case_max_events,
-                            prefer_current_agent: false,
-                            current_agent_scope_key: "agent:codex".to_string(),
-                            provider: ContextModelProviderConfig::default(),
-                        },
                     );
-                    retrieve.blocks
-                };
                 let elapsed_ms = retrieve_started.elapsed().as_millis();
-                if trace_enabled {
-                    eprintln!(
-                        "external_context_benchmark case={} retrieve_ms={} blocks={}",
-                        case.query_id,
-                        elapsed_ms,
-                        blocks.len()
-                    );
-                }
                 retrieval_ms_override = Some(elapsed_ms);
                 retrieved_source_sets.insert(source_digest, blocks.clone());
                 blocks
@@ -1600,12 +1541,6 @@ fn normalize_selected_source_id(value: &str) -> String {
         .split_whitespace()
         .collect::<Vec<_>>()
         .join(" ")
-}
-
-fn external_benchmark_trace_enabled() -> bool {
-    std::env::var("TEMPORALSTORE_CONTEXT_BENCHMARK_TRACE")
-        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
-        .unwrap_or(false)
 }
 
 fn external_case_source_digest(case: &ExternalContextBenchmarkCase) -> u64 {

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -8,7 +8,7 @@ within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 295 of them, read by 92 functions.
+There are 293 of them, read by 91 functions.
 
 Deleting unreachable code is not the lever. An earlier version of this document argued that
 by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
@@ -46,12 +46,12 @@ Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 295 |
-| booleans whose default this could read off the source | 31 |
+| total | 293 |
+| booleans whose default this could read off the source | 29 |
 | numbers whose default this could read off the source | 35 |
-| **defaulting on, and set by nothing** | 2 |
+| **defaulting on, and set by nothing** | 1 |
 | offered on the portal | 26 |
-| **that nothing in this repository sets** | 174 |
+| **that nothing in this repository sets** | 172 |
 | documented as keeping an older path alive | 5 |
 | reaching more than two files | 15 |
 | whose doc comment is really about another flag | 43 |
@@ -334,7 +334,7 @@ Who the caller is, not what the engine does. Supplied per request or per process
 | `TEMPORALSTORE_AGENT_NAME` | — | launch | 2 | — |
 | `MATRIXARK_SESSION_ID` | — | nothing | 1 | — |
 
-## diagnostic (4)
+## diagnostic (3)
 
 Extra evidence for someone investigating. Off by default.
 
@@ -342,10 +342,9 @@ Extra evidence for someone investigating. Off by default.
 |---|---|---|---|---|
 | `MATRIXARK_RUST_PROXY_SINGLE_SHOT_DEBUG` | off | script | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_REPORT_ONLY` | off | nothing | 1 | — |
-| `TEMPORALSTORE_CONTEXT_BENCHMARK_TRACE` | off | nothing | 1 | — |
 | `TS_SCALE_STORAGE_ROOT` | — | nothing | 1 | — |
 
-## benchmark (8)
+## benchmark (7)
 
 Read only by the benchmark harnesses. Never consulted on a serving path.
 
@@ -358,7 +357,6 @@ Read only by the benchmark harnesses. Never consulted on a serving path.
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_JSONL` | — | script | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_SELECTED_ID_LIMIT` | 128 | nothing | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_SOURCE_ORDER_RANKING` | off | nothing | 1 | — |
-| `TEMPORALSTORE_CONTEXT_BENCHMARK_STORED_RECORD_SCORING` | on | nothing | 1 | — |
 
 ## behaviour (61)
 

--- a/tools/test_a_two_path_flag_says_why.py
+++ b/tools/test_a_two_path_flag_says_why.py
@@ -41,8 +41,6 @@ KNOWN_TWO_PATH_FLAGS: Dict[str, str] = {
         "retrieval does not read the ctxidx refs, so ON is write-only cost on the live path -- but "
         "ON is what the harness query-back validation reads, and the accessor calls it the escape "
         "hatch for anything still on that surface, held until a redesign gives the refs a reader",
-    "TEMPORALSTORE_CONTEXT_BENCHMARK_STORED_RECORD_SCORING": "benchmark harness mode",
-    "TEMPORALSTORE_CONTEXT_BENCHMARK_TRACE": "benchmark harness mode",
 }
 
 # The eight benchmark modes are one decision, not eight, and it is worth saying so once: they live


### PR DESCRIPTION
`TEMPORALSTORE_CONTEXT_BENCHMARK_TRACE` gated four `eprintln` blocks in the harness.
`TEMPORALSTORE_CONTEXT_BENCHMARK_STORED_RECORD_SCORING` defaulted ON and chose between scoring
stored source blocks and going back through `retrieve_context`.

**Nothing sets either.** The script that drives this binary,
`tools/run_locomo_rust_harness.py`, sets **six** of their sibling knobs and never these two — so
every run took the quiet path and scored stored blocks, carrying the other arms without taking them.

Both keep the arm that ran.

### On the editing

The trace blocks were bounded by **brace balance from their own line** rather than matched by
pattern, because their bodies contain braces — and so was the two-armed statement, because both
arms do.

### What this leaves

**One flag** in the decision list: `MATRIXARK_CONTEXT_SECONDARY_INDEX` — and it is the one worth
stopping at. Its ON arm is what the harness query-back validation reads, so collapsing it would
leave `validate_resource_skill_secondary_indexes` checking something that is never built.

The six benchmark knobs the harness script **does** set were struck from that list in
[#1017](https://github.com/matrixarkai/TemporalStore/pull/1017), not collapsed. They have two
reachable arms on purpose.

### Checks

| | |
|---|---|
| harness binary | compiles, no new warnings |
| `retrieve_context` import | still used elsewhere in the file, so it stays |
| engine inventory | 295 → **293** flags |
