### PR TITLE
One default for the two TemporalStore SDK timeouts

### DIFF
--- a/tools/matrixark_mcp_backends.py
+++ b/tools/matrixark_mcp_backends.py
@@ -139,16 +139,23 @@ def add_backend_arguments(parser: argparse.ArgumentParser) -> None:
         default=os.environ.get("MATRIXARK_TEMPORALSTORE_RUST_CLI", ""),
         help="Path to the Rust matrixark_rust_proxy or direct SDK binary for --backend temporalstore-rust.",
     )
+    # 60000 for both, which is the number every launcher supplies and the one the deployment
+    # runs on. These were 20000 here and 60000 in the two agent hooks: one option, one meaning,
+    # three parsers, two numbers -- so a deployment that set nothing got a timeout three times
+    # shorter or longer depending on which path asked, and only that deployment, which is the
+    # one nobody tests. `matrixark_mcp_rust_server.sh` starts THIS server, exports 60000 and
+    # passes --request-timeout-ms explicitly; the three installers export the same. So this
+    # default is reached only by a server started outside all of them, and it was the odd one.
     parser.add_argument(
         "--request-timeout-ms",
         type=int,
-        default=int(os.environ.get("MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS", "20000")),
+        default=int(os.environ.get("MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS", "60000")),
         help="Per-request timeout for the native TemporalStore SDK.",
     )
     parser.add_argument(
         "--io-timeout-ms",
         type=int,
-        default=int(os.environ.get("MATRIXARK_TEMPORALSTORE_IO_TIMEOUT_MS", "20000")),
+        default=int(os.environ.get("MATRIXARK_TEMPORALSTORE_IO_TIMEOUT_MS", "60000")),
         help="BRPC I/O timeout for the native TemporalStore SDK.",
     )
 

--- a/tools/test_numeric_defaults_agree.py
+++ b/tools/test_numeric_defaults_agree.py
@@ -16,11 +16,18 @@ schema used to quote the wrong one of those two numbers at callers, which is wha
 one layer up. Both readers now agree, so the entry goes: the rule below is that a list of known
 differences which is allowed to go stale is read as a description of the tree.
 
-The five below were present when this was written and are NOT endorsed here. Several look like a
-deliberate difference between a client and the server it calls, and one is two reader paths in a
-benchmark. None has been examined, and this file does not pretend otherwise: it exists so a SEVENTH
-has to be looked at rather than joining them quietly. Strike an entry when its difference is either
-justified in the code or removed.
+The remaining three are NOT endorsed here. One looks like a deliberate difference between a client
+and the server it calls, and one is two reader paths in a benchmark. Neither has been examined, and
+this file does not pretend otherwise: it exists so the next one has to be looked at rather than
+joining them quietly. Strike an entry when its difference is either justified in the code or
+removed.
+
+The two TemporalStore SDK timeouts are struck. They were not a client/server difference: one option
+with one meaning, declared by three parsers, defaulting to 20000 in the backend resolver and 60000
+in both agent hooks. Every launcher supplies 60000 -- the three installers, the codex hook wrapper,
+the topology waiter, and `matrixark_mcp_rust_server.sh`, which starts the very server the 20000
+belonged to and passes the value explicitly. So the short number was reached only by a server
+started outside every shipped path, and the resolver now agrees at 60000.
 """
 from __future__ import annotations
 
@@ -47,10 +54,6 @@ KNOWN_DISAGREEMENTS: Dict[str, str] = {
         "two reader paths in one benchmark script, 160 and 64",
     "MATRIXARK_RETRIEVAL_TIMEOUT_MS":
         "the retrieve paths use 0 (no deadline), the MCP server 30000",
-    "MATRIXARK_TEMPORALSTORE_IO_TIMEOUT_MS":
-        "hooks pass 60000, the backend resolver uses 20000",
-    "MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS":
-        "hooks pass 60000, the backend resolver uses 20000",
 }
 
 # 196 when this was written.


### PR DESCRIPTION
`test_numeric_defaults_agree` carries five variables whose readers disagree about the number to use
when nothing is set. Its own docstring says they are unexamined and asks that each be struck once
the difference is justified or removed. This examines two of them and strikes them; three are left.

### They were not a client/server difference

`MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS` and `MATRIXARK_TEMPORALSTORE_IO_TIMEOUT_MS` are one
option each, with one meaning, declared by three argument parsers:

| reader | default |
|---|---|
| `matrixark_agent_hook.py` | 60000 |
| `matrixark_codex_hook.py` | 60000 |
| `matrixark_mcp_backends.py` | **20000** |

Same flag names, same help text — "Per-request timeout for the native TemporalStore SDK" and "BRPC
I/O timeout for the native TemporalStore SDK". A deployment that set nothing got a timeout three
times shorter or longer depending on which path asked, and only that deployment, which is the one
nobody tests.

### Which number is the live one

Every launcher supplies **60000**, and the question is not close:

- `install_linux_temporalstore.sh`, `install_macos_temporalstore.sh` and
  `install_windows_docker_temporalstore.ps1` export both at 60000, twice each.
- `matrixark_codex_rust_hook.sh` and `wait_temporalstore_topology_ready.sh` default both to 60000.
- `matrixark_mcp_rust_server.sh` — which starts **the very server the 20000 belonged to** — exports
  60000 and then passes `--request-timeout-ms` and `--io-timeout-ms` explicitly.

So the 20000 was reachable only by a server started outside every shipped launch path. It is the
odd one out in a family that otherwise agrees, which is the shape a drifted default takes. The
resolver now agrees at 60000, and the comment says where the number comes from rather than
restating it.

This also matches what the live deployment is observed to do: a store request that gives up "after
62.0s" is this variable at 60000 plus the two-second envelope, not a longer deadline elsewhere.

### Checks

| | |
|---|---|
| `test_numeric_defaults_agree` | **4 passed**, three entries left |
| mutation — restore the 20000 with the entries struck | **fails**, naming both numbers |
| mutation — keep the fix, re-list an entry | **fails** as a stale entry |
| six suites that name these timeouts or the old number | all pass |
| `test_matrixark_mcp_backend_policy`, name-diffed against `main` | identical |

Raising a default timeout only ever turns a slow failure into a slow success, and only for a
deployment that sets nothing — no shipped path is affected, because every one of them sets it.
