### PR TITLE
The block log defaults on

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -195,19 +195,17 @@ _SHARD_CODEC_ZLIB = b"\x01"
 #: ACTIVE log can take: a sealed shard is finished and compresses whole, but a log is appended to,
 #: and a stream of self-describing blocks is appendable where a single deflate stream is not.
 _SHARD_CODEC_BLOCKS = b"\x02"
-#: Off, and it stays off -- the hazard is demonstrated rather than argued. Turning it on breaks
-#: `test_a_writer_in_another_process_does_not_corrupt_the_view` and
-#: `test_both_append_paths_write_the_same_tail`: both append raw JSON lines to a log this module
-#: created, which is what a writer that is NOT this module does, and a plain append onto a
-#: block-framed log corrupts it. A store this build creates has to remain appendable by something
-#: that writes plain JSONL, and defaulting this on takes that away.
+#: ON. It was off for one demonstrated reason: a plain append onto a block-framed log made
+#: everything past it unreadable, and a store this build creates has to stay appendable by something
+#: that writes plain JSONL -- fixtures are built that way and out-of-process writers exist. The
+#: reader tolerates that now, resuming block parsing where the text stops, so the two tests that
+#: kept this off pass with it on.
 #:
-#: Everything else about it is safe and measured -- an existing plain log stays plain because the
-#: form is read from the FILE, and a store written with this on reads byte-identically with it off
-#: (144 records, 82 vectors, same digest). It is a per-deployment choice for anyone who knows their
-#: log has a single writer, not a default.
+#: Nothing already on disk is converted: the form is read from the FILE, so an existing plain log
+#: stays plain and only a fresh one adopts blocks. A store written with this on reads
+#: byte-identically with it off -- the flag chooses what to write, never what can be read.
 LOCAL_JSONL_BLOCK_LOG = os.environ.get(
-    "MATRIXARK_LOCAL_JSONL_BLOCK_LOG", "0"
+    "MATRIXARK_LOCAL_JSONL_BLOCK_LOG", "1"
 ).strip().lower() not in ("0", "false", "no", "off")
 #: On, and reversible: the reader takes either form, so a store written with this on still reads
 #: with it off, and a shard sealed once never needs unsealing.
@@ -8217,12 +8215,23 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             survivors = apply_memory_tombstones(raw)
             bytes_before = sum(path.stat().st_size for path in paths if path.exists())
             tmp_path = self.event_log.with_name(f"{self.event_log.name}.purge.{os.getpid()}.{threading.get_ident()}.tmp")
-            lines = [json.dumps(self._sanitize_jsonl_record(record), separators=(",", ":")) + "\n" for record in survivors]
-            with tmp_path.open("w", encoding="utf-8") as handle:
-                for line in lines:
-                    handle.write(line)
-                handle.flush()
-                os.fsync(handle.fileno())
+            sanitized = [self._sanitize_jsonl_record(record) for record in survivors]
+            # In the form the log is already in. Writing plain lines here converted a block-framed
+            # log back to text and GREW it -- 12,954 bytes became 35,962 -- which is the opposite of
+            # what a purge is for, and left the log plain until the next rotation.
+            if self._log_append_form() == _SHARD_CODEC_BLOCKS:
+                with tmp_path.open("wb") as handle:
+                    handle.write(_SHARD_CONTAINER_MAGIC + _SHARD_CODEC_BLOCKS)
+                    for start in range(0, len(sanitized), 256):
+                        handle.write(_encode_log_block(sanitized[start:start + 256]))
+                    handle.flush()
+                    os.fsync(handle.fileno())
+            else:
+                with tmp_path.open("w", encoding="utf-8") as handle:
+                    for record in sanitized:
+                        handle.write(json.dumps(record, separators=(",", ":")) + "\n")
+                    handle.flush()
+                    os.fsync(handle.fileno())
             os.replace(tmp_path, self.event_log)  # atomic commit point
             # Fold rotated shards into the (now consolidated) primary: remove them post-commit.
             for path in paths:

--- a/tools/test_codex_pipeline_part4.py
+++ b/tools/test_codex_pipeline_part4.py
@@ -62,6 +62,20 @@ except ImportError:
 )
 
 
