### PR TITLE
The budget the agent gets is not the one the panel showed

### DIFF
--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -50,8 +50,8 @@ Anything else is blank, and a blank means go and look.
 | booleans whose default this could read off the source | 26 |
 | numbers whose default this could read off the source | 34 |
 | **defaulting on, and set by nothing** | 0 |
-| offered on the portal | 26 |
-| **that nothing in this repository sets** | 169 |
+| offered on the portal | 27 |
+| **that nothing in this repository sets** | 168 |
 | documented as keeping an older path alive | 5 |
 | reaching more than two files | 15 |
 | whose doc comment is really about another flag | 43 |
@@ -154,7 +154,7 @@ Secrets. Never a form field, never in a launch artifact.
 | flag | default | set by | files | keeps an older path |
 |---|---|---|---|---|
 | `TS_RAFT_AUTH_TOKEN` | — | harness, script | 2 | — |
-| `MATRIXARK_HOOK_MAX_CONTEXT_TOKENS` | — | nothing | 1 | — |
+| `MATRIXARK_HOOK_MAX_CONTEXT_TOKENS` | — | test, portal | 1 | — |
 | `MATRIXARK_MODEL_API_KEY` | — | nothing | 1 | — |
 | `TS_API_AUTH_TOKEN` | — | nothing | 1 | — |
 | `TS_META_ADMIN_TOKEN` | — | nothing | 1 | — |

--- a/tools/matrixark_agent_hook.py
+++ b/tools/matrixark_agent_hook.py
@@ -14,6 +14,15 @@ from __future__ import annotations
 import argparse
 import json
 try:
+    from tools.matrixark_mcp_runtime_config import (
+        hook_max_context_tokens as _hook_max_context_tokens,
+    )
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_runtime_config import (  # type: ignore
+        hook_max_context_tokens as _hook_max_context_tokens,
+    )
+
+try:
     from tools import matrixark_hook_pack_cache as _pack_cache
 except ImportError:  # running from inside tools/, as the hooks do
     import matrixark_hook_pack_cache as _pack_cache
@@ -231,7 +240,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--team", default=os.environ.get("MATRIXARK_TEAM", "agent"))
     parser.add_argument("--project", default=os.environ.get("MATRIXARK_PROJECT", "local"))
     parser.add_argument("--query", default="")
-    parser.add_argument("--max-context-tokens", type=int, default=int(os.environ.get("MATRIXARK_HOOK_MAX_CONTEXT_TOKENS", os.environ.get("MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS", "128000"))))
+    parser.add_argument("--max-context-tokens", type=int,
+                        default=_hook_max_context_tokens())
     parser.add_argument("--metaserver", default=os.environ.get("MATRIXARK_TEMPORALSTORE_METASERVER", "127.0.0.1:18000"))
     parser.add_argument("--namespace", default=os.environ.get("MATRIXARK_TEMPORALSTORE_NAMESPACE", "deploy_ns"))
     parser.add_argument("--table", default=os.environ.get("MATRIXARK_TEMPORALSTORE_TABLE", "deploy_table"))

--- a/tools/matrixark_codex_hook.py
+++ b/tools/matrixark_codex_hook.py
@@ -13,6 +13,15 @@ import argparse
 import hashlib
 import json
 try:
+    from tools.matrixark_mcp_runtime_config import (
+        hook_max_context_tokens as _hook_max_context_tokens,
+    )
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_runtime_config import (  # type: ignore
+        hook_max_context_tokens as _hook_max_context_tokens,
+    )
+
+try:
     from tools import matrixark_hook_pack_cache as _pack_cache
 except ImportError:  # running from inside tools/, as the hooks do
     import matrixark_hook_pack_cache as _pack_cache
@@ -2394,7 +2403,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--team", default=os.environ.get("MATRIXARK_TEAM", "codex"))
     parser.add_argument("--project", default=os.environ.get("MATRIXARK_PROJECT", "local"))
     parser.add_argument("--query", default="")
