### PR TITLE
A block-framed log tolerates a plain append

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -283,21 +283,84 @@ def _encode_log_block(records: list[Json]) -> bytes:
     return _DELTA_BLOCK_CODEC_ZLIB + len(payload).to_bytes(4, "big") + payload
 
 
+def _plain_run_lines(head: bytes, handle):
+    """JSON lines at a block boundary, stopping where they stop.
+
+    A process that is not this module appends plain JSON to a log, and that has to stay readable --
+    fixtures are built that way and out-of-process writers exist. At a block boundary the framing is
+    exact, so a reader can tell them apart: a plain line starts with `{`, a block starts with a
+    codec byte.
+
+    The run is NOT assumed to reach the end of the file. `_log_append_form` reads the magic at the
+    head, so this module keeps appending blocks after someone else's plain lines, and a real log
+    interleaves:
+
+        [block][block][plain][plain][block]
+
+    Reading the remainder as one string fails to decode at that trailing block and loses everything
+    after the plain run -- which is what "75 != 50" looked like. So this consumes complete lines
+    while they decode and look like JSON, then leaves the handle positioned at the first byte that
+    does not, for the caller to parse as a block.
+
+    A line at a time, because a shard runs to MATRIXARK_LOCAL_JSONL_MAX_BYTES and reading it whole
+    would undo the bound the streaming reader exists for.
+
+    Yields nothing and restores the position when the first bytes are not text at all: that is the
+    TORN-BLOCK case, and it must keep being dropped rather than read as garbage.
+    """
+    start = handle.tell() - len(head)
+    handle.seek(start)
+    lines: list[str] = []
+    while True:
+        at = handle.tell()
+        raw = handle.readline()
+        if not raw:
+            break
+        try:
+            line = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            handle.seek(at)
+            break
+        if not line.strip():
+            continue
+        if not line.lstrip().startswith("{"):
+            handle.seek(at)
+            break
+        lines.append(line)
+    if not lines:
+        handle.seek(start)
+    return lines
+
+
 def _iter_block_stream_lines(handle):
     """Every line of a block-stream shard, one block decompressed at a time."""
     while True:
         header = handle.read(_DELTA_BLOCK_HEADER_BYTES)
         if len(header) < _DELTA_BLOCK_HEADER_BYTES:
+            if header:
+                # Fewer bytes than a header, at a boundary: plain text is the only thing this can
+                # be other than a torn write, and _plain_run_lines tells them apart.
+                for line in _plain_run_lines(header, handle):
+                    yield line
             return
         codec = header[:1]
         length = int.from_bytes(header[1:], "big")
+        if codec not in (_DELTA_BLOCK_CODEC_ZLIB, _DELTA_BLOCK_CODEC_ZLIB_ARRAY):
+            # Not a block. Either something appended plain JSON here -- which another process is
+            # allowed to do and must keep reading -- or the file is damaged. `_plain_run_lines`
+            # tells them apart and leaves the handle where the text stops, so a block written
+            # AFTER that append is read by the next turn of this loop rather than lost.
+            plain = _plain_run_lines(header, handle)
+            for line in plain:
+                yield line
+            if plain:
+                continue
+            return
         body = handle.read(length)
-        if len(body) < length or codec not in (_DELTA_BLOCK_CODEC_ZLIB,
-                                               _DELTA_BLOCK_CODEC_ZLIB_ARRAY):
-            # A torn final block, or one this build does not know. Both mean the same thing here:
-            # stop, and let the caller work with what came before it -- a half-written append is
-            # exactly what a crash mid-write leaves, and dropping it is what the plain form does
-            # with a half-written line.
+        if len(body) < length:
+            # A torn final block: stop, and let the caller work with what came before it. A
+            # half-written append is what a crash mid-write leaves, and dropping it is what the
+            # plain form does with a half-written line.
             return
         decoded = zlib.decompress(body)
         if codec == _DELTA_BLOCK_CODEC_ZLIB_ARRAY:

--- a/tools/test_matrixark_the_log_is_written_in_blocks.py
+++ b/tools/test_matrixark_the_log_is_written_in_blocks.py
@@ -230,5 +230,118 @@ class LogIsWrittenInBlocksTest(unittest.TestCase):
         self.assertLessEqual(len(rotated) + 1, retained)
 
 
