### PR TITLE
A purge keeps the log in the form it is already in

### DIFF
--- a/tools/test_matrixark_the_log_is_written_in_blocks.py
+++ b/tools/test_matrixark_the_log_is_written_in_blocks.py
@@ -230,6 +230,56 @@ class LogIsWrittenInBlocksTest(unittest.TestCase):
         self.assertLessEqual(len(rotated) + 1, retained)
 
 
+    def test_a_purge_rewrites_the_log_in_the_form_it_is_already_in(self):
+        """A purge REPLACES the log, so it is the one operation that can change its form.
+
+        It read through `_iter_shard_lines`, which knows every form, and then wrote plain lines
+        regardless: a purge of a block log grew it from 12,954 bytes to 35,962, the opposite of
+        what a purge is for. The lasting half is worse than the size, because the form is read
+        from the FILE -- every later append inherited plain from the rewritten file, so one purge
+        left the log uncompressed until the next rotation.
+
+        Fixed in the rewrite, but covered only incidentally: the assertion that caught it lives in
+        test_mem0_complete and is about tombstones reclaiming space, so it would still pass if the
+        log came back smaller in the wrong form. This names the form.
+        """
+        adapter_module.LOCAL_JSONL_BLOCK_LOG = True
+        adapter = MatrixArkLocalAdapter(self.log)
+        for batch in range(6):
+            adapter.append_many(_records(batch * 20, 20))
+        adapter.append_many([
+            {
+                "record_type": adapter_module.MEMORY_TOMBSTONE_RECORD_TYPE,
+                "event_id_hash": 900 + index,
+                "target_event_id_hash": index,
+                "updated_at_ms": 1780000009000 + index,
+            }
+            for index in range(20)
+        ])
+        before_bytes = self.log.stat().st_size
+        self.assertTrue(self.log.read_bytes().startswith(_SHARD_CONTAINER_MAGIC),
+                        "the log was not a block stream, so the purge has nothing to keep")
+
+        result = adapter.purge_tombstones(force=True)
+        self.assertTrue(result.get("purged"),
+                        "nothing was purged, so this asserts nothing about a rewrite")
+        self.assertTrue(self.log.read_bytes().startswith(_SHARD_CONTAINER_MAGIC),
+                        "the purge rewrote the block log as plain text, and every later "
+                        "append would inherit that form from it")
+        self.assertLess(self.log.stat().st_size, before_bytes,
+                        "the purged log is no smaller, so the rewrite lost the compression")
+
+        # The markers are gone and every surviving record still reads back. Asserted on the
+        # purge's own count and on the served view rather than on which records a tombstone
+        # matches: what is under test here is the rewrite, and the matching rules are another
+        # test's subject.
+        self.assertEqual(20, result.get("removed_tombstones"),
+                         "the purge did not remove the markers it reported on")
+        _clear_process_read_cache()
+        kept = self._appended(self.log)
+        self.assertEqual(120, len(kept),
+                         "the rewrite lost records that no tombstone removes")
+
     def test_a_plain_append_onto_a_block_log_still_reads(self):
         """The reason this format shipped off by default.
 


### PR DESCRIPTION
#1025 fixed the one operation that could change the event log's storage form: `purge_tombstones`
read through `_iter_shard_lines`, which knows every form, and then wrote plain JSON lines
regardless — so purging a block-framed log grew it from 12,954 bytes to 35,962 and left it plain
until the next rotation. The fix is right and the reasoning is written down. It has no test of its
own.

What covers it today is `test_mem0_complete`, which asserts a purged log is **smaller** than it
was. That does catch the regression, which is how it was noticed — but only incidentally. It is a
test about tombstones reclaiming space, in another file, and it would keep passing if a purge
returned a smaller log in the wrong form.

This names the form. After a purge of a block log it asserts the file still begins with the
container magic, is smaller than before, removed the markers it reported removing, and lost none of
the records no tombstone removes.

### Why the form is the thing worth asserting

The size is the smaller half of that defect. Because the form is read from the **file**, a purge
that wrote plain did not just produce one larger file — every later append inherited plain from it,
so a single purge turned the compression off until the next rotation. An assertion about bytes
cannot see that; an assertion about the head can.

### Checks

| | |
|---|---|
| the block log's suite | **14 passed** |
| mutation — `if self._log_append_form() == _SHARD_CODEC_BLOCKS:` → `if False:` | **fails**, and is the only failure in the file |
| restored | green |

The mutation is the shape of the defect #1025 fixed, so the guard is pinned to that behaviour
rather than to the code that implements it.
