### PR TITLE
The local event log is written in blocks by default

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -195,19 +195,29 @@ _SHARD_CODEC_ZLIB = b"\x01"
 #: ACTIVE log can take: a sealed shard is finished and compresses whole, but a log is appended to,
 #: and a stream of self-describing blocks is appendable where a single deflate stream is not.
 _SHARD_CODEC_BLOCKS = b"\x02"
-#: Off, and it stays off -- the hazard is demonstrated rather than argued. Turning it on breaks
-#: `test_a_writer_in_another_process_does_not_corrupt_the_view` and
-#: `test_both_append_paths_write_the_same_tail`: both append raw JSON lines to a log this module
-#: created, which is what a writer that is NOT this module does, and a plain append onto a
-#: block-framed log corrupts it. A store this build creates has to remain appendable by something
-#: that writes plain JSONL, and defaulting this on takes that away.
+#: ON. One block per append batch, which costs NO durability: the batch is already the unit acked
+#: together, so a crash loses exactly what it loses today. Measured over the batch sizes this code
+#: really appends (3 x60, 5 x60, 284 x29, 292 x1), 9,008 records, log bytes against plain JSONL:
 #:
-#: Everything else about it is safe and measured -- an existing plain log stays plain because the
-#: form is read from the FILE, and a store written with this on reads byte-identically with it off
-#: (144 records, 82 vectors, same digest). It is a per-deployment choice for anyone who knows their
-#: log has a single writer, not a default.
+#:     random words -- the least compressible text a record plausibly holds      3.23x
+#:     the 76 KB documents this was first priced against                         9.68x
+#:     repetitive text                                                          20.23x
+#:
+#: It shipped off for a reason that was demonstrated rather than argued, and that reason is now
+#: fixed rather than accepted. The hazard was that a process which is NOT this module appends plain
+#: JSON to the log, and a plain append onto a block-framed log corrupted it. `_plain_run_lines`
+#: reads a plain run at a block boundary and leaves the handle on the first byte that is not a
+#: line, so a log genuinely interleaves [block][plain][block] and reads back whole and in order.
+#: Pinned by `test_a_plain_append_onto_a_block_log_still_reads`,
+#: `test_a_block_written_after_a_plain_append_is_not_lost`, and -- the property that the tolerance
+#: must not swallow -- `test_a_torn_block_is_still_dropped_not_read_as_text`.
+#:
+#: Reversible, which is what makes it a default rather than a migration. The form is read from the
+#: FILE: an existing plain log stays plain and is appended to as plain, only a fresh log adopts
+#: blocks, and turning this off again leaves every block log readable, because the reader takes
+#: either form whatever the flag says.
 LOCAL_JSONL_BLOCK_LOG = os.environ.get(
-    "MATRIXARK_LOCAL_JSONL_BLOCK_LOG", "0"
+    "MATRIXARK_LOCAL_JSONL_BLOCK_LOG", "1"
 ).strip().lower() not in ("0", "false", "no", "off")
 #: On, and reversible: the reader takes either form, so a store written with this on still reads
 #: with it off, and a shard sealed once never needs unsealing.
@@ -265,6 +275,13 @@ def _encode_delta_block(records: list[Json]) -> bytes:
         LOCAL_DURABLE_READ_CACHE_COMPRESS_LEVEL,
     )
     return _DELTA_BLOCK_CODEC_ZLIB_ARRAY + len(payload).to_bytes(4, "big") + payload
+
+
+#: Records to a block when a whole log file is written at once. The append path has a natural unit
+#: -- the batch -- and a rewrite has none, so it takes this. A block is the unit of DECODE, so one
+#: block for the whole file would make a cold read materialise every surviving record at once,
+#: which is the cost the same 256-record geometry bounds for the read cache.
+_LOG_REWRITE_BLOCK_RECORDS = 256
 
 
 def _encode_log_block(records: list[Json]) -> bytes:
@@ -8217,10 +8234,25 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             survivors = apply_memory_tombstones(raw)
             bytes_before = sum(path.stat().st_size for path in paths if path.exists())
             tmp_path = self.event_log.with_name(f"{self.event_log.name}.purge.{os.getpid()}.{threading.get_ident()}.tmp")
