### PR TITLE
The portal shows the footprint it asks you to trade

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -4000,16 +4000,12 @@ def _configured_engine_settings() -> list:
     return sorted(set(names))
 
 
-def _probe_storage_backend(cfg: GatewayConfig) -> Optional[Json]:
-    """Which storage backend the datanode actually resolved. None => could not determine.
+def _engine_metrics_text(cfg: GatewayConfig) -> Optional[str]:
+    """The datanode's /metrics response, or None if it could not be read.
 
-    Read from the engine instead of re-derived here, because the two can disagree and the engine is
-    the one that is right: `TS_STORAGE_BACKEND=shared` with no directory, or `matrixobject` on a
-    build without the feature, both fall through to auto-detection without erroring, so a
-    deployment routinely runs a backend nobody selected. The engine publishes what it chose as
-    `temporalstore_storage_backend{backend=...}`; the *reason* it chose it exists only in a startup
-    log line, so this reports the outcome and the portal says plainly that the reason is not
-    available over HTTP.
+    Lifted out of the backend probe because the same response answers more than one question and
+    the overview should not ask twice for it. Everything that reads it is a pure parser over this
+    text, so a series the engine does not publish is absent rather than fatal to the others.
     """
     try:
         conn = cfg.blob_connection_factory(cfg)
@@ -4025,7 +4021,146 @@ def _probe_storage_backend(cfg: GatewayConfig) -> Optional[Json]:
         _safe_close(conn)
         if status >= 400:
             return None
-        text = body.decode("utf-8", "replace")
+        return body.decode("utf-8", "replace")
+    except Exception:
+        return None
+
+
+def _prom_samples(text: str, name: str):
+    """(labels, value) for every sample of one series. A malformed line is skipped, not fatal."""
+    prefix = name + "{"
+    for line in text.splitlines():
+        if not line.startswith(prefix):
+            continue
+        close = line.rfind("}")
+        if close < 0:
+            continue
+        try:
+            value = float(line[close + 1:].strip().split()[0])
+        except (IndexError, ValueError):
+            continue
+        yield _parse_prom_labels(line), value
+
+
+def _engine_footprint(text: Optional[str]) -> Json:
+    """What the engine says it is holding, summed across shards.
+
+    `available` is false when the engine published none of it, which is a fact about the
+    deployment rather than an error -- an older engine, or one that has not served a request yet.
+    Reporting zero for that would be a number, and a wrong one.
+
+    `cache_memory_bytes` is the tier the two cache-size settings actually trade: their help calls
+    it "a direct trade of footprint against lookup latency" and this is the footprint half.
+    Logical and physical store bytes are carried together because the ratio between them is the
+    compression a deployment is really getting, which no single number shows.
+    """
+    if not text:
+        return {"available": False}
+    found = False
+    cache: Json = {}
+    for labels, value in _prom_samples(text, "temporalstore_cache_bytes"):
+        tier = labels.get("tier") or ""
+        if not tier:
+            continue
+        found = True
+        cache[tier] = cache.get(tier, 0.0) + value
+    logical = physical = 0.0
+    for labels, value in _prom_samples(text, "temporalstore_storage_slot_bytes"):
+        kind = labels.get("kind") or ""
+        if kind == "logical":
+            found = True
+            logical += value
+        elif kind == "physical":
+            found = True
+            physical += value
+    if not found:
+        return {"available": False}
+    out: Json = {
+        "available": True,
+        "cache_memory_bytes": int(cache.get("memory", 0.0)),
+        "cache_disk_bytes": int(cache.get("disk", 0.0)),
+        "cache_compression_saved_bytes": int(cache.get("compression_saved", 0.0)),
+        "store_logical_bytes": int(logical),
+        "store_physical_bytes": int(physical),
+    }
+    # Only when both halves are real: a ratio against a zero denominator is not a compression
+    # figure, and 0.0 beside "compression" reads as "none", which is a different claim.
+    if physical > 0 and logical > 0:
+        out["store_compression_ratio"] = round(logical / physical, 2)
+    return out
+
+
+def _worker_resident() -> Json:
+    """This worker's resident memory, and where the number came from.
+
+    The source is reported because the two ways of asking do not agree about units:
+    `ru_maxrss` is kilobytes on Linux and BYTES on macOS, and a panel that picks wrong is out by a
+    factor of 1024 while looking entirely plausible. /proc is unambiguous, so it is preferred and
+    named.
+    """
+    try:
+        with open("/proc/self/status", encoding="utf-8") as handle:
+            fields: Json = {}
+            for line in handle:
+                if line.startswith(("VmRSS:", "VmHWM:")):
+                    key, value = line.split(":", 1)
+                    fields[key] = int(value.strip().split()[0]) * 1024
+        if fields.get("VmRSS"):
+            return {"resident_bytes": int(fields["VmRSS"]),
+                    "peak_bytes": int(fields.get("VmHWM") or fields["VmRSS"]),
+                    "source": "/proc/self/status"}
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import resource as _resource
+
+        raw = _resource.getrusage(_resource.RUSAGE_SELF).ru_maxrss
+        peak = int(raw) * (1 if sys.platform == "darwin" else 1024)
+        # Only the peak is available this way. Reporting it as "resident" would overstate a worker
+        # that has since given memory back.
+        return {"resident_bytes": None, "peak_bytes": peak, "source": "ru_maxrss"}
+    except Exception:  # pragma: no cover - a platform with neither
+        return {"resident_bytes": None, "peak_bytes": None, "source": "unavailable"}
+
+
+def _footprint_summary(cfg: GatewayConfig, text: Optional[str] = None) -> Json:
+    """What this deployment is holding, on the page that asks an operator to trade it.
+
+    Six settings ask for that trade in their own words -- the page and block index caches call it
+    "a direct trade of footprint against lookup latency", `generate_embeddings` prices itself at
+    "~13% of resident memory", `share_repeated_values` quotes 761 MB against 1.1 GB -- and the
+    portal showed no footprint at all. A control whose stated unit is invisible on the same page
+    is a decision the customer is asked to make blind.
+
+    The worker figures are ONE worker's and are never summed. Resident sets share pages, so adding
+    four workers together produces a number larger than the machine is using; the worker count is
+    reported beside them so the reader can see there are others without being handed a total that
+    would be wrong.
+    """
+    worker = _worker_resident()
+    worker["workers"] = _worker_count()
+    return {
+        "worker": worker,
+        "engine": _engine_footprint(_engine_metrics_text(cfg) if text is None else text),
+    }
+
+
+def _probe_storage_backend(cfg: GatewayConfig, text: Optional[str] = None) -> Optional[Json]:
+    """Which storage backend the datanode actually resolved. None => could not determine.
+
+    Read from the engine instead of re-derived here, because the two can disagree and the engine is
+    the one that is right: `TS_STORAGE_BACKEND=shared` with no directory, or `matrixobject` on a
+    build without the feature, both fall through to auto-detection without erroring, so a
+    deployment routinely runs a backend nobody selected. The engine publishes what it chose as
+    `temporalstore_storage_backend{backend=...}`; the *reason* it chose it exists only in a startup
+    log line, so this reports the outcome and the portal says plainly that the reason is not
+    available over HTTP.
+    """
+    try:
+        if text is None:
+            text = _engine_metrics_text(cfg)
+        if text is None:
+            return None
         outcome: Json = {}
         reason = ""
         for line in text.splitlines():
@@ -4618,11 +4753,15 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
             imports = _import_progress()
             # Asked once per overview. Best-effort: an unreachable datanode leaves the row
             # saying so rather than failing the page that exists to report on the deployment.
-            live = _probe_storage_backend(cfg)
+            engine_metrics = _engine_metrics_text(cfg)
+            live = _probe_storage_backend(cfg, engine_metrics)
             if live:
                 config_snapshot = dict(config_snapshot)
                 config_snapshot["live_storage_backend"] = live.get("backend")
                 config_snapshot["live_storage_reason"] = live.get("reason") or ""
+            # `or ""` and not `or None`: None means nobody has asked, which would send this to ask
+            # a second time for a response the line above already has.
+            footprint = _footprint_summary(cfg, engine_metrics or "")
             # From the frame's shared cache, so this endpoint adds no probing of its own.
             datanode_state = await _datanode_for_frame(cfg)
             checks = _readiness_checks(config_snapshot, counts, cfg,
@@ -4637,6 +4776,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                 "ready": all(c["status"] != "todo" for c in checks),
                 "counts": counts,
                 "traffic": traffic,
+                "footprint": footprint,
                 "imports": imports,
                 "config": config_snapshot,
             })
@@ -4892,6 +5032,25 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                 config_snapshot = _model_config_snapshot()
             except Exception:
                 config_snapshot = None
+            try:
+                resident = _worker_resident()
+                extra.append("# HELP matrixark_gateway_worker_resident_bytes Resident memory of "
+                             "the worker that served this scrape.")
+                extra.append("# TYPE matrixark_gateway_worker_resident_bytes gauge")
+                # Labelled by source so a scrape taken through the fallback is distinguishable
+                # from one taken through /proc, rather than silently comparable to it.
+                for field, series in (("resident_bytes", "matrixark_gateway_worker_resident_bytes"),
+                                      ("peak_bytes", "matrixark_gateway_worker_peak_bytes")):
+                    value = resident.get(field)
+                    if value is None:
+                        continue
+                    if series.endswith("peak_bytes"):
+                        extra.append("# TYPE matrixark_gateway_worker_peak_bytes gauge")
+                    extra.append('%s{source="%s"} %d'
+                                 % (series, resident.get("source", "unknown"), int(value)))
+                extra.append("matrixark_gateway_workers %d" % _worker_count())
+            except Exception:  # pragma: no cover - the scrape is worth more than this figure
+                pass
             body = _gwmetrics.prometheus_text(config_snapshot, extra)
             return await _text(send, 200, body, content_type="text/plain; version=0.0.4")
 

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -1096,6 +1096,19 @@ SETUP_BODY = """
       or last Tuesday.</p>
     <div id="failures"><div class="empty">Nothing yet.</div></div>
   </section>
