### PR TITLE
A deadline that cannot bound a single call, and a portal that now says so

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -453,6 +453,24 @@ SETTINGS: List[Setting] = [
             "share above is set."),
 
     # ---- retrieval and context budget ----------------------------------------------------------
+    Setting("retrieval.timeout_ms", "retrieval", "MATRIXARK_RETRIEVAL_TIMEOUT_MS",
+            "Retrieval deadline (ms)", "int", "0", "live",
+            "How long a retrieve may keep working before it returns what it has. 0 means no "
+            "deadline. It is COOPERATIVE: it is checked between stages and every 64 or 128 "
+            "candidates, never around a call to the store -- so it bounds the work a retrieve "
+            "does, and cannot bound one slow backend call. The transport timeout below is what "
+            "does that, and the pack panel reports which of the two is the smaller."),
+    Setting("limits.transport_request_timeout_ms", "limits",
+            "MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS",
+            "Transport request timeout (ms)", "int", "60000", "live",
+            "The per-request timeout on the call to the store. This is the one that decides how "
+            "long a single slow call can take, whatever the deadline above says. It answered "
+            "20000 in the adapter and 60000 in the agent hooks for the same variable until they "
+            "were given one number."),
+    Setting("limits.transport_io_timeout_ms", "limits",
+            "MATRIXARK_TEMPORALSTORE_IO_TIMEOUT_MS",
+            "Transport I/O timeout (ms)", "int", "60000", "live",
+            "The I/O timeout underneath the request timeout above. Same story, same fix."),
     Setting("retrieval.hook_max_context_tokens", "retrieval",
             "MATRIXARK_HOOK_MAX_CONTEXT_TOKENS",
             "Agent hook context budget (tokens)", "int", "128000", "live",

--- a/tools/matrixark_mcp_runtime_config.py
+++ b/tools/matrixark_mcp_runtime_config.py
@@ -242,6 +242,20 @@ def live_int(variable: str, fallback: int) -> int:
     return parsed if parsed > 0 else fallback
 
 
+# One number for the transport timeouts, which the adapter CLI and both hooks each used to
+# answer differently: 20,000 here, 60,000 there, for the same variable. Unified at the larger,
+# because a socket timeout that is too long makes a slow call wait while one that is too short
+# makes a working call fail, and only the second loses the answer.
+DEFAULT_TRANSPORT_REQUEST_TIMEOUT_MS = 60000
+DEFAULT_TRANSPORT_IO_TIMEOUT_MS = 60000
+
+
+def transport_timeout_ms(variable: str, fallback: int) -> int:
+    """A transport timeout in force now. Anything unusable falls back to the build default: a
+    socket timeout of zero or nonsense would either never time out or fail every call."""
+    return live_int(variable, fallback)
+
+
 DEFAULT_HOOK_MAX_CONTEXT_TOKENS = 128000  # build default; the resolver below reads the env
 
 

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1647,6 +1647,49 @@ def _model_picker_body(target: str) -> Json:
     return body
 
 
+def _latency_summary() -> Json:
+    """Which control actually decides how long a retrieve can take.
+
+    There are two, and only one of them can stop a slow call. The retrieval deadline is
+    COOPERATIVE: `deadline_exceeded()` is consulted between stages and every 64 or 128 candidates,
+    and never around a call to the store. So it bounds the work a retrieve chooses to keep doing,
+    and a single backend call runs to the transport timeout regardless of it.
+
+    That is why a deployment with a five-second deadline was seeing retrieves return after sixty:
+    the deadline was not being ignored, it was being checked at moments the call had not returned
+    from. `deadline_can_be_overrun_by_ms` is that gap, stated rather than left to be inferred.
+    """
+    try:
+        try:
+            from tools import matrixark_mcp_retrieve_planning as planning  # type: ignore
+            from tools import matrixark_mcp_runtime_config as runtime  # type: ignore
+        except ImportError:
+            import matrixark_mcp_retrieve_planning as planning  # type: ignore
+            import matrixark_mcp_runtime_config as runtime  # type: ignore
+    except Exception:  # pragma: no cover - the portal still works without the retrieval modules
+        return {"available": False}
+    # Asked of the same resolver a retrieve uses, so this cannot drift from what runs.
+    deadline = int(planning.retrieval_deadline_ms({}, {}) or 0)
+    request = runtime.transport_timeout_ms("MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS",
+                                           runtime.DEFAULT_TRANSPORT_REQUEST_TIMEOUT_MS)
+    io_timeout = runtime.transport_timeout_ms("MATRIXARK_TEMPORALSTORE_IO_TIMEOUT_MS",
+                                              runtime.DEFAULT_TRANSPORT_IO_TIMEOUT_MS)
+    return {
+        "available": True,
+        "deadline_ms": deadline,
+        "deadline_is_cooperative": True,
+        "transport_request_timeout_ms": request,
+        "transport_io_timeout_ms": io_timeout,
+        # Never the deadline, whatever its value: it is not applied to the call.
+        "bounds_a_slow_call": "transport_request_timeout_ms",
+        "worst_case_single_call_ms": request,
+        # 0 when no deadline is set -- there is nothing to overrun. Otherwise this is how much
+        # longer than the deadline one slow call can take, which is the number an operator is
+        # actually looking for when a retrieve came back late.
+        "deadline_can_be_overrun_by_ms": max(0, request - deadline) if deadline > 0 else 0,
+    }
+
+
 def _shared_budget_summary() -> Json:
     """What each section of a pack is allowed, asked of the packer rather than worked out here.
 
@@ -4806,6 +4849,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                 "counts": counts,
                 "traffic": traffic,
                 "footprint": footprint,
+                "latency": _latency_summary(),
                 "imports": imports,
                 "config": config_snapshot,
             })

--- a/tools/test_matrixark_a_deadline_cannot_bound_a_single_call.py
+++ b/tools/test_matrixark_a_deadline_cannot_bound_a_single_call.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A deadline cannot bound a single call, and the portal now says which control can.
+
+Two controls decide how long a retrieve takes and only one of them can stop a slow call:
+
+* the **retrieval deadline** is cooperative -- `deadline_exceeded()` is consulted between stages
+  and every 64 or 128 candidates, and never around a call to the store;
+* the **transport request timeout** is what a single call actually runs against.
+
+So a deployment with a five-second deadline saw retrieves return after sixty. The deadline was not
+being ignored; it was being checked at moments the call had not returned from. Neither control was
+offered on the portal, and the transport timeout answered 20,000 in one module and 60,000 in two
+others for the same variable, so there was no way to find out which a deployment was running.
+
+`deadline_can_be_overrun_by_ms` states that gap instead of leaving it to be inferred.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+import matrixark_gateway_config as cfg  # noqa: E402
+import matrixark_mcp_retrieve_planning as planning  # noqa: E402
+import matrixark_mcp_runtime_config as runtime  # noqa: E402
+import matrixark_v1_gateway as gateway  # noqa: E402
+
+VARIABLES = ("MATRIXARK_RETRIEVAL_TIMEOUT_MS",
+             "MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS",
+             "MATRIXARK_TEMPORALSTORE_IO_TIMEOUT_MS")
+
+SETTINGS = {
+    "retrieval.timeout_ms": "MATRIXARK_RETRIEVAL_TIMEOUT_MS",
+    "limits.transport_request_timeout_ms": "MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS",
+    "limits.transport_io_timeout_ms": "MATRIXARK_TEMPORALSTORE_IO_TIMEOUT_MS",
+}
+
+
+class Case(unittest.TestCase):
+    def setUp(self) -> None:
+        self._saved = {n: os.environ.get(n) for n in VARIABLES}
+        for name in VARIABLES:
+            os.environ.pop(name, None)
+
+    def tearDown(self) -> None:
+        for name, value in self._saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+class TheDeadlineIsResolvedInOnePlaceTest(Case):
+    """The adapter resolved it inline, directly below a comment claiming the policy beside it came
+    'from one implementation'. The audit policy had been consolidated; the deadline had not."""
+
+    def inline(self, args, ranking):
+        """What the adapter used to compute for itself."""
+        raw = args.get("deadline_ms",
+                       ranking.get("deadline_ms",
+                                   os.environ.get("MATRIXARK_RETRIEVAL_TIMEOUT_MS", 0)))
+        return int(raw or 0)
+
+    def test_the_shared_resolver_answers_the_same(self) -> None:
+        cases = [
+            ({}, {}, None),
+            ({"deadline_ms": 1234}, {}, None),
+            ({}, {"deadline_ms": 4321}, None),
+            ({}, {}, "5000"),
+            ({"deadline_ms": 10}, {"deadline_ms": 20}, "30"),
+            ({}, {}, "0"),
+        ]
+        for args, ranking, env in cases:
+            with self.subTest(args=args, ranking=ranking, env=env):
+                if env is None:
+                    os.environ.pop("MATRIXARK_RETRIEVAL_TIMEOUT_MS", None)
+                else:
+                    os.environ["MATRIXARK_RETRIEVAL_TIMEOUT_MS"] = env
+                self.assertEqual(self.inline(args, ranking),
+                                 planning.retrieval_deadline_ms(args, ranking))
+
+    def test_the_cases_are_not_all_zero(self) -> None:
+        """The floor: six cases that all resolve to 0 would agree trivially."""
+        os.environ["MATRIXARK_RETRIEVAL_TIMEOUT_MS"] = "5000"
+        self.assertEqual(5000, planning.retrieval_deadline_ms({}, {}))
+        self.assertEqual(77, planning.retrieval_deadline_ms({"deadline_ms": 77}, {}))
+
+    def test_the_adapter_no_longer_carries_its_own_copy(self) -> None:
+        with open(os.path.join(TOOLS, "matrixark_local_adapter_retrieve.py"),
+                  encoding="utf-8") as handle:
+            source = handle.read()
+        self.assertNotIn('os.environ.get("MATRIXARK_RETRIEVAL_TIMEOUT_MS"', source)
+        self.assertIn("_retrieve_planning.retrieval_deadline_ms(args, ranking)", source)
+
+
+class TheDeadlineIsCooperativeTest(unittest.TestCase):
+    """Derived from where the check is, not asserted: this is the reason a deadline cannot bound a
+    single call, and if it ever stopped being true the panel's claim would become false."""
+
+    def deadline_check_sites(self):
+        path = os.path.join(TOOLS, "matrixark_local_adapter_retrieve.py")
+        with open(path, encoding="utf-8") as handle:
+            tree = ast.parse(handle.read(), filename=path)
+        found = []
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+                    and node.func.id == "deadline_exceeded"):
+                found.append(node.lineno)
+        return found
+
+    def test_the_deadline_is_checked_in_many_places(self) -> None:
+        """A cooperative deadline is one that is polled. If it were applied to the call instead
+        there would be one site, not a dozen."""
+        self.assertGreater(len(self.deadline_check_sites()), 8)
+
+    def test_the_panel_says_it_is_cooperative(self) -> None:
+        self.assertTrue(gateway._latency_summary()["deadline_is_cooperative"])
+
+
+class ThePanelNamesWhatBoundsASlowCallTest(Case):
+
+    def test_it_is_never_the_deadline(self) -> None:
+        """Whatever the deadline is set to. It is not applied to the call."""
+        for deadline in ("0", "5000", "300000"):
+            with self.subTest(deadline=deadline):
+                os.environ["MATRIXARK_RETRIEVAL_TIMEOUT_MS"] = deadline
+                self.assertEqual("transport_request_timeout_ms",
+                                 gateway._latency_summary()["bounds_a_slow_call"])
+
+    def test_the_overrun_is_the_gap_between_them(self) -> None:
+        """The live observation: a five-second deadline and a call able to run for sixty."""
+        os.environ["MATRIXARK_RETRIEVAL_TIMEOUT_MS"] = "5000"
+        os.environ["MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS"] = "60000"
+        self.assertEqual(55000, gateway._latency_summary()["deadline_can_be_overrun_by_ms"])
+
+    def test_lowering_the_transport_timeout_closes_it(self) -> None:
+        """And the operator has a lever, which is the point of offering it."""
+        os.environ["MATRIXARK_RETRIEVAL_TIMEOUT_MS"] = "5000"
+        os.environ["MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS"] = "8000"
+        self.assertEqual(3000, gateway._latency_summary()["deadline_can_be_overrun_by_ms"])
+
+    def test_no_deadline_means_nothing_to_overrun(self) -> None:
+        """0 here has to mean "no deadline is set", not "a deadline that is never exceeded"."""
+        os.environ.pop("MATRIXARK_RETRIEVAL_TIMEOUT_MS", None)
+        summary = gateway._latency_summary()
+        self.assertEqual(0, summary["deadline_ms"])
+        self.assertEqual(0, summary["deadline_can_be_overrun_by_ms"])
+
+    def test_a_deadline_larger_than_the_transport_cannot_be_overrun(self) -> None:
+        """The 300-second knob: the transport bounds it, so there is no overrun -- and the panel
+        must not report a negative one."""
+        os.environ["MATRIXARK_RETRIEVAL_TIMEOUT_MS"] = "300000"
+        self.assertEqual(0, gateway._latency_summary()["deadline_can_be_overrun_by_ms"])
+
+    def test_the_panel_reads_the_same_resolver_a_retrieve_does(self) -> None:
+        os.environ["MATRIXARK_RETRIEVAL_TIMEOUT_MS"] = "4321"
+        self.assertEqual(planning.retrieval_deadline_ms({}, {}),
+                         gateway._latency_summary()["deadline_ms"])
+
+
+class TheTransportTimeoutHasOneNumberTest(Case):
+    """Unifying the two transport defaults was done separately, in #1039, and more simply: the odd
+    literal was corrected in place with the reasoning written beside it.
+
+    What this change owes is narrower. The panel below has to resolve the same timeout in order to
+    report it, which is a SECOND site for that number, and nothing in the tree ties a constant to a
+    literal in an argument parser. This does."""
+
+    def backend_default(self, variable: str) -> int:
+        """The number `matrixark_mcp_backends` actually parses, read out of its source."""
+        with open(os.path.join(TOOLS, "matrixark_mcp_backends.py"), encoding="utf-8") as handle:
+            source = handle.read()
+        marker = 'os.environ.get("%s", "' % variable
+        start = source.index(marker) + len(marker)
+        return int(source[start:source.index('"', start)])
+
+    def test_the_panel_resolves_the_number_the_backend_parses(self) -> None:
+        for variable, constant in (
+                ("MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS",
+                 runtime.DEFAULT_TRANSPORT_REQUEST_TIMEOUT_MS),
+                ("MATRIXARK_TEMPORALSTORE_IO_TIMEOUT_MS",
+                 runtime.DEFAULT_TRANSPORT_IO_TIMEOUT_MS)):
+            with self.subTest(variable=variable):
+                self.assertEqual(
+                    self.backend_default(variable), constant,
+                    "the panel would report a timeout the backend does not use")
+
+    def test_the_reader_found_a_real_number(self) -> None:
+        """The floor: a parse that returned nothing would make the rule above compare two
+        constants against each other and pass on anything."""
+        self.assertGreater(self.backend_default("MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS"), 0)
+
+    def test_it_is_read_per_call(self) -> None:
+        os.environ["MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS"] = "9000"
+        self.assertEqual(9000, runtime.transport_timeout_ms(
+            "MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS",
+            runtime.DEFAULT_TRANSPORT_REQUEST_TIMEOUT_MS))
+
+    def test_a_bad_value_falls_back(self) -> None:
+        """A socket timeout of zero never times out; nonsense would fail every call."""
+        for raw in ("", "  ", "soon", "0", "-1"):
+            with self.subTest(value=raw):
+                os.environ["MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS"] = raw
+                self.assertEqual(runtime.DEFAULT_TRANSPORT_REQUEST_TIMEOUT_MS,
+                                 runtime.transport_timeout_ms(
+                                     "MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS",
+                                     runtime.DEFAULT_TRANSPORT_REQUEST_TIMEOUT_MS))
+
+
+class ThePortalOffersThemTest(unittest.TestCase):
+
+    def test_all_three_are_offered(self) -> None:
+        for key, variable in SETTINGS.items():
+            with self.subTest(setting=key):
+                self.assertIn(key, cfg.SETTINGS_BY_KEY)
+                self.assertEqual(variable, cfg.SETTINGS_BY_KEY[key].env)
+
+    def test_they_take_effect_without_a_restart(self) -> None:
+        for key in SETTINGS:
+            with self.subTest(setting=key):
+                self.assertEqual("live", cfg.SETTINGS_BY_KEY[key].applies)
+
+    def test_the_declared_defaults_are_what_the_build_runs(self) -> None:
+        self.assertEqual(0, int(cfg.SETTINGS_BY_KEY["retrieval.timeout_ms"].default))
+        self.assertEqual(
+            runtime.DEFAULT_TRANSPORT_REQUEST_TIMEOUT_MS,
+            int(cfg.SETTINGS_BY_KEY["limits.transport_request_timeout_ms"].default))
+        self.assertEqual(
+            runtime.DEFAULT_TRANSPORT_IO_TIMEOUT_MS,
+            int(cfg.SETTINGS_BY_KEY["limits.transport_io_timeout_ms"].default))
+
+    def test_the_deadline_help_says_it_cannot_bound_a_call(self) -> None:
+        """The one thing an operator has to know before setting it, or they will set it and
+        conclude it does not work."""
+        help_text = cfg.SETTINGS_BY_KEY["retrieval.timeout_ms"].help.lower()
+        self.assertIn("cooperative", help_text)
+        self.assertIn("cannot bound one slow backend call", help_text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two controls decide how long a retrieve takes, and only one of them can stop a slow call.

- The **retrieval deadline** is *cooperative*. `deadline_exceeded()` is consulted between stages and
  every 64 or 128 candidates — a dozen sites, all of them loop boundaries — and **never around a
  call to the store**.
- The **transport request timeout** is what a single call actually runs against.

So a deployment with a five-second deadline saw retrieves come back after sixty. The deadline was
not being ignored; it was being checked at moments the call had not returned from. Neither control
was offered anywhere.

### What the panel says now

| | deadline | transport | overrun | bounds a slow call |
|---|---|---|---|---|
| nothing set | 0 | 60,000 | 0 | transport |
| a 5s deadline | 5,000 | 60,000 | **55,000** | transport |
| same, transport lowered to 8s | 5,000 | 8,000 | 3,000 | transport |
| a 300s deadline | 300,000 | 60,000 | 0 | transport |

`deadline_can_be_overrun_by_ms` is the number an operator is actually looking for when a retrieve
came back late, stated instead of left to be inferred. Row 3 is the point of offering the controls:
lowering the transport timeout is the only thing that closes the gap. Row 4 is the other half — a
300-second deadline cannot be overrun because the transport bounds it first, which is why raising
that knob never governed anything.

### Three settings

`retrieval.timeout_ms`, `limits.transport_request_timeout_ms`, `limits.transport_io_timeout_ms`. The
code reads twelve or more timeout variables; the portal offered three, none of them these.

The deadline's help says it is **cooperative and cannot bound one slow backend call** — otherwise an
operator sets it, sees a retrieve overrun, and concludes the setting is broken. A test pins both
phrases, because that warning is the setting's whole usability.

### The adapter stopped resolving the deadline for itself

It computed it inline, *immediately below* a comment saying the policy beside it comes "from one
implementation … the only thing that differs". The audit policy had been consolidated; the deadline
on the next line had not. A test compares the shared resolver against the expression it replaces
over six shapes of args/ranking/environment, with a floor asserting they do not all resolve to zero.

### Narrowed after #1039

This originally also unified the two transport defaults — 20,000 in one module, 60,000 in two
others. [#1039](https://github.com/matrixarkai/TemporalStore/pull/1039) landed first and did it
better: it corrected the odd literal in place, with the reasoning written beside it and the
launcher evidence for which number is the real one. That half is dropped here and main's version
taken whole, including its strike-off from `test_numeric_defaults_agree`.

What remains is the second site that *this* change introduces: the panel must resolve the same
timeout in order to report it, and nothing in the tree ties a constant to a literal in an argument
parser. A test reads the number `matrixark_mcp_backends` actually parses out of its source and
requires the panel's constant to equal it, so the panel cannot report a timeout the backend does not
use. With a floor, because a parse that found nothing would compare two constants and pass on
anything.

```
the adapter resolves the deadline for itself again       -> FAIL
the panel names the deadline as what bounds a call       -> FAIL
the overrun is allowed to go negative                    -> FAIL
an unset deadline reports an overrun anyway              -> FAIL
the panel stops calling the deadline cooperative         -> FAIL
a zero socket timeout is accepted                        -> FAIL
the portal promises a restart for the deadline           -> FAIL
the help stops warning that the deadline is cooperative  -> FAIL
```

19 tests. "Cooperative" is **derived**, not asserted: a test parses the adapter and counts the
`deadline_exceeded()` call sites, on the grounds that a deadline applied to the call would have one
site rather than a dozen — and if that ever stopped being true, the panel's claim would quietly
become false.