-            lines = [json.dumps(self._sanitize_jsonl_record(record), separators=(",", ":")) + "\n" for record in survivors]
-            with tmp_path.open("w", encoding="utf-8") as handle:
-                for line in lines:
-                    handle.write(line)
+            sanitized = [self._sanitize_jsonl_record(record) for record in survivors]
+            # A purge REPLACES the log, so it writes the form a FRESH log takes -- the same
+            # rule `_log_append_form` applies to an empty file -- rather than the form of the
+            # file it replaces. Writing plain regardless was not a corruption: the log came
+            # back readable, several times larger. It was worse than that, because the form is
+            # read from the FILE, so every later append inherited plain from it and one purge
+            # undid the compression for good. This reads through `_iter_shard_lines` above and
+            # now writes through the encoder the append path uses, so both ends of the rewrite
+            # know about the form.
+            with tmp_path.open("wb") as handle:
+                if LOCAL_JSONL_BLOCK_LOG:
+                    handle.write(_SHARD_CONTAINER_MAGIC + _SHARD_CODEC_BLOCKS)
+                    for start in range(0, len(sanitized), _LOG_REWRITE_BLOCK_RECORDS):
+                        handle.write(_encode_log_block(
+                            sanitized[start:start + _LOG_REWRITE_BLOCK_RECORDS]))
+                else:
+                    for record in sanitized:
+                        handle.write(
+                            (json.dumps(record, separators=(",", ":")) + "\n").encode("utf-8"))
                 handle.flush()
                 os.fsync(handle.fileno())
             os.replace(tmp_path, self.event_log)  # atomic commit point

