### PR TITLE
A single-point page is not measured before it is written

### DIFF
--- a/crates/temporalstore-rust/src/engine/packed_pages.rs
+++ b/crates/temporalstore-rust/src/engine/packed_pages.rs
@@ -308,6 +308,17 @@ fn append_timestamped_kv_pages_inner(
 }
 
 pub(super) fn chunk_timestamped_kv_points(points: Vec<FeaturePoint>) -> Vec<Vec<FeaturePoint>> {
+    // One point is always exactly one page, so measuring it is wasted work. The split below fires
+    // only when `current` is non-empty, which a lone point never is, so its encoded length is
+    // computed and never read -- and computing it is a FULL `serde_json` serialisation of the
+    // point, the same work `encode_feature_page` is about to do again on the way to the page.
+    //
+    // A page carries its value as a `Vec<u8>`, which serde_json writes as an array of decimal
+    // numbers, so that measurement costs several times the value it measures. Every context write
+    // path -- summary, event, index, audit, child, compression -- passes exactly one point.
+    if points.len() == 1 {
+        return vec![points];
+    }
     let mut chunks = Vec::new();
     let mut current = Vec::new();
     let empty_page_len = empty_feature_page_encoded_len();
@@ -440,5 +451,45 @@ pub(super) fn read_feature_point_cached(
             packed_page_cache.insert(address.clone(), None);
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod single_point_chunking_tests {
+    use super::*;
+    use crate::types::FeaturePoint;
+
+    fn point(ts: u64, len: usize) -> FeaturePoint {
+        FeaturePoint { timestamp_ms: ts, value: vec![b'v'; len] }
+    }
+
+    #[test]
+    fn a_lone_point_chunks_exactly_as_the_general_path_would() {
+        // The short circuit above returns early for one point. It is only correct because the
+        // split fires solely when `current` is non-empty, which a lone point never is -- so this
+        // pins the three cases that would catch it being wrong.
+
+        // 1. One point -> one chunk holding it, however large. A page target cannot split a point.
+        for len in [0usize, 8, 64_000] {
+            let chunks = chunk_timestamped_kv_points(vec![point(1, len)]);
+            assert_eq!(chunks.len(), 1, "one point must make one chunk (len {len})");
+            assert_eq!(chunks[0].len(), 1, "the chunk must hold the point (len {len})");
+            assert_eq!(chunks[0][0].timestamp_ms, 1, "and it must be THAT point (len {len})");
+            assert_eq!(chunks[0][0].value.len(), len, "with its value intact (len {len})");
+        }
+
+        // 2. Two small points still share one page -- so the early return is not what produced
+        //    the single chunk above, and this test can tell the two apart.
+        let together = chunk_timestamped_kv_points(vec![point(1, 8), point(2, 8)]);
+        assert_eq!(together.len(), 1, "two small points share a page");
+        assert_eq!(together[0].len(), 2, "and both are in it");
+
+        // 3. Two points too big to share DO split, which is the behaviour the short circuit must
+        //    not have disabled for the multi-point path.
+        let target = context_page_target_bytes();
+        let split = chunk_timestamped_kv_points(vec![point(1, target), point(2, target)]);
+        assert_eq!(split.len(), 2, "two oversized points must not share a page");
+        assert_eq!(split[0][0].timestamp_ms, 1, "order is preserved across the split");
+        assert_eq!(split[1][0].timestamp_ms, 2, "order is preserved across the split");
     }
 }


### PR DESCRIPTION
`chunk_timestamped_kv_points` measured every point before deciding whether it fits the current
page. Measuring means `feature_point_encoded_len`, a full `serde_json::to_vec` of the point -- and
a point carries its value as a `Vec<u8>`, which serde_json writes as an array of decimal numbers,
so the measurement costs several times the value being measured.

For a single point that work is never used. The split fires only when the current page is
non-empty, which a lone point never is, so the length is computed, added to a running total, and
discarded. Every context write path -- summary, event, index, audit, child ref, compression --
passes exactly one point.

## Measured

Allocated bytes, 20 writes, alloc probe, A/B on this base:

| | before | after |
|---|---|---|
| summary write, 384-dim vector | 43,225 | 38,801 (-10.2%) |
| summary write, 1024-dim vector | 86,135 | 77,615 (-9.9%) |
| whole message ingest | 119,839 | 115,783 (-3.4%) |

A summary write is 61% of a message ingest, which is why a change this small is visible end to
end. It is a ~3% ingest win, not a headline one.

## Test

One point must produce one chunk holding that point, at 0, 8 and 64,000 bytes. Two small points
must still share a page -- so a single chunk cannot be mistaken for proof the short circuit fired
-- and two oversized points must still split, so the general path is unchanged.

Verified to FAIL if the short circuit is widened to `points.len() <= 2`, with "two oversized
points must not share a page".

## Not addressed here

The page itself is stored as JSON, and `append_timestamped_kv_pages` allocates roughly 22-25 bytes
per payload byte (48 B payload -> 5,298; 813 B -> 24,652; 2,297 B -> 56,146). That is the dominant
cost, and it is a durable format question -- a reader has to understand a new form before a writer
emits one -- so it is left alone here.

Ruled out by measurement while finding this, each of which looked likely: the WAL append (386
bytes flat at 0, 384 and 1024 dimensions), the context wire encoding (~2.1 bytes per dimension,
smaller than the raw f32 it stores), and the L1 copy of the vector onto the node (50 bytes).
