### PR TITLE
Ingest does not build index refs nothing reads

### DIFF
--- a/crates/temporalstore-rust/src/context_workflow.rs
+++ b/crates/temporalstore-rust/src/context_workflow.rs
@@ -31,20 +31,6 @@ const LEXICAL_SCORE_SATURATION: i64 = 1_000;
 /// remain rankable (never a flat 0) instead of collapsing to recency order.
 const LEXICAL_MATCH_MICROS: i64 = 500_000;
 
-/// MATRIXARK_CONTEXT_SECONDARY_INDEX (default OFF): whether ingest builds the ctxidx
-/// secondary-index refs at all.
-///
-/// Retrieval does not read them -- candidate selection is namespace nodes plus vector and
-/// lexical scoring -- so on the live path they are write-only cost: one durable command per
-/// (index, value) per ingest whose only reader is the ingest verifier checking that the writes
-/// it just made landed. Skipped by default until the redesign gives them a reader; the env var
-/// is the escape hatch for anything still relying on the query-back surface.
-pub(crate) fn context_secondary_index_enabled() -> bool {
-    std::env::var("MATRIXARK_CONTEXT_SECONDARY_INDEX")
-        .ok()
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false)
-}
 
 /// Map a raw lexical-relevance score into the same micros scale cosine similarity
 /// uses (`context_embedding_similarity_micros`), so lexical and cosine node scores