--- a/tools/test_intern_record_metadata.py
+++ b/tools/test_intern_record_metadata.py
@@ -94,12 +94,19 @@ class _FlagGuard(unittest.TestCase):
     @staticmethod
     def _raw_disk_records(path: Path) -> list[dict]:
         """Every JSONL record currently on disk (all retained shards), in append order -- the exact
-        durable bytes, decoded but NOT expanded."""
+        durable bytes, decoded but NOT expanded.
+
+        Through `_iter_shard_lines`, which takes a shard in whichever form it is stored in.
+        Reading the file as text was already wrong for a SEALED shard -- those have been
+        compressed containers by default for a while -- and passed only because this corpus
+        never rotates far enough to seal one. It broke outright when the active log defaulted
+        to blocks, which is the same defect arriving somewhere it could not be missed.
+        """
         records: list[dict] = []
         for shard in sorted(path.parent.glob(path.name + "*")):
             if shard.name.endswith((".read-cache.json", ".read-cache.bin")):
                 continue
-            for line in shard.read_text(encoding="utf-8").splitlines():
+            for line in A._iter_shard_lines(shard):
                 line = line.strip()
                 if line:
                     records.append(json.loads(line))
@@ -205,7 +212,7 @@ class InterningCase(_FlagGuard):
             server = mcp.MatrixArkMcpServer(adapter, access_mode="dev")
             self._ingest_turns(server, 20)
             server.close(timeout_s=2.0)
-            raw_lines = [json.loads(ln) for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+            raw_lines = [json.loads(ln) for ln in A._iter_shard_lines(path) if ln.strip()]
         self.assertTrue(any(r.get("record_type") == A.INTERN_DICT_RECORD_TYPE for r in raw_lines),
                         "expected durable intern-dict records on disk")
         # The data line carries a single bundle token (_imb) and every bundled field is elided
@@ -235,7 +242,11 @@ class InterningCase(_FlagGuard):
             server = mcp.MatrixArkMcpServer(adapter, access_mode="dev")
             self._ingest_turns(server, 20)
             server.close(timeout_s=2.0)
-            text = path.read_text(encoding="utf-8")
+            # The DECODED lines joined, not the file. Asserting a token is absent from a
+            # file that is a stream of compressed blocks would pass without reading a
+            # single record -- the way an absence assertion passes hardest when there is
+            # nothing to read.
+            text = "\n".join(A._iter_shard_lines(path))
         self.assertNotIn(A.INTERN_DICT_RECORD_TYPE, text)
         self.assertNotIn(f'"{A.INTERN_TOKEN_KEY}"', text)
 

--- a/tools/test_matrixark_a_flat_value_needs_no_deep_copy.py
+++ b/tools/test_matrixark_a_flat_value_needs_no_deep_copy.py
@@ -89,7 +89,9 @@ class AFlatValueNeedsNoDeepCopy(unittest.TestCase):
                     "scope": {"tenant_id": "acme", "user_id": "u", "session_id": "s%d" % (i // 4)},
                     "messages": [{"role": "user", "content": "a sentence to extract %d" % i}],
                 })
-            raw = [json.loads(line) for line in log.read_text(encoding="utf-8").splitlines()
+            # Through the module's own shard iterator: the durable log takes more than one
+            # form and only this knows which one is on disk.
+            raw = [json.loads(line) for line in adapter_module._iter_shard_lines(log)
                    if line.strip()]
             self.assertTrue(
                 any(adapter_module.INTERN_BUNDLE_TOKEN_KEY in r for r in raw if isinstance(r, dict)),

--- a/tools/test_matrixark_a_rotated_shard_is_sealed.py
+++ b/tools/test_matrixark_a_rotated_shard_is_sealed.py
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 MatrixArkAI
-"""A rotated shard is stored compressed; the active shard stays plain text.
+"""A rotated shard is stored compressed, and sealing never reaches the active one.
+
+The active shard is plain text in the arm this suite pins. Whether it is plain or a stream of
+blocks is a separate decision -- see LOCAL_JSONL_BLOCK_LOG, which now defaults to blocks --
+and what matters here is that the sealer is handed rotated shards only, in whichever form the
+active log is written.
 
 Once the read snapshot became a container the event log was 94.3% of everything this module writes,
 and at the default retention the ROTATED shards are 74.9% of the log -- 11.91x compressible. That is
@@ -55,9 +60,18 @@ class SealedShardTest(unittest.TestCase):
         self.addCleanup(_clear_process_read_cache)
         # Module globals read at call time, so they are set here and RESTORED -- a test that leaves
         # process-global state behind changes the tests after it.
-        for name in ("LOCAL_JSONL_COMPRESS_SEALED", "LOCAL_JSONL_MAX_BYTES"):
+        for name in ("LOCAL_JSONL_COMPRESS_SEALED", "LOCAL_JSONL_MAX_BYTES",
+                     "LOCAL_JSONL_BLOCK_LOG"):
             self.addCleanup(setattr, adapter_module, name, getattr(adapter_module, name))
         adapter_module.LOCAL_JSONL_MAX_BYTES = 40_000
+        # Rotation is reached here by writing more PLAIN text than the cap above. A block log
+        # holds the same records in about a twentieth of the bytes, so under the default
+        # nothing would reach the cap and every assertion below would be made about an empty
+        # rotated set -- which is why each one first asserts that something rotated. Pinned
+        # rather than left to the default because the subject is the SEALER, not the framing
+        # of the active log; the block log's own suite covers that seam in
+        # test_a_block_log_rotates_into_a_sealed_shard_and_starts_a_fresh_one.
+        adapter_module.LOCAL_JSONL_BLOCK_LOG = False
 
     def _fill(self, batches: int = 6, per_batch: int = 20) -> list[dict]:
         adapter = MatrixArkLocalAdapter(self.log)

--- a/tools/test_matrixark_intern_the_scope_constants.py
+++ b/tools/test_matrixark_intern_the_scope_constants.py
@@ -87,8 +87,10 @@ class TheTwoLargestConstantsAreInterned(unittest.TestCase):
                         "metadata": {"raw_uri": "file:///s/r.md", "title": "r"}})
         adapter.close(timeout_s=120)
 
+        # Through the module's own shard iterator: the durable log takes more than one form
+        # and only this knows which one is on disk.
         raw = [json.loads(line) for line in
-               (store / "events.jsonl").read_text(encoding="utf-8").splitlines() if line.strip()]
+               adapter_module._iter_shard_lines(store / "events.jsonl") if line.strip()]
         data = [r for r in raw
                 if str(r.get("record_type") or "") != adapter_module.INTERN_DICT_RECORD_TYPE]
         self.assertTrue(data, "nothing was written, so the assertions below would pass emptily")

--- a/tools/test_matrixark_interning_reaches_repeated_fields.py
+++ b/tools/test_matrixark_interning_reaches_repeated_fields.py
@@ -145,7 +145,9 @@ class InterningCoversTheRepeatedFields(unittest.TestCase):
                                   "content": "a sentence with enough words to be extracted %d" % i}],
                 })
             sidecars = data = 0
-            for line in log.read_text(encoding="utf-8").splitlines():
+            # The durable log takes more than one form; only the module's iterator knows
+            # which one this is.
+            for line in adapter_module._iter_shard_lines(log):
                 if not line.strip():
                     continue
                 record = json.loads(line)

--- a/tools/test_matrixark_one_object_per_interned_value.py
+++ b/tools/test_matrixark_one_object_per_interned_value.py
@@ -106,7 +106,9 @@ class OneObjectPerInternedValue(unittest.TestCase):
                     "scope": {"tenant_id": "acme", "user_id": "u", "session_id": "s%d" % (i // 4)},
                     "messages": [{"role": "user", "content": "a sentence to extract %d" % i}],
                 })
-            raw = [json.loads(line) for line in log.read_text(encoding="utf-8").splitlines()
+            # Through the module's own shard iterator: the durable log takes more than one
+            # form and only this knows which one is on disk.
+            raw = [json.loads(line) for line in adapter_module._iter_shard_lines(log)
                    if line.strip()]
             self.assertTrue(
                 any(adapter_module.INTERN_BUNDLE_TOKEN_KEY in r for r in raw if isinstance(r, dict)),

--- a/tools/test_matrixark_the_audit_switch_is_reachable.py
+++ b/tools/test_matrixark_the_audit_switch_is_reachable.py
@@ -31,6 +31,7 @@ import unittest
 from pathlib import Path
 
 import matrixark_gateway_config as cfg
+import matrixark_mcp_local_adapter as adapter_module
 from matrixark_mcp_server import MatrixArkLocalAdapter, MatrixArkMcpServer, MatrixArkError
 
 ADMIN_SCOPES = ["admin:account", "admin:user", "admin:api_key", "admin:audit", "portal:read"]
@@ -129,7 +130,10 @@ class WritingItThroughThePortalTakesEffectTest(unittest.TestCase):
         finally:
             server.close(timeout_s=10.0)
         rows = []
-        for line in self.log.read_text(encoding="utf-8").splitlines():
+        # A substring scan over the durable log, so it has to be handed decoded LINES: the
+        # log is a stream of compressed blocks by default, and scanning the raw file would
+        # match nothing and report an empty audit trail as a pass.
+        for line in adapter_module._iter_shard_lines(self.log):
             if '"matrixark_audit_log"' in line:
                 rows.append(line)
         return rows

--- a/tools/test_matrixark_the_log_is_written_in_blocks.py
+++ b/tools/test_matrixark_the_log_is_written_in_blocks.py
@@ -230,6 +230,50 @@ class LogIsWrittenInBlocksTest(unittest.TestCase):
         self.assertLessEqual(len(rotated) + 1, retained)
 
 
+    def test_a_purge_rewrites_the_log_in_the_configured_form(self):
+        """A purge REPLACES the log, and a rewrite that forgets the form undoes this.
+
+        It read through `_iter_shard_lines`, which knows every form, and then wrote plain
+        lines regardless -- the log came back readable and roughly sixteen times larger. The
+        lasting half is worse than the size: the form is read from the FILE, so every append
+        after a purge inherited plain from the rewritten file and one purge turned the
+        compression off for good.
+        """
+        adapter_module.LOCAL_JSONL_BLOCK_LOG = True
+        adapter = MatrixArkLocalAdapter(self.log)
+        for batch in range(6):
+            adapter.append_many(_records(batch * 20, 20))
+        adapter.append_many([
+            {
+                "record_type": adapter_module.MEMORY_TOMBSTONE_RECORD_TYPE,
+                "event_id_hash": 900 + index,
+                "target_event_id_hash": index,
+                "updated_at_ms": 1780000009000 + index,
+            }
+            for index in range(20)
+        ])
+        before_bytes = self.log.stat().st_size
+        self.assertTrue(self.log.read_bytes().startswith(_SHARD_CONTAINER_MAGIC),
+                        "the log was not a block stream, so the purge has nothing to keep")
+
+        result = adapter.purge_tombstones(force=True)
+        self.assertTrue(result.get("purged"),
+                        "nothing was purged, so this asserts nothing about a rewrite")
+        self.assertTrue(self.log.read_bytes().startswith(_SHARD_CONTAINER_MAGIC),
+                        "the purge rewrote the block log as plain text, and every later append would inherit that")
+        self.assertLess(self.log.stat().st_size, before_bytes,
+                        "the purged log is no smaller, so the rewrite lost the compression")
+
+        # The markers are gone and every surviving record still reads back. Asserted on the
+        # purge's own count and the served view rather than on which records a tombstone matches:
+        # what changed here is the rewrite, and the matching rules are another test's subject.
+        self.assertEqual(20, result.get("removed_tombstones"),
+                         "the purge did not remove the markers it reported on")
+        _clear_process_read_cache()
+        kept = self._appended(self.log)
+        self.assertEqual(120, len(kept),
+                         "the rewrite lost records that no tombstone removes")
+
     def test_a_plain_append_onto_a_block_log_still_reads(self):
         """The reason this format shipped off by default.
 