+    def test_a_plain_append_onto_a_block_log_still_reads(self):
+        """The reason this format shipped off by default.
+
+        Something that is not this module appends plain JSON lines to the log -- fixtures are built
+        that way and out-of-process writers exist -- and that used to make everything past the
+        append unreadable. At a block boundary the framing is exact, so a reader can tell a plain
+        line (starts with `{`) from a block (starts with a codec byte).
+        """
+        import json as _json
+
+        adapter_module.LOCAL_JSONL_BLOCK_LOG = True
+        adapter = MatrixArkLocalAdapter(self.log)
+        adapter.append_many(_records(0, 5))
+        before = self._appended(self.log)
+        self.assertEqual(5, len(before))
+
+        with self.log.open("a", encoding="utf-8") as handle:
+            for record in _records(100, 3):
+                print(_json.dumps(record, separators=(",", ":")), file=handle)
+
+        after = self._appended(self.log)
+        self.assertEqual(before, after[:len(before)],
+                         "the block records stopped reading after a plain append")
+        self.assertEqual(8, len(after), "the plain append was not read")
+
+    def test_a_block_written_after_a_plain_append_is_not_lost(self):
+        """A plain run does NOT mean the rest of the file is text.
+
+        `_log_append_form` reads the magic at the head, so this module keeps appending blocks after
+        someone else's plain lines and a real log interleaves. Reading the remainder as one string
+        fails to decode at the trailing block and silently drops everything after the plain run --
+        which is what a "75 != 50" looked like while this was being written.
+        """
+        import json as _json
+
+        adapter_module.LOCAL_JSONL_BLOCK_LOG = True
+        adapter = MatrixArkLocalAdapter(self.log)
+        adapter.append_many(_records(0, 4))
+        with self.log.open("a", encoding="utf-8") as handle:
+            for record in _records(100, 2):
+                print(_json.dumps(record, separators=(",", ":")), file=handle)
+        MatrixArkLocalAdapter(self.log).append_many(_records(200, 4))
+
+        ids = [record["event_id_hash"] for record in self._appended(self.log)]
+        self.assertEqual(10, len(ids), "records were lost across the block/plain/block seam")
+        for expected in (0, 100, 200):
+            self.assertIn(expected, ids, "the run starting at %d is missing" % expected)
+        self.assertEqual(sorted(ids), ids, "records came back out of order across the seam")
+
+    def test_a_torn_block_is_still_dropped_not_read_as_text(self):
+        """The tolerance must not swallow the crash-safety property.
+
+        A torn block's remainder is compressed bytes. It must keep being dropped rather than read
+        as lines -- otherwise a half-written append turns into garbage records instead of an
+        absence, which is the one outcome worse than losing the append.
+        """
+        adapter_module.LOCAL_JSONL_BLOCK_LOG = True
+        adapter = MatrixArkLocalAdapter(self.log)
+        adapter.append_many(_records(0, 5))
+        adapter.append_many(_records(5, 5))
+        whole = self._appended(self.log)
+        self.assertEqual(10, len(whole))
+
+        raw = self.log.read_bytes()
+        self.log.write_bytes(raw[: len(raw) - 25])
+        kept = self._appended(self.log)
+        self.assertLess(len(kept), len(whole), "the torn block was read rather than dropped")
+        self.assertEqual(whole[:len(kept)], kept, "the survivors are not a clean prefix")
+
+
+    def test_the_plain_run_stops_at_text_that_is_not_json(self):
+        """The shape guard, exercised directly.
+
+        End-to-end it never decides anything: a compressed block fails the UTF-8 decode first, so
+        the two guards overlap and a mutation removing this one survives every scenario test. It
+        matters for input that IS valid UTF-8 and is NOT JSON -- which is what a block's payload is
+        whenever it happens to be ASCII-safe.
+
+        Asserts the handle is left AT the offending byte, because the caller resumes block parsing
+        from there: stopping without rewinding loses a block, and not stopping at all reads one as
+        text.
+        """
+        from tools.matrixark_mcp_local_adapter import _plain_run_lines
+
+        blob = (b'{"record_type":"context_event","event_id_hash":1}\n'
+                b'{"record_type":"context_event","event_id_hash":2}\n'
+                b'NOT-JSON-BUT-VALID-UTF8\n'
+                b'{"record_type":"context_event","event_id_hash":3}\n')
+        path = self.store / "crafted.bin"
+        path.write_bytes(blob)
+        with path.open("rb") as handle:
+            head = handle.read(5)
+            lines = _plain_run_lines(head, handle)
+            stopped_at = handle.tell()
+
+        self.assertEqual(2, len(lines), "the run did not stop at the non-JSON line")
+        self.assertEqual(blob.index(b"NOT-JSON"), stopped_at,
+                         "the handle is not positioned at the byte that stopped the run")
+
+    def test_the_plain_run_refuses_bytes_that_are_not_text(self):
+        """The torn-block case, exercised directly for the same reason."""
+        from tools.matrixark_mcp_local_adapter import _plain_run_lines
+
+        path = self.store / "torn.bin"
+        path.write_bytes(b"\x02\x00\x00\x10\xff\xfe\x00\x9c\x81\x02\xab")
+        with path.open("rb") as handle:
+            head = handle.read(5)
+            lines = _plain_run_lines(head, handle)
+            self.assertEqual([], lines, "compressed bytes were read as lines")
+            self.assertEqual(0, handle.tell(),
+                             "the handle was not rewound, so the caller cannot retry the block")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The block log is worth **9.68×** on the largest artifact this module writes and ships **off**, for
one specific reason demonstrated by two tests: a process that is not this module appends plain JSON
lines, and a plain append onto a block-framed log made everything past it unreadable. That is a real
pattern — fixtures are built that way and out-of-process writers exist — so the flag stayed off.