+
+  <section>
+    <h2>Footprint</h2>
+    <p class="hint" style="margin-top:0">What this deployment is holding. Several settings ask you
+      to trade memory against speed &mdash; the page and block index caches call it
+      &ldquo;a direct trade of footprint against lookup latency&rdquo;, and turning embeddings off
+      is priced at about 13%% of resident memory &mdash; and this is the half of that trade the
+      portal could not show you.</p>
+    <p class="hint">The worker figures are <strong>one worker&rsquo;s</strong>. Resident sets share
+      pages, so four workers do not come to four times this, and no total is offered here that
+      would be wrong.</p>
+    <div id="footprint"><div class="empty">Loading&hellip;</div></div>
+  </section>
   </section>
 
   <section class="pane" role="tabpanel" aria-labelledby="tab-deployment" id="pane-deployment" hidden>
@@ -2307,6 +2320,50 @@ SETUP_JS = r"""
     }));
   }
 
+  /* ---------- footprint ---------- */
+  function mib(bytes) {
+    /* A dash, not a zero: "not published" and "holding nothing" are different answers and only
+       one of them is ever true here. */
+    if (bytes === null || bytes === undefined) { return "\u2014"; }
+    var mb = bytes / 1048576;
+    return mb >= 1024 ? (mb / 1024).toFixed(2) + " GB" : mb.toFixed(1) + " MB";
+  }
+
+  function renderFootprint(data) {
+    var w = (data || {}).worker || {};
+    var e = (data || {}).engine || {};
+    var rows = "";
+    function row(label, value, aux) {
+      rows += "<tr><td>" + label + '</td><td class="num">' + value
+            + '</td><td class="aux">' + (aux || "") + "</td></tr>";
+    }
+    row("This worker, resident", mib(w.resident_bytes), w.source || "");
+    row("This worker, peak", mib(w.peak_bytes),
+        w.workers > 1 ? w.workers + " workers &mdash; not summed" : "");
+    if (e.available) {
+      row("Engine cache, in memory", mib(e.cache_memory_bytes),
+          "what the index cache sizes trade");
+      row("Store on disk", mib(e.store_physical_bytes),
+          e.store_compression_ratio
+            ? e.store_compression_ratio + "\u00d7 smaller than its logical size" : "");
+    } else {
+      /* Not zero. An engine that publishes none of this is a fact about the deployment, and a
+         zero here would be a number the operator could act on wrongly. */
+      row("Engine", "\u2014", "this datanode does not publish it");
+    }
+    $("footprint").innerHTML = "<table><tbody>" + rows + "</tbody></table>";
+  }
+
+  function loadFootprint() {
+    fetch("/v1/admin/overview", { headers: auth() })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+      .then(function (d) { renderFootprint(d.footprint); })
+      .catch(function () {
+        $("footprint").innerHTML =
+          '<div class="msg err">Could not read the footprint.</div>';
+      });
+  }
+
   function loadTraffic() {
     fetch("/v1/metrics?ts=" + Date.now())
       .then(function (r) { return r.ok ? r.text() : Promise.reject(r.status); })
@@ -2850,6 +2907,7 @@ SETUP_JS = r"""
   markDirty();
   load();
   loadTraffic();  /* one read so the table is populated before the first frame arrives */
