### PR TITLE
Let the maintenance cycle dump the buckets that block log reclaim

### DIFF
--- a/crates/temporalstore-rust/src/engine/reports.rs
+++ b/crates/temporalstore-rust/src/engine/reports.rs
@@ -3026,6 +3026,13 @@ fn commit_dirty_buckets_before_truncation_default() -> bool {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StorageManagerCycleRequest {
     pub shard_id: ShardId,
+    /// Dump exactly these buckets instead of the dirty ones.
+    ///
+    /// Reclaim wants a dump manifest matching each bucket's current generation; a bucket that
+    /// went clean without ever being dumped at that generation has none, and the dirty-only
+    /// cadence will never dump it again. Naming buckets here is the only way to clear that.
+    #[serde(default)]
+    pub selected_dump_buckets: Vec<u32>,
     #[serde(default)]
     pub dry_run: bool,
     #[serde(default = "default_storage_manager_stage_enabled")]
@@ -3111,6 +3118,7 @@ impl Default for StorageManagerCycleRequest {
     fn default() -> Self {
         Self {
             shard_id: 0,
+            selected_dump_buckets: Vec::new(),
             dry_run: false,
             enable_prepare: true,
             enable_wal_reclaim: true,

--- a/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
+++ b/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
@@ -83,7 +83,7 @@ impl TemporalEngine {
         .collect::<Vec<_>>();
         let plan_request = StorageLifecycleRequest {
             shard_id: request.shard_id,
-            selected_dump_buckets: Vec::new(),
+            selected_dump_buckets: request.selected_dump_buckets.clone(),
             max_dump_buckets_per_round: request.max_dump_buckets_per_round,
             min_undumped_wal_records: if request.enable_wal_reclaim {
                 request.min_undumped_wal_records

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -16856,3 +16856,78 @@ fn an_entity_upsert_does_not_report_its_page_uncovered() {
         "an entity upsert reported its own page uncovered, so every entity write rebuilds the          whole bucket index: {stray:?}"
     );
 }
+
+/// A caller's bucket list reaches the lifecycle planner.
+///
+/// `run_storage_manager_cycle` hardcoded `selected_dump_buckets: Vec::new()`, so nothing outside
+/// the engine could ask for particular buckets to be dumped -- and that list is the only way to
+/// dump a bucket that is not dirty.
+///
+/// It matters because reclaim wants a dump manifest matching each bucket's CURRENT generation, and
+/// a bucket that went clean without ever being dumped at that generation has none. The ordinary
+/// cadence only ever selects DIRTY buckets, so such a bucket is never dumped again and the log can
+/// never be reclaimed past it. Seen on a live store as 3,085 such buckets, unchanged however many
+/// cycles were run, while the log grew ~15 MB/hour and cold start grew with it.
+#[test]
+fn a_requested_bucket_list_reaches_the_lifecycle_planner() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringSet {
+            key: "named".to_string(),
+            value: b"v1".to_vec(),
+        },
+    });
+
+    // Dump what is dirty, so the store is clean and the ordinary cadence has nothing to select.
+    engine.run_storage_manager_cycle(StorageManagerCycleRequest {
+        shard_id: 1,
+        max_dump_buckets_per_round: 64,
+        warm_cache: false,
+        ..StorageManagerCycleRequest::default()
+    });
+
+    // The control: with nothing dirty and no list, the planner selects nothing. Without this, a
+    // cycle that always dumped everything would satisfy the assertion below and bring back the
+    // write amplification the dirty-only selection exists to avoid.
+    let unnamed = engine.run_storage_manager_cycle(StorageManagerCycleRequest {
+        shard_id: 1,
+        max_dump_buckets_per_round: 64,
+        warm_cache: false,
+        ..StorageManagerCycleRequest::default()
+    });
+    assert!(
+        unnamed.plan.selected_dump_buckets.is_empty(),
+        "a clean store with no requested buckets must select nothing to dump, got {:?}",
+        unnamed.plan.selected_dump_buckets
+    );
+
+    let every_bucket = engine
+        .bucket_storage_summaries(1)
+        .iter()
+        .map(|summary| summary.routing_bucket)
+        .collect::<Vec<u32>>();
+    assert!(
+        !every_bucket.is_empty(),
+        "the fixture must have produced at least one bucket to name"
+    );
+    let named = engine.run_storage_manager_cycle(StorageManagerCycleRequest {
+        shard_id: 1,
+        selected_dump_buckets: every_bucket.clone(),
+        max_dump_buckets_per_round: 64,
+        warm_cache: false,
+        ..StorageManagerCycleRequest::default()
+    });
+    assert_eq!(
+        named.plan.selected_dump_buckets, every_bucket,
+        "the requested buckets must reach the planner even when none of them is dirty -- \
+         otherwise a bucket that went clean undumped can never be covered and the log stays blocked"
+    );
+}

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -3620,11 +3620,40 @@ fn execute_record_log_request(
             // `shard_size` carries the dump budget: the request shape has no field for it, and
             // adding one would change a wire format for a maintenance call.
             let budget = request.shard_size.unwrap_or(4).clamp(1, 1024) as usize;
+            // `field == "unblock_reclaim"` dumps the buckets that BLOCK reclaim rather than the
+            // dirty ones. Reclaim wants a manifest matching each bucket's current generation; a
+            // bucket that went clean without ever being dumped at that generation has none, and
+            // the ordinary cadence only selects DIRTY buckets -- so it will never be dumped again
+            // and the log can never be reclaimed past it. Observed on one box as 3,085 such
+            // buckets, unchanged across cycles, with the log growing ~15 MB/hour and cold start
+            // growing with it at ~0.13 s per MB.
+            let selected_dump_buckets = if request.field == "unblock_reclaim" {
+                // EVERY bucket, not just the ones reclaim currently reports as missing.
+                //
+                // Coverage is exactly the last round's dump: the cycle keeps one bucket-dump
+                // manifest, so dumping the missing buckets covers those and un-covers everything
+                // dumped before. Measured on a real store, chasing the missing list oscillated --
+                // 2085 dumped left 1008 missing, then 1032 dumped left 2061 missing -- and would
+                // never converge. If only the last round is covered, the last round has to hold
+                // every bucket.
+                local
+                    .bucket_storage_summaries(DEFAULT_SHARD_ID)
+                    .into_iter()
+                    .map(|summary| summary.routing_bucket)
+                    .collect::<Vec<u32>>()
+            } else {
+                Vec::new()
+            };
+            let requested_unblock_buckets = selected_dump_buckets.len();
+            // The ordinary budget paces the dirty-bucket cadence; it must not silently truncate an
+            // unblock round, which would leave the log blocked and look like it had been tried.
+            let dump_cap = budget.max(requested_unblock_buckets);
             let report = local.run_storage_manager_cycle(
                 temporalstore_rust::engine::reports::StorageManagerCycleRequest {
                     shard_id: DEFAULT_SHARD_ID,
-                    max_dump_buckets_per_round: budget,
+                    max_dump_buckets_per_round: dump_cap,
                     warm_cache: false,
+                    selected_dump_buckets,
                     ..Default::default()
                 },
             );
@@ -3639,7 +3668,10 @@ fn execute_record_log_request(
                 serde_json::json!({
                     "completed": report.completed,
                     "shard_id": DEFAULT_SHARD_ID,
-                    "max_dump_buckets_per_round": budget,
+                    "max_dump_buckets_per_round": dump_cap,
+                    // Say how many blocking buckets this round took on, so a caller can tell
+                    // "nothing was blocking" from "the budget only reached part of the backlog".
+                    "requested_unblock_buckets": requested_unblock_buckets,
                     "duration_ms": report.duration_ms,
                     "stages": report.native_stage_order,
                     "wal_reclaim_report": reclaim,


### PR DESCRIPTION
A log that can never be reclaimed makes every cold start slower, forever. On one box the log had
reached **766 MB across 676 files**, growing ~15 MB/hour and never once shrinking, beside a base
index of 9.5 MB — so the durable state was small and the log was unbounded.

### Why reclaim refused

Reclaim wants, for every bucket, a dump manifest matching that bucket's **current generation**.
Buckets without one are reported as `missing_slot_generations` and raise
`slot_generation_without_durable_dump`. There were **3,085** of them.

The dump stage only ever selects buckets with `dirty_object_count > 0`. A bucket can go clean
without ever having been dumped at its current generation, and once clean nothing will dump it
again — so the blocker is permanent. Three back-to-back cycles at budget 256 left `missing=3085`
unchanged with `covered=0` every round: **not a budget problem**, and no amount of running the
existing cycle could fix it.

`selected_dump_buckets` already bypasses the dirty filter in the lifecycle planner, but
`run_storage_manager_cycle` hardcoded `selected_dump_buckets: Vec::new()`, so no caller could ever
reach it.

### The change

- `StorageManagerCycleRequest` gains `selected_dump_buckets`, threaded through to the planner.
- The proxy op takes `field == "unblock_reclaim"`, which dumps **every** bucket in one round and
  raises its own dump cap to fit, reporting `requested_unblock_buckets`.

Dumping only the *missing* buckets does not work, and the measurements say why: coverage is exactly
the last round's dump, because the cycle keeps one bucket-dump manifest. Chasing the missing list
oscillates —

```
dumped 2085 (all then-missing) -> covered=2085, missing=1008
dumped 1032 (the new missing)  -> covered=1032, missing=2061
```

— and never converges. If only the last round is covered, the last round has to hold every bucket.

### Measured

On a copy of that store, with the whole bucket set named:

```
requested_unblock=3093  covered=3093  missing=0  blockers=[]
applied=true            wal 706 MB -> 378 MB    (399 s)
```

Reclaim applied for the first time and the log halved in one round. Cold start, on two copies
differing only in whether reclaim had run, arms alternated across three rounds because load on that
box swings by 5x:

| | reclaimed (380 MB) | unreclaimed (766 MB) |
|---|---|---|
| round 1 | 29.6 s | 66.1 s |
| round 2 | 30.5 s | 41.8 s |
| round 3 | 21.0 s | 34.3 s |
| **mean** | **27.0 s** | **47.4 s** |

**1.75x faster cold start.** Peak RSS was ~410 MB in every run, so this buys latency, not memory.

An earlier single reading showed the reclaimed store *slower* (81.5 s); it was taken at load 25
against a quiet-box baseline. It is listed here because it is the reason the comparison above
alternates arms and records the load each run saw.

### Test

`a_requested_bucket_list_reaches_the_lifecycle_planner` asserts the requested buckets reach the
planner when none of them is dirty, with a control that a clean store and no list selects nothing —
without which "dump everything every cycle" would pass and reintroduce the write amplification the
dirty-only selection exists to avoid. Verified to fail with the previous `Vec::new()` restored.

`cargo test --release -p temporalstore-rust --lib storage_manager` — 11 passed.