@@ -1817,16 +1803,6 @@ pub(crate) fn extract_context_gated(
         commands.push(Command::ContextUpsertSummary {
             tenant_hash: request.tenant_hash,
             summary: summary_l1,
-        });
-    }
-    if context_secondary_index_enabled() {
-        commands.push(Command::ContextWriteIndexRef {
-            tenant_hash: request.tenant_hash,
-            index_name: "source".to_string(),
-            index_value_hash: stable_hash64(&request.source_id),
-            scope_hash: 0,
-            event_time_ms: timestamp_ms,
-            index_ref: index_ref.clone(),
         });
     }
     if embedding_deferred {

--- a/crates/temporalstore-rust/src/context_workflow/ingest.rs
+++ b/crates/temporalstore-rust/src/context_workflow/ingest.rs
@@ -333,44 +333,16 @@ pub fn ingest_resource_skill_context(
         fanout.compression_count += 1;
 
         for (index_name, index_ref_value) in index_writes {
-            if !crate::context_workflow::context_secondary_index_enabled() {
-                // The refs are still REPORTED (callers read the report to know what would be
-                // indexed); only the durable writes and their query-back are skipped.
-                match index_name.as_str() {
-                    "resource_ref" => secondary_indexes.resource_refs.push(index_ref_value),
-                    "skill_ref" => secondary_indexes.skill_refs.push(index_ref_value),
-                    "entity_ref" => secondary_indexes.entity_refs.push(index_ref_value),
-                    "source_ref" => secondary_indexes.source_refs.push(index_ref_value),
-                    "summary_ref" => secondary_indexes.summary_refs.push(index_ref_value),
-                    _ => {}
-                }
-                continue;
-            }
-            let response = engine.execute_durable(ExecuteRequest {
-                shard_id: request.shard_id,
-                command: Command::ContextWriteIndexRef {
-                    tenant_hash: request.tenant_hash,
-                    index_name: index_name.clone(),
-                    index_value_hash: stable_hash64(&index_ref_value),
-                    scope_hash: 0,
-                    event_time_ms: extract.event.event_time_ms,
-                    index_ref: extract.index_ref.clone(),
-                },
-            });
-            if response.status.ok {
-                fanout.secondary_index_count += 1;
-                match index_name.as_str() {
-                    "resource_ref" => secondary_indexes.resource_refs.push(index_ref_value),
-                    "skill_ref" => secondary_indexes.skill_refs.push(index_ref_value),
-                    "entity_ref" => secondary_indexes.entity_refs.push(index_ref_value),
-                    "source_ref" => secondary_indexes.source_refs.push(index_ref_value),
-                    "summary_ref" => secondary_indexes.summary_refs.push(index_ref_value),
-                    _ => {}
-                }
-            } else {
-                secondary_indexes
-                    .missing_refs
-                    .push(format!("{index_name}:{index_ref_value}"));
+            // The refs are REPORTED, so a caller still learns what would be indexed.
+            // Nothing is written: retrieval does not read these, so the write was cost
+            // with no reader.
+            match index_name.as_str() {
+                "resource_ref" => secondary_indexes.resource_refs.push(index_ref_value),
+                "skill_ref" => secondary_indexes.skill_refs.push(index_ref_value),
+                "entity_ref" => secondary_indexes.entity_refs.push(index_ref_value),
+                "source_ref" => secondary_indexes.source_refs.push(index_ref_value),
+                "summary_ref" => secondary_indexes.summary_refs.push(index_ref_value),
+                _ => {}
             }
         }
 
@@ -669,56 +641,6 @@ pub(crate) fn verify_resource_skill_fanout(
     let entity_refs = secondary_indexes.entity_refs.clone();
     let source_refs = secondary_indexes.source_refs.clone();
     let summary_refs = secondary_indexes.summary_refs.clone();
-    verify_secondary_index_refs(
-        engine,
-        shard_id,
-        tenant_hash,
-        "resource_ref",
-        &resource_refs,
-        start_time_ms,
-        end_time_ms,
-        secondary_indexes,
-    );
-    verify_secondary_index_refs(
-        engine,
-        shard_id,
-        tenant_hash,
-        "skill_ref",
-        &skill_refs,
-        start_time_ms,
-        end_time_ms,
-        secondary_indexes,
-    );
-    verify_secondary_index_refs(
-        engine,
-        shard_id,
-        tenant_hash,
-        "entity_ref",
-        &entity_refs,
-        start_time_ms,
-        end_time_ms,
-        secondary_indexes,
-    );
-    verify_secondary_index_refs(
-        engine,
-        shard_id,
-        tenant_hash,
-        "source_ref",
-        &source_refs,
-        start_time_ms,
-        end_time_ms,
-        secondary_indexes,
-    );
-    verify_secondary_index_refs(
-        engine,
-        shard_id,
-        tenant_hash,
-        "summary_ref",
-        &summary_refs,
-        start_time_ms,
-        end_time_ms,
-        secondary_indexes,
-    );
 
     missing.sort();
     missing.dedup();
@@ -778,33 +700,6 @@ pub(crate) fn context_resource_skill_embedding_evidence(
     report
 }
 
-pub(crate) fn verify_secondary_index_refs(
-    engine: &TemporalEngine,
-    shard_id: ShardId,
-    tenant_hash: u64,
-    index_name: &str,
-    refs: &[String],
-    start_time_ms: u64,
-    end_time_ms: u64,
-    report: &mut ContextResourceSkillSecondaryIndexReport,
-) {
-    // Nothing was written when index building is off, so there is nothing to query back --
-    // reporting every ref as missing would fail the ingest for skipping work on purpose.
-    if !crate::context_workflow::context_secondary_index_enabled() {
-        return;
-    }
-    report
-        .missing_refs
-        .extend(query_missing_secondary_index_refs(
-            engine,
-            shard_id,
-            tenant_hash,
-            index_name,
-            refs,
-            start_time_ms,
-            end_time_ms,
-        ));
-}
 
 pub(crate) fn query_missing_secondary_index_refs(
     engine: &TemporalEngine,

--- a/crates/temporalstore-rust/src/context_workflow/tests.rs
+++ b/crates/temporalstore-rust/src/context_workflow/tests.rs
@@ -6,17 +6,6 @@ use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::thread;
 
-fn with_secondary_indexes<T>(body: impl FnOnce() -> T + std::panic::UnwindSafe) -> T {
-    // The gate is read per call, and CI runs --test-threads=1, so set/restore around the body
-    // is race-free there; the restore survives a failing assertion.
-    std::env::set_var("MATRIXARK_CONTEXT_SECONDARY_INDEX", "1");
-    let outcome = std::panic::catch_unwind(body);
-    std::env::remove_var("MATRIXARK_CONTEXT_SECONDARY_INDEX");
-    match outcome {
-        Ok(value) => value,
-        Err(panic) => std::panic::resume_unwind(panic),
-    }
-}
 
 fn test_engine() -> TemporalEngine {
     let dir = tempfile::tempdir().unwrap();
@@ -1052,135 +1041,116 @@ fn context_retrieval_limits_namespace_fanout_with_summary_and_locality_plan() {
 // shared-corpus: context_benchmark_injection_entity_slab_index
 #[test]
 fn context_benchmark_injection_uses_entity_slab_l0_l1_and_secondary_index() {
-    with_secondary_indexes(|| {
-        let engine = test_engine();
-        let extract = extract_context(
-                &engine,
-                ContextExtractRequest {
-                    shard_id: 1,
-                    tenant_hash: 20260622,
-                    source_kind: ContextSourceKind::Chat,
-                    source_id: "locomo-conv-7-session-3-turn-18".to_string(),
-                    title: "Caroline medical appointment update".to_string(),
-                    body: "Caroline told Maya on March 12 that her cardiology appointment moved after the museum visit. Maya should remind her brother Leo before Friday. The updated cardiology appointment is now confirmed for the following week.".to_string(),
-                    timestamp_ms: 1_712_300_000_000,
-                    provider: ContextModelProviderConfig::default(),
-                },
-            );
-        assert!(extract.status.ok, "{:?}", extract.status);
-
-        let node_entity: crate::ContextNode = extract.node.clone();
-        let slab: crate::ContextSlab = extract.event.clone();
-        assert_eq!(node_entity.node_hash, extract.index_ref.primary_node_hash);
-        assert_eq!(slab.event_id_hash, extract.index_ref.event_id_hash);
-        assert!(node_entity.l0.contains("Caroline"));
-        assert!(node_entity.l1_ref.contains("kind=Chat"));
-        assert!(slab
-            .text
-            .contains("cardiology appointment moved after the museum visit"));
-        assert!(slab.related_node_hashes.is_empty());
-        assert_eq!(extract.related_node_hashes, vec![node_entity.node_hash]);
-
-        let indexed = engine.execute(ExecuteRequest {
-            shard_id: 1,
-            command: Command::ContextQueryIndex {
-                tenant_hash: 20260622,
-                index_name: "source".to_string(),
-                index_value_hash: stable_hash64("locomo-conv-7-session-3-turn-18"),
-                scope_hash: 0,
-                start_time_ms: 1_712_299_000_000,
-                end_time_ms: 1_712_301_000_000,
-                limit: Some(4),
-            },
-        });
-        let refs = match indexed.response {
-            CommandResponse::ContextIndexRefs { refs, .. } => refs,
-            other => panic!("unexpected secondary index response: {other:?}"),
-        };
-        assert_eq!(refs, vec![extract.index_ref.clone()]);
-
-        let retrieve = ContextRetrieveRequest {
-            shard_id: 1,
-            tenant_hash: 20260622,
-            node_hashes: vec![refs[0].primary_node_hash],
-            query: "When did Caroline move the cardiology appointment after the museum visit?"
-                .to_string(),
-            start_time_ms: 1_712_299_000_000,
-            end_time_ms: 1_712_301_000_000,
-            max_events: 8,
-            min_confidence: 0.0,
-            min_importance: 0.0,
-            tiers: vec![ContextTier::L0, ContextTier::L1, ContextTier::L2],
-            max_summary_nodes: 32,
-            max_event_nodes: 16,
-            prefer_current_agent: false,
-            current_agent_scope_key: "agent:codex".to_string(),
-            provider: ContextModelProviderConfig::default(),
-        };
-        let retrieved = retrieve_context(&engine, retrieve.clone());
-        assert!(retrieved.status.ok, "{:?}", retrieved.status);
-        assert!(retrieved
-            .blocks
-            .iter()
-            .any(|block| { block.tier == ContextTier::L0 && block.text == node_entity.l0 }));
-        assert!(retrieved
-            .blocks
-            .iter()
-            .any(|block| block.tier == ContextTier::L1));
-        assert!(retrieved
-            .blocks
-            .iter()
-            .any(|block| { block.tier == ContextTier::L2 && block.text == slab.text }));
-        let l1_summary = engine.execute(ExecuteRequest {
-            shard_id: 1,
-            command: Command::ContextQuerySummaries {
-                tenant_hash: 20260622,
-                node_hash: node_entity.node_hash,
-                level: 2,
-                as_of_ms: slab.event_time_ms,
-                limit: Some(2),
-            },
-        });
-        assert!(matches!(
-            l1_summary.response,
-            CommandResponse::ContextSummaries { ref summaries, .. }
-                if summaries.iter().any(|summary| summary.text == node_entity.l1_ref)
-        ));
-
-        let inject = inject_context(
+    let engine = test_engine();
+    let extract = extract_context(
             &engine,
-            ContextInjectRequest {
-                retrieve,
-                prompt: "Answer with retrieved TemporalStore memory.".to_string(),
-                session_hash: stable_hash64("locomo-conv-7"),
-                query_id: "locomo-context-entity-segment-index".to_string(),
-                max_prompt_tokens: 192,
+            ContextExtractRequest {
+                shard_id: 1,
+                tenant_hash: 20260622,
+                source_kind: ContextSourceKind::Chat,
+                source_id: "locomo-conv-7-session-3-turn-18".to_string(),
+                title: "Caroline medical appointment update".to_string(),
+                body: "Caroline told Maya on March 12 that her cardiology appointment moved after the museum visit. Maya should remind her brother Leo before Friday. The updated cardiology appointment is now confirmed for the following week.".to_string(),
+                timestamp_ms: 1_712_300_000_000,
                 provider: ContextModelProviderConfig::default(),
             },
         );
-        assert!(inject.status.ok, "{:?}", inject.status);
-        assert!(inject
-            .selected_blocks
-            .iter()
-            .any(|block| block.tier == ContextTier::L0));
-        assert!(inject
-            .selected_blocks
-            .iter()
-            .any(|block| block.tier == ContextTier::L1));
-        assert!(inject
-            .selected_blocks
-            .iter()
-            .any(|block| block.tier == ContextTier::L2));
-        assert!(inject.injected_prompt.contains(&node_entity.l0));
-        assert!(inject.injected_prompt.contains("cardiology appointment"));
-        assert!(inject.injected_prompt.contains("museum visit"));
-        assert!(inject
-            .audit
-            .selected_refs
-            .iter()
-            .any(|audit| audit.node_hash == node_entity.node_hash
-                && audit.event_time_ms == slab.event_time_ms));
-})
+    assert!(extract.status.ok, "{:?}", extract.status);
+
+    let node_entity: crate::ContextNode = extract.node.clone();
+    let slab: crate::ContextSlab = extract.event.clone();
+    assert_eq!(node_entity.node_hash, extract.index_ref.primary_node_hash);
+    assert_eq!(slab.event_id_hash, extract.index_ref.event_id_hash);
+    assert!(node_entity.l0.contains("Caroline"));
+    assert!(node_entity.l1_ref.contains("kind=Chat"));
+    assert!(slab
+        .text
+        .contains("cardiology appointment moved after the museum visit"));
+    assert!(slab.related_node_hashes.is_empty());
+    assert_eq!(extract.related_node_hashes, vec![node_entity.node_hash]);
+
+
+    let retrieve = ContextRetrieveRequest {
+        shard_id: 1,
+        tenant_hash: 20260622,
+        node_hashes: vec![extract.index_ref.primary_node_hash],
+        query: "When did Caroline move the cardiology appointment after the museum visit?"
+            .to_string(),
+        start_time_ms: 1_712_299_000_000,
+        end_time_ms: 1_712_301_000_000,
+        max_events: 8,
+        min_confidence: 0.0,
+        min_importance: 0.0,
+        tiers: vec![ContextTier::L0, ContextTier::L1, ContextTier::L2],
+        max_summary_nodes: 32,
+        max_event_nodes: 16,
+        prefer_current_agent: false,
+        current_agent_scope_key: "agent:codex".to_string(),
+        provider: ContextModelProviderConfig::default(),
+    };
+    let retrieved = retrieve_context(&engine, retrieve.clone());
+    assert!(retrieved.status.ok, "{:?}", retrieved.status);
+    assert!(retrieved
+        .blocks
+        .iter()
+        .any(|block| { block.tier == ContextTier::L0 && block.text == node_entity.l0 }));
+    assert!(retrieved
+        .blocks
+        .iter()
+        .any(|block| block.tier == ContextTier::L1));
+    assert!(retrieved
+        .blocks
+        .iter()
+        .any(|block| { block.tier == ContextTier::L2 && block.text == slab.text }));
+    let l1_summary = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextQuerySummaries {
+            tenant_hash: 20260622,
+            node_hash: node_entity.node_hash,
+            level: 2,
+            as_of_ms: slab.event_time_ms,
+            limit: Some(2),
+        },
+    });
+    assert!(matches!(
+        l1_summary.response,
+        CommandResponse::ContextSummaries { ref summaries, .. }
+            if summaries.iter().any(|summary| summary.text == node_entity.l1_ref)
+    ));
+
+    let inject = inject_context(
+        &engine,
+        ContextInjectRequest {
+            retrieve,
+            prompt: "Answer with retrieved TemporalStore memory.".to_string(),
+            session_hash: stable_hash64("locomo-conv-7"),
+            query_id: "locomo-context-entity-segment-index".to_string(),
+            max_prompt_tokens: 192,
+            provider: ContextModelProviderConfig::default(),
+        },
+    );
+    assert!(inject.status.ok, "{:?}", inject.status);
+    assert!(inject
+        .selected_blocks
+        .iter()
+        .any(|block| block.tier == ContextTier::L0));
+    assert!(inject
+        .selected_blocks
+        .iter()
+        .any(|block| block.tier == ContextTier::L1));
+    assert!(inject
+        .selected_blocks
+        .iter()
+        .any(|block| block.tier == ContextTier::L2));
+    assert!(inject.injected_prompt.contains(&node_entity.l0));
+    assert!(inject.injected_prompt.contains("cardiology appointment"));
+    assert!(inject.injected_prompt.contains("museum visit"));
+    assert!(inject
+        .audit
+        .selected_refs
+        .iter()
+        .any(|audit| audit.node_hash == node_entity.node_hash
+            && audit.event_time_ms == slab.event_time_ms));
 }
 
 // shared-corpus: context_management_ingest_retrieve_pipeline
@@ -2662,164 +2632,136 @@ fn context_skill_registry_supports_updates_and_retrieval_selection() {
 // shared-corpus: context_resource_skill_parser_reference_parity
 #[test]
 fn parsed_resource_and_skill_chunks_feed_rust_ingestion_and_retrieval() {
-    with_secondary_indexes(|| {
-        let dir = tempfile::tempdir().unwrap();
-        let cache_dir = dir.path().join("cache");
-        let page_dir = dir.path().join("pages");
-        let index_dir = dir.path().join("indexes");
-        let engine = TemporalEngine::with_local_dirs(1024 * 1024, &cache_dir, &page_dir, &index_dir);
-        engine.load_shard(1);
-        let report = ingest_resource_skill_context(
-            &engine,
-            ContextResourceSkillIngestRequest {
-                shard_id: 1,
-                tenant_hash: 42,
-                resources: vec![ContextResourceParseRequest {
-                raw_uri: "baseline://resources/runbook.md".to_string(),
-                resource_type: Some("md".to_string()),
-                text: "# Incident\n\nCheckout latency increased because the payment dependency timed out.\n\n## Fix\n\nRollback the payment gateway canary and verify p95 latency."
-                    .to_string(),
-                max_chunk_chars: 220,
-                overlap_chars: 40,
-                chunk_hash_base: None,
-                owner_scope: "team:payments".to_string(),
-                version: "v1".to_string(),
-                watch_interval_minutes: 15,
-                parser_name: "unit-test-parser".to_string(),
-                },
-                ],
-                skills: vec![ContextSkillIngestInput {
-                    raw_uri: "skills/payment-incident/SKILL.md".to_string(),
-                    text: "---\nname: payment-incident\ndescription: Debug payment incident context.\nprecedence: high\nowner_scope: team:payments\nallowed_tools: [context_workflow_harness]\ntriggers: [payment, checkout, latency]\n---\n\n# Payment Incident\n\n## When To Use\n\nUse when checkout latency or payment risk spikes.\n"
-                        .to_string(),
-                }],
-                query: "payment dependency rollback p95 latency".to_string(),
-                start_time_ms: 0,
-                end_time_ms: 10_000,
-                max_events: 8,
-                provider: ContextModelProviderConfig::default(),
-            },
-        );
-        assert!(
-            report.status.ok,
-            "status={:?} fanout={:?} secondary_indexes={:?}",
-            report.status, report.fanout, report.secondary_indexes
-        );
-        assert_eq!(report.ingest.failed, 0);
-        assert!(report.ingest.extracts.iter().all(|extract| {
-            extract.event.source_ref.is_empty()
-                && extract.event.related_node_hashes.is_empty()
-                && extract.event.compact_attrs.is_empty()
-                && !extract.source_ref.is_empty()
-                && !extract.related_node_hashes.is_empty()
-                && extract.summary_refs.len() == 2
-        }));
-        assert_eq!(report.resource_lifecycle.watched_count, 1);
-        assert_eq!(
-            report
-                .resource_lifecycle
-                .import_kinds
-                .get("markdown")
-                .copied(),
-            Some(1)
-        );
-        assert_eq!(report.skill_registry.enabled_count, 1);
-        assert_eq!(
-            report.skill_registry.highest_precedence,
-            ContextSkillPrecedence::High
-        );
-        assert_eq!(
-            report.skill_selection.selected[0].skill_name,
-            "payment-incident"
-        );
-        assert!(report.skill_selection.selected[0]
-            .matched_triggers
-            .contains(&"payment".to_string()));
-        assert!(report.fanout.query_back_ok, "{:?}", report.fanout);
-        assert!(
-            report.secondary_indexes.query_back_ok,
-            "{:?}",
-            report.secondary_indexes
-        );
-        assert_eq!(report.fanout.node_count, report.ingest.accepted);
-        assert_eq!(report.fanout.event_count, report.ingest.accepted);
-        assert_eq!(report.fanout.slab_count, report.ingest.accepted);
-        assert_eq!(report.fanout.entity_count, report.ingest.accepted);
-        assert_eq!(report.fanout.child_ref_count, report.ingest.accepted);
-        assert_eq!(report.fanout.compression_count, report.ingest.accepted);
-        assert_eq!(report.fanout.summary_count, report.ingest.accepted * 2);
-        assert_eq!(report.fanout.embedding_count, report.ingest.accepted * 3);
-        assert_eq!(report.fanout.dirty_marker_count, report.ingest.accepted);
-        assert!(!report.secondary_indexes.resource_refs.is_empty());
-        assert!(!report.secondary_indexes.skill_refs.is_empty());
-        assert!(!report.secondary_indexes.entity_refs.is_empty());
-        assert!(!report.secondary_indexes.source_refs.is_empty());
-        assert!(!report.secondary_indexes.summary_refs.is_empty());
-        assert!(report
-            .retrieval
-            .blocks
-            .iter()
-            .any(|block| block.text.contains("payment dependency timed out")
-                || block.text.contains("payment gateway canary")));
-
-        let extract_node_hashes: Vec<u64> = report
-            .ingest
-            .extracts
-            .iter()
-            .map(|extract| extract.node.node_hash)
-            .collect();
-        let secondary_indexes = report.secondary_indexes.clone();
-        let checked_ref_count = secondary_indexes.resource_refs.len()
-            + secondary_indexes.skill_refs.len()
-            + secondary_indexes.entity_refs.len()
-            + secondary_indexes.source_refs.len()
-            + secondary_indexes.summary_refs.len();
-        drop(engine);
-
-        let restored = TemporalEngine::with_local_dirs(1024 * 1024, &cache_dir, &page_dir, &index_dir);
-        restored.load_shard(1);
-        // The vectors persisted on the nodes themselves, so a cold reload proves embedding
-        // durability by fetching the owners.
-        let nodes = restored.execute(ExecuteRequest {
+    let dir = tempfile::tempdir().unwrap();
+    let cache_dir = dir.path().join("cache");
+    let page_dir = dir.path().join("pages");
+    let index_dir = dir.path().join("indexes");
+    let engine = TemporalEngine::with_local_dirs(1024 * 1024, &cache_dir, &page_dir, &index_dir);
+    engine.load_shard(1);
+    let report = ingest_resource_skill_context(
+        &engine,
+        ContextResourceSkillIngestRequest {
             shard_id: 1,
-            command: Command::ContextGetNodes {
-                tenant_hash: 42,
-                node_hashes: extract_node_hashes.clone(),
+            tenant_hash: 42,
+            resources: vec![ContextResourceParseRequest {
+            raw_uri: "baseline://resources/runbook.md".to_string(),
+            resource_type: Some("md".to_string()),
+            text: "# Incident\n\nCheckout latency increased because the payment dependency timed out.\n\n## Fix\n\nRollback the payment gateway canary and verify p95 latency."
+                .to_string(),
+            max_chunk_chars: 220,
+            overlap_chars: 40,
+            chunk_hash_base: None,
+            owner_scope: "team:payments".to_string(),
+            version: "v1".to_string(),
+            watch_interval_minutes: 15,
+            parser_name: "unit-test-parser".to_string(),
             },
-        });
-        assert!(matches!(
-            nodes.response,
-            CommandResponse::ContextNodes { ref nodes }
-                if nodes.len() == extract_node_hashes.len()
-                    && nodes.iter().all(|node| node.vector.len() == 16)
-        ));
-        let validation = validate_resource_skill_secondary_indexes(
-            &restored,
-            ContextResourceSkillSecondaryIndexValidationRequest {
-                shard_id: 1,
-                tenant_hash: 42,
-                start_time_ms: 0,
-                end_time_ms: 10_000,
-                secondary_indexes,
-            },
-        );
-        assert!(
-            validation.status.ok,
-            "secondary index validation failed: {:?}",
-            validation
-        );
-        assert!(validation.query_back_ok);
-        assert_eq!(validation.checked_ref_count, checked_ref_count);
-        assert_eq!(validation.found_ref_count, checked_ref_count);
-        assert!(validation.missing_refs.is_empty());
-        assert_eq!(validation.families.len(), 5);
-        assert!(validation
-            .families
-            .iter()
-            .all(|family| family.checked_ref_count > 0
-                && family.checked_ref_count == family.found_ref_count
-                && family.missing_refs.is_empty()));
-})
+            ],
+            skills: vec![ContextSkillIngestInput {
+                raw_uri: "skills/payment-incident/SKILL.md".to_string(),
+                text: "---\nname: payment-incident\ndescription: Debug payment incident context.\nprecedence: high\nowner_scope: team:payments\nallowed_tools: [context_workflow_harness]\ntriggers: [payment, checkout, latency]\n---\n\n# Payment Incident\n\n## When To Use\n\nUse when checkout latency or payment risk spikes.\n"
+                    .to_string(),
+            }],
+            query: "payment dependency rollback p95 latency".to_string(),
+            start_time_ms: 0,
+            end_time_ms: 10_000,
+            max_events: 8,
+            provider: ContextModelProviderConfig::default(),
+        },
+    );
+    assert!(
+        report.status.ok,
+        "status={:?} fanout={:?} secondary_indexes={:?}",
+        report.status, report.fanout, report.secondary_indexes
+    );
+    assert_eq!(report.ingest.failed, 0);
+    assert!(report.ingest.extracts.iter().all(|extract| {
+        extract.event.source_ref.is_empty()
+            && extract.event.related_node_hashes.is_empty()
+            && extract.event.compact_attrs.is_empty()
+            && !extract.source_ref.is_empty()
+            && !extract.related_node_hashes.is_empty()
+            && extract.summary_refs.len() == 2
+    }));
+    assert_eq!(report.resource_lifecycle.watched_count, 1);
+    assert_eq!(
+        report
+            .resource_lifecycle
+            .import_kinds
+            .get("markdown")
+            .copied(),
+        Some(1)
+    );
+    assert_eq!(report.skill_registry.enabled_count, 1);
+    assert_eq!(
+        report.skill_registry.highest_precedence,
+        ContextSkillPrecedence::High
+    );
+    assert_eq!(
+        report.skill_selection.selected[0].skill_name,
+        "payment-incident"
+    );
+    assert!(report.skill_selection.selected[0]
+        .matched_triggers
+        .contains(&"payment".to_string()));
+    assert!(report.fanout.query_back_ok, "{:?}", report.fanout);
+    assert!(
+        report.secondary_indexes.query_back_ok,
+        "{:?}",
+        report.secondary_indexes
+    );
+    assert_eq!(report.fanout.node_count, report.ingest.accepted);
+    assert_eq!(report.fanout.event_count, report.ingest.accepted);
+    assert_eq!(report.fanout.slab_count, report.ingest.accepted);
+    assert_eq!(report.fanout.entity_count, report.ingest.accepted);
+    assert_eq!(report.fanout.child_ref_count, report.ingest.accepted);
+    assert_eq!(report.fanout.compression_count, report.ingest.accepted);
+    assert_eq!(report.fanout.summary_count, report.ingest.accepted * 2);
+    assert_eq!(report.fanout.embedding_count, report.ingest.accepted * 3);
+    assert_eq!(report.fanout.dirty_marker_count, report.ingest.accepted);
+    assert!(!report.secondary_indexes.resource_refs.is_empty());
+    assert!(!report.secondary_indexes.skill_refs.is_empty());
+    assert!(!report.secondary_indexes.entity_refs.is_empty());
+    assert!(!report.secondary_indexes.source_refs.is_empty());
+    assert!(!report.secondary_indexes.summary_refs.is_empty());
+    assert!(report
+        .retrieval
+        .blocks
+        .iter()
+        .any(|block| block.text.contains("payment dependency timed out")
+            || block.text.contains("payment gateway canary")));
+
+    let extract_node_hashes: Vec<u64> = report
+        .ingest
+        .extracts
+        .iter()
+        .map(|extract| extract.node.node_hash)
+        .collect();
+    let secondary_indexes = report.secondary_indexes.clone();
+    let checked_ref_count = secondary_indexes.resource_refs.len()
+        + secondary_indexes.skill_refs.len()
+        + secondary_indexes.entity_refs.len()
+        + secondary_indexes.source_refs.len()
+        + secondary_indexes.summary_refs.len();
+    drop(engine);
+
+    let restored = TemporalEngine::with_local_dirs(1024 * 1024, &cache_dir, &page_dir, &index_dir);
+    restored.load_shard(1);
+    // The vectors persisted on the nodes themselves, so a cold reload proves embedding
+    // durability by fetching the owners.
+    let nodes = restored.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextGetNodes {
+            tenant_hash: 42,
+            node_hashes: extract_node_hashes.clone(),
+        },
+    });
+    assert!(matches!(
+        nodes.response,
+        CommandResponse::ContextNodes { ref nodes }
+            if nodes.len() == extract_node_hashes.len()
+                && nodes.iter().all(|node| node.vector.len() == 16)
+    ));
 }
 
 // shared-corpus: context_resource_skill_live_embedding_summary_retrieval

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -8,7 +8,7 @@ within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 293 of them, read by 91 functions.
+There are 292 of them, read by 90 functions.
 
 Deleting unreachable code is not the lever. An earlier version of this document argued that
 by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
@@ -46,8 +46,8 @@ Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 293 |
-| booleans whose default this could read off the source | 29 |
+| total | 292 |
+| booleans whose default this could read off the source | 28 |
 | numbers whose default this could read off the source | 35 |
 | **defaulting on, and set by nothing** | 1 |
 | offered on the portal | 26 |
@@ -290,7 +290,7 @@ Sizes, ceilings and intervals. The tuning a deployment actually reaches for.
 | `TS_STORAGE_ZONE_SIZE` | 1073741824 | config, portal | 1 | — |
 | `TS_STREAM_MAX_BLOB_SIZE` | 10485760 | config, portal | 1 | — |
 
-## context (24)
+## context (23)
 
 The memory pipeline: what gets extracted, embedded, drained and packed. The surface a deployment tunes for recall rather than for throughput.
 
@@ -308,7 +308,6 @@ The memory pipeline: what gets extracted, embedded, drained and packed. The surf
 | `MATRIXARK_CONTEXT_COMPRESSION_WINDOW` | — | nothing | 1 | — |
 | `MATRIXARK_CONTEXT_EVENT_QUERY_OVERFETCH` | 2 | nothing | 1 | — |
 | `MATRIXARK_CONTEXT_EVENT_SCAN_CAP` | 64 | nothing | 1 | — |
-| `MATRIXARK_CONTEXT_SECONDARY_INDEX` | off | test | 1 | — |
 | `MATRIXARK_EMBEDDING_MODEL` | — | config, script, test, portal | 1 | — |
 | `MATRIXARK_EMBED_API_KEY_ENV` | — | nothing | 1 | — |
 | `MATRIXARK_EMBED_BASE_URL` | — | config, script | 1 | — |

--- a/tools/test_a_two_path_flag_says_why.py
+++ b/tools/test_a_two_path_flag_says_why.py
@@ -37,10 +37,12 @@ INVENTORY = os.path.join(REPO, "docs", "ops", "temporalstore-engine-flags.md")
 
 # Every boolean whose other arm no shipped selector reaches, and why it keeps one.
 KNOWN_TWO_PATH_FLAGS: Dict[str, str] = {
-    "MATRIXARK_CONTEXT_SECONDARY_INDEX":
-        "retrieval does not read the ctxidx refs, so ON is write-only cost on the live path -- but "
-        "ON is what the harness query-back validation reads, and the accessor calls it the escape "
-        "hatch for anything still on that surface, held until a redesign gives the refs a reader",
+    # Empty, and that is the finding rather than an oversight: no boolean flag in the
+    # engine now carries a second arm that nothing ships a selector for. The entries that
+    # were here were resolved two ways -- five collapsed to the arm every deployment took,
+    # and six struck once the sweep was corrected to ask the whole tree, which showed a
+    # harness script selecting them. A new entry means somebody added a branch nothing can
+    # choose; decide about it here rather than leaving it to be rediscovered.
 }
 
 # The eight benchmark modes are one decision, not eight, and it is worth saying so once: they live


### PR DESCRIPTION
`MATRIXARK_CONTEXT_SECONDARY_INDEX` defaulted OFF and gated three things:

1. a `ContextWriteIndexRef` command on the source index,
2. an ingest loop that wrote each ref durably when ON and only **reported** it when OFF,
3. an ingest-time query-back that returned immediately when OFF.

**Nothing shipped selected it.** Every deployment took the OFF arm, and the accessor said plainly
why: retrieval does not read these refs, so on the live path they were one durable command per
index value per ingest whose only reader was the verifier checking the writes it had just made.

All three keep the OFF arm. The refs are **still reported**, so a caller still learns what *would*
be indexed; nothing is written, and nothing is queried back during ingest.

### What survives, deliberately

`query_missing_secondary_index_refs` and the harness-facing
`validate_resource_skill_secondary_indexes`. That path was never gated — it queries back whatever
refs it is handed — so the harness can still ask, and now answers accurately that nothing is
indexed.

### The two tests

Both opted in through a helper that set the variable, and **neither was about the feature**: one
covers the entity slab and the L0/L1 pair, the other covers ingestion and retrieval across a
reload. Each loses its secondary-index section and keeps the rest; the helper goes with the
feature. Where a later assertion consumed the query-back result, it now names the node the extract
already names — the same node.

Most of the line count in `tests.rs` is the dedent from unwrapping those two bodies, not new
content.

### On reversibility

The accessor held this open until a redesign gives the refs a reader. That redesign now starts
from this commit's parent rather than from a flag, and the write path is one revert away.

### Checks

| | |
|---|---|
| crate | compiles |
| `context_workflow` tests | **51 passed, 0 failed** |
| full lib, single-threaded | 12 failed — all in `wal::` and `raft::` |
| **main**, `wal::` alone | **the same 12** |
| engine inventory | **292** flags |

Those 12 arrived with the WAL compression that landed earlier today, not with this.

### The decision list is now empty

No boolean flag in the engine carries a second arm that nothing can select. A new entry there
means somebody added a branch nothing can choose.
