### PR TITLE
The page shows the budget and the timing it already fetched

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -453,6 +453,24 @@ SETTINGS: List[Setting] = [
             "share above is set."),
 
     # ---- retrieval and context budget ----------------------------------------------------------
+    Setting("retrieval.timeout_ms", "retrieval", "MATRIXARK_RETRIEVAL_TIMEOUT_MS",
+            "Retrieval deadline (ms)", "int", "0", "live",
+            "How long a retrieve may keep working before it returns what it has. 0 means no "
+            "deadline. It is COOPERATIVE: it is checked between stages and every 64 or 128 "
+            "candidates, never around a call to the store -- so it bounds the work a retrieve "
+            "does, and cannot bound one slow backend call. The transport timeout below is what "
+            "does that, and the pack panel reports which of the two is the smaller."),
+    Setting("limits.transport_request_timeout_ms", "limits",
+            "MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS",
+            "Transport request timeout (ms)", "int", "60000", "live",
+            "The per-request timeout on the call to the store. This is the one that decides how "
+            "long a single slow call can take, whatever the deadline above says. It answered "
+            "20000 in the adapter and 60000 in the agent hooks for the same variable until they "
+            "were given one number."),
+    Setting("limits.transport_io_timeout_ms", "limits",
+            "MATRIXARK_TEMPORALSTORE_IO_TIMEOUT_MS",
+            "Transport I/O timeout (ms)", "int", "60000", "live",
+            "The I/O timeout underneath the request timeout above. Same story, same fix."),
     Setting("retrieval.hook_max_context_tokens", "retrieval",
             "MATRIXARK_HOOK_MAX_CONTEXT_TOKENS",
             "Agent hook context budget (tokens)", "int", "128000", "live",

--- a/tools/matrixark_mcp_runtime_config.py
+++ b/tools/matrixark_mcp_runtime_config.py
@@ -242,6 +242,20 @@ def live_int(variable: str, fallback: int) -> int:
     return parsed if parsed > 0 else fallback
 
 
+# One number for the transport timeouts, which the adapter CLI and both hooks each used to
+# answer differently: 20,000 here, 60,000 there, for the same variable. Unified at the larger,
+# because a socket timeout that is too long makes a slow call wait while one that is too short
+# makes a working call fail, and only the second loses the answer.
+DEFAULT_TRANSPORT_REQUEST_TIMEOUT_MS = 60000
+DEFAULT_TRANSPORT_IO_TIMEOUT_MS = 60000
+
+
+def transport_timeout_ms(variable: str, fallback: int) -> int:
+    """A transport timeout in force now. Anything unusable falls back to the build default: a
+    socket timeout of zero or nonsense would either never time out or fail every call."""
+    return live_int(variable, fallback)
+
+
 DEFAULT_HOOK_MAX_CONTEXT_TOKENS = 128000  # build default; the resolver below reads the env
 
 

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1647,6 +1647,49 @@ def _model_picker_body(target: str) -> Json:
     return body
 
 
+def _latency_summary() -> Json:
+    """Which control actually decides how long a retrieve can take.
+
+    There are two, and only one of them can stop a slow call. The retrieval deadline is
+    COOPERATIVE: `deadline_exceeded()` is consulted between stages and every 64 or 128 candidates,
+    and never around a call to the store. So it bounds the work a retrieve chooses to keep doing,
+    and a single backend call runs to the transport timeout regardless of it.
+
+    That is why a deployment with a five-second deadline was seeing retrieves return after sixty:
+    the deadline was not being ignored, it was being checked at moments the call had not returned
+    from. `deadline_can_be_overrun_by_ms` is that gap, stated rather than left to be inferred.
+    """
+    try:
+        try:
+            from tools import matrixark_mcp_retrieve_planning as planning  # type: ignore
+            from tools import matrixark_mcp_runtime_config as runtime  # type: ignore
+        except ImportError:
+            import matrixark_mcp_retrieve_planning as planning  # type: ignore
+            import matrixark_mcp_runtime_config as runtime  # type: ignore
+    except Exception:  # pragma: no cover - the portal still works without the retrieval modules
+        return {"available": False}
+    # Asked of the same resolver a retrieve uses, so this cannot drift from what runs.
+    deadline = int(planning.retrieval_deadline_ms({}, {}) or 0)
+    request = runtime.transport_timeout_ms("MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS",
+                                           runtime.DEFAULT_TRANSPORT_REQUEST_TIMEOUT_MS)
+    io_timeout = runtime.transport_timeout_ms("MATRIXARK_TEMPORALSTORE_IO_TIMEOUT_MS",
+                                              runtime.DEFAULT_TRANSPORT_IO_TIMEOUT_MS)
+    return {
+        "available": True,
+        "deadline_ms": deadline,
+        "deadline_is_cooperative": True,
+        "transport_request_timeout_ms": request,
+        "transport_io_timeout_ms": io_timeout,
+        # Never the deadline, whatever its value: it is not applied to the call.
+        "bounds_a_slow_call": "transport_request_timeout_ms",
+        "worst_case_single_call_ms": request,
+        # 0 when no deadline is set -- there is nothing to overrun. Otherwise this is how much
+        # longer than the deadline one slow call can take, which is the number an operator is
+        # actually looking for when a retrieve came back late.
+        "deadline_can_be_overrun_by_ms": max(0, request - deadline) if deadline > 0 else 0,
+    }
+
+
 def _shared_budget_summary() -> Json:
     """What each section of a pack is allowed, asked of the packer rather than worked out here.
 
@@ -4806,6 +4849,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                 "counts": counts,
                 "traffic": traffic,
                 "footprint": footprint,
+                "latency": _latency_summary(),
                 "imports": imports,
                 "config": config_snapshot,
             })

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -1109,6 +1109,23 @@ SETUP_BODY = """
       would be wrong.</p>
     <div id="footprint"><div class="empty">Loading&hellip;</div></div>
   </section>
+
+  <section>
+    <h2>Pack budget</h2>
+    <p class="hint" style="margin-top:0">What each section of a context pack is allowed. The share
+      is a percentage of the context budget &mdash; and there are two of those, because the agent
+      hooks have never used the one an API caller gets. A percentage is the same on both; what it
+      comes to is not.</p>
+    <div id="budgets"><div class="empty">Loading&hellip;</div></div>
+  </section>
+
+  <section>
+    <h2>Retrieve timing</h2>
+    <p class="hint" style="margin-top:0">Two controls decide how long a retrieve takes and only one
+      of them can stop a slow call. The deadline is checked between stages, never around a call to
+      the store, so a single slow call runs to the transport timeout whatever the deadline says.</p>
+    <div id="latency"><div class="empty">Loading&hellip;</div></div>
+  </section>
   </section>
 
   <section class="pane" role="tabpanel" aria-labelledby="tab-deployment" id="pane-deployment" hidden>
@@ -2354,13 +2371,80 @@ SETUP_JS = r"""
     $("footprint").innerHTML = "<table><tbody>" + rows + "</tbody></table>";
   }
 
+  function num(v) {
+    if (v === null || v === undefined) { return "\u2014"; }
+    return String(v).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  }
+
+  function renderBudgets(budgets) {
+    if (!budgets || !budgets.available) {
+      $("budgets").innerHTML = '<div class="empty">Not available.</div>';
+      return;
+    }
+    var paths = budgets.paths || [];
+    var rows = "<tr><th>Caller</th><th>Context budget</th><th>Skills</th>"
+             + "<th>Resources</th></tr>";
+    paths.forEach(function (p) {
+      rows += "<tr><td>" + p.label + '</td><td class="num">' + num(p.context_budget_tokens)
+            + '</td><td class="num">' + num((p.sections || {}).skills)
+            + '</td><td class="num">' + num((p.sections || {}).resources) + "</td></tr>";
+    });
+    var note = "";
+    ["skills", "resources"].forEach(function (name) {
+      var s = budgets[name];
+      if (!s) { return; }
+      /* The share, and which of the three limits decided it. A percentage something else is
+         overriding is a control that does not control anything. */
+      note += "<p class=\"hint\">" + name + ": " + s.percent + "% asked "
+            + s.asked_percent + "%, guard " + s.guard_percent + "% &mdash; set by "
+            + s.bound_by.replace(/_/g, " ") + ".</p>";
+    });
+    if (budgets.paths_differ) {
+      note += '<p class="hint"><strong>The two callers run different budgets.</strong> '
+            + "A token figure is only true for the row it is on.</p>";
+    }
+    $("budgets").innerHTML = "<table><tbody>" + rows + "</tbody></table>" + note;
+  }
+
+  function renderLatency(lat) {
+    if (!lat || !lat.available) {
+      $("latency").innerHTML = '<div class="empty">Not available.</div>';
+      return;
+    }
+    var rows = "";
+    function row(label, value, aux) {
+      rows += "<tr><td>" + label + '</td><td class="num">' + value
+            + '</td><td class="aux">' + (aux || "") + "</td></tr>";
+    }
+    row("Retrieval deadline", lat.deadline_ms ? num(lat.deadline_ms) + " ms" : "none set",
+        lat.deadline_is_cooperative ? "cooperative &mdash; cannot stop a call in flight" : "");
+    row("Transport request timeout", num(lat.transport_request_timeout_ms) + " ms",
+        "what one slow call actually runs against");
+    row("Transport I/O timeout", num(lat.transport_io_timeout_ms) + " ms", "");
+    /* The number an operator is looking for when a retrieve came back late. */
+    row("A slow call can overrun the deadline by",
+        lat.deadline_can_be_overrun_by_ms
+          ? num(lat.deadline_can_be_overrun_by_ms) + " ms" : "\u2014",
+        lat.deadline_can_be_overrun_by_ms
+          ? "lower the transport timeout to close this" : "nothing to overrun");
+    $("latency").innerHTML = "<table><tbody>" + rows + "</tbody></table>";
+  }
+
   function loadFootprint() {
     fetch("/v1/admin/overview", { headers: auth() })
       .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
-      .then(function (d) { renderFootprint(d.footprint); })
+      .then(function (d) {
+        /* One response, three panels. The overview already carried all of this; asking three
+           times for it would be three times the probing for the same answer. */
+        renderFootprint(d.footprint);
+        renderBudgets((((d.config || {}).skills) || {}).budgets);
+        renderLatency(d.latency);
+      })
       .catch(function () {
         $("footprint").innerHTML =
           '<div class="msg err">Could not read the footprint.</div>';
+        $("budgets").innerHTML = '<div class="msg err">Could not read the budget.</div>';
+        $("latency").innerHTML = '<div class="msg err">Could not read the timing.</div>';
       });
   }
 

--- a/tools/portal/overview_panels_harness.js
+++ b/tools/portal/overview_panels_harness.js
@@ -1,0 +1,182 @@
+/* Run the Setup page, hand it one overview response, and read what the three panels drew.
+ *
+ * The claim under test is not just that each panel renders. It is that ONE response feeds all
+ * three: the overview already carried the footprint, the budget and the timing, and asking three
+ * times for the same answer would be three times the probing. A fetch count is the only way to see
+ * that from outside.
+ *
+ * Usage: node overview_panels_harness.js <setup_portal.html> [differ|aligned]
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const mode = process.argv[3] || "differ";
+const scripts = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+const HOOK_BUDGET = mode === "aligned" ? 500000 : 10000;
+const OVERVIEW = {
+  status: "ok",
+  footprint: {
+    worker: { resident_bytes: 412 * 1048576, peak_bytes: 455 * 1048576,
+              source: "/proc/self/status", workers: 1 },
+    engine: { available: false }
+  },
+  latency: mode === "aligned" ? {
+    available: true, deadline_ms: 0, deadline_is_cooperative: true,
+    transport_request_timeout_ms: 60000, transport_io_timeout_ms: 60000,
+    bounds_a_slow_call: "transport_request_timeout_ms",
+    worst_case_single_call_ms: 60000, deadline_can_be_overrun_by_ms: 0
+  } : {
+    available: true, deadline_ms: 5000, deadline_is_cooperative: true,
+    transport_request_timeout_ms: 60000, transport_io_timeout_ms: 60000,
+    bounds_a_slow_call: "transport_request_timeout_ms",
+    worst_case_single_call_ms: 60000, deadline_can_be_overrun_by_ms: 55000
+  },
+  config: {
+    skills: {
+      budgets: {
+        available: true,
+        context_budget_tokens: 500000,
+        skills: { percent: 10, asked_percent: 10, guard_percent: 50, tokens: 50000,
+                  ceiling_tokens: 262144, by_percentage_tokens: 50000,
+                  bound_by: "percentage" },
+        resources: { percent: 25, asked_percent: 40, guard_percent: 50, tokens: 125000,
+                     ceiling_tokens: 262144, by_percentage_tokens: 125000,
+                     bound_by: "share_guard" },
+        paths: [
+          { path: "api", label: "API callers", context_budget_tokens: 500000,
+            variable: "MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS",
+            sections: { skills: 50000, resources: 125000 } },
+          { path: "agent_hooks", label: "Agent hooks", context_budget_tokens: HOOK_BUDGET,
+            variable: "MATRIXARK_HOOK_MAX_CONTEXT_TOKENS",
+            sections: { skills: HOOK_BUDGET / 10, resources: HOOK_BUDGET / 4 } }
+        ],
+        paths_differ: mode !== "aligned"
+      }
+    }
+  }
+};
+
+const els = new Map();
+function makeEl(id) {
+  return {
+    id: id || "", hidden: false, textContent: "",
+    value: id === "key" ? "k-admin" : "", checked: true, className: "",
+    style: {}, dataset: {}, files: [], options: [], children: [], _html: "",
+    get innerHTML() { return this._html; },
+    set innerHTML(v) { this._html = String(v); },
+    addEventListener() {}, removeEventListener() {}, appendChild() {}, removeChild() {},
+    setAttribute() {}, getAttribute() { return null; }, closest() { return null; },
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    scrollIntoView() {}, focus() {}, click() {},
+    classList: { add() {}, remove() {}, toggle() {} }
+  };
+}
+function el(id) {
+  if (!els.has(id)) { els.set(id, makeEl(id)); }
+  return els.get(id);
+}
+
+let overviewCalls = 0;
+
+const win = {
+  document: {
+    getElementById: (id) => el(id),
+    querySelector: () => makeEl(), querySelectorAll: () => [],
+    createElement: () => makeEl(), addEventListener() {}, body: makeEl(), hidden: false
+  },
+  addEventListener() {},
+  location: { origin: "http://localhost", href: "http://localhost", reload() {} },
+  sessionStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  localStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  navigator: {},
+  setTimeout: () => 0, setInterval: () => 0, clearInterval() {},
+  Number, JSON, String, Math, Date, Object, Array, Promise, RegExp, Error, isNaN,
+  encodeURIComponent, decodeURIComponent, parseInt, parseFloat,
+  TextDecoder: function () { this.decode = (v) => Buffer.from(v || []).toString("utf8"); },
+  AbortController: function () { this.abort = () => {}; this.signal = {}; },
+  FileReader: function () {}, Blob: function () {},
+  URL: { createObjectURL: () => "", revokeObjectURL() {} },
+  fetch: (url) => {
+    const u = String(url);
+    if (u.indexOf("/v1/admin/overview") >= 0) {
+      overviewCalls += 1;
+      return Promise.resolve({ ok: true, status: 200,
+                               json: () => Promise.resolve(OVERVIEW),
+                               text: () => Promise.resolve(JSON.stringify(OVERVIEW)) });
+    }
+    if (u.indexOf("/v1/admin/events") >= 0) {
+      return Promise.resolve({ ok: true, status: 200,
+                               body: { getReader: () => ({ read: () => new Promise(() => {}) }) },
+                               json: () => Promise.resolve({}), text: () => Promise.resolve("") });
+    }
+    return Promise.resolve({ ok: true, status: 200,
+                             json: () => Promise.resolve({ settings: {} }),
+                             text: () => Promise.resolve("") });
+  }
+};
+win.window = win;
+
+const names = Object.keys(win);
+const values = names.map((k) => win[k]);
+scripts.forEach((body, index) => {
+  try { new Function(...names, body)(...values); }
+  catch (e) { console.log("FAIL script " + index + " threw: " + e.message); failures += 1; }
+});
+
+setTimeout(function () {
+  const budgets = el("budgets").innerHTML;
+  const latency = el("latency").innerHTML;
+  const footprint = el("footprint").innerHTML;
+
+  /* The whole reason these three sit on one fetch. */
+  ok("one response fed all three panels", overviewCalls === 1,
+     "overview calls: " + overviewCalls);
+  ok("the footprint still drew", /412\.0 MB/.test(footprint), footprint.slice(0, 200));
+
+  ok("the budget panel names both callers",
+     /API callers/.test(budgets) && /Agent hooks/.test(budgets), budgets.slice(0, 400));
+  ok("the API budget is shown with separators", /500,000/.test(budgets), budgets.slice(0, 400));
+  ok("a share says which limit set it", /set by percentage/.test(budgets),
+     budgets.slice(0, 700));
+  /* A percentage the guard is holding down is the defect the panel exists to show. */
+  ok("a share held by the guard says so", /set by share guard/.test(budgets),
+     budgets.slice(0, 700));
+
+  if (mode === "aligned") {
+    ok("no difference is claimed when there is none", !/different budgets/.test(budgets),
+       budgets.slice(0, 700));
+    ok("no deadline means nothing to overrun", /nothing to overrun/.test(latency),
+       latency.slice(0, 500));
+    /* The cell itself, not the note beside it. A mutation that printed
+       `transport - deadline` here left the note reading "nothing to overrun" next to a number,
+       and a check for one particular figure missed it. */
+    ok("and no overrun figure is invented",
+       /overrun the deadline by<\/td><td class="num">—</.test(latency),
+       latency.slice(0, 700));
+  } else {
+    ok("the agent's smaller budget is shown, not the API one",
+       /10,000/.test(budgets), budgets.slice(0, 400));
+    ok("and the page says the two callers differ", /different budgets/.test(budgets),
+       budgets.slice(0, 700));
+    ok("the overrun an operator is looking for is shown", /55,000 ms/.test(latency),
+       latency.slice(0, 500));
+    ok("with the lever that closes it", /lower the transport timeout/.test(latency),
+       latency.slice(0, 500));
+  }
+
+  ok("the deadline is described as cooperative", /cannot stop a call in flight/.test(latency),
+     latency.slice(0, 500));
+  ok("the transport timeout is named as what a call runs against",
+     /what one slow call actually runs against/.test(latency), latency.slice(0, 500));
+
+  console.log(failures ? "\n" + failures + " failed" : "\nall ok");
+  process.exit(failures ? 1 : 0);
+}, 60);

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -606,6 +606,23 @@
       would be wrong.</p>
     <div id="footprint"><div class="empty">Loading&hellip;</div></div>
   </section>
+
+  <section>
+    <h2>Pack budget</h2>
+    <p class="hint" style="margin-top:0">What each section of a context pack is allowed. The share
+      is a percentage of the context budget &mdash; and there are two of those, because the agent
+      hooks have never used the one an API caller gets. A percentage is the same on both; what it
+      comes to is not.</p>
+    <div id="budgets"><div class="empty">Loading&hellip;</div></div>
+  </section>
+
+  <section>
+    <h2>Retrieve timing</h2>
+    <p class="hint" style="margin-top:0">Two controls decide how long a retrieve takes and only one
+      of them can stop a slow call. The deadline is checked between stages, never around a call to
+      the store, so a single slow call runs to the transport timeout whatever the deadline says.</p>
+    <div id="latency"><div class="empty">Loading&hellip;</div></div>
+  </section>
   </section>
 
   <section class="pane" role="tabpanel" aria-labelledby="tab-deployment" id="pane-deployment" hidden>
@@ -2069,13 +2086,80 @@ function liveStream(options) {
     $("footprint").innerHTML = "<table><tbody>" + rows + "</tbody></table>";
   }
 
+  function num(v) {
+    if (v === null || v === undefined) { return "\u2014"; }
+    return String(v).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  }
+
+  function renderBudgets(budgets) {
+    if (!budgets || !budgets.available) {
+      $("budgets").innerHTML = '<div class="empty">Not available.</div>';
+      return;
+    }
+    var paths = budgets.paths || [];
+    var rows = "<tr><th>Caller</th><th>Context budget</th><th>Skills</th>"
+             + "<th>Resources</th></tr>";
+    paths.forEach(function (p) {
+      rows += "<tr><td>" + p.label + '</td><td class="num">' + num(p.context_budget_tokens)
+            + '</td><td class="num">' + num((p.sections || {}).skills)
+            + '</td><td class="num">' + num((p.sections || {}).resources) + "</td></tr>";
+    });
+    var note = "";
+    ["skills", "resources"].forEach(function (name) {
+      var s = budgets[name];
+      if (!s) { return; }
+      /* The share, and which of the three limits decided it. A percentage something else is
+         overriding is a control that does not control anything. */
+      note += "<p class=\"hint\">" + name + ": " + s.percent + "% asked "
+            + s.asked_percent + "%, guard " + s.guard_percent + "% &mdash; set by "
+            + s.bound_by.replace(/_/g, " ") + ".</p>";
+    });
+    if (budgets.paths_differ) {
+      note += '<p class="hint"><strong>The two callers run different budgets.</strong> '
+            + "A token figure is only true for the row it is on.</p>";
+    }
+    $("budgets").innerHTML = "<table><tbody>" + rows + "</tbody></table>" + note;
+  }
+
+  function renderLatency(lat) {
+    if (!lat || !lat.available) {
+      $("latency").innerHTML = '<div class="empty">Not available.</div>';
+      return;
+    }
+    var rows = "";
+    function row(label, value, aux) {
+      rows += "<tr><td>" + label + '</td><td class="num">' + value
+            + '</td><td class="aux">' + (aux || "") + "</td></tr>";
+    }
+    row("Retrieval deadline", lat.deadline_ms ? num(lat.deadline_ms) + " ms" : "none set",
+        lat.deadline_is_cooperative ? "cooperative &mdash; cannot stop a call in flight" : "");
+    row("Transport request timeout", num(lat.transport_request_timeout_ms) + " ms",
+        "what one slow call actually runs against");
+    row("Transport I/O timeout", num(lat.transport_io_timeout_ms) + " ms", "");
+    /* The number an operator is looking for when a retrieve came back late. */
+    row("A slow call can overrun the deadline by",
+        lat.deadline_can_be_overrun_by_ms
+          ? num(lat.deadline_can_be_overrun_by_ms) + " ms" : "\u2014",
+        lat.deadline_can_be_overrun_by_ms
+          ? "lower the transport timeout to close this" : "nothing to overrun");
+    $("latency").innerHTML = "<table><tbody>" + rows + "</tbody></table>";
+  }
+
   function loadFootprint() {
     fetch("/v1/admin/overview", { headers: auth() })
       .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
-      .then(function (d) { renderFootprint(d.footprint); })
+      .then(function (d) {
+        /* One response, three panels. The overview already carried all of this; asking three
+           times for it would be three times the probing for the same answer. */
+        renderFootprint(d.footprint);
+        renderBudgets((((d.config || {}).skills) || {}).budgets);
+        renderLatency(d.latency);
+      })
       .catch(function () {
         $("footprint").innerHTML =
           '<div class="msg err">Could not read the footprint.</div>';
+        $("budgets").innerHTML = '<div class="msg err">Could not read the budget.</div>';
+        $("latency").innerHTML = '<div class="msg err">Could not read the timing.</div>';
       });
   }
 

--- a/tools/test_matrixark_a_deadline_cannot_bound_a_single_call.py
+++ b/tools/test_matrixark_a_deadline_cannot_bound_a_single_call.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A deadline cannot bound a single call, and the portal now says which control can.
+
+Two controls decide how long a retrieve takes and only one of them can stop a slow call:
+
+* the **retrieval deadline** is cooperative -- `deadline_exceeded()` is consulted between stages
+  and every 64 or 128 candidates, and never around a call to the store;
+* the **transport request timeout** is what a single call actually runs against.
+
+So a deployment with a five-second deadline saw retrieves return after sixty. The deadline was not
+being ignored; it was being checked at moments the call had not returned from. Neither control was
+offered on the portal, and the transport timeout answered 20,000 in one module and 60,000 in two
+others for the same variable, so there was no way to find out which a deployment was running.
+
+`deadline_can_be_overrun_by_ms` states that gap instead of leaving it to be inferred.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+import matrixark_gateway_config as cfg  # noqa: E402
+import matrixark_mcp_retrieve_planning as planning  # noqa: E402
+import matrixark_mcp_runtime_config as runtime  # noqa: E402
+import matrixark_v1_gateway as gateway  # noqa: E402
+
+VARIABLES = ("MATRIXARK_RETRIEVAL_TIMEOUT_MS",
+             "MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS",
+             "MATRIXARK_TEMPORALSTORE_IO_TIMEOUT_MS")
+
+SETTINGS = {
+    "retrieval.timeout_ms": "MATRIXARK_RETRIEVAL_TIMEOUT_MS",
+    "limits.transport_request_timeout_ms": "MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS",
+    "limits.transport_io_timeout_ms": "MATRIXARK_TEMPORALSTORE_IO_TIMEOUT_MS",
+}
+
+
+class Case(unittest.TestCase):
+    def setUp(self) -> None:
+        self._saved = {n: os.environ.get(n) for n in VARIABLES}
+        for name in VARIABLES:
+            os.environ.pop(name, None)
+
+    def tearDown(self) -> None:
+        for name, value in self._saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+class TheDeadlineIsResolvedInOnePlaceTest(Case):
+    """The adapter resolved it inline, directly below a comment claiming the policy beside it came
+    'from one implementation'. The audit policy had been consolidated; the deadline had not."""
+
+    def inline(self, args, ranking):
+        """What the adapter used to compute for itself."""
+        raw = args.get("deadline_ms",
+                       ranking.get("deadline_ms",
+                                   os.environ.get("MATRIXARK_RETRIEVAL_TIMEOUT_MS", 0)))
+        return int(raw or 0)
+
+    def test_the_shared_resolver_answers_the_same(self) -> None:
+        cases = [
+            ({}, {}, None),
+            ({"deadline_ms": 1234}, {}, None),
+            ({}, {"deadline_ms": 4321}, None),
+            ({}, {}, "5000"),
+            ({"deadline_ms": 10}, {"deadline_ms": 20}, "30"),
+            ({}, {}, "0"),
+        ]
+        for args, ranking, env in cases:
+            with self.subTest(args=args, ranking=ranking, env=env):
+                if env is None:
+                    os.environ.pop("MATRIXARK_RETRIEVAL_TIMEOUT_MS", None)
+                else:
+                    os.environ["MATRIXARK_RETRIEVAL_TIMEOUT_MS"] = env
+                self.assertEqual(self.inline(args, ranking),
+                                 planning.retrieval_deadline_ms(args, ranking))
+
+    def test_the_cases_are_not_all_zero(self) -> None:
+        """The floor: six cases that all resolve to 0 would agree trivially."""
+        os.environ["MATRIXARK_RETRIEVAL_TIMEOUT_MS"] = "5000"
+        self.assertEqual(5000, planning.retrieval_deadline_ms({}, {}))
+        self.assertEqual(77, planning.retrieval_deadline_ms({"deadline_ms": 77}, {}))
+
+    def test_the_adapter_no_longer_carries_its_own_copy(self) -> None:
+        with open(os.path.join(TOOLS, "matrixark_local_adapter_retrieve.py"),
+                  encoding="utf-8") as handle:
+            source = handle.read()
+        self.assertNotIn('os.environ.get("MATRIXARK_RETRIEVAL_TIMEOUT_MS"', source)
+        self.assertIn("_retrieve_planning.retrieval_deadline_ms(args, ranking)", source)
+
+
+class TheDeadlineIsCooperativeTest(unittest.TestCase):
+    """Derived from where the check is, not asserted: this is the reason a deadline cannot bound a
+    single call, and if it ever stopped being true the panel's claim would become false."""
+
+    def deadline_check_sites(self):
+        path = os.path.join(TOOLS, "matrixark_local_adapter_retrieve.py")
+        with open(path, encoding="utf-8") as handle:
+            tree = ast.parse(handle.read(), filename=path)
+        found = []
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+                    and node.func.id == "deadline_exceeded"):
+                found.append(node.lineno)
+        return found
+
+    def test_the_deadline_is_checked_in_many_places(self) -> None:
+        """A cooperative deadline is one that is polled. If it were applied to the call instead
+        there would be one site, not a dozen."""
+        self.assertGreater(len(self.deadline_check_sites()), 8)
+
+    def test_the_panel_says_it_is_cooperative(self) -> None:
+        self.assertTrue(gateway._latency_summary()["deadline_is_cooperative"])
+
+
+class ThePanelNamesWhatBoundsASlowCallTest(Case):
+
+    def test_it_is_never_the_deadline(self) -> None:
+        """Whatever the deadline is set to. It is not applied to the call."""
+        for deadline in ("0", "5000", "300000"):
+            with self.subTest(deadline=deadline):
+                os.environ["MATRIXARK_RETRIEVAL_TIMEOUT_MS"] = deadline
+                self.assertEqual("transport_request_timeout_ms",
+                                 gateway._latency_summary()["bounds_a_slow_call"])
+
+    def test_the_overrun_is_the_gap_between_them(self) -> None:
+        """The live observation: a five-second deadline and a call able to run for sixty."""
+        os.environ["MATRIXARK_RETRIEVAL_TIMEOUT_MS"] = "5000"
+        os.environ["MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS"] = "60000"
+        self.assertEqual(55000, gateway._latency_summary()["deadline_can_be_overrun_by_ms"])
+
+    def test_lowering_the_transport_timeout_closes_it(self) -> None:
+        """And the operator has a lever, which is the point of offering it."""
+        os.environ["MATRIXARK_RETRIEVAL_TIMEOUT_MS"] = "5000"
+        os.environ["MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS"] = "8000"
+        self.assertEqual(3000, gateway._latency_summary()["deadline_can_be_overrun_by_ms"])
+
+    def test_no_deadline_means_nothing_to_overrun(self) -> None:
+        """0 here has to mean "no deadline is set", not "a deadline that is never exceeded"."""
+        os.environ.pop("MATRIXARK_RETRIEVAL_TIMEOUT_MS", None)
+        summary = gateway._latency_summary()
+        self.assertEqual(0, summary["deadline_ms"])
+        self.assertEqual(0, summary["deadline_can_be_overrun_by_ms"])
+
+    def test_a_deadline_larger_than_the_transport_cannot_be_overrun(self) -> None:
+        """The 300-second knob: the transport bounds it, so there is no overrun -- and the panel
+        must not report a negative one."""
+        os.environ["MATRIXARK_RETRIEVAL_TIMEOUT_MS"] = "300000"
+        self.assertEqual(0, gateway._latency_summary()["deadline_can_be_overrun_by_ms"])
+
+    def test_the_panel_reads_the_same_resolver_a_retrieve_does(self) -> None:
+        os.environ["MATRIXARK_RETRIEVAL_TIMEOUT_MS"] = "4321"
+        self.assertEqual(planning.retrieval_deadline_ms({}, {}),
+                         gateway._latency_summary()["deadline_ms"])
+
+
+class TheTransportTimeoutHasOneNumberTest(Case):
+    """Unifying the two transport defaults was done separately, in #1039, and more simply: the odd
+    literal was corrected in place with the reasoning written beside it.
+
+    What this change owes is narrower. The panel below has to resolve the same timeout in order to
+    report it, which is a SECOND site for that number, and nothing in the tree ties a constant to a
+    literal in an argument parser. This does."""
+
+    def backend_default(self, variable: str) -> int:
+        """The number `matrixark_mcp_backends` actually parses, read out of its source."""
+        with open(os.path.join(TOOLS, "matrixark_mcp_backends.py"), encoding="utf-8") as handle:
+            source = handle.read()
+        marker = 'os.environ.get("%s", "' % variable
+        start = source.index(marker) + len(marker)
+        return int(source[start:source.index('"', start)])
+
+    def test_the_panel_resolves_the_number_the_backend_parses(self) -> None:
+        for variable, constant in (
+                ("MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS",
+                 runtime.DEFAULT_TRANSPORT_REQUEST_TIMEOUT_MS),
+                ("MATRIXARK_TEMPORALSTORE_IO_TIMEOUT_MS",
+                 runtime.DEFAULT_TRANSPORT_IO_TIMEOUT_MS)):
+            with self.subTest(variable=variable):
+                self.assertEqual(
+                    self.backend_default(variable), constant,
+                    "the panel would report a timeout the backend does not use")
+
+    def test_the_reader_found_a_real_number(self) -> None:
+        """The floor: a parse that returned nothing would make the rule above compare two
+        constants against each other and pass on anything."""
+        self.assertGreater(self.backend_default("MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS"), 0)
+
+    def test_it_is_read_per_call(self) -> None:
+        os.environ["MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS"] = "9000"
+        self.assertEqual(9000, runtime.transport_timeout_ms(
+            "MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS",
+            runtime.DEFAULT_TRANSPORT_REQUEST_TIMEOUT_MS))
+
+    def test_a_bad_value_falls_back(self) -> None:
+        """A socket timeout of zero never times out; nonsense would fail every call."""
+        for raw in ("", "  ", "soon", "0", "-1"):
+            with self.subTest(value=raw):
+                os.environ["MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS"] = raw
+                self.assertEqual(runtime.DEFAULT_TRANSPORT_REQUEST_TIMEOUT_MS,
+                                 runtime.transport_timeout_ms(
+                                     "MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS",
+                                     runtime.DEFAULT_TRANSPORT_REQUEST_TIMEOUT_MS))
+
+
+class ThePortalOffersThemTest(unittest.TestCase):
+
+    def test_all_three_are_offered(self) -> None:
+        for key, variable in SETTINGS.items():
+            with self.subTest(setting=key):
+                self.assertIn(key, cfg.SETTINGS_BY_KEY)
+                self.assertEqual(variable, cfg.SETTINGS_BY_KEY[key].env)
+
+    def test_they_take_effect_without_a_restart(self) -> None:
+        for key in SETTINGS:
+            with self.subTest(setting=key):
+                self.assertEqual("live", cfg.SETTINGS_BY_KEY[key].applies)
+
+    def test_the_declared_defaults_are_what_the_build_runs(self) -> None:
+        self.assertEqual(0, int(cfg.SETTINGS_BY_KEY["retrieval.timeout_ms"].default))
+        self.assertEqual(
+            runtime.DEFAULT_TRANSPORT_REQUEST_TIMEOUT_MS,
+            int(cfg.SETTINGS_BY_KEY["limits.transport_request_timeout_ms"].default))
+        self.assertEqual(
+            runtime.DEFAULT_TRANSPORT_IO_TIMEOUT_MS,
+            int(cfg.SETTINGS_BY_KEY["limits.transport_io_timeout_ms"].default))
+
+    def test_the_deadline_help_says_it_cannot_bound_a_call(self) -> None:
+        """The one thing an operator has to know before setting it, or they will set it and
+        conclude it does not work."""
+        help_text = cfg.SETTINGS_BY_KEY["retrieval.timeout_ms"].help.lower()
+        self.assertIn("cooperative", help_text)
+        self.assertIn("cannot bound one slow backend call", help_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_the_page_shows_the_budget_and_the_timing.py
+++ b/tools/test_matrixark_the_page_shows_the_budget_and_the_timing.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The page shows the budget and the timing, from the response it already fetched.
+
+The pack budget and the retrieve timing were computed, returned by `/v1/admin/overview`, and shown
+to nobody: the setup page fetched that endpoint for the footprint panel and read one key out of it.
+A number a customer cannot see is a number that cannot inform a decision, which is the whole
+argument for every panel on that page.
+
+Both are rendered now, from the same fetch. That is the part worth testing rather than asserting:
+three panels drawn from one response is a claim about how many times the deployment is asked, and
+only a fetch count shows it.
+
+The page is RUN here, not read. A renderer exists whether or not anything calls it, and a figure
+written into the wrong cell looks the same in a diff as one written into the right cell.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+import matrixark_v1_gateway as gateway  # noqa: E402
+
+PORTAL = os.path.join(TOOLS, "portal")
+PAGE = os.path.join(PORTAL, "setup_portal.html")
+GENERATOR = os.path.join(PORTAL, "build_portal_pages.py")
+
+
+class ThePanelsAreOnThePageTest(unittest.TestCase):
+
+    def page(self) -> str:
+        with open(PAGE, encoding="utf-8") as handle:
+            return handle.read()
+
+    def test_both_panels_have_somewhere_to_draw(self) -> None:
+        for anchor in ('id="budgets"', 'id="latency"'):
+            with self.subTest(anchor=anchor):
+                self.assertIn(anchor, self.page())
+
+    def test_both_have_a_renderer(self) -> None:
+        for fn in ("function renderBudgets", "function renderLatency"):
+            with self.subTest(renderer=fn):
+                self.assertIn(fn, self.page())
+
+    def test_the_markup_lives_in_the_generator_not_the_output(self) -> None:
+        """`setup_portal.html` is generated. An edit made to the output survives exactly until the
+        next person runs the generator, and then vanishes."""
+        with open(GENERATOR, encoding="utf-8") as handle:
+            source = handle.read()
+        self.assertIn('id="budgets"', source)
+        self.assertIn("function renderLatency", source)
+
+
+class TheServerSendsWhatThePageReadsTest(unittest.TestCase):
+    """The page reads `d.config.skills.budgets` and `d.latency`. Those paths are decided on the
+    server, and a rename there would leave the panels blank on every deployment -- which reads as a
+    deployment with nothing to report rather than as a page looking in the wrong place."""
+
+    def test_the_latency_summary_is_a_top_level_key(self) -> None:
+        summary = gateway._latency_summary()
+        self.assertTrue(summary.get("available"))
+        for field in ("deadline_ms", "transport_request_timeout_ms", "transport_io_timeout_ms",
+                      "deadline_is_cooperative", "deadline_can_be_overrun_by_ms"):
+            with self.subTest(field=field):
+                self.assertIn(field, summary)
+
+    def test_the_budget_summary_is_where_the_page_looks_for_it(self) -> None:
+        snapshot = gateway._model_config_snapshot()
+        budgets = ((snapshot.get("skills") or {}).get("budgets")) or {}
+        self.assertTrue(budgets.get("available"),
+                        "the page reads config.skills.budgets; it is not there")
+        for field in ("paths", "paths_differ", "skills", "resources"):
+            with self.subTest(field=field):
+                self.assertIn(field, budgets)
+
+    def test_each_path_carries_what_the_row_prints(self) -> None:
+        snapshot = gateway._model_config_snapshot()
+        paths = (((snapshot.get("skills") or {}).get("budgets")) or {}).get("paths") or []
+        self.assertGreaterEqual(len(paths), 2)
+        for row in paths:
+            with self.subTest(path=row.get("path")):
+                for field in ("label", "context_budget_tokens", "sections"):
+                    self.assertIn(field, row)
+                for section in ("skills", "resources"):
+                    self.assertIn(section, row["sections"])
+
+    def test_each_share_carries_what_decided_it(self) -> None:
+        budgets = ((gateway._model_config_snapshot().get("skills") or {}).get("budgets")) or {}
+        for name in ("skills", "resources"):
+            with self.subTest(section=name):
+                for field in ("percent", "asked_percent", "guard_percent", "bound_by"):
+                    self.assertIn(field, budgets[name])
+
+
+class ThePageDrawsThemTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    def harness(self, mode: str) -> str:
+        out = subprocess.run(
+            ["node", "overview_panels_harness.js", "setup_portal.html", mode],
+            cwd=PORTAL, capture_output=True, text=True, timeout=600)
+        return out.stdout + out.stderr
+
+    def test_two_callers_with_different_budgets(self) -> None:
+        out = self.harness("differ")
+        self.assertIn("all ok", out, out)
+
+    def test_and_the_case_where_they_agree(self) -> None:
+        """The floor for the panel's warning: it must not claim a difference that is not there,
+        nor invent an overrun where no deadline is set."""
+        out = self.harness("aligned")
+        self.assertIn("all ok", out, out)
+
+    def test_the_harness_counts_the_fetches(self) -> None:
+        """The claim is one response for three panels. If the harness stopped counting, the two
+        tests above would pass with the page asking three times."""
+        with open(os.path.join(PORTAL, "overview_panels_harness.js"), encoding="utf-8") as handle:
+            source = handle.read()
+        self.assertIn("overviewCalls === 1", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The pack budget and the retrieve timing were computed, returned by `/v1/admin/overview`, and shown
to nobody. The setup page fetched that endpoint for the footprint panel and read **one key** out of
it. A number a customer cannot see is a number that cannot inform a decision, which is the argument
for every panel on that page.

Both are rendered now, **from the same fetch** — the overview already carried all three, and asking
three times for one answer is three times the probing.

### Pack budget

| Caller | Context budget | Skills | Resources |
|---|---|---|---|
| API callers | 500,000 | 50,000 | 125,000 |
| Agent hooks | 10,000 | 1,000 | 2,500 |

with a line per section saying what actually set it — `set by percentage`, `set by share guard`,
`set by ceiling` — and, when the two callers run different budgets, a note that **a token figure is
only true for the row it is on**. Those are the two defects the last three changes fixed, made
visible on the page where an operator sets them rather than only in an API response.

### Retrieve timing

| | | |
|---|---|---|
| Retrieval deadline | 5,000 ms | cooperative — cannot stop a call in flight |
| Transport request timeout | 60,000 ms | what one slow call actually runs against |
| A slow call can overrun the deadline by | **55,000 ms** | lower the transport timeout to close this |

The last row is the number an operator is looking for when a retrieve came back late, and the aux
text names the only lever that closes it.

```
the page asks a second time for the same response          -> FAIL
the budget is read from a path the server does not use     -> FAIL
the page stops saying the two callers differ               -> FAIL
an overrun is printed where no deadline is set             -> FAIL
a share stops saying which limit set it                    -> FAIL
the deadline stops being described as cooperative          -> FAIL
the latency panel loses its renderer                       -> FAIL
the markup is edited in the OUTPUT instead of the generator -> FAIL
```

### One survivor, and what it exposed

`an overrun is printed where no deadline is set` **survived the first pass.** The mutation printed
`transport - deadline` into the value cell, leaving a number sitting next to a note that read
"nothing to overrun" — and my assertion excluded one particular figure (`55,000`) rather than
checking the cell. It now asserts the cell holds a dash, and the mutation dies.

That is the failure this suite exists to prevent: a panel that contradicts itself in two adjacent
cells looks fine in a diff, and a test that names a value instead of a position does not see it.

14 tests. The page is **run**, not read: a Node harness executes the page's own scripts against a
stubbed DOM in two states — two callers with different budgets, and two that agree — because the
"they agree" case is where a panel is most likely to claim a difference that is not there or invent
an overrun where no deadline is set.

Four tests tie the page's read paths to the server's write paths. The page reads
`d.config.skills.budgets` and `d.latency`; those keys are decided on the server, and a rename there
would leave the panels blank on every deployment — which reads as a deployment with nothing to
report rather than as a page looking in the wrong place.

The markup and both renderers live in `build_portal_pages.py`, not in the generated
`setup_portal.html`; the last mutation above is the guard for that, and it is a mistake I have
already made once in this area.

Follows [#1029](https://github.com/matrixarkai/TemporalStore/pull/1029),
[#1033](https://github.com/matrixarkai/TemporalStore/pull/1033) and
[#1036](https://github.com/matrixarkai/TemporalStore/pull/1036), which produced the three things
this displays.
