### PR TITLE
A placement head is stored compact when it is rewritten

### DIFF
--- a/tools/matrixark_temporal_direct_backend.py
+++ b/tools/matrixark_temporal_direct_backend.py
@@ -1505,7 +1505,7 @@ class _TemporalDirectBackendMixin:
         head_versions = head_versions if isinstance(head_versions, list) else []
         if tail_index != chunk_count or merged_versions != head_versions:
             payload = {
-                "locations": head_locations,
+                "locations": compact_location_list(head_locations, self._location_base()),
                 "resource_versions": merged_versions,
                 "location_chunks": tail_index,
             }

--- a/tools/test_matrixark_the_placement_head_keeps_the_long_form.py
+++ b/tools/test_matrixark_the_placement_head_keeps_the_long_form.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A placement head is rewritten in whatever form it was already stored in.
+
+`_locator_entries_for_ref` and `_placement_entries_for_node` are the same routine written twice:
+read the head, append to the tail chunk, and rewrite the head when the chunk count rolls over. The
+locator compacts its head on that rewrite. The placement one did not -- it wrote `head_locations`
+straight back -- so a head holding the sixty-nine-byte `{"key", "field"}` form re-emitted every one
+of those entries on each rollover and never upgraded, however many times it was rewritten.
+
+That is not only a historical-data concern. The head is read back from storage, so the long form is
+self-perpetuating: once a head holds it, every later rollover writes it out again.
+
+Measured on the live one-box log before this: one 331,054-byte segment carried 364 long-form
+location dicts, 28,392 bytes, 8.58% of the segment -- and every one of them was the plainly
+compactable shape (key `base` + six digits, field twenty digits).
+
+The tail assertions are the positive control. They share the fixture and the base with the head, so
+a failure there would mean the fixture never had a compactable location to begin with; the head
+assertions only mean something because the tail ones pass.
+"""
+import json
+import unittest
+
+try:
+    from tools import matrixark_temporal_direct_backend as backend
+    from tools.matrixark_temporal_location_codec import expand_location
+except ImportError:  # run from tools/ dir
+    import matrixark_temporal_direct_backend as backend
+    from matrixark_temporal_location_codec import expand_location
+
+PREFIX = "matrixark:mcp"
+BASE = f"{PREFIX}:records"
+NODE_KEY = f"{PREFIX}:context_placement_lookup:t=1"
+NODE_FIELD = "909"
+
+
+class _Client:
+    def __init__(self, stored):
+        self.stored = dict(stored)
+
+    def hget(self, key, field):
+        return self.stored.get((key, field), "")
+
+    def batch_hget(self, entries):
+        return [
+            {"key": e["key"], "field": e["field"],
+             "value": self.stored.get((e["key"], e["field"]), "")}
+            for e in entries
+        ]
+
+
+def _adapter(client):
+    obj = object.__new__(backend._TemporalDirectBackendMixin)
+    obj._client = client
+    obj._storage_prefix = PREFIX
+    return obj
+
+
+def _long(shard: int, offset: int) -> dict:
+    """The sixty-nine byte form, in the shape the codec is able to compact."""
+    return {"key": "%s:%06d" % (BASE, shard), "field": "%020d" % offset}
+
+
+def _run(adapter, client, head_payload, new_locations):
+    client.stored[(NODE_KEY, NODE_FIELD)] = json.dumps(head_payload)
+
+    def existing_for(key, field):
+        return client.stored.get((key, field), "")
+
+    return adapter._placement_entries_for_node(
+        NODE_KEY, NODE_FIELD, new_locations, set(), existing_for, {})
+
+
+def _by_field(entries):
+    return {row["field"]: json.loads(row["value"]) for row in entries}
+
+
+class PlacementHeadFormTests(unittest.TestCase):
+    def setUp(self):
+        self.client = _Client({})
+        self.adapter = _adapter(self.client)
+        # A head already at the chunk limit, so appending one more location rolls the chunk over
+        # and forces the head rewrite -- the only branch that touches head_locations.
+        self.head_locations = [_long(0, i) for i in range(backend._TemporalDirectBackendMixin.PLACEMENT_CHUNK_LOCATIONS)]
+
+    def test_the_rewritten_head_is_stored_compact(self):
+        entries = _run(self.adapter, self.client,
+                       {"locations": self.head_locations, "resource_versions": []},
+                       [_long(0, 500)])
+        by_field = _by_field(entries)
+        self.assertIn(NODE_FIELD, by_field, "the head was not rewritten, so the branch never ran")
+        head = by_field[NODE_FIELD]["locations"]
+        long_form = [item for item in head if isinstance(item, dict)]
+        self.assertEqual(
+            [], long_form,
+            f"{len(long_form)} of {len(head)} head locations kept the long form")
+
+    def test_the_tail_is_stored_compact(self):
+        """Positive control: the same fixture and base DO compact on the tail."""
+        entries = _run(self.adapter, self.client,
+                       {"locations": self.head_locations, "resource_versions": []},
+                       [_long(0, 500)])
+        by_field = _by_field(entries)
+        tail_fields = [f for f in by_field if f != NODE_FIELD]
+        self.assertTrue(tail_fields, "no tail chunk was written")
+        tail = by_field[tail_fields[0]]["locations"]
+        self.assertEqual([], [item for item in tail if isinstance(item, dict)],
+                         "the tail did not compact, so the fixture is wrong, not the head")
+        self.assertIn("0:500", tail)
+
+    def test_the_head_still_names_the_same_records(self):
+        """Compacting is a re-encoding, not a change of contents."""
+        entries = _run(self.adapter, self.client,
+                       {"locations": self.head_locations, "resource_versions": []},
+                       [_long(0, 500)])
+        head = _by_field(entries)[NODE_FIELD]["locations"]
+        self.assertEqual(
+            [(loc["key"], loc["field"]) for loc in self.head_locations],
+            [expand_location(item, BASE) for item in head],
+            "the head no longer points at the same records")
+
+    def test_a_head_already_compact_is_left_alone(self):
+        """Idempotent: re-encoding an already-compact head must not disturb it."""
+        compact_head = ["0:%d" % i for i in range(backend._TemporalDirectBackendMixin.PLACEMENT_CHUNK_LOCATIONS)]
+        entries = _run(self.adapter, self.client,
+                       {"locations": compact_head, "resource_versions": []},
+                       [_long(0, 500)])
+        self.assertEqual(compact_head, _by_field(entries)[NODE_FIELD]["locations"])
+
+    def test_a_foreign_base_stays_a_dict(self):
+        """A location the compact form cannot express must survive the rewrite unchanged."""
+        foreign = {"key": "someone:else:records:000000", "field": "00000000000000000007"}
+        head = [foreign] + [_long(0, i) for i in range(backend._TemporalDirectBackendMixin.PLACEMENT_CHUNK_LOCATIONS)]
+        entries = _run(self.adapter, self.client,
+                       {"locations": head, "resource_versions": []},
+                       [_long(0, 500)])
+        stored = _by_field(entries)[NODE_FIELD]["locations"]
+        self.assertIn(foreign, stored, "the foreign-base location was lost or mangled")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A record location is stored as `"shard:offset"` — about six bytes where the `{"key", "field"}`
dict took sixty-nine. `_locator_entries_for_ref` and `_placement_entries_for_node` are the same
routine written twice: read the head, append to the tail chunk, and rewrite the head when the chunk
count rolls over.

The locator compacts its head on that rewrite. The placement one did not — it wrote `head_locations`
straight back:

```python
payload = {
    "locations": head_locations,          # the locator writes compact_location_list(head_locations, base)
    "resource_versions": merged_versions,
    "location_chunks": tail_index,
}
```

`head_locations` is read back from storage, so the long form is **self-perpetuating**: once a head
holds it, every later rollover writes all of it out again, and the head never upgrades however many
times it is rewritten.

## What it costs

Measured across the one-box log as it stands, 809 pieces and 510,082,640 bytes:

| | |
|---|---|
| long-form location dicts of the compactable shape | 18,449 |
| as stored | 1,439,022 B |
| as the compact form | 137,267 B |
| recovered | **1,301,755 B — 0.26% of the log** |
| per entry | 78.0 B -> 7.4 B (10.5x) |

0.26% of the log is the honest whole-log number. A single segment reads far worse — one
331,054-byte piece carried 364 of these, 28,392 bytes, 8.58% of that piece — because a head
rewrite dumps a whole head at once. The per-entry ratio is the part that generalises.

Every one of the 18,449 was the plainly compactable shape: key `base` + six digits, field twenty
digits. None were left alone for being a foreign base, so none of this count is a location the
compact form cannot express.

## The change

One line, so the two branches read the same way:

```python
"locations": compact_location_list(head_locations, self._location_base()),
```

`compact_location_list` leaves anything it cannot compact exactly as it is, and `expand_location`
has always accepted both shapes, so a store written before this reads unchanged and an already
compact head is untouched.

## Tests

`tools/test_matrixark_the_placement_head_keeps_the_long_form.py`, five tests:

* the rewritten head is stored compact — **fails without the change**, 64 of 64 head locations kept
  the long form
* the tail is stored compact — the positive control. It shares the fixture and the base with the
  head, so the head assertion only means something because this one passes
* the head still names the same records, through `expand_location`
* an already-compact head is left alone (idempotent)
* a foreign-base location survives the rewrite unchanged

20 tests pass across `test_placement_chunks`, `test_side_index_batch_read`, `test_side_index_merge`
and this file. This suite needs both import paths on `PYTHONPATH` (repo root and `tools/`).