It does not have to be unreadable. At a block boundary the framing is exact, so a reader can tell: a
plain line starts with `{`, a block starts with a codec byte.

## The run does not reach the end of the file

Assuming it did was this change's first bug. `_log_append_form` reads the magic at the head, so this
module keeps appending blocks *after* someone else's plain lines and a real log interleaves:

```
[block][block][plain][plain][block]
```

Reading the remainder as one string fails to decode at that trailing block and silently drops
everything after the plain run — which is what `75 != 50` looked like in
`test_a_writer_in_another_process_does_not_corrupt_the_view`. Consuming a line at a time and resuming
block parsing where the text stops also keeps the memory bound the streaming reader exists for: a
shard runs to 64 MB and reading it whole would undo it.

A torn block must still be **dropped**, not read as text. The two cases are told apart by what the
bytes are: a torn block's remainder is compressed and does not decode as UTF-8 beginning with `{`.

## The blocker is gone

With the block log turned on, the two tests that blocked its default now pass:

- `test_a_writer_in_another_process_does_not_corrupt_the_view`
- `test_both_append_paths_write_the_same_tail`

## The default is not changed here

Turning it on also needs the sealed-shard suite reworked: that feature and this one share the
container magic and differ only by codec byte, so "is this sealed" and "is this a block stream"
overlap in the fixture as well as in the code. I started down that path, found myself three patches
deep and adding errors, and stopped — it is a coherent change on its own and a poor passenger on this
one. What this removes is the correctness blocker.

## Tests, and an honest mutation count

Five: a plain append onto a block log still reads, a block written after a plain append is not lost,
a torn block is still dropped, and **two unit tests for the guards themselves**.

The unit tests exist because the end-to-end ones cannot reach the guards. Four mutations, **two
caught**. The two that survive are **inert, not uncovered**: `_plain_run_lines` stops on a line that
fails to decode as UTF-8 *or* does not start with `{`, and each branch already restores the handle
position the other's mutation would break — so removing either leaves behaviour unchanged. I checked
that by running the interleaving scenario against both, and got identical output.

The unit tests drive each guard with input only it can decide: valid UTF-8 that is not JSON, and
bytes that are not text at all. They assert the handle's **position**, because the caller resumes
block parsing from there — stopping without rewinding loses a block, and not stopping reads one as
text.
