### PR TITLE
The Rust SDK called eleven routes the proxy does not serve

### DIFF
--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -4996,6 +4996,39 @@ mod tests {
                 i += 1;
             }
         }
+        // The Rust SDK is the other published proxy client. `sdk/README.md` says both are
+        // "Proxy SDKs -- pure-language HTTP/JSON clients that call a TemporalStore proxy", and its
+        // shipped example connects to one, so every route it names has to be served too.
+        let rust_sdk = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../sdk/rust/temporalstore/src");
+        if let Ok(entries) = std::fs::read_dir(&rust_sdk) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                    continue;
+                }
+                let text = std::fs::read_to_string(&path).unwrap_or_default();
+                let chars: Vec<char> = text.chars().collect();
+                let mut i = 0;
+                while i < chars.len() {
+                    if chars[i] == '"' {
+                        if let Some(end) = chars[i + 1..].iter().position(|c| *c == '"') {
+                            let literal: String = chars[i + 1..i + 1 + end].iter().collect();
+                            if literal.starts_with('/')
+                                && literal.len() > 1
+                                && literal.chars().all(|c| c.is_ascii_alphanumeric() || "/_".contains(c))
+                            {
+                                routes.push(literal);
+                            }
+                            i += end + 2;
+                            continue;
+                        }
+                    }
+                    i += 1;
+                }
+            }
+        }
+
         routes.sort();
         routes.dedup();
 
@@ -5028,10 +5061,20 @@ mod tests {
             }
         }
 
-        assert!(
-            unserved.is_empty(),
-            "the shipped Python SDK posts to {} path(s) the proxy answers 404 for, so those SDK              methods cannot work: {unserved:?}",
-            unserved.len()
+        // Three routes the proxy has never served. Whether to add them or to drop the methods is
+        // a product decision, not a test's to make -- so they are named here rather than silently
+        // skipped, and the assertion is EXACT in both directions: implement one and this fails
+        // telling you to take it off the list, add a new dead route and it fails too.
+        let mut known_unimplemented = vec![
+            "/ProxyService/ControlStateCPCQuery".to_string(),
+            "/ProxyService/ControlStateCPCSet".to_string(),
+            "/ProxyService/ControlStateHquery".to_string(),
+        ];
+        known_unimplemented.sort();
+        unserved.sort();
+        assert_eq!(
+            unserved, known_unimplemented,
+            "the set of SDK routes the proxy does not serve has moved. A route that is now served              must come off this list; a route that has stopped being served is an SDK method that              cannot work"
         );
     }
 