+def _log_lines(path):
+    """Every non-blank line of the durable log, whichever form it is written in.
+
+    `read_text` asserts the log is text. It is, until MATRIXARK_LOCAL_JSONL_BLOCK_LOG is on, and
+    then it is a stream of compressed blocks. The module's own reader takes either form, and a test
+    about durable RECORDS should not depend on the encoding they arrive in.
+    """
+    try:
+        from tools.matrixark_mcp_local_adapter import _iter_shard_lines
+    except ImportError:  # Direct script execution from tools/.
+        from matrixark_mcp_local_adapter import _iter_shard_lines
+    return [line for line in _iter_shard_lines(path) if line.strip()]
+
+
 class _CodexPipelinePart4:
     def test_retrieve_recovers_hot_event_type_from_embedding_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -1849,7 +1863,7 @@ class _CodexPipelinePart4:
             # with nothing interned.
             records = expand_interned_records([
                 json.loads(line)
-                for line in event_log.read_text(encoding="utf-8").splitlines()
+                for line in _log_lines(event_log)
                 if line.strip()
             ])
             assistant_events = [

--- a/tools/test_intern_record_metadata.py
+++ b/tools/test_intern_record_metadata.py
@@ -48,6 +48,20 @@ def _serialized_bytes(records: list[dict]) -> int:
     return sum(len(json.dumps(r, separators=(",", ":")).encode()) + 1 for r in records)
 
 
+def _log_lines(path):
+    """Every non-blank line of the durable log, whichever form it is written in.
+
+    `read_text` asserts the log is text. It is, until MATRIXARK_LOCAL_JSONL_BLOCK_LOG is on, and
+    then it is a stream of compressed blocks. The module's own reader takes either form, and a test
+    about durable RECORDS should not depend on the encoding they arrive in.
+    """
+    try:
+        from tools.matrixark_mcp_local_adapter import _iter_shard_lines
+    except ImportError:  # Direct script execution from tools/.
+        from matrixark_mcp_local_adapter import _iter_shard_lines
+    return [line for line in _iter_shard_lines(path) if line.strip()]
+
+
 class _FlagGuard(unittest.TestCase):
     """Save/restore the two module-global flags so each test controls them in isolation."""
 
@@ -99,7 +113,7 @@ class _FlagGuard(unittest.TestCase):
         for shard in sorted(path.parent.glob(path.name + "*")):
             if shard.name.endswith((".read-cache.json", ".read-cache.bin")):
                 continue
-            for line in shard.read_text(encoding="utf-8").splitlines():
+            for line in _log_lines(shard):
                 line = line.strip()
                 if line:
                     records.append(json.loads(line))
@@ -205,7 +219,7 @@ class InterningCase(_FlagGuard):
             server = mcp.MatrixArkMcpServer(adapter, access_mode="dev")
             self._ingest_turns(server, 20)
             server.close(timeout_s=2.0)
-            raw_lines = [json.loads(ln) for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+            raw_lines = [json.loads(ln) for ln in _log_lines(path) if ln.strip()]
         self.assertTrue(any(r.get("record_type") == A.INTERN_DICT_RECORD_TYPE for r in raw_lines),
                         "expected durable intern-dict records on disk")
         # The data line carries a single bundle token (_imb) and every bundled field is elided
@@ -235,7 +249,7 @@ class InterningCase(_FlagGuard):
             server = mcp.MatrixArkMcpServer(adapter, access_mode="dev")
             self._ingest_turns(server, 20)
             server.close(timeout_s=2.0)
-            text = path.read_text(encoding="utf-8")
+            text = "\n".join(_log_lines(path))
         self.assertNotIn(A.INTERN_DICT_RECORD_TYPE, text)
         self.assertNotIn(f'"{A.INTERN_TOKEN_KEY}"', text)
 

--- a/tools/test_matrixark_a_flat_value_needs_no_deep_copy.py
+++ b/tools/test_matrixark_a_flat_value_needs_no_deep_copy.py
@@ -24,6 +24,20 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import matrixark_mcp_local_adapter as adapter_module
 
 
+def _log_lines(path):
+    """Every non-blank line of the durable log, whichever form it is written in.
+
+    `read_text` asserts the log is text. It is, until MATRIXARK_LOCAL_JSONL_BLOCK_LOG is on, and
+    then it is a stream of compressed blocks. The module's own reader takes either form, and a test
+    about durable RECORDS should not depend on the encoding they arrive in.
+    """
+    try:
+        from tools.matrixark_mcp_local_adapter import _iter_shard_lines
+    except ImportError:  # Direct script execution from tools/.
+        from matrixark_mcp_local_adapter import _iter_shard_lines
+    return [line for line in _iter_shard_lines(path) if line.strip()]
+
+
 class AFlatValueNeedsNoDeepCopy(unittest.TestCase):
     def test_one_record_cannot_change_another_records_value(self):
         """The guarantee this file was written for, now kept a different way.
@@ -89,7 +103,7 @@ class AFlatValueNeedsNoDeepCopy(unittest.TestCase):
                     "scope": {"tenant_id": "acme", "user_id": "u", "session_id": "s%d" % (i // 4)},
                     "messages": [{"role": "user", "content": "a sentence to extract %d" % i}],
                 })
-            raw = [json.loads(line) for line in log.read_text(encoding="utf-8").splitlines()
+            raw = [json.loads(line) for line in _log_lines(log)
                    if line.strip()]
             self.assertTrue(
                 any(adapter_module.INTERN_BUNDLE_TOKEN_KEY in r for r in raw if isinstance(r, dict)),

--- a/tools/test_matrixark_a_rotated_shard_is_sealed.py
+++ b/tools/test_matrixark_a_rotated_shard_is_sealed.py
@@ -55,9 +55,13 @@ class SealedShardTest(unittest.TestCase):
         self.addCleanup(_clear_process_read_cache)
         # Module globals read at call time, so they are set here and RESTORED -- a test that leaves
         # process-global state behind changes the tests after it.
-        for name in ("LOCAL_JSONL_COMPRESS_SEALED", "LOCAL_JSONL_MAX_BYTES"):
+        for name in ("LOCAL_JSONL_COMPRESS_SEALED", "LOCAL_JSONL_MAX_BYTES",
+                     "LOCAL_JSONL_BLOCK_LOG"):
             self.addCleanup(setattr, adapter_module, name, getattr(adapter_module, name))
-        adapter_module.LOCAL_JSONL_MAX_BYTES = 40_000
+        # Small enough to rotate whichever form the log is in. At 40,000 the block-framed log --
+        # roughly a tenth the size of the plain one -- never reached the threshold, and six tests
+        # here failed with "nothing rotated": their own guards catching a vacuous run.
+        adapter_module.LOCAL_JSONL_MAX_BYTES = 4_000
 
     def _fill(self, batches: int = 6, per_batch: int = 20) -> list[dict]:
         adapter = MatrixArkLocalAdapter(self.log)
@@ -66,11 +70,29 @@ class SealedShardTest(unittest.TestCase):
         _clear_process_read_cache()
         return MatrixArkLocalAdapter(self.log).read_all()
 
+    @staticmethod
+    def _is_sealed(path: Path) -> bool:
+        """Sealed is the CODEC, not the magic.
+
+        A block-stream shard carries the same magic and is a different thing: appendable, and
+        compressed per batch rather than whole-file.
+        """
+        head = path.read_bytes()[:len(_SHARD_CONTAINER_MAGIC) + 1]
+        return (head.startswith(_SHARD_CONTAINER_MAGIC)
+                and head[len(_SHARD_CONTAINER_MAGIC):] == _SHARD_CODEC_ZLIB)
+
     def _rotated(self) -> list[Path]:
         return [path for path in sorted(self.log.parent.iterdir())
                 if path.name.startswith("events.jsonl.") and path.suffix.lstrip(".").isdigit()]
 
-    def test_a_rotated_shard_is_stored_compressed(self):
+    def test_a_plain_rotated_shard_is_sealed(self):
+        """Sealing is a whole-file compress of a shard that is finished.
+
+        Pinned with the block log OFF, because that is the case sealing is for: a plain rotated
+        shard is 11.66x smaller sealed. A block-stream shard is already compressed and the sealer
+        leaves it alone -- see the test below.
+        """
+        adapter_module.LOCAL_JSONL_BLOCK_LOG = False
         adapter_module.LOCAL_JSONL_COMPRESS_SEALED = True
         self._fill()
         rotated = self._rotated()
@@ -86,15 +108,42 @@ class SealedShardTest(unittest.TestCase):
                             "%s is not materially smaller, so it is not earning its format"
                             % path.name)
 
-    def test_the_active_shard_stays_plain_text(self):
-        """Appends, crash recovery and anyone reading the log by hand all go to this file."""
+    def test_a_block_stream_shard_is_left_alone_because_it_is_already_compressed(self):
+        """The other half, and why the sealer is not changed to handle it.
+
+        A block-stream shard carries the container magic, so the sealer skips it. Measured, that
+        costs 1.09x -- against the 11.66x sealing a PLAIN shard is worth, because the block stream
+        is already compressed per batch and lands within 14% of the sealed plain shard. A second
+        whole-file pass over compressed bytes for nine percent is a poor trade.
+        """
+        adapter_module.LOCAL_JSONL_BLOCK_LOG = True
+        adapter_module.LOCAL_JSONL_COMPRESS_SEALED = True
+        self._fill()
+        rotated = self._rotated()
+        self.assertTrue(rotated, "nothing rotated, so this proves nothing")
+        for path in rotated:
+            head = path.read_bytes()[:len(_SHARD_CONTAINER_MAGIC) + 1]
+            self.assertTrue(head.startswith(_SHARD_CONTAINER_MAGIC))
+            self.assertFalse(self._is_sealed(path),
+                             "%s was re-compressed whole; it was already a block stream" % path.name)
+            self.assertTrue(list(adapter_module._iter_shard_lines(path)),
+                            "%s does not read back" % path.name)
+
+    def test_the_active_shard_is_never_sealed(self):
+        """Appends, crash recovery and anyone reading the log by hand all go to this file.
+
+        The invariant is that the SEALER never touches it -- a sealed shard is a whole-file
+        compress, and a file still being appended to must never carry one. It is NOT that the
+        active shard is plain text: with MATRIXARK_LOCAL_JSONL_BLOCK_LOG on it is a block stream,
+        which is appendable and is a different thing from sealed.
+        """
         adapter_module.LOCAL_JSONL_COMPRESS_SEALED = True
         self._fill()
         self.assertTrue(self._rotated(), "nothing rotated, so there was no seal to over-reach")
-        head = self.log.read_bytes()[:len(_SHARD_CONTAINER_MAGIC)]
-        self.assertFalse(head.startswith(_SHARD_CONTAINER_MAGIC),
+        self.assertFalse(self._is_sealed(self.log),
                          "the ACTIVE shard was sealed; appends land in this file")
-        self.assertTrue(self.log.read_text(encoding="utf-8").lstrip().startswith("{"))
+        self.assertTrue(list(adapter_module._iter_shard_lines(self.log)),
+                        "the active shard is unreadable, whichever form it is in")
 
     def test_sealing_does_not_change_the_view(self):
         adapter_module.LOCAL_JSONL_COMPRESS_SEALED = False
@@ -118,7 +167,8 @@ class SealedShardTest(unittest.TestCase):
         written = self._fill()
         rotated = self._rotated()
         self.assertTrue(rotated)
-        self.assertFalse(rotated[0].read_bytes().startswith(_SHARD_CONTAINER_MAGIC))
+        self.assertFalse(self._is_sealed(rotated[0]),
+                         "the shard was sealed with sealing turned off")
 
         adapter_module.LOCAL_JSONL_COMPRESS_SEALED = True
         _clear_process_read_cache()

--- a/tools/test_matrixark_intern_the_scope_constants.py
+++ b/tools/test_matrixark_intern_the_scope_constants.py
@@ -34,6 +34,20 @@ def _rows(count):
     ]
 
 
+def _log_lines(path):
+    """Every non-blank line of the durable log, whichever form it is written in.
+
+    `read_text` asserts the log is text. It is, until MATRIXARK_LOCAL_JSONL_BLOCK_LOG is on, and
+    then it is a stream of compressed blocks. The module's own reader takes either form, and a test
+    about durable RECORDS should not depend on the encoding they arrive in.
+    """
+    try:
+        from tools.matrixark_mcp_local_adapter import _iter_shard_lines
+    except ImportError:  # Direct script execution from tools/.
+        from matrixark_mcp_local_adapter import _iter_shard_lines
+    return [line for line in _iter_shard_lines(path) if line.strip()]
+
+
 class TheTwoLargestConstantsAreInterned(unittest.TestCase):
     def _encode(self, rows):
         emitted = set()
@@ -88,7 +102,7 @@ class TheTwoLargestConstantsAreInterned(unittest.TestCase):
         adapter.close(timeout_s=120)
 
         raw = [json.loads(line) for line in
-               (store / "events.jsonl").read_text(encoding="utf-8").splitlines() if line.strip()]
+               _log_lines(store / "events.jsonl") if line.strip()]
         data = [r for r in raw
                 if str(r.get("record_type") or "") != adapter_module.INTERN_DICT_RECORD_TYPE]
         self.assertTrue(data, "nothing was written, so the assertions below would pass emptily")

--- a/tools/test_matrixark_interning_reaches_repeated_fields.py
+++ b/tools/test_matrixark_interning_reaches_repeated_fields.py
@@ -22,6 +22,20 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import matrixark_mcp_local_adapter as adapter_module
 
 
+def _log_lines(path):
+    """Every non-blank line of the durable log, whichever form it is written in.
+
+    `read_text` asserts the log is text. It is, until MATRIXARK_LOCAL_JSONL_BLOCK_LOG is on, and
+    then it is a stream of compressed blocks. The module's own reader takes either form, and a test
+    about durable RECORDS should not depend on the encoding they arrive in.
+    """
+    try:
+        from tools.matrixark_mcp_local_adapter import _iter_shard_lines
+    except ImportError:  # Direct script execution from tools/.
+        from matrixark_mcp_local_adapter import _iter_shard_lines
+    return [line for line in _iter_shard_lines(path) if line.strip()]
+
+
 class InterningCoversTheRepeatedFields(unittest.TestCase):
     # Read at import by matrixark_mcp_temporal_append, and another file in this suite sets it and
     # re-imports that module without putting it back. Left on, the warm view and a cold read
@@ -145,7 +159,7 @@ class InterningCoversTheRepeatedFields(unittest.TestCase):
                                   "content": "a sentence with enough words to be extracted %d" % i}],
                 })
             sidecars = data = 0
-            for line in log.read_text(encoding="utf-8").splitlines():
+            for line in _log_lines(log):
                 if not line.strip():
                     continue
                 record = json.loads(line)

--- a/tools/test_matrixark_one_object_per_interned_value.py
+++ b/tools/test_matrixark_one_object_per_interned_value.py
@@ -36,6 +36,20 @@ def _log(token="tok", n=3):
     return records, bundle
 
 
+def _log_lines(path):
+    """Every non-blank line of the durable log, whichever form it is written in.
+
+    `read_text` asserts the log is text. It is, until MATRIXARK_LOCAL_JSONL_BLOCK_LOG is on, and
+    then it is a stream of compressed blocks. The module's own reader takes either form, and a test
+    about durable RECORDS should not depend on the encoding they arrive in.
+    """
+    try:
+        from tools.matrixark_mcp_local_adapter import _iter_shard_lines
+    except ImportError:  # Direct script execution from tools/.
+        from matrixark_mcp_local_adapter import _iter_shard_lines
+    return [line for line in _iter_shard_lines(path) if line.strip()]
+
+
 class OneObjectPerInternedValue(unittest.TestCase):
     def test_every_record_holds_the_same_object(self):
         """The saving. A copy per record is what cost three times the serialised size."""
@@ -106,7 +120,7 @@ class OneObjectPerInternedValue(unittest.TestCase):
                     "scope": {"tenant_id": "acme", "user_id": "u", "session_id": "s%d" % (i // 4)},
                     "messages": [{"role": "user", "content": "a sentence to extract %d" % i}],
                 })
-            raw = [json.loads(line) for line in log.read_text(encoding="utf-8").splitlines()
+            raw = [json.loads(line) for line in _log_lines(log)
                    if line.strip()]
             self.assertTrue(
                 any(adapter_module.INTERN_BUNDLE_TOKEN_KEY in r for r in raw if isinstance(r, dict)),

--- a/tools/test_matrixark_the_audit_switch_is_reachable.py
+++ b/tools/test_matrixark_the_audit_switch_is_reachable.py
@@ -38,6 +38,20 @@ A = {"account_id": "acct_a", "tenant_id": "tenant_a"}
 B = {"account_id": "acct_b", "tenant_id": "tenant_b"}
 
 
+def _log_lines(path):
+    """Every non-blank line of the durable log, whichever form it is written in.
+
+    `read_text` asserts the log is text. It is, until MATRIXARK_LOCAL_JSONL_BLOCK_LOG is on, and
+    then it is a stream of compressed blocks. The module's own reader takes either form, and a test
+    about durable RECORDS should not depend on the encoding they arrive in.
+    """
+    try:
+        from tools.matrixark_mcp_local_adapter import _iter_shard_lines
+    except ImportError:  # Direct script execution from tools/.
+        from matrixark_mcp_local_adapter import _iter_shard_lines
+    return [line for line in _iter_shard_lines(path) if line.strip()]
+
+
 class TheSwitchIsInTheRegistryTest(unittest.TestCase):
 
     def setUp(self) -> None:
@@ -129,7 +143,7 @@ class WritingItThroughThePortalTakesEffectTest(unittest.TestCase):
         finally:
             server.close(timeout_s=10.0)
         rows = []
-        for line in self.log.read_text(encoding="utf-8").splitlines():
+        for line in _log_lines(self.log):
             if '"matrixark_audit_log"' in line:
                 rows.append(line)
         return rows


### PR DESCRIPTION
The blocker is gone. This shipped off for one demonstrated reason — a plain append onto a
block-framed log made everything past it unreadable, and a store this build creates has to stay
appendable by something that writes plain JSONL. #1023 made the reader tolerate that, resuming block
parsing where the text stops, and the two tests that kept the flag off pass with it on.

## Measured

Same corpus, 60 documents of 76 KB, **10,818 records both ways**:

```
                      store        B/record   vs source
block log off    21,534,683           1,991       4.61x
block log on      2,540,847             235       0.54x    8.47x smaller
```

The store ends up **smaller than the text it was built from**.

## Three premises that were true only while the active shard was plain text

None of them is about sealing:

- **The rotation threshold.** At 40,000 bytes a block-framed log — roughly a tenth the plain size —
  never rotates, and six tests failed with `nothing rotated`: their own guards catching a vacuous run
  rather than a defect.
- **"The active shard stays plain text."** With this on it is a block stream. The invariant being
  defended is that the **sealer** never touches it — a sealed shard is a whole-file compress, and a
  file still being appended to must never carry one. Block stream and sealed are different things
  that share a magic and differ by codec byte, so the check is now the codec.
- **"A rotated shard is stored compressed."** It asserted the sealed codec on *every* rotated shard.
  With this on a rotated shard is a block stream and the sealer correctly leaves it alone. Split in
  two: the plain case, which sealing is for, and the block-stream case, which is already compressed.

## The sealer is unchanged, and that is a measurement

```
plain JSONL shard      1,721,959 -> 147,727   11.66x from sealing
block-stream shard       167,986 -> 154,469    1.09x from sealing
```

Sealing a plain shard is the whole win. A second whole-file pass over already-compressed bytes is
**nine percent**, and the block stream already lands within 14% of the sealed plain shard — so
teaching the sealer to re-compress it would cost a full pass for very little.

> An earlier draft of mine claimed that figure was far larger, by comparing a block log's ratio
> against a plain log's whole-file ratio. Two different baselines.

## Nothing on disk is converted

The form is read from the **file**, so an existing plain log stays plain and only a fresh one adopts
blocks. A store written with this on reads byte-identically with it off — the flag chooses what to
write, never what can be read.
