### PR TITLE
The WAL tests measure how bytes are laid out, not how well they compress

### DIFF
--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -4468,7 +4468,7 @@ mod tests {
                         1,
                         Command::StringSet {
                             key: format!("k{index:05}"),
-                            value: vec![b'v'; 1024],
+                            value: incompressible(1024),
                         },
                         false,
                     )
@@ -4500,7 +4500,7 @@ mod tests {
                     1,
                     Command::StringSet {
                         key: format!("k{index:05}"),
-                        value: vec![b'v'; 1024],
+                        value: incompressible(1024),
                     },
                     false,
                 )
@@ -4630,7 +4630,7 @@ mod tests {
                     1,
                     Command::StringSet {
                         key: format!("k{index:06}"),
-                        value: vec![b'v'; 1024],
+                        value: incompressible(1024),
                     },
                     false,
                 )
@@ -4702,6 +4702,29 @@ mod tests {
             decode_wal_line(line).expect("every record must still decode");
         }
         set_wal_segment_bytes_for_test(None);
+    }
+
+    /// A payload the record compressor cannot shrink.
+    ///
+    /// These tests are about block geometry, rolling and truncation, and every one of them used a
+    /// single byte repeated. Once records began being compressed by default that payload encoded
+    /// to almost nothing, so the workloads stopped filling blocks and stopped rolling, and the
+    /// tests failed saying so: "the workload must span several blocks or this proves nothing:
+    /// 115870", "at a 262144-byte threshold this log should be several pieces, got 1 file(s)".
+    /// One of them subtracted 40 from a payload that was no longer 40 bytes long and panicked.
+    ///
+    /// A test that measures how bytes are LAID OUT needs bytes the compressor cannot remove.
+    fn incompressible(len: usize) -> Vec<u8> {
+        // xorshift64*, seeded by length so each size gets its own stream and runs are repeatable.
+        let mut state = 0x2545_F491_4F6C_DD1D_u64 ^ (len as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+        (0..len)
+            .map(|_| {
+                state ^= state >> 12;
+                state ^= state << 25;
+                state ^= state >> 27;
+                (state.wrapping_mul(0x2545_F491_4F6C_DD1D) >> 32) as u8
+            })
+            .collect()
     }
 
     /// A record that ENDS inside a block's footer slot, in a log written without footers.
@@ -4811,7 +4834,7 @@ mod tests {
                     1,
                     Command::StringSet {
                         key: format!("k{index:05}"),
-                        value: vec![b'v'; 1024],
+                        value: incompressible(1024),
                     },
                     false,
                 )
@@ -4859,7 +4882,7 @@ mod tests {
                     1,
                     Command::StringSet {
                         key: format!("k{index:05}"),
-                        value: vec![b'v'; 1024],
+                        value: incompressible(1024),
                     },
                     false,
                 )
@@ -4915,7 +4938,7 @@ mod tests {
                     1,
                     Command::StringSet {
                         key: format!("k{index:05}"),
-                        value: vec![b'v'; 1024],
+                        value: incompressible(1024),
                     },
                     false,
                 )
@@ -4964,7 +4987,7 @@ mod tests {
                     1,
                     Command::StringSet {
                         key: format!("k{index:05}"),
-                        value: vec![b'v'; 1024],
+                        value: incompressible(1024),
                     },
                     false,
                 )
@@ -5042,7 +5065,7 @@ mod tests {
                         1,
                         Command::StringSet {
                             key: format!("k{index:06}"),
-                            value: vec![118u8; 256],
+                            value: incompressible(256),
                         },
                         // Sync ON: with it off nothing syncs, the counters read zero on both
                         // sides, and the comparison below passes on having measured nothing.
@@ -5353,7 +5376,7 @@ mod tests {
         set_wal_segment_bytes_for_test(Some(4 * 1024));
         let dir = tempfile::tempdir().unwrap();
         let store = LocalWriteAheadLogStore::new(dir.path());
-        let value = vec![118u8; 512];
+        let value = incompressible(512);
 
         for index in 0..40usize {
             store
@@ -5414,7 +5437,7 @@ mod tests {
                     1,
                     Command::StringSet {
                         key: format!("k{index:05}"),
-                        value: vec![118u8; 512],
+                        value: incompressible(512),
                     },
                 )
                 .unwrap();
@@ -5859,7 +5882,7 @@ mod tests {
                         1,
                         Command::StringSet {
                             key: format!("k{index:06}"),
-                            value: vec![118u8; 256],
+                            value: incompressible(256),
                         },
                     )
                     .unwrap();
@@ -6006,7 +6029,7 @@ mod tests {
         for value_len in [64usize, 1024, 4096] {
             let dir = tempfile::tempdir().unwrap();
             let store = LocalWriteAheadLogStore::new(dir.path());
-            let value = vec![118u8; value_len];
+            let value = incompressible(value_len);
             let path = write_ahead_log_path(dir.path(), 1);
 
             let append = |index: usize| {
@@ -7956,7 +7979,7 @@ mod tests {
             sequence: 8,
             command: Some(Command::StringSet {
                 key: "k".to_string(),
-                value: vec![7u8; 900],
+                value: incompressible(900),
             }),
             metadata: None,
             staged_pages: Vec::new(),


### PR DESCRIPTION
Twelve tests in the WAL module are failing on main. They are all the same thing, and none of them
is a defect in the code they cover.

Records are now compressed by default. Every one of these tests built its payload from a single
byte repeated -- `vec![b'v'; 1024]`, `vec![118u8; 256]`, `vec![7u8; 900]` -- which compresses to
almost nothing. So the workloads stopped being the size the tests believed they were: they no
longer filled a block, no longer crossed a roll threshold, and in one case were no longer long
enough to have forty bytes removed from them.

The failures say so plainly:

- `the workload must span several blocks or this proves nothing: 115870` -- that is under one
  131,072-byte block
- `at a 262144-byte threshold this log should be several pieces, got 1 file(s)`
- `several blocks were filled, so at least one footer must have been written`
- `the default must actually roll this workload`
- `attempt to subtract with overflow` -- `payload.truncate(payload.len() - 40)` on a payload that
  no longer had forty bytes in it

These tests are about block geometry, rolling, footers and truncation. A test that measures how
bytes are LAID OUT cannot use bytes the compressor can remove, or it measures the compressor
instead. So they now build their payload with a small xorshift generator, which the compressor can
do nothing with, and they are back to exercising what their names say.

Nothing about the product changed. `what_a_record_actually_costs_on_disk` returns to the figures it
reported before compression landed -- 113.0, 1077.0 and 4149.0 bytes a record for 64, 1,024 and
4,096-byte values -- which is the same story it always told: the envelope is about fifty bytes and
does not grow with the value.

The module goes from 85 passed with 12 failed to 97 passed with none.

One judgement worth stating: these tests could have been made green by asserting the smaller sizes
instead. That would have been wrong. `a_truncated_carried_payload_is_refused` would then be
truncating a payload too short to hold a record, and the block tests would be asserting that a
workload which never fills a block still proves something about blocks.