--- a/sdk/rust/temporalstore/src/lib.rs
+++ b/sdk/rust/temporalstore/src/lib.rs
@@ -140,6 +140,9 @@ pub enum RiskFolType {
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "proxy", derive(serde::Serialize, serde::Deserialize))]
 pub struct SequenceFeatureRow {
+    // The engine's row names this `timestamp_ms` and requires it. The Rust name stays as it was
+    // so callers do not change; only the wire name is corrected.
+    #[cfg_attr(feature = "proxy", serde(rename = "timestamp_ms"))]
     pub timestamp: u64,
     pub gid: u64,
     pub action_type: u32,
@@ -1351,8 +1354,9 @@ impl ProxyClient {
     }
 
     pub fn put_string(&self, key: &str, value: &str) -> Result<()> {
-        let body = self.key_body(key, &[("value", serde_json::json!(value))]);
-        self.post("/v1/string/put", body).map(|_| ())
+        // Delegates, as `put_string_with_ttl` already delegates to `set_ex`. This used to post to
+        // `/v1/string/put`, which the proxy does not serve.
+        self.set(key, value)
     }
 
     pub fn put_string_with_ttl(&self, key: &str, value: &str, ttl_ms: u64) -> Result<()> {
@@ -1360,21 +1364,17 @@ impl ProxyClient {
     }
 
     pub fn get_string(&self, key: &str) -> Result<String> {
-        let body = self.key_body(key, &[]);
-        let data = self.post("/v1/string/get", body)?;
-        Ok(data
-            .get("value")
-            .and_then(|value| value.as_str())
-            .unwrap_or("")
-            .to_string())
+        // A missing key reads as empty, which is what the old `/v1/string/get` shape returned.
+        Ok(self.get(key)?.unwrap_or_default())
     }
 
     pub fn add_sequence_feature_rows(&self, key: &str, rows: &[SequenceFeatureRow]) -> Result<()> {
-        let body = self.key_body(
+        let body = self.proxy_service_body(
             key,
             &[("rows", serde_json::to_value(rows).map_err(json_error)?)],
         );
-        self.post("/v1/sequence/add", body).map(|_| ())
+        self.proxy_service_execute("/ProxyService/SequenceAdd", body)
+            .map(|_| ())
     }
 
     pub fn query_sequence_feature_rows(
@@ -1395,16 +1395,16 @@ impl ProxyClient {
                 })
             })
             .collect();
-        let body = self.key_body(
+        let body = self.proxy_service_body(
             key,
             &[
-                ("start_ts", serde_json::json!(start_ts)),
-                ("end_ts", serde_json::json!(end_ts)),
+                ("start_ms", serde_json::json!(start_ts)),
+                ("end_ms", serde_json::json!(end_ts)),
                 ("count", serde_json::json!(count)),
                 ("filters", serde_json::json!(encoded_filters)),
             ],
         );
-        let data = self.post("/v1/sequence/query", body)?;
+        let data = self.proxy_service_execute("/ProxyService/SequenceQuery", body)?;
         serde_json::from_value(
             data.get("rows")
                 .cloned()
@@ -1587,7 +1587,7 @@ impl ProxyClient {
                 ("amount", serde_json::json!(amount)),
             ],
         );
-        self.proxy_service_execute("/ProxyService/RiskHset", body)
+        self.proxy_service_execute("/ProxyService/ControlStateHset", body)
             .map(|_| ())
     }
 
@@ -1606,18 +1606,19 @@ impl ProxyClient {
                 ("occur_time_ms", serde_json::json!(occur_time_ms)),
                 ("ttl_ms", serde_json::json!(ttl_ms)),
                 (
-                    "fol_type",
+                    // The route parses this as `selection_type`; the argument keeps its name.
+                    "selection_type",
                     serde_json::to_value(fol_type).map_err(json_error)?,
                 ),
             ],
         );
