### PR TITLE
The published proxy API described a surface the proxy does not serve

### DIFF
--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -4788,6 +4788,145 @@ mod tests {
         assert_eq!(policy.max_inflight_requests, 1);
     }
 
+    /// A body shaped the way the published spec describes is one the proxy can parse.
+    ///
+    /// The key fields are READ OUT OF THE SPEC, not written here. The spec used to name the field
+    /// `table` while every proxy request type names it `table_name`, with no serde alias, so a
+    /// reader following the document got `400 missing field table_name` on their first call. A
+    /// hand-written body in this test would only ever have restated whichever name I typed.
+    ///
+    /// Driven through `handle` rather than reasoned about: a struct field is not proof of what a
+    /// route accepts.
+    #[test]
+    fn a_body_shaped_like_the_published_spec_parses() {
+        let spec_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../sdk/proxy/openapi.yaml");
+        let spec = std::fs::read_to_string(&spec_path).expect("the published proxy spec");
+
+        // `KeyRequest` is the shape nearly every documented command builds on.
+        let anchor = spec.find("    KeyRequest:").expect("the spec defines KeyRequest");
+        let mut fields: Vec<String> = Vec::new();
+        let mut in_props = false;
+        for line in spec[anchor..].lines().skip(1) {
+            if line.starts_with("    ") && !line.starts_with("     ") {
+                break;
+            }
+            if line.trim() == "properties:" {
+                in_props = true;
+                continue;
+            }
+            if in_props {
+                if let Some(name) = line.trim().strip_suffix(':') {
+                    if !name.is_empty() && line.starts_with("        ") {
+                        fields.push(name.to_string());
+                    }
+                }
+            }
+        }
+        assert!(
+            fields.len() >= 3,
+            "read {fields:?} out of the spec's KeyRequest; with fewer than three this test would              be posting an empty body and proving nothing"
+        );
+
+        let body = format!(
+            "{{{}}}",
+            fields
+                .iter()
+                .map(|f| format!("\"{f}\":\"x\""))
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+
+        let proxy = scoped_proxy(ProxyOptions::default());
+        let (code, answered) = proxy.handle(crate::proxy::HttpRequest {
+            method: "POST".to_string(),
+            path: "/ProxyService/Get".to_string(),
+            body: body.clone().into_bytes(),
+        });
+        let text = String::from_utf8_lossy(&answered).to_string();
+        assert!(
+            !text.contains("bad_request"),
+            "a body built from the spec's own KeyRequest fields ({body}) is rejected by the route              the spec documents: {code} {text}"
+        );
+    }
+
+    /// Every route the published proxy API documents is one the proxy actually answers.
+    ///
+    /// `sdk/proxy/openapi.yaml` is the contract an outside user builds against -- it ships in the
+    /// open-source repo and is the only description of this surface they have. A path in it that
+    /// the dispatcher does not know answers 404, and nothing in the tree noticed, because the spec
+    /// is a document and the routes are code.
+    ///
+    /// This drives the REAL dispatcher rather than comparing two lists: a route is "served" if
+    /// `handle` gives it anything other than 404. A 400 for an empty body counts -- the question
+    /// is whether the route exists, not whether `{}` satisfies it.
+    #[test]
+    fn every_documented_proxy_route_is_served() {
+        let spec_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../sdk/proxy/openapi.yaml");
+        let spec = std::fs::read_to_string(&spec_path)
+            .unwrap_or_else(|err| panic!("the published proxy spec must be readable at {spec_path:?}: {err}"));
+
+        // The `paths:` block, whose two-space keys are the routes and four-space keys the methods.
+        let mut documented: Vec<(String, String)> = Vec::new();
+        let mut in_paths = false;
+        let mut route = String::new();
+        for line in spec.lines() {
+            if line.starts_with("paths:") {
+                in_paths = true;
+                continue;
+            }
+            if !in_paths {
+                continue;
+            }
+            if !line.is_empty() && !line.starts_with(' ') {
+                break;
+            }
+            let trimmed = line.trim_end();
+            if let Some(rest) = trimmed.strip_prefix("  /") {
+                if !trimmed.starts_with("    ") {
+                    if let Some(name) = rest.strip_suffix(':') {
+                        route = format!("/{name}");
+                    }
+                    continue;
+                }
+            }
+            if let Some(rest) = trimmed.strip_prefix("    ") {
+                if let Some(method) = rest.strip_suffix(':') {
+                    let upper = method.to_ascii_uppercase();
+                    if matches!(upper.as_str(), "GET" | "POST" | "PUT" | "DELETE") && !route.is_empty() {
+                        documented.push((upper, route.clone()));
+                    }
+                }
+            }
+        }
+
+        assert!(
+            documented.len() >= 15,
+            "the spec parse found only {} routes, so this test would pass by finding nothing",
+            documented.len()
+        );
+
+        let proxy = scoped_proxy(ProxyOptions::default());
+        let mut missing: Vec<String> = Vec::new();
+        for (method, path) in &documented {
+            let (code, _) = proxy.handle(crate::proxy::HttpRequest {
+                method: method.clone(),
+                path: path.clone(),
+                body: b"{}".to_vec(),
+            });
+            if code == 404 {
+                missing.push(format!("{method} {path}"));
+            }
+        }
+
+        assert!(
+            missing.is_empty(),
+            "the published proxy spec documents {} route(s) the proxy answers 404 for, so anyone              building against it gets a 404: {missing:?}",
+            missing.len()
+        );
+    }
+
     #[test]
     fn proxy_write_quota_leaves_read_capacity_free() {
         let proxy = scoped_proxy(ProxyOptions {

--- a/sdk/proxy/openapi.yaml
+++ b/sdk/proxy/openapi.yaml
@@ -115,43 +115,19 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/Envelope'
-  /ProxyService/RiskIncrement:
+  /ProxyService/ControlStateIncrement:
     post:
-      summary: Increment a risk counter.
+      summary: Increment a control-state counter.
       requestBody:
-        $ref: '#/components/requestBodies/RiskIncrement'
+        $ref: '#/components/requestBodies/ControlStateIncrement'
       responses:
         '200':
           $ref: '#/components/responses/Envelope'
-  /ProxyService/RiskCount:
+  /ProxyService/ControlStateCount:
     post:
-      summary: Query a risk counter window.
+      summary: Query a control-state counter window.
       requestBody:
-        $ref: '#/components/requestBodies/RiskCount'
-      responses:
-        '200':
-          $ref: '#/components/responses/Envelope'
-  /matrixark/append_records:
-    post:
-      summary: Append MatrixArk record bundles natively through the proxy.
-      requestBody:
-        $ref: '#/components/requestBodies/MatrixArkAppendRecords'
-      responses:
-        '200':
-          $ref: '#/components/responses/Envelope'
-  /matrixark/scan_candidates:
-    post:
-      summary: Scan MatrixArk candidates with scope and secondary-index prefiltering in the proxy.
-      requestBody:
-        $ref: '#/components/requestBodies/MatrixArkScanCandidates'
-      responses:
-        '200':
-          $ref: '#/components/responses/Envelope'
-  /matrixark/retrieve_context_pack:
-    post:
-      summary: Return a fully assembled MatrixArk ContextPack from the proxy.
-      requestBody:
-        $ref: '#/components/requestBodies/MatrixArkRetrieveContextPack'
+        $ref: '#/components/requestBodies/ControlStateCount'
       responses:
         '200':
           $ref: '#/components/responses/Envelope'
@@ -218,36 +194,18 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/FeatureQueryRequest'
-    RiskIncrement:
+    ControlStateIncrement:
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/RiskIncrementRequest'
-    RiskCount:
+            $ref: '#/components/schemas/ControlStateIncrementRequest'
+    ControlStateCount:
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/RiskCountRequest'
-    MatrixArkAppendRecords:
-      required: true
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/MatrixArkAppendRecordsRequest'
-    MatrixArkScanCandidates:
-      required: true
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/MatrixArkScanCandidatesRequest'
-    MatrixArkRetrieveContextPack:
-      required: true
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/MatrixArkRetrieveContextPackRequest'
+            $ref: '#/components/schemas/ControlStateCountRequest'
   schemas:
     Envelope:
       type: object
@@ -263,11 +221,11 @@ components:
           type: object
     KeyRequest:
       type: object
-      required: [namespace, table, key]
+      required: [namespace, table_name, key]
       properties:
         namespace:
           type: string
-        table:
+        table_name:
           type: string
         key:
           type: string
@@ -380,10 +338,10 @@ components:
         - type: object
           required: [start_ts, end_ts, count]
           properties:
-            start_ts:
+            start_ms:
               type: integer
               format: int64
-            end_ts:
+            end_ms:
               type: integer
               format: int64
             count:
@@ -393,113 +351,33 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/FeatureFilter'
-    RiskIncrementRequest:
+    ControlStateIncrementRequest:
       allOf:
         - $ref: '#/components/schemas/KeyRequest'
         - type: object
-          required: [amount, ttl_seconds, precision]
+          required: [timestamp_ms, amount]
           properties:
+            timestamp_ms:
+              type: integer
+              format: int64
             amount:
               type: integer
               format: int64
-            ttl_seconds:
+            precision_ms:
               type: integer
               format: int64
-            precision:
-              type: integer
-            uuid:
-              type: string
-            occur_time_seconds:
+            ttl_ms:
               type: integer
               format: int64
-    RiskCountRequest:
+    ControlStateCountRequest:
       allOf:
         - $ref: '#/components/schemas/KeyRequest'
         - type: object
-          required: [precision, window_start, window_end, window_unit]
+          required: [start_ms, end_ms]
           properties:
-            precision:
-              type: integer
-            window_start:
+            start_ms:
               type: integer
               format: int64
-            window_end:
+            end_ms:
               type: integer
               format: int64
-            window_unit:
-              type: integer
-    MatrixArkHashEntry:
-      type: object
-      required: [key, field, value]
-      properties:
-        key:
-          type: string
-        field:
-          type: string
-        value:
-          type: string
-    MatrixArkAppendRecordsRequest:
-      type: object
-      required: [namespace, table, entries]
-      properties:
-        namespace:
-          type: string
-        table:
-          type: string
-        entries:
-          type: array
-          items:
-            $ref: '#/components/schemas/MatrixArkHashEntry'
-        count_key:
-          type: string
-        count_value:
-          type: string
-    MatrixArkScanCandidatesRequest:
-      type: object
-      required: [namespace, table, count_key, record_hash_key, shard_size]
-      properties:
-        namespace:
-          type: string
-        table:
-          type: string
-        count_key:
-          type: string
-        record_hash_key:
-          type: string
-        shard_size:
-          type: integer
-          format: int64
-        scope:
-          type: object
-        record_types:
-          type: array
-          items:
-            type: string
-        secondary_index_groups:
-          type: array
-          items:
-            type: array
-            items:
-              type: string
-        selected_node_hashes:
-          type: array
-          items:
-            type: integer
-            format: int64
-    MatrixArkRetrieveContextPackRequest:
-      type: object
-      required: [namespace, table, count_key, record_hash_key, shard_size, request]
-      properties:
-        namespace:
-          type: string
-        table:
-          type: string
-        count_key:
-          type: string
-        record_hash_key:
-          type: string
-        shard_size:
-          type: integer
-          format: int64
-        request:
-          type: object


### PR DESCRIPTION
`sdk/proxy/openapi.yaml` is the contract an outside user builds against — it ships in the open-source repo and is the only description of this surface they have. Two things in it were untrue, and nothing in the tree could notice, because the spec is a document and the routes are code.

## 1. Five documented routes answer 404

| documented | status |
|---|---|
| `POST /ProxyService/RiskCount` | renamed to `ControlStateCount` |
| `POST /ProxyService/RiskIncrement` | renamed to `ControlStateIncrement` |
| `POST /matrixark/append_records` | no such route |
| `POST /matrixark/retrieve_context_pack` | no such route |
| `POST /matrixark/scan_candidates` | no such route |

`RiskCount` and `RiskIncrement` were not just renamed, they were reshaped: the documented body asks for `precision`, `window_start`, `window_end`, `window_unit`, while the route parses `start_ms` and `end_ms`. So the two are re-documented against the types the proxy actually parses, and the three `/matrixark/*` entries are removed along with their now-unreferenced bodies and schemas.

## 2. The shared body names a field the proxy does not accept

`KeyRequest` — which nearly every documented command builds on — named the field `table`. Every proxy request type names it `table_name`, with no serde alias:

```
400 {"code":"bad_request","message":"json error: missing field `table_name`"}
```

A reader following the document failed on their first call. `FeatureQueryRequest` had the same class of defect: `start_ts`/`end_ts` against the `start_ms`/`end_ms` the route parses.

## Two guards, both driven through the real dispatcher

`every_documented_proxy_route_is_served` parses the spec's `paths:` and asks `handle` for each one; anything answering 404 fails the test with the list. `a_body_shaped_like_the_published_spec_parses` **reads the key field names out of the spec** and posts a body built from them — hand-writing that body would only have restated whichever name I typed.

Neither compares two lists. I checked a route table by eye earlier in this work and concluded `/shards/{id}` was unserved; it is served, via a prefix match my extraction missed. Asking the dispatcher is the only thing that settles it.

Controls: with the five routes restored the first test fails naming all five; with `table` put back in the spec the second fails with the exact 400 above.

## Left undone, deliberately

`/context/ingest` and `/context/retrieve` are served and used by 68 Python files each, and the spec documents neither. Their request types are large and nested, and I would rather leave them undocumented than transcribe them wrongly into a contract people build against.