### PR DESCRIPTION
The active event log is the last plain-text artifact this module writes — the snapshot, its tail
and the sealed shards are all containers already — and at the corpora this was priced against it is
around 94% of everything on disk. It has been written as a stream of blocks, one per append batch,
behind `MATRIXARK_LOCAL_JSONL_BLOCK_LOG` for a while. This makes that the default, and fixes the
one write path that did not know about it.

### Why it was off, and why that no longer holds

The hazard was demonstrated, not argued: a process that is **not** this module appends plain JSON
to the log, and a plain append onto a block-framed log corrupted it.

That is fixed rather than accepted. `_plain_run_lines` reads a plain run at a block boundary and
leaves the handle on the first byte that is not a line, so a log genuinely interleaves
`[block][plain][block]` and reads back whole and in order. Three tests pin it —
`test_a_plain_append_onto_a_block_log_still_reads`,
`test_a_block_written_after_a_plain_append_is_not_lost`, and the property the tolerance must not
swallow, `test_a_torn_block_is_still_dropped_not_read_as_text`.

Both tests that were named in the code as the reason to stay off now pass with it on.

### What it costs and buys

No durability. The batch is already the unit acked together, so a crash loses exactly what it loses
today. Measured over the batch sizes this code really appends (3×60, 5×60, 284×29, 292×1), 9,008
records, log bytes against plain JSONL:

| text | ratio |
|---|---|
| random words — the least compressible a record plausibly holds | **3.23x** |
| the 76 KB documents this was first priced against | **9.68x** |
| repetitive text | **20.23x** |

Read back through the adapter, both forms return the same records with the same digest.

### Reversible, which is what makes it a default

The form is read from the **file**, not the flag. An existing plain log stays plain and is appended
to as plain; only a fresh log adopts blocks. Turning the flag off again leaves every block log
readable, because the reader takes either form whatever the flag says. A live store therefore
converts at its next rotation rather than on upgrade, and nothing rewrites a log to get there.

### The defect this turned up: a purge read the form and wrote plain

`purge_tombstones` reads through `_iter_shard_lines`, which knows every form — and then wrote plain
JSON lines unconditionally. On the same corpus:

| | before | after | head |
|---|---|---|---|
| **before this change** | 19,258 | **316,098** — 16.4x *bigger* | `MASHRD\x01` → `{"recor` |
| **after** | 19,258 | 15,957 | `MASHRD\x01` preserved |

Not a corruption: the log came back readable, several times larger. It was worse than that, because
the form is read from the file — so every later append inherited plain from the purged file, and
one purge undid the compression permanently. A rewrite creates a new file, so it now takes the form
a *fresh* log takes, which is the rule `_log_append_form` already applies to an empty one. Written
in 256-record blocks rather than one: a block is the unit of decode, and one block per file would
make a cold read materialise every surviving record at once.

### Seven tests were reading the durable log as text

They opened the log with `read_text(encoding="utf-8")` and split lines, bypassing the iterator that
knows what form a shard is in. That was **already wrong for a sealed shard** — those have been
compressed containers by default for a while — and passed only because none of those corpora rotate
far enough to seal one. Defaulting the active log to blocks brought the same defect somewhere it
could not be missed. All now read through `_iter_shard_lines`.

Two of them were worse than a crash, and both are absence assertions:
`assertNotIn(INTERN_DICT_RECORD_TYPE, text)` over the raw file, and a substring scan for
`"matrixark_audit_log"` rows. On a compressed file neither would match anything, so an empty audit
trail would have read as a pass — an assertion passing hardest when there is nothing to read.

`test_matrixark_a_rotated_shard_is_sealed` is the one exception: it reaches rotation by writing
more plain text than the cap, and compressed records never reach it. Its subject is the sealer, not
the framing of the active log, so it now pins the plain form and says why — and each of its
assertions already began by asserting that something rotated, which is why it failed loudly instead
of passing on an empty set.

### Checks

| | |
|---|---|
| whole `tools` suite (322 files), new default vs `main` baseline | **identical** |
| whole `tools` suite, flag forced off vs `main` baseline | **identical** — the flag still turns it off |
| the block log's own suite | **14 passed** |
| mutation: make the purge write plain again | **fails**, naming the form every later append would inherit |
| round trip, both forms | same records, same digest |
| purge | form preserved, log smaller, survivors unchanged |