+  loadFootprint();
 }());
 </script>
 """

--- a/tools/portal/footprint_panel_harness.js
+++ b/tools/portal/footprint_panel_harness.js
@@ -1,0 +1,146 @@
+/* Run the Setup page, hand it a footprint, and read what it drew.
+ *
+ * Nothing here is provable from source. The renderer exists whether or not anything calls it, a
+ * figure written into the wrong cell looks the same in a diff as one written into the right one,
+ * and the case that matters most -- an engine that publishes no footprint -- differs from the
+ * healthy case only in whether a dash or a zero reaches the page.
+ *
+ * Usage: node footprint_panel_harness.js <setup_portal.html> [published|absent|multiworker]
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const mode = process.argv[3] || "published";
+const scripts = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+const WORKER = {
+  resident_bytes: 412 * 1048576,
+  peak_bytes: 455 * 1048576,
+  source: "/proc/self/status",
+  workers: mode === "multiworker" ? 4 : 1
+};
+const ENGINE = mode === "absent" ? { available: false } : {
+  available: true,
+  cache_memory_bytes: 96 * 1048576,
+  cache_disk_bytes: 12 * 1048576,
+  cache_compression_saved_bytes: 3 * 1048576,
+  store_logical_bytes: 6 * 1073741824,
+  store_physical_bytes: 2 * 1073741824,
+  store_compression_ratio: 3.0
+};
+const OVERVIEW = { status: "ok", footprint: { worker: WORKER, engine: ENGINE } };
+
+const els = new Map();
+function makeEl(id) {
+  return {
+    id: id || "", hidden: false, textContent: "",
+    value: id === "key" ? "k-admin" : "", checked: true, className: "",
+    style: {}, dataset: {}, files: [], options: [], children: [], _html: "",
+    get innerHTML() { return this._html; },
+    set innerHTML(v) { this._html = String(v); },
+    addEventListener() {}, removeEventListener() {}, appendChild() {}, removeChild() {},
+    setAttribute() {}, getAttribute() { return null; }, closest() { return null; },
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    scrollIntoView() {}, focus() {}, click() {},
+    classList: { add() {}, remove() {}, toggle() {} }
+  };
+}
+function el(id) {
+  if (!els.has(id)) { els.set(id, makeEl(id)); }
+  return els.get(id);
+}
+
+let overviewCalls = 0;
+
+const win = {
+  document: {
+    getElementById: (id) => el(id),
+    querySelector: () => makeEl(), querySelectorAll: () => [],
+    createElement: () => makeEl(), addEventListener() {}, body: makeEl(), hidden: false
+  },
+  addEventListener() {},
+  location: { origin: "http://localhost", href: "http://localhost", reload() {} },
+  sessionStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  localStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  navigator: {},
+  setTimeout: () => 0, setInterval: () => 0, clearInterval() {},
+  Number, JSON, String, Math, Date, Object, Array, Promise, RegExp, Error, isNaN,
+  encodeURIComponent, decodeURIComponent, parseInt, parseFloat,
+  TextDecoder: function () { this.decode = (v) => Buffer.from(v || []).toString("utf8"); },
+  AbortController: function () { this.abort = () => {}; this.signal = {}; },
+  FileReader: function () {}, Blob: function () {},
+  URL: { createObjectURL: () => "", revokeObjectURL() {} },
+  fetch: (url) => {
+    const u = String(url);
+    if (u.indexOf("/v1/admin/overview") >= 0) {
+      overviewCalls += 1;
+      return Promise.resolve({ ok: true, status: 200,
+                               json: () => Promise.resolve(OVERVIEW),
+                               text: () => Promise.resolve(JSON.stringify(OVERVIEW)) });
+    }
+    if (u.indexOf("/v1/admin/events") >= 0) {
+      return Promise.resolve({ ok: true, status: 200,
+                               body: { getReader: () => ({ read: () => new Promise(() => {}) }) },
+                               json: () => Promise.resolve({}), text: () => Promise.resolve("") });
+    }
+    return Promise.resolve({ ok: true, status: 200,
+                             json: () => Promise.resolve({ settings: {} }),
+                             text: () => Promise.resolve("") });
+  }
+};
+win.window = win;
+
+const names = Object.keys(win);
+const values = names.map((k) => win[k]);
+scripts.forEach((body, index) => {
+  try { new Function(...names, body)(...values); }
+  catch (e) { console.log("FAIL script " + index + " threw: " + e.message); failures += 1; }
+});
+
+setTimeout(function () {
+  const html = el("footprint").innerHTML;
+
+  ok("the page asked for the footprint", overviewCalls > 0, "overview calls: " + overviewCalls);
+  ok("it is no longer the loading placeholder", !/Loading/.test(html), html.slice(0, 160));
+
+  /* The whole point of the panel: a number, in a unit a person reads. */
+  ok("this worker's resident memory is shown", /412\.0 MB/.test(html), html.slice(0, 400));
+  ok("the peak is shown too", /455\.0 MB/.test(html), html.slice(0, 400));
+  ok("where the number came from is named", /\/proc\/self\/status/.test(html),
+     html.slice(0, 400));
+
+  if (mode === "multiworker") {
+    /* Resident sets share pages. A total would be larger than the machine is using, so the panel
+       must say there are others WITHOUT offering one. */
+    ok("it says the figure is one worker's of several", /4 workers/.test(html),
+       html.slice(0, 500));
+    ok("it offers no total", !/1648\.0 MB/.test(html) && !/1\.61 GB/.test(html),
+       html.slice(0, 500));
+  }
+
+  if (mode === "absent") {
+    /* The case this panel is most likely to get wrong: an engine publishing nothing must not read
+       as an engine holding nothing. */
+    ok("an unpublished engine footprint is a dash, not a zero",
+       /—/.test(html) && !/0\.0 MB/.test(html), html.slice(0, 500));
+    ok("and it says why", /does not publish/.test(html), html.slice(0, 500));
+  } else {
+    ok("the engine cache memory is shown", /96\.0 MB/.test(html), html.slice(0, 500));
+    ok("the store size is shown in GB, not thousands of MB", /2\.00 GB/.test(html),
+       html.slice(0, 500));
+    /* Logical and physical are carried together because the ratio between them is the only place
+       the compression a deployment actually gets is visible. */
+    ok("the compression it is really getting is shown", /3×|3 ?×/.test(html),
+       html.slice(0, 500));
+  }
+
+  console.log(failures ? "\n" + failures + " failed" : "\nall ok");
+  process.exit(failures ? 1 : 0);
+}, 60);

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -593,6 +593,19 @@
       or last Tuesday.</p>
     <div id="failures"><div class="empty">Nothing yet.</div></div>
   </section>
+
+  <section>
+    <h2>Footprint</h2>
+    <p class="hint" style="margin-top:0">What this deployment is holding. Several settings ask you
+      to trade memory against speed &mdash; the page and block index caches call it
+      &ldquo;a direct trade of footprint against lookup latency&rdquo;, and turning embeddings off
+      is priced at about 13% of resident memory &mdash; and this is the half of that trade the
+      portal could not show you.</p>
+    <p class="hint">The worker figures are <strong>one worker&rsquo;s</strong>. Resident sets share
+      pages, so four workers do not come to four times this, and no total is offered here that
+      would be wrong.</p>
+    <div id="footprint"><div class="empty">Loading&hellip;</div></div>
+  </section>
   </section>
 
   <section class="pane" role="tabpanel" aria-labelledby="tab-deployment" id="pane-deployment" hidden>
@@ -2022,6 +2035,50 @@ function liveStream(options) {
     }));
   }
 
+  /* ---------- footprint ---------- */
+  function mib(bytes) {
+    /* A dash, not a zero: "not published" and "holding nothing" are different answers and only
+       one of them is ever true here. */
+    if (bytes === null || bytes === undefined) { return "\u2014"; }
+    var mb = bytes / 1048576;
+    return mb >= 1024 ? (mb / 1024).toFixed(2) + " GB" : mb.toFixed(1) + " MB";
+  }
+
+  function renderFootprint(data) {
+    var w = (data || {}).worker || {};
+    var e = (data || {}).engine || {};
+    var rows = "";
+    function row(label, value, aux) {
+      rows += "<tr><td>" + label + '</td><td class="num">' + value
+            + '</td><td class="aux">' + (aux || "") + "</td></tr>";
+    }
+    row("This worker, resident", mib(w.resident_bytes), w.source || "");
+    row("This worker, peak", mib(w.peak_bytes),
+        w.workers > 1 ? w.workers + " workers &mdash; not summed" : "");
+    if (e.available) {
+      row("Engine cache, in memory", mib(e.cache_memory_bytes),
+          "what the index cache sizes trade");
+      row("Store on disk", mib(e.store_physical_bytes),
+          e.store_compression_ratio
+            ? e.store_compression_ratio + "\u00d7 smaller than its logical size" : "");
+    } else {
+      /* Not zero. An engine that publishes none of this is a fact about the deployment, and a
+         zero here would be a number the operator could act on wrongly. */
+      row("Engine", "\u2014", "this datanode does not publish it");
+    }
+    $("footprint").innerHTML = "<table><tbody>" + rows + "</tbody></table>";
+  }
+
+  function loadFootprint() {
+    fetch("/v1/admin/overview", { headers: auth() })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+      .then(function (d) { renderFootprint(d.footprint); })
+      .catch(function () {
+        $("footprint").innerHTML =
+          '<div class="msg err">Could not read the footprint.</div>';
+      });
+  }
+
   function loadTraffic() {
     fetch("/v1/metrics?ts=" + Date.now())
       .then(function (r) { return r.ok ? r.text() : Promise.reject(r.status); })
@@ -2565,6 +2622,7 @@ function liveStream(options) {
   markDirty();
   load();
   loadTraffic();  /* one read so the table is populated before the first frame arrives */
+  loadFootprint();
 }());
 </script>
 <script>

--- a/tools/test_matrixark_the_portal_shows_the_footprint_it_asks_you_to_trade.py
+++ b/tools/test_matrixark_the_portal_shows_the_footprint_it_asks_you_to_trade.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The portal shows the footprint it asks you to trade.
+
+Six settings ask an operator to trade memory against speed in their own words -- the page and block
+index caches call it "a direct trade of footprint against lookup latency", `generate_embeddings`
+prices itself at "~13% of resident memory", `share_repeated_values` quotes 761 MB against 1.1 GB --
+and the portal reported no footprint at all. Nothing anywhere did: not the page, not the overview,
+not `/v1/metrics`. A control whose stated unit is invisible on the same page is a decision the
+customer is asked to make blind.
+
+Two things here are easier to get wrong than to get right, so both are pinned:
+
+* **A dash is not a zero.** An engine that publishes no footprint and an engine holding nothing
+  differ only in what reaches the page, and "0.0 MB" is a number an operator can act on wrongly.
+* **Worker figures do not add up.** Resident sets share pages, so summing four workers produces a
+  figure larger than the machine is using. The panel names the worker count and offers no total.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+import matrixark_gateway_config as cfg  # noqa: E402
+import matrixark_v1_gateway as gateway  # noqa: E402
+
+PORTAL = os.path.join(TOOLS, "portal")
+CRATE = os.path.abspath(os.path.join(TOOLS, os.pardir, "crates", "temporalstore-rust", "src"))
+
+# The engine's own format, shard-labelled exactly as `prometheus_metrics.rs` emits it.
+SAMPLE = "\n".join([
+    "# HELP temporalstore_cache_bytes Cache bytes by shard and tier.",
+    "# TYPE temporalstore_cache_bytes gauge",
+    'temporalstore_cache_bytes{shard_id="1",tier="memory"} 12345',
+    'temporalstore_cache_bytes{shard_id="2",tier="memory"} 23456',
+    'temporalstore_cache_bytes{shard_id="1",tier="disk"} 999',
+    'temporalstore_cache_bytes{shard_id="1",tier="compression_saved"} 4096',
+    'temporalstore_storage_slot_bytes{shard_id="1",slot="0",kind="logical"} 1000000',
+    'temporalstore_storage_slot_bytes{shard_id="1",slot="1",kind="logical"} 200000',
+    'temporalstore_storage_slot_bytes{shard_id="1",slot="0",kind="physical"} 250000',
+    'temporalstore_storage_slot_bytes{shard_id="1",slot="1",kind="physical"} 50000',
+    'temporalstore_storage_backend{backend="shared",replication="none"} 1',
+])
+
+# The settings that name the trade. Derived from their own words, not listed by hand, so a setting
+# that starts talking about memory joins the rule automatically.
+TRADE_WORDS = ("resident memory", "trade of footprint", "peak memory", "hold more memory",
+               "% of resident memory")
+
+
+class CountingConfig:
+    """A cfg whose connection factory records how often anything asked the engine."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def blob_connection_factory(self, _cfg):
+        self.calls += 1
+        raise OSError("no engine here")
+
+
+class TheEngineFootprintIsParsedTest(unittest.TestCase):
+
+    def test_cache_memory_is_summed_across_shards(self) -> None:
+        found = gateway._engine_footprint(SAMPLE)
+        self.assertTrue(found["available"])
+        self.assertEqual(12345 + 23456, found["cache_memory_bytes"])
+
+    def test_the_other_tiers_are_kept_apart(self) -> None:
+        """Summing disk into memory would report resident memory the process is not holding, and
+        the cache settings would then look far more expensive than they are."""
+        found = gateway._engine_footprint(SAMPLE)
+        self.assertEqual(999, found["cache_disk_bytes"])
+        self.assertEqual(4096, found["cache_compression_saved_bytes"])
+        for tier, value in (("disk", 999), ("compression_saved", 4096)):
+            with self.subTest(tier=tier):
+                self.assertNotEqual(12345 + 23456 + value, found["cache_memory_bytes"],
+                                    "the %s tier was counted as memory" % tier)
+
+    def test_the_store_is_summed_by_kind(self) -> None:
+        found = gateway._engine_footprint(SAMPLE)
+        self.assertEqual(1200000, found["store_logical_bytes"])
+        self.assertEqual(300000, found["store_physical_bytes"])
+
+    def test_the_ratio_is_the_compression_actually_achieved(self) -> None:
+        """Logical and physical travel together because neither alone shows it."""
+        self.assertEqual(4.0, gateway._engine_footprint(SAMPLE)["store_compression_ratio"])
+
+    def test_a_malformed_line_is_skipped_not_fatal(self) -> None:
+        broken = SAMPLE + "\n" + 'temporalstore_cache_bytes{shard_id="3",tier="memory"} bananas'
+        self.assertEqual(12345 + 23456, gateway._engine_footprint(broken)["cache_memory_bytes"])
+
+
+class AnUnpublishedFootprintIsNotAZeroTest(unittest.TestCase):
+    """The case most likely to be got wrong, and the one an operator would act on."""
+
+    def test_an_engine_publishing_none_of_it_says_so(self) -> None:
+        for text in (None, "", "# nothing this build publishes"):
+            with self.subTest(text=text):
+                found = gateway._engine_footprint(text)
+                self.assertFalse(found["available"])
+
+    def test_and_reports_no_bytes_at_all_rather_than_zero_bytes(self) -> None:
+        found = gateway._engine_footprint("# nothing this build publishes")
+        for key in found:
+            self.assertFalse(key.endswith("_bytes"),
+                             "%s reported as a number when nothing published it" % key)
+
+    def test_the_ratio_is_absent_when_it_would_be_meaningless(self) -> None:
+        """A ratio against a zero denominator is not a compression figure, and 0.0 beside
+        'compression' reads as 'none', which is a different claim."""
+        only_logical = 'temporalstore_storage_slot_bytes{shard_id="1",slot="0",kind="logical"} 10'
+        found = gateway._engine_footprint(only_logical)
+        self.assertTrue(found["available"])
+        self.assertNotIn("store_compression_ratio", found)
+
+    def test_the_positive_control(self) -> None:
+        """The floor: a parser that found nothing anywhere would satisfy every test above."""
+        self.assertTrue(gateway._engine_footprint(SAMPLE)["available"])
+
+
+class TheWorkerReportsItsOwnMemoryTest(unittest.TestCase):
+
+    def test_it_reports_a_number_and_where_it_came_from(self) -> None:
+        found = gateway._worker_resident()
+        self.assertIn(found["source"], ("/proc/self/status", "ru_maxrss", "unavailable"))
+        if found["source"] != "unavailable":
+            self.assertGreater(found["peak_bytes"], 0)
+
+    def test_the_units_are_bytes(self) -> None:
+        """`ru_maxrss` is kilobytes on Linux and BYTES on macOS, so a unit slip is off by 1024x and
+        looks entirely plausible. Cross-checking the two sources catches it: they measure nearly
+        the same thing, so a factor of 1024 between them is not a rounding difference.
+        """
+        found = gateway._worker_resident()
+        if found["source"] != "/proc/self/status":
+            self.skipTest("no /proc on this platform, so there is nothing to cross-check against")
+        import resource
+
+        rusage_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        self.assertGreater(found["peak_bytes"], rusage_kb * 1024 / 4)
+        self.assertLess(found["peak_bytes"], rusage_kb * 1024 * 4)
+
+    def test_the_worker_count_travels_with_it(self) -> None:
+        """Resident sets share pages. The count is what stops a reader summing them."""
+        summary = gateway._footprint_summary(None, SAMPLE)
+        self.assertIn("workers", summary["worker"])
+        self.assertGreaterEqual(summary["worker"]["workers"], 1)
+
+
+class TheEngineIsAskedOnceTest(unittest.TestCase):
+    """The overview needs the backend AND the footprint out of one response."""
+
+    def test_neither_reader_fetches_when_handed_the_text(self) -> None:
+        counting = CountingConfig()
+        gateway._probe_storage_backend(counting, SAMPLE)
+        gateway._footprint_summary(counting, SAMPLE)
+        self.assertEqual(0, counting.calls)
+
+    def test_the_parameter_is_not_ignored(self) -> None:
+        """The floor: a reader that always fetched would still pass the test above if the fetch
+        were free, and one that never fetched would pass it while being useless on its own."""
+        counting = CountingConfig()
+        gateway._footprint_summary(counting)
+        self.assertEqual(1, counting.calls)
+
+    def test_the_backend_probe_still_reads_the_same_text(self) -> None:
+        found = gateway._probe_storage_backend(CountingConfig(), SAMPLE)
+        self.assertEqual("shared", (found or {}).get("backend"))
+
+    def test_the_overview_hands_both_readers_one_response(self) -> None:
+        with open(os.path.join(TOOLS, "matrixark_v1_gateway.py"), encoding="utf-8") as handle:
+            source = handle.read()
+        block = source[source.index('path == "/v1/admin/overview"'):]
+        block = block[:block.index('"config": config_snapshot')]
+        self.assertIn("engine_metrics = _engine_metrics_text(cfg)", block)
+        self.assertIn("_probe_storage_backend(cfg, engine_metrics)", block)
+        self.assertIn("_footprint_summary(cfg, engine_metrics", block)
+
+
+class TheSeriesAreTheOnesTheEngineEmitsTest(unittest.TestCase):
+    """Ask the artefact. A renamed series would leave this panel blank on every deployment, which
+    reads as a deployment holding nothing rather than as a parser looking for the wrong name."""
+
+    def series_in_the_crate(self) -> set:
+        if not os.path.isdir(CRATE):
+            self.skipTest("the engine crate is not in this checkout")
+        found = set()
+        for root, _dirs, files in os.walk(CRATE):
+            for name in files:
+                if not name.endswith(".rs"):
+                    continue
+                with open(os.path.join(root, name), encoding="utf-8", errors="replace") as handle:
+                    found.update(re.findall(r"temporalstore_[a-z_]+", handle.read()))
+        return found
+
+    def test_every_series_this_parses_is_one_the_engine_emits(self) -> None:
+        emitted = self.series_in_the_crate()
+        with open(os.path.join(TOOLS, "matrixark_v1_gateway.py"), encoding="utf-8") as handle:
+            parsed = set(re.findall(r'"(temporalstore_[a-z_]+)"', handle.read()))
+        self.assertTrue(parsed, "the gateway names no engine series at all")
+        for name in sorted(parsed):
+            with self.subTest(series=name):
+                self.assertIn(name, emitted)
+
+    def test_the_two_this_panel_needs_are_among_them(self) -> None:
+        """The floor: the rule above passes on an empty intersection if the panel stopped naming
+        any series, which is exactly what a silent rename would look like."""
+        emitted = self.series_in_the_crate()
+        for name in ("temporalstore_cache_bytes", "temporalstore_storage_slot_bytes"):
+            self.assertIn(name, emitted)
+
+
+class TheScrapeCarriesItTooTest(unittest.TestCase):
+    """A figure that exists only on a page cannot be alerted on or watched over time, which is
+    most of what a footprint is for."""
+
+    def test_the_metrics_route_exports_the_worker_gauge(self) -> None:
+        with open(os.path.join(TOOLS, "matrixark_v1_gateway.py"), encoding="utf-8") as handle:
+            source = handle.read()
+        self.assertIn("matrixark_gateway_worker_resident_bytes", source)
+        self.assertIn("matrixark_gateway_workers", source)
+
+
+class ThePageDrawsItTest(unittest.TestCase):
+    """The renderer exists whether or not anything calls it, and a figure in the wrong cell looks
+    the same in a diff as one in the right cell. So the page is run."""
+
+    def run_harness(self, mode: str) -> str:
+        node = subprocess.run(
+            ["node", "footprint_panel_harness.js", "setup_portal.html", mode],
+            cwd=PORTAL, capture_output=True, text=True, timeout=600)
+        return node.stdout + node.stderr
+
+    def setUp(self) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    def test_a_published_footprint_is_drawn(self) -> None:
+        out = self.run_harness("published")
+        self.assertIn("all ok", out, out)
+
+    def test_an_absent_one_is_a_dash(self) -> None:
+        out = self.run_harness("absent")
+        self.assertIn("all ok", out, out)
+
+    def test_several_workers_are_named_and_not_summed(self) -> None:
+        out = self.run_harness("multiworker")
+        self.assertIn("all ok", out, out)
+
+
+class TheSettingsThatAskForTheTradeTest(unittest.TestCase):
+    """Why this panel exists, kept honest: if no setting asked for the trade any more, the panel
+    would be decoration and this suite should say so rather than passing quietly."""
+
+    def settings_naming_memory(self):
+        return [s for s in cfg.SETTINGS
+                if any(word in (s.label + " " + s.help).lower() for word in TRADE_WORDS)]
+
+    def test_several_settings_still_price_themselves_in_memory(self) -> None:
+        found = self.settings_naming_memory()
+        self.assertGreaterEqual(len(found), 3,
+                                "only %d settings name the trade: %s"
+                                % (len(found), [s.key for s in found]))
+
+    def test_the_index_caches_are_among_them(self) -> None:
+        keys = {s.key for s in self.settings_naming_memory()}
+        self.assertIn("storage_engine.page_index_cache_bytes", keys)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Six settings ask an operator to trade memory against speed, in their own words:

| setting | what its help says |
|---|---|
| `storage_engine.page_index_cache_bytes` | "This is resident memory the process keeps, so it is **a direct trade of footprint against lookup latency**." |
| `storage_engine.block_index_cache_bytes` | "Same trade as the page index cache, on the block side." |
| `behaviour.generate_embeddings` | "embeddings are **~13% of resident memory**" |
| `ingestion.share_repeated_values` | "resident memory at **761 MB instead of 1.1 GB**" |
| `storage_engine.stream_max_blob_size` | "raises the **peak memory** a single request can hold" |
| `storage_engine.malloc_trim` | "asks the allocator to hand back memory it is no longer using" |

The portal showed no footprint at all — and neither did anything else. Not the page, not
`/v1/admin/overview`, not `/v1/metrics`. Six controls priced in a unit the deployment never
reported, so every one of those decisions was made blind.

This reports what the deployment is holding, on the page that asks for the trade.

- **This worker**: resident and peak bytes, and *which* of the two ways of asking produced them.
  `/proc/self/status` is preferred and named; `ru_maxrss` is the fallback and is labelled as such,
  because it is kilobytes on Linux and **bytes** on macOS — a panel that picks wrong is out by
  1024× and looks entirely plausible either way. A test cross-checks the two sources against each
  other, which is what catches a dropped unit conversion.