-        self.proxy_service_execute("/ProxyService/RiskFolSet", body)
+        self.proxy_service_execute("/ProxyService/ControlStateFolSet", body)
             .map(|_| ())
     }
 
     pub fn risk_fol_query(&self, key: &str) -> Result<Option<String>> {
         let body = self.proxy_service_body(key, &[]);
-        let response = self.proxy_service_execute("/ProxyService/RiskFolQuery", body)?;
+        let response = self.proxy_service_execute("/ProxyService/ControlStateFolQuery", body)?;
         Ok(response
             .get("value")
             .cloned()
@@ -1627,7 +1628,7 @@ impl ProxyClient {
 
     pub fn risk_manager(&self, key: &str) -> Result<Vec<(String, String)>> {
         let body = self.proxy_service_body(key, &[]);
-        let response = self.proxy_service_execute("/ProxyService/RiskManager", body)?;
+        let response = self.proxy_service_execute("/ProxyService/ControlStateManager", body)?;
         Ok(response_hash_entries_to_strings(response))
     }
 
@@ -1790,19 +1791,6 @@ impl ProxyClient {
             != 0)
     }
 
-    fn key_body(&self, key: &str, extra: &[(&str, serde_json::Value)]) -> serde_json::Value {
-        let mut body = serde_json::json!({
-            "namespace": self.options.namespace_name,
-            "table": self.options.table_name,
-            "key": key,
-        });
-        let object = body.as_object_mut().expect("object body");
-        for (name, value) in extra {
-            object.insert((*name).to_string(), value.clone());
-        }
-        body
-    }
-
     fn proxy_service_body(
         &self,
         key: &str,
@@ -1855,31 +1843,6 @@ impl ProxyClient {
             });
         }
         Ok(response)
-    }
-
-    fn post(&self, path: &str, body: serde_json::Value) -> Result<serde_json::Value> {
-        let envelope = self.post_raw(path, body)?;
-        if !envelope
-            .get("ok")
-            .and_then(|value| value.as_bool())
-            .unwrap_or(false)
-        {
-            return Err(Error {
-                code: envelope
-                    .get("code")
-                    .and_then(|value| value.as_i64())
-                    .unwrap_or(0) as i32,
-                message: envelope
-                    .get("message")
-                    .and_then(|value| value.as_str())
-                    .unwrap_or("proxy request failed")
-                    .to_string(),
-            });
-        }
-        Ok(envelope
-            .get("data")
-            .cloned()
-            .unwrap_or_else(|| serde_json::json!({})))
     }
 
     fn get_raw(&self, path: &str) -> Result<serde_json::Value> {


### PR DESCRIPTION
`sdk/README.md` says both SDKs are "**Proxy SDKs** — pure-language HTTP/JSON clients that call a TemporalStore proxy." The Rust one names **eleven routes the proxy answers 404 for**, confirmed by putting each to the real dispatcher rather than reading a route table.

Its own shipped example fails on line two:

```rust
let client = ProxyClient::connect(ProxyOptions::new("http://127.0.0.1:8080", ...))?;
client.put_string("rust:proxy:user:42", r#"{"tier":"gold"}"#)?;   // POST /v1/string/put -> 404
```

## Eight of them have served equivalents

| method | posted to | now posts to |
|---|---|---|
| `put_string` | `/v1/string/put` | delegates to `set` |
| `get_string` | `/v1/string/get` | delegates to `get` |
| `add_sequence_feature_rows` | `/v1/sequence/add` | `/ProxyService/SequenceAdd` |
| `query_sequence_feature_rows` | `/v1/sequence/query` | `/ProxyService/SequenceQuery` |
| `risk_hset` | `/ProxyService/RiskHset` | `/ProxyService/ControlStateHset` |
| `risk_fol_set` | `/ProxyService/RiskFolSet` | `/ProxyService/ControlStateFolSet` |
| `risk_fol_query` | `/ProxyService/RiskFolQuery` | `/ProxyService/ControlStateFolQuery` |
| `risk_manager` | `/ProxyService/RiskManager` | `/ProxyService/ControlStateManager` |

The string pair just delegates — `put_string_with_ttl` already delegated to `set_ex`, so the working one was sitting next to the broken one.

**Three body shapes were wrong too**, and each was checked field by field against the type the route parses:

- `key_body` built `"table"`; every proxy request type reads `table_name`. It had exactly four callers — the four `/v1` methods — so it is gone, and with it the last user of `post`.
- `query_sequence_feature_rows` sent `start_ts`/`end_ts` where the route parses `start_ms`/`end_ms` — the same defect #1021 fixed in the published spec.
- `SequenceFeatureRow.timestamp` is `timestamp_ms` on the wire. The Rust field name stays, so callers do not change; only a `serde(rename)` is added.

`risk_fol_set`'s `fol_type` is `selection_type` on the wire. Both enums are `{First, Last}` with `rename_all = "snake_case"`, so the values already match — only the field name moved.

## Three are left alone, on purpose

`ControlStateCPCQuery`, `ControlStateCPCSet` and `ControlStateHquery` have no served route and no engine command behind them. Whether to add the routes or drop the methods is a product decision, not a test's to make, and they are pinned in `client_api_tests.rs`.

So the guard names them and asserts the unserved set **exactly**, in both directions: implement one and the test fails telling you to take it off the list; a new dead route fails it too. That is a two-sided exception rather than a skip list that goes quietly stale.

SDK library builds clean with `--features proxy` (no warnings), its tests pass, and 92 proxy tests pass.
