### PR TITLE
Three benchmark flags collapse to the arm every caller takes

### DIFF
--- a/crates/temporalstore-rust/src/bin/context_workflow_harness.rs
+++ b/crates/temporalstore-rust/src/bin/context_workflow_harness.rs
@@ -620,10 +620,6 @@ fn main() {
         && benchmark_sweep.threshold_violations.is_empty();
     let external_benchmark = run_external_context_benchmark(&engine);
     let resource_skill_scale = run_resource_skill_conversation_scale(&engine);
-    let external_benchmark_report_only =
-        std::env::var("TEMPORALSTORE_CONTEXT_BENCHMARK_REPORT_ONLY")
-            .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
-            .unwrap_or(false);
     let context_pipeline_ready = parity.pipeline_ready
         && restart_replay_ready
         && shared_store_sync_ready
@@ -636,7 +632,7 @@ fn main() {
         && resource_skill_scale.ready
         && benchmark_ready
         && benchmark_sweep_ready
-        && (external_benchmark.ready || external_benchmark_report_only);
+        && external_benchmark.ready;
     assert!(
         context_pipeline_ready,
         "context pipeline readiness failed: parity={} restart={} sync={} async={} raft={} corpus={} management={} ingest_extract={} retrieve={} resource_skill_scale={} benchmark={} sweep={} external_benchmark={} retrieve_events={} retrieve_blocks={} sweep_status={} sweep_message={} sweep_min_hit_at_k={} sweep_min_mrr={} sweep_min_evidence_retention={} sweep_min_token_reduction={} sweep_max_selected_tokens={} sweep_violations={:?}",
@@ -1212,11 +1208,6 @@ fn run_external_context_benchmark(engine: &TemporalEngine) -> ExternalContextBen
         .and_then(|value| value.parse::<usize>().ok())
         .filter(|value| *value > 0)
         .unwrap_or(128);
-    let ingest_chunk_size = std::env::var("TEMPORALSTORE_CONTEXT_BENCHMARK_INGEST_CHUNK_SIZE")
-        .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .filter(|value| *value > 0)
-        .unwrap_or(64);
     let direct_source_scoring =
         std::env::var("TEMPORALSTORE_CONTEXT_BENCHMARK_DIRECT_SOURCE_SCORING")
             .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
@@ -1225,10 +1216,6 @@ fn run_external_context_benchmark(engine: &TemporalEngine) -> ExternalContextBen
         std::env::var("TEMPORALSTORE_CONTEXT_BENCHMARK_SOURCE_ORDER_RANKING")
             .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
             .unwrap_or(false);
-    let compact_source_replay =
-        std::env::var("TEMPORALSTORE_CONTEXT_BENCHMARK_COMPACT_SOURCE_REPLAY")
-            .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
-            .unwrap_or(true);
     let mut ingested_source_sets = BTreeMap::<u64, Vec<u64>>::new();
     let mut retrieved_source_sets = BTreeMap::<u64, Vec<temporalstore_rust::ContextBlock>>::new();
     for (_index, case) in cases.iter().enumerate() {
@@ -1293,34 +1280,9 @@ fn run_external_context_benchmark(engine: &TemporalEngine) -> ExternalContextBen
                         .collect::<Vec<_>>();
                     let mut node_hashes = Vec::new();
                     let mut ingest_ok = true;
-                    if all_source_replay || compact_source_replay {
-                        let started = Instant::now();
-                        match ingest_external_benchmark_sources(engine, tenant_hash, &sources) {
-                            Some(hashes) => node_hashes = hashes,
-                            None => ingest_ok = false,
-                        }
-                    } else {
-                        for chunk in sources.chunks(ingest_chunk_size) {
-                            let started = Instant::now();
-                            let ingest = ingest_extract_context(
-                                engine,
-                                ContextIngestExtractRequest {
-                                    shard_id: 1,
-                                    tenant_hash,
-                                    sources: chunk.to_vec(),
-                                    query: case.query.clone(),
-                                    start_time_ms: 0,
-                                    end_time_ms: 10_000,
-                                    max_events: case_max_events,
-                                    provider: ContextModelProviderConfig::default(),
-                                },
-                            );
-                            if !ingest.status.ok {
-                                ingest_ok = false;
-                                break;
-                            }
-                            node_hashes.extend(ingest.node_hashes);
-                        }
+                    match ingest_external_benchmark_sources(engine, tenant_hash, &sources) {
+                        Some(hashes) => node_hashes = hashes,
+                        None => ingest_ok = false,
                     }
                     if !ingest_ok {
                         Vec::new()

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -8,7 +8,7 @@ within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 292 of them, read by 90 functions.
+There are 289 of them, read by 90 functions.
 
 Deleting unreachable code is not the lever. An earlier version of this document argued that
 by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
@@ -46,12 +46,12 @@ Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 292 |
-| booleans whose default this could read off the source | 28 |
-| numbers whose default this could read off the source | 35 |
-| **defaulting on, and set by nothing** | 1 |
+| total | 289 |
+| booleans whose default this could read off the source | 26 |
+| numbers whose default this could read off the source | 34 |
+| **defaulting on, and set by nothing** | 0 |
 | offered on the portal | 26 |
-| **that nothing in this repository sets** | 172 |
+| **that nothing in this repository sets** | 169 |
 | documented as keeping an older path alive | 5 |
 | reaching more than two files | 15 |
 | whose doc comment is really about another flag | 43 |
@@ -202,7 +202,7 @@ The shape of what is written. Readers generally accept both shapes, which is wha
 | `TS_VECTOR_INT8` | off | test, portal | 1 | — |
 | `TS_VECTOR_SCALED` | on | launch, test, portal | 1 | — |
 
-## capacity (81)
+## capacity (80)
 
 Sizes, ceilings and intervals. The tuning a deployment actually reaches for.
 
@@ -224,7 +224,6 @@ Sizes, ceilings and intervals. The tuning a deployment actually reaches for.
 | `MATRIXARK_RUST_PROXY_PAGE_COMPRESSION_MIN_BYTES` | 256 | test | 1 | — |
 | `MATRIXARK_TEMPORALSTORE_PROXY_CONNECT_TIMEOUT_MS` | — | nothing | 1 | — |
 | `MATRIXARK_TEMPORALSTORE_PROXY_IO_TIMEOUT_MS` | 30000 | nothing | 1 | — |
-| `TEMPORALSTORE_CONTEXT_BENCHMARK_INGEST_CHUNK_SIZE` | 64 | nothing | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_MAX_EVENTS` | 32 | nothing | 1 | — |
 | `TS_BLOB_CHUNK_BYTES` | — | config | 1 | — |
 | `TS_BLOB_PEER_FETCH_TIMEOUT_MS` | — | nothing | 1 | — |
@@ -333,24 +332,22 @@ Who the caller is, not what the engine does. Supplied per request or per process
 | `TEMPORALSTORE_AGENT_NAME` | — | launch | 2 | — |
 | `MATRIXARK_SESSION_ID` | — | nothing | 1 | — |
 
-## diagnostic (3)
+## diagnostic (2)
 
 Extra evidence for someone investigating. Off by default.
 
 | flag | default | set by | files | keeps an older path |
 |---|---|---|---|---|
 | `MATRIXARK_RUST_PROXY_SINGLE_SHOT_DEBUG` | off | script | 1 | — |
-| `TEMPORALSTORE_CONTEXT_BENCHMARK_REPORT_ONLY` | off | nothing | 1 | — |
 | `TS_SCALE_STORAGE_ROOT` | — | nothing | 1 | — |
 
-## benchmark (7)
+## benchmark (6)
 
 Read only by the benchmark harnesses. Never consulted on a serving path.
 
 | flag | default | set by | files | keeps an older path |
 |---|---|---|---|---|
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_ALL_SOURCE_REPLAY` | off | nothing | 1 | — |
-| `TEMPORALSTORE_CONTEXT_BENCHMARK_COMPACT_SOURCE_REPLAY` | on | nothing | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_DIRECT_SOURCE_SCORING` | off | nothing | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_EXTERNAL_ONLY` | off | nothing | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_JSONL` | — | script | 1 | — |

--- a/tools/run_locomo_rust_harness.py
+++ b/tools/run_locomo_rust_harness.py
@@ -83,7 +83,10 @@ def run_rust_temporalstore_backend(args: argparse.Namespace) -> dict[str, Any]:
             f"{converted.stderr.strip() or converted.stdout.strip()}"
         )
     source_limit_applied = int(args.rust_temporalstore_source_limit) > 0
-    rust_source_order_ranking = source_limit_applied or int(args.rust_temporalstore_source_limit) == 0
+    # A source limit is non-negative by contract -- 0 means "all sources" -- so this is on for
+    # every value the argument accepts. The harness default off is what a caller that sets no
+    # benchmark environment gets.
+    rust_source_order_ranking = int(args.rust_temporalstore_source_limit) >= 0
     if source_limit_applied:
         limit_rust_temporalstore_sources(jsonl_path, int(args.rust_temporalstore_source_limit), args.max_events)
     source_pack_size = int(getattr(args, "rust_temporalstore_source_pack_size", 0) or 0)
@@ -103,14 +106,12 @@ def run_rust_temporalstore_backend(args: argparse.Namespace) -> dict[str, Any]:
     env.update(
         {
             "TEMPORALSTORE_CONTEXT_BENCHMARK_EXTERNAL_ONLY": "1",
-            "TEMPORALSTORE_CONTEXT_BENCHMARK_REPORT_ONLY": "1",
             "TEMPORALSTORE_CONTEXT_BENCHMARK_JSONL": str(jsonl_path),
             "TEMPORALSTORE_CONTEXT_BENCHMARK_MAX_EVENTS": str(args.max_events),
             "TEMPORALSTORE_CONTEXT_BENCHMARK_ALL_SOURCE_REPLAY": "1"
             if args.require_full_rust_temporalstore_replay and int(args.rust_temporalstore_source_limit) == 0
             else "0",
             "TEMPORALSTORE_CONTEXT_BENCHMARK_DIRECT_SOURCE_SCORING": "0",
-            "TEMPORALSTORE_CONTEXT_BENCHMARK_COMPACT_SOURCE_REPLAY": "1",
             "TEMPORALSTORE_CONTEXT_BENCHMARK_SOURCE_ORDER_RANKING": "1"
             if rust_source_order_ranking
             else "0",

--- a/tools/test_a_two_path_flag_says_why.py
+++ b/tools/test_a_two_path_flag_says_why.py
@@ -37,12 +37,15 @@ INVENTORY = os.path.join(REPO, "docs", "ops", "temporalstore-engine-flags.md")
 
 # Every boolean whose other arm no shipped selector reaches, and why it keeps one.
 KNOWN_TWO_PATH_FLAGS: Dict[str, str] = {
-    # Empty, and that is the finding rather than an oversight: no boolean flag in the
-    # engine now carries a second arm that nothing ships a selector for. The entries that
-    # were here were resolved two ways -- five collapsed to the arm every deployment took,
-    # and six struck once the sweep was corrected to ask the whole tree, which showed a
-    # harness script selecting them. A new entry means somebody added a branch nothing can
-    # choose; decide about it here rather than leaving it to be rediscovered.
+    # The arm that produces a benchmark result the project refuses to publish. Turning it on
+    # scores the source text directly instead of retrieving it, and marks the run
+    # rust_context_event_ingest=false; validate_benchmark_claims.py and
+    # archive_context_benchmark_report.py both reject a report whose
+    # rust_temporalstore_direct_source_scoring is true. The harness pins it to "0", its own
+    # default, so the published field is always false. The branch is what gives those refusals
+    # something to refuse, and it is the only way to measure the ceiling a real retrieval is
+    # scored against, so it stays.
+    "TEMPORALSTORE_CONTEXT_BENCHMARK_DIRECT_SOURCE_SCORING": "benchmark ceiling, refused when published",
 }
 
 # The eight benchmark modes are one decision, not eight, and it is worth saying so once: they live
@@ -79,14 +82,21 @@ def _rows() -> List[Tuple[str, str, str]]:
     return rows
 
 
-def _selected_anywhere() -> set:
+def _assigned_values() -> Dict[str, set]:
     """Every flag name a tracked file ASSIGNS, anywhere in the repository.
 
     The inventory's own `set by` column cannot answer this: it is built from engine sources, so a
-    flag a Python harness or a shell script sets reads there as selected by nothing. Six of the
-    eight benchmark flags were listed that way, and `tools/run_locomo_rust_harness.py` sets them --
-    four to their non-default arm. A list that says "nothing selects this" about a flag something
-    selects is worse than no list, because it licenses a removal.
+    flag a Python harness or a shell script sets reads there as selected by nothing. Most of the
+    benchmark flags were listed that way while `tools/run_locomo_rust_harness.py` sets them,
+    several to their non-default arm. A list that says "nothing selects this" about a flag
+    something selects is worse than no list, because it licenses a removal.
+
+    An assignment is only a selector when it writes something OTHER than the flag's own default:
+    pinning a flag to the value it already has reaches no second arm. So each name is mapped to
+    the literal values assigned to it, and a name assigned by a form not readable as a literal --
+    a conditional, an f-string, a variable -- keeps counting as a selector. That is the safe
+    direction to be wrong in: it leaves a flag on the list to look at again, where the other
+    direction would license removing a branch something reaches.
     """
     listed = subprocess.run(["git", "ls-files"], cwd=REPO,
                             capture_output=True, text=True).stdout.split()
@@ -95,7 +105,10 @@ def _selected_anywhere() -> set:
         r'|export\s+((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)='            # a shell export
         r'|environ\[\s*"((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)"\s*\]\s*='  # a python set
         r'|set_var\(\s*"((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)"')      # a rust set
-    found = set()
+    literal = re.compile(
+        r""""((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)"\s*:\s*"([^"]*)"\s*,?\s*$"""
+        r"""|export\s+((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)=["']?([A-Za-z01]*)["']?\s*$""")
+    found: Dict[str, set] = {}
     for path in listed:
         if os.path.splitext(path)[1] not in (".py", ".sh", ".rs", ".toml", ".json", ".yaml"):
             continue
@@ -116,16 +129,35 @@ def _selected_anywhere() -> set:
         except OSError:
             continue
         for match in assign.finditer(source):
-            found.add(next(group for group in match.groups() if group))
+            found.setdefault(next(group for group in match.groups() if group), set()).add(None)
+        for line in source.splitlines():
+            hit = literal.search(line)
+            if hit:
+                name = hit.group(1) or hit.group(3)
+                value = hit.group(2) if hit.group(1) else hit.group(4)
+                found.setdefault(name, set()).discard(None)
+                found[name].add(value)
     return found
+
+
+_ON_LITERALS = {"1", "true", "TRUE", "yes", "YES", "True"}
+_OFF_LITERALS = {"0", "false", "FALSE", "no", "NO", "False", ""}
+
+
+def _reaches_the_other_arm(values: set, default: str) -> bool:
+    """True when some assignment writes a value the default does not already have."""
+    if None in values or not values:
+        return True
+    already = _ON_LITERALS if default == "on" else _OFF_LITERALS
+    return any(value not in already for value in values)
 
 
 def _unselected() -> List[str]:
     """Booleans whose other arm nothing ships a selector for, asked of the whole tree."""
-    selected = _selected_anywhere()
+    assigned = _assigned_values()
     out = []
     for name, _default, set_by in _rows():
-        if name in selected:
+        if name in assigned and _reaches_the_other_arm(assigned[name], _default):
             continue
         if set_by == "nothing" or set(part.strip() for part in set_by.split(",")) <= {
                 "test", "harness"}:


### PR DESCRIPTION
The six benchmark flags were the last booleans whose arms had not been decided one at a time.
They are not one decision. Asked individually, three collapse and three stay, and the split is
not where the count suggested.

### The three that collapse

| flag | why the other arm is unreachable |
|---|---|
| `..._REPORT_ONLY` | Its **only setter also sets `EXTERNAL_ONLY=1`**, which returns from `main` at line 389 — before the read at line 624. The two callers that reach the read (`run_temporalstore_conformance_gate.sh`, `run_context_workflow_local.sh`) set no benchmark environment at all. It was always `false` at the point it was read. |
| `..._COMPACT_SOURCE_REPLAY` | Every caller resolves it **true**: the harness script sets `"1"`, and a caller that sets nothing gets the default, which is already `true`. |
| `..._INGEST_CHUNK_SIZE` | Read only inside the branch the line above made unreachable. |

`REPORT_ONLY` was not inert. It read
`(external_benchmark.ready || external_benchmark_report_only)` — an escape meant to let a
report-only run pass when the external benchmark is not ready. Because the flag could never be
true where it was read, the assertion has always required `external_benchmark.ready` outright.
The condition now says that, so what the code promises and what it enforces are the same thing.

Collapsing `COMPACT_SOURCE_REPLAY` removes the chunked ingest branch — 23 lines that no caller
could enter — and the chunk-size knob that only that branch read.

### The three that stay, and why

- **`..._EXTERNAL_ONLY`** — genuinely two live arms. The harness script sets `1`; the conformance
  gate and the local validation script run the same binary with no environment and take the full
  readiness path. Both ship.
- **`..._ALL_SOURCE_REPLAY`** — the script sends `1` or `0` depending on `--require-full-…-replay`
  and `--…-source-limit`, and shipped callers pass that limit both ways (three scripts default it
  to 64, others to 0). Real logic with a real selector.
- **`..._SOURCE_ORDER_RANKING`** — the script always sends `1`; a caller that sets nothing gets
  the default `false`. Both arms reachable.

### A fourth that stays for a different reason, now written down

`..._DIRECT_SOURCE_SCORING` looks selected — the script assigns it — but it assigns `"0"`, which
is its own default. **Pinning a flag to the value it already has reaches no second arm.** So its
ON arm has no shipped selector, and it needed a decision rather than a pass.

It stays. Turning it on scores the source text directly instead of retrieving it, and marks the
run `rust_context_event_ingest=false`. `validate_benchmark_claims.py` and
`archive_context_benchmark_report.py` both **refuse** a report whose
`rust_temporalstore_direct_source_scoring` is true. The branch is what gives those refusals
something to refuse, and it is the only way to measure the ceiling a real retrieval is scored
against. That reason is now recorded in the decision list.

### The guard was passing it for the wrong reason

`test_a_two_path_flag_says_why.py` counted **any** assignment as a selector. It now maps each
name to the literal values assigned to it and asks whether any of them differs from the default.
A name assigned by a form it cannot read as a literal — a conditional, an f-string, a variable —
still counts as a selector: that is the safe direction to be wrong in, since it leaves a flag on
the list to look at again, where the other direction would license removing a branch something
reaches.

Measured before changing it: of 26 booleans, **exactly one** is only ever assigned its own
default, and it is the flag above. The rule finds what a hand pass found, and nothing else.

### Also

`rust_source_order_ranking` read `(limit > 0) or (limit == 0)`. A source limit is non-negative by
contract — `0` means "all sources" — so that is `limit >= 0`, true for every value the argument
accepts. Written as it now reads, identical for every integer including negatives.

### Checks

| | |
|---|---|
| harness | compiles |
| guard, both mutations | drop the decision → **fails undecided**; let the script send `"1"` → **fails stale**; restore → **green** |
| guard | 5 passed |
| engine inventory | 292 → **289** flags |