- **The engine**: cache memory by tier, and the store's logical and physical size. Both halves of
  the store figure travel together because the ratio between them is the compression a deployment
  is *actually* getting, which neither number alone shows.

### Two things it refuses to do

**It does not sum workers.** Resident sets share pages, so four workers do not come to four times
one worker's figure — the total would be larger than the machine is using. The panel reports one
worker's numbers and names the worker count beside them, and a test asserts no total appears.

**It does not report zero for an unpublished figure.** An engine that publishes none of this and an
engine holding nothing differ only in what reaches the page, and `0.0 MB` is a number an operator
can act on. Absent is absent: `{"available": false}` with no `_bytes` keys at all, and a dash on
the page. The compression ratio is likewise omitted rather than shown as `0.0`, because "0.0"
beside "compression" reads as *none*, which is a different claim.

### One response, two readers

The overview already fetched the datanode's `/metrics` to ask which storage backend it resolved.
The fetch is lifted out into `_engine_metrics_text`, and the backend probe and the footprint are
both pure parsers over that text — so the footprint costs no additional request, and a series one
of them wants but the engine does not publish is absent rather than fatal to the other.
`_probe_storage_backend(cfg)` keeps working unchanged for its two other callers.

The worker figures are in `/v1/metrics` too. A number that exists only on a page cannot be alerted
on or watched over time, which is most of what a footprint is for.