-    parser.add_argument("--max-context-tokens", type=int, default=int(os.environ.get("MATRIXARK_HOOK_MAX_CONTEXT_TOKENS", os.environ.get("MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS", "128000"))))
+    parser.add_argument("--max-context-tokens", type=int,
+                        default=_hook_max_context_tokens())
     parser.add_argument("--metaserver", default=os.environ.get("MATRIXARK_TEMPORALSTORE_METASERVER", "127.0.0.1:18000"))
     parser.add_argument("--namespace", default=os.environ.get("MATRIXARK_TEMPORALSTORE_NAMESPACE", "deploy_ns"))
     parser.add_argument("--table", default=os.environ.get("MATRIXARK_TEMPORALSTORE_TABLE", "deploy_table"))

--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -453,6 +453,14 @@ SETTINGS: List[Setting] = [
             "share above is set."),
 
     # ---- retrieval and context budget ----------------------------------------------------------
+    Setting("retrieval.hook_max_context_tokens", "retrieval",
+            "MATRIXARK_HOOK_MAX_CONTEXT_TOKENS",
+            "Agent hook context budget (tokens)", "int", "128000", "live",
+            "The budget the agent hooks ask for. They have never used the setting below, and the "
+            "installation manual sets this to 10000 -- so on a deployment installed by the book "
+            "the agent path runs a budget fifty times smaller than the one the panels quoted. "
+            "Every share on the budget panel is a percentage of whichever of the two the caller "
+            "uses."),
     Setting("retrieval.default_max_context_tokens", "retrieval",
             "MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS",
             "Default context budget (tokens)", "int", "500000", "restart",

--- a/tools/matrixark_mcp_runtime_config.py
+++ b/tools/matrixark_mcp_runtime_config.py
@@ -242,6 +242,35 @@ def live_int(variable: str, fallback: int) -> int:
     return parsed if parsed > 0 else fallback
 
 
+DEFAULT_HOOK_MAX_CONTEXT_TOKENS = 128000  # build default; the resolver below reads the env
+
+
+def hook_max_context_tokens() -> int:
+    """The budget an AGENT HOOK asks for, which is not the one an API caller gets.
+
+    `DEFAULT_MAX_CONTEXT_TOKENS` above is 500,000 and is what the packer, the schema documentation
+    and the portal's budget panel all quote. The hooks never used it: they read
+    `MATRIXARK_HOOK_MAX_CONTEXT_TOKENS` first, fall back to `MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS`,
+    and fall back again to a number of their own -- and the installation manual sets the first one
+    to 10,000. So on a deployment installed by the book the agent path runs a budget fifty times
+    smaller than every surface reporting it.
+
+    Both hooks carried this expression inline, which is why nothing could report it: a duplicated
+    literal in two scripts is not something a panel can ask.
+    """
+    for variable in ("MATRIXARK_HOOK_MAX_CONTEXT_TOKENS", "MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS"):
+        raw = os.environ.get(variable)
+        if raw is None:
+            continue
+        try:
+            parsed = int(str(raw).strip())
+        except (TypeError, ValueError):
+            continue
+        if parsed > 0:
+            return parsed
+    return DEFAULT_HOOK_MAX_CONTEXT_TOKENS
+
+
 def live_float(variable: str, fallback: float) -> float:
     """A section's share of the budget, read per pack. The float counterpart of `live_int`.
 

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1700,13 +1700,42 @@ def _shared_budget_summary() -> Json:
             "bound_by": bound_by,
         }
 
+    skills = section("skill", "MATRIXARK_SHARED_SKILL_BUDGET_RATIO",
+                     "DEFAULT_SHARED_SKILL_BUDGET_RATIO")
+    resources = section("resource", "MATRIXARK_SHARED_RESOURCE_BUDGET_RATIO",
+                        "DEFAULT_SHARED_RESOURCE_BUDGET_RATIO")
+    # The agent hooks do not use the budget above and never did. Reporting one number as "the"
+    # context budget made every token figure on this panel wrong for the path that serves agents --
+    # by fifty times on a deployment installed by the manual, which sets the hook budget to 10,000.
+    # The SHARE is the same on both paths; only what it comes to differs, so both are reported and
+    # neither is called the answer.
+    hook_total = runtime.hook_max_context_tokens()
+    paths = []
+    for name, label, budget, variable in (
+            ("api", "API callers", total, "MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS"),
+            ("agent_hooks", "Agent hooks", hook_total, "MATRIXARK_HOOK_MAX_CONTEXT_TOKENS")):
+        paths.append({
+            "path": name,
+            "label": label,
+            "context_budget_tokens": budget,
+            "variable": variable,
+            "sections": {
+                "skills": min(int(budget * float(policy.get("skill_budget_ratio") or 0.0)),
+                              int(policy.get("skill_max_budget_tokens") or budget) or budget),
+                "resources": min(
+                    int(budget * float(policy.get("resource_budget_ratio") or 0.0)),
+                    int(policy.get("resource_max_budget_tokens") or budget) or budget),
+            },
+        })
     return {
         "available": True,
         "context_budget_tokens": total,
-        "skills": section("skill", "MATRIXARK_SHARED_SKILL_BUDGET_RATIO",
-                          "DEFAULT_SHARED_SKILL_BUDGET_RATIO"),
-        "resources": section("resource", "MATRIXARK_SHARED_RESOURCE_BUDGET_RATIO",
-                             "DEFAULT_SHARED_RESOURCE_BUDGET_RATIO"),
+        "skills": skills,
+        "resources": resources,
+        "paths": paths,
+        # Not a warning: on a default deployment they DO differ, and a warning that always fires is
+        # noise. It is a fact the reader needs in order to read the rows above correctly.
+        "paths_differ": hook_total != total,
     }
 
 

--- a/tools/test_a_setting_says_what_overrides_it.py
+++ b/tools/test_a_setting_says_what_overrides_it.py
@@ -39,9 +39,12 @@ _PAIR = re.compile(
     r'environ\.get\(\s*["\']((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)["\']\s*,\s*'
     r'(?:os\.)?(?:environ\.get|getenv)\(\s*["\']((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)["\']')
 
-# 10 pairs and 3 shadowed settings when this was written.
+# 10 pairs and 3 shadowed settings when this was written. The context-token budget was one of the
+# three: the panel field is no longer read as a fallback behind the value the agent is given, so the
+# population is 2 and the floor follows it down. Lowering a floor is only honest when an instance
+# was FIXED -- if this drops again, check that the scan still matches before moving it.
 EXPECTED_PAIR_FLOOR = 6
-EXPECTED_SHADOWED_FLOOR = 3
+EXPECTED_SHADOWED_FLOOR = 2
 
 
 def _pairs() -> Dict[str, str]:

--- a/tools/test_matrixark_the_budget_the_agent_gets.py
+++ b/tools/test_matrixark_the_budget_the_agent_gets.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The budget the agent gets is not the one the panel showed.
+
+The portal's budget panel quoted `MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS` -- 500,000 -- and worked
+every section's token count out of it. The agent hooks have never used that variable first. They
+read `MATRIXARK_HOOK_MAX_CONTEXT_TOKENS`, fall back to the one the panel quotes, and fall back again
+to a number of their own; and the installation manual sets the first to **10,000**.
+
+So on a deployment installed by the book, the panel said skills were allowed 50,000 tokens and the
+agent path allowed 1,000. Fifty times out, on the path that serves agents.
+
+The expression lived inline in two hook scripts, which is why nothing could report it: a duplicated
+literal in two standalone scripts is not something a panel can ask. It is one resolver now, the
+panel reports both budgets, and neither is called *the* budget.
+
+The safety property this suite exists for: the resolver must answer exactly what the inline
+expression answered, on every shape of environment. These hooks run on live sessions.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+import matrixark_gateway_config as cfg  # noqa: E402
+import matrixark_mcp_runtime_config as runtime  # noqa: E402
+import matrixark_v1_gateway as gateway  # noqa: E402
+
+HOOKS = ("matrixark_agent_hook.py", "matrixark_codex_hook.py")
+VARIABLES = ("MATRIXARK_HOOK_MAX_CONTEXT_TOKENS", "MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS")
+
+# What the two hooks used to compute inline. Kept here as the thing the resolver is checked
+# against, so "unchanged behaviour" is a measurement rather than an assurance.
+INLINE = ("int(os.environ.get('MATRIXARK_HOOK_MAX_CONTEXT_TOKENS', "
+          "os.environ.get('MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS', '128000')))")
+
+
+class Case(unittest.TestCase):
+    def setUp(self) -> None:
+        self._saved = {name: os.environ.get(name) for name in VARIABLES}
+        for name in VARIABLES:
+            os.environ.pop(name, None)
+
+    def tearDown(self) -> None:
+        for name, value in self._saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+class TheResolverAnswersWhatTheInlineExpressionDidTest(unittest.TestCase):
+    """These hooks run on live sessions, so the only acceptable behaviour change is none."""
+
+    CASES = (
+        ({}, "nothing set"),
+        ({"MATRIXARK_HOOK_MAX_CONTEXT_TOKENS": "10000"}, "the manual's install"),
+        ({"MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS": "500000"}, "only the API budget set"),
+        ({"MATRIXARK_HOOK_MAX_CONTEXT_TOKENS": "10000",
+          "MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS": "500000"}, "both set"),
+        ({"MATRIXARK_HOOK_MAX_CONTEXT_TOKENS": " 64000 "}, "padded"),
+    )
+
+    def probe(self, extra):
+        script = ("import os, sys\n"
+                  "sys.path.insert(0, %r)\n" % TOOLS +
+                  "import matrixark_mcp_runtime_config as rc\n"
+                  "print('%d %d' % (rc.hook_max_context_tokens(), " + INLINE + "))\n")
+        env = {k: v for k, v in os.environ.items() if k not in VARIABLES}
+        env.update(extra)
+        out = subprocess.run([sys.executable, "-c", script],
+                             capture_output=True, text=True, env=env, timeout=600)
+        self.assertEqual(0, out.returncode, out.stderr)
+        return out.stdout.split()
+
+    def test_it_agrees_on_every_shape_of_environment(self) -> None:
+        for extra, label in self.CASES:
+            with self.subTest(case=label):
+                resolver, inline = self.probe(extra)
+                self.assertEqual(inline, resolver)
+
+    def test_the_cases_are_not_all_the_same_answer(self) -> None:
+        """The floor: five cases that all resolve to one number would agree trivially."""
+        answers = {self.probe(extra)[0] for extra, _label in self.CASES}
+        self.assertGreater(len(answers), 2, "the cases exercise only %d answers" % len(answers))
+
+
+class NeitherHookRepeatsTheExpressionTest(unittest.TestCase):
+    """A literal duplicated across two standalone scripts is not something a panel can ask."""
+
+    def test_the_hooks_no_longer_carry_their_own_fallback(self) -> None:
+        for hook in HOOKS:
+            with open(os.path.join(TOOLS, hook), encoding="utf-8") as handle:
+                source = handle.read()
+            with self.subTest(hook=hook):
+                self.assertNotIn('os.environ.get("MATRIXARK_HOOK_MAX_CONTEXT_TOKENS"', source)
+                self.assertIn("_hook_max_context_tokens()", source)
+
+    def test_the_build_has_exactly_one_number_for_it(self) -> None:
+        """The floor: the rule above is satisfied by deleting the fallback altogether, which would
+        be a behaviour change rather than a consolidation."""
+        self.assertEqual(128000, runtime.DEFAULT_HOOK_MAX_CONTEXT_TOKENS)
+        os.environ.pop("MATRIXARK_HOOK_MAX_CONTEXT_TOKENS", None)
+        os.environ.pop("MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS", None)
+        self.assertEqual(128000, runtime.hook_max_context_tokens())
+
+
+class ABadValueDoesNotBecomeTheBudgetTest(Case):
+
+    def test_nonsense_falls_through_to_the_next_source(self) -> None:
+        for raw in ("", "   ", "not-a-number", "0", "-5"):
+            with self.subTest(value=raw):
+                os.environ["MATRIXARK_HOOK_MAX_CONTEXT_TOKENS"] = raw
+                os.environ["MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS"] = "500000"
+                self.assertEqual(500000, runtime.hook_max_context_tokens())
+
+    def test_and_to_the_build_default_when_neither_is_usable(self) -> None:
+        os.environ["MATRIXARK_HOOK_MAX_CONTEXT_TOKENS"] = "nonsense"
+        os.environ["MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS"] = "also nonsense"
+        self.assertEqual(runtime.DEFAULT_HOOK_MAX_CONTEXT_TOKENS,
+                         runtime.hook_max_context_tokens())
+
+    def test_a_good_value_is_still_taken(self) -> None:
+        os.environ["MATRIXARK_HOOK_MAX_CONTEXT_TOKENS"] = "24000"
+        self.assertEqual(24000, runtime.hook_max_context_tokens())
+
+
+class ThePanelReportsBothBudgetsTest(Case):
+
+    def panel(self):
+        return gateway._shared_budget_summary()
+
+    def test_both_paths_are_named(self) -> None:
+        paths = {row["path"] for row in self.panel()["paths"]}
+        self.assertEqual({"api", "agent_hooks"}, paths)
+
+    def test_the_manual_install_is_reported_as_it_is(self) -> None:
+        """The case the panel was wrong about: 10,000 for the agent, 500,000 for an API caller."""
+        os.environ["MATRIXARK_HOOK_MAX_CONTEXT_TOKENS"] = "10000"
+        os.environ["MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS"] = "500000"
+        rows = {row["path"]: row for row in self.panel()["paths"]}
+        self.assertEqual(500000, rows["api"]["context_budget_tokens"])
+        self.assertEqual(10000, rows["agent_hooks"]["context_budget_tokens"])
+        # And the section figures follow the budget they belong to, rather than one of them being
+        # quoted for both -- which is what the panel used to do.
+        self.assertGreater(rows["api"]["sections"]["skills"],
+                           rows["agent_hooks"]["sections"]["skills"] * 10)
+
+    def test_it_says_when_they_differ(self) -> None:
+        os.environ["MATRIXARK_HOOK_MAX_CONTEXT_TOKENS"] = "10000"
+        os.environ["MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS"] = "500000"
+        self.assertTrue(self.panel()["paths_differ"])
+
+    def test_and_when_they_do_not(self) -> None:
+        """The floor: a flag hard-coded to True would pass the test above."""
+        os.environ["MATRIXARK_HOOK_MAX_CONTEXT_TOKENS"] = "500000"
+        os.environ["MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS"] = "500000"
+        self.assertFalse(self.panel()["paths_differ"])
+
+    def test_the_rows_the_panel_already_had_are_unchanged(self) -> None:
+        """This is additive. Anything reading the old shape keeps reading it."""
+        panel = self.panel()
+        for key in ("context_budget_tokens", "skills", "resources"):
+            self.assertIn(key, panel)
+        self.assertIn("percent", panel["skills"])
+        self.assertIn("bound_by", panel["skills"])
+
+
+class ThePortalOffersItTest(unittest.TestCase):
+    """The help for the budget beside it already told operators to set this one. A flag whose text
+    advises an operator has to be reachable."""
+
+    KEY = "retrieval.hook_max_context_tokens"
+
+    def test_it_is_offered(self) -> None:
+        self.assertIn(self.KEY, cfg.SETTINGS_BY_KEY)
+
+    def test_it_takes_effect_without_a_restart(self) -> None:
+        self.assertEqual("live", cfg.SETTINGS_BY_KEY[self.KEY].applies)
+
+    def test_the_declared_default_is_the_one_the_build_runs(self) -> None:
+        """The resolver reads its variables through a loop, so the declared-default sweep cannot
+        pair them automatically. This is that comparison, made by hand because it has to be."""
+        self.assertEqual(runtime.DEFAULT_HOOK_MAX_CONTEXT_TOKENS,
+                         int(cfg.SETTINGS_BY_KEY[self.KEY].default))
+
+    def test_the_neighbouring_setting_still_names_it(self) -> None:
+        """The premise: the other budget's help is what advised operators to set this. If that text
+        went away, this setting would need to explain itself rather than lean on it."""
+        neighbour = cfg.SETTINGS_BY_KEY["retrieval.default_max_context_tokens"]
+        self.assertIn("MATRIXARK_HOOK_MAX_CONTEXT_TOKENS", neighbour.help)
+
+
+class TheHooksStillLoadTest(unittest.TestCase):
+    """They are started per turn on live sessions. An import error here is a dead agent."""
+
+    def test_each_hook_imports(self) -> None:
+        for hook in HOOKS:
+            module = hook[:-3]
+            with self.subTest(hook=module):
+                out = subprocess.run(
+                    [sys.executable, "-c", "import sys; sys.path.insert(0, %r); import %s"
+                     % (TOOLS, module)],
+                    capture_output=True, text=True, timeout=600)
+                self.assertEqual(0, out.returncode, out.stderr[-600:])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_numeric_defaults_agree.py
+++ b/tools/test_numeric_defaults_agree.py
@@ -8,14 +8,15 @@ half-applies. A NUMBER drifts the same way and shows less: two readers with diff
 agree on every value anyone sets, and part company only for the deployment that leaves the variable
 alone -- which is most of them, and the one nobody tests.
 
-`MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS` is the worked example. The backend resolves an omitted budget
-to 500000 and the two agent hooks pass 128000, so an operator who sets nothing gets a quarter of the
-documented window through one path and all of it through another. The schema used to quote the wrong
-one of those two numbers at callers, which is what
+`MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS` was the worked example, and is now struck off. The backend
+resolved an omitted budget to 500000 while the two agent hooks passed 128000, so an operator who set
+nothing got a quarter of the documented window through one path and all of it through another. The
+schema used to quote the wrong one of those two numbers at callers, which is what
 `test_matrixark_the_schema_quotes_the_budget_it_applies` was written for -- the same pair of numbers,
-one layer up.
+one layer up. Both readers now agree, so the entry goes: the rule below is that a list of known
+differences which is allowed to go stale is read as a description of the tree.
 
-The six below were present when this was written and are NOT endorsed here. Several look like a
+The five below were present when this was written and are NOT endorsed here. Several look like a
 deliberate difference between a client and the server it calls, and one is two reader paths in a
 benchmark. None has been examined, and this file does not pretend otherwise: it exists so a SEVENTH
 has to be looked at rather than joining them quietly. Strike an entry when its difference is either
@@ -40,8 +41,6 @@ _READ = re.compile(
 # Known, unexamined. Each is a variable whose readers do not agree on the number to use when it is
 # unset. The note says what the difference looks like, not that it is right.
 KNOWN_DISAGREEMENTS: Dict[str, str] = {
-    "MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS":
-        "hooks pass 128000, the backend resolves an omitted budget to 500000",
     "MATRIXARK_HTTP_PORT":
         "servers bind 8080, the CLI paths use 0 (an ephemeral port)",
     "MATRIXARK_READER_MAX_TOKENS":


### PR DESCRIPTION
The budget panel quoted `MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS` — 500,000 — and worked every
section's token count out of it. **The agent hooks have never read that variable first.**

```
matrixark_agent_hook.py:234   int(os.environ.get("MATRIXARK_HOOK_MAX_CONTEXT_TOKENS",
matrixark_codex_hook.py:2397      os.environ.get("MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS", "128000")))
```

…and `docs/matrixark_codex_mcp_hook_installation_manual.md:127` sets the first one:

```
MATRIXARK_HOOK_MAX_CONTEXT_TOKENS=10000
```

So on a deployment installed by the book:

| | panel said | agent path actually had |
|---|---|---|
| context budget | 500,000 | **10,000** |
| skills (10%) | 50,000 | **1,000** |
| resources (25%) | 125,000 | **2,500** |

Fifty times out, on the path that serves agents — and the panel offered no hint that a second
budget existed, because the expression lived inline in two standalone scripts and a duplicated
literal is not something a panel can ask.

### What changed

**One resolver**, `hook_max_context_tokens()`, beside the budget it is not. Both hooks call it
through the same dual-path import they already use for every other shared module.

**The panel reports both budgets and calls neither of them *the* budget.** The share is identical on
both paths; it is what the share *comes to* that differs, so both are reported with the variable
that decides each, plus `paths_differ` — a fact rather than a warning, because on a default
deployment they do differ and a warning that always fires is noise. The existing keys are untouched:
anything reading the old shape keeps reading it.

**The hook budget is a setting now.** The neighbouring setting's help had been telling operators to
set `MATRIXARK_HOOK_MAX_CONTEXT_TOKENS` while the portal offered no way to. A test pins that premise
— if that help stops naming it, this setting has to explain itself rather than lean on it.

### The safety property

These hooks are started per turn on live sessions, so the only acceptable behaviour change is
**none**. The resolver is checked against the expression it replaces, evaluated side by side in one
subprocess, across every shape of environment:

```
nothing set                  resolver=128000   inline=128000   same
the manual's install         resolver=10000    inline=10000    same
only the API budget set      resolver=500000   inline=500000   same
both set                     resolver=10000    inline=10000    same
padded                       resolver=64000    inline=64000    same
```

with a floor asserting those five cases do not all resolve to one number, and a test that each hook
still imports — an import error there is a dead agent, not a failed test.

A value that is unparseable, zero or negative falls through to the next source rather than becoming
the budget, which is the one place the resolver is deliberately stricter than the expression it
replaces: `int("0")` would have been accepted before and a budget of zero is not a budget.

```
the resolver ignores the hook's own variable      -> FAIL
the build default becomes the API one             -> FAIL
a zero budget is accepted                         -> FAIL
the panel quotes one budget for both paths        -> FAIL
paths_differ is always true                       -> FAIL
the panel stops reporting paths at all            -> FAIL
the portal promises a restart                     -> FAIL
the declared default drifts from the build        -> FAIL
a hook goes back to computing it inline           -> FAIL
the panel drops the rows it already had           -> FAIL
```

17 tests, plus 119 across the eight suites that police these files.

### How this was found

A sweep of every `MATRIXARK_*` variable read with a literal default: **30 of 323 are given more than
one default by the build.** Most are legitimate — a per-provider API base, a CLI binding
`127.0.0.1` where a server binds `0.0.0.0`. This one was not, and it sat underneath a panel shipped
two changes ago. The remaining twenty-nine are worth their own pass; several of the timeout knobs
have the same shape (`MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS` is 20,000 in one module and 60,000
in two others, and none of the four retrieval timeouts is offered at all).

Rendering this panel on the setup page is the natural next step and is deliberately not in here: this
change touches two hooks that run on live sessions, and mixing page work into it would make the part
that matters harder to review.

Follows [#1026](https://github.com/matrixarkai/TemporalStore/pull/1026), which made those shares
settable, and [#1029](https://github.com/matrixarkai/TemporalStore/pull/1029).

---

Replaces #1032, which GitHub closed as merged when a mid-rebase HEAD was force-pushed to its branch: the branch briefly pointed at `main`, so the PR had no diff. That merge was a no-op and `main` is unchanged — this is the same commit, rebased.