```
nothing published is reported as zero bytes             -> FAIL
the disk tier is summed into the memory tier            -> FAIL
a second shard replaces the first instead of adding     -> FAIL
a ratio is offered against a zero denominator           -> FAIL
the worker's kilobytes are reported as bytes            -> FAIL
the summary ignores the response it was handed          -> FAIL
the overview goes back to asking twice                  -> FAIL
the page draws a zero where nothing was published       -> FAIL
the page offers a total across workers                  -> FAIL
the page stops asking for the footprint                 -> FAIL
the parser looks for a series the engine does not emit  -> FAIL
```

24 tests. The page is **run**, not read: a Node harness executes the page's own scripts against a
stubbed DOM in three states — published, absent, and several workers — because the renderer exists
whether or not anything calls it, and a figure written into the wrong cell looks the same in a diff
as one written into the right cell.

One test asks the artefact rather than the plan: every `temporalstore_*` series this parser names
is checked against the names the engine crate actually emits. A renamed series would leave the
panel blank on every deployment, which reads as a deployment holding nothing rather than as a
parser looking for the wrong word.

A last test keeps the premise honest — if no setting priced itself in memory any more, this panel
would be decoration, and the suite says so rather than passing quietly.

### One thing worth naming

The first version of the panel was written straight into `setup_portal.html`, which is **generated**
by `build_portal_pages.py`. `test_matrixark_portal_pages` caught it — an edit made to the output
survives exactly until the next person runs the generator, and then vanishes. The markup and the
renderer live in the generator now, and the emitted page is byte-identical to what was committed.
The generator renders each body through `body % {"nav": ...}`, so the literal `13%` quoted above had
to be doubled; without that the render dies rather than producing a wrong page, which is the better
of the two failures.

Neighbours: the derived list of every suite naming the gateway, the portal pages, the metrics
module or the storage probe — 75, one process each. 74 green. `bundle_harness`'s "the copy button is
wired" fails identically on the base branch and is not from this change.

Stacked on [#1026](https://github.com/matrixarkai/TemporalStore/pull/1026).
