### PR TITLE
Never remember a failure notice as a context pack

### DIFF
--- a/tools/matrixark_codex_hook.py
+++ b/tools/matrixark_codex_hook.py
@@ -1946,9 +1946,13 @@ def codex_hook_output(
             _cache_path = _pack_cache.context_pack_cache_path(
                 "codex", str(agent_context.get("workspace_root") or "")
             )
-            if additional_context.strip():
+            if error:
+                # `additional_context` holds a failure NOTICE here, not a pack. Remembering it
+                # would serve "retrieval failed" back to a later turn as remembered history.
+                pass
+            elif additional_context.strip():
                 _pack_cache.remember_context_pack(_cache_path, additional_context)
-            elif not error and not _pack_cache.store_answered(retrieve):
+            elif not _pack_cache.store_answered(retrieve):
                 _previous, _age_s = _pack_cache.recover_context_pack(
                     _cache_path, max_age_s=_pack_cache.pack_cache_max_age_s()
                 )

--- a/tools/matrixark_hook_pack_cache.py
+++ b/tools/matrixark_hook_pack_cache.py
@@ -36,8 +36,33 @@ def context_pack_cache_path(agent: str, workspace_root: str) -> Path:
     return Path(root) / f"{agent}-{stamp}.txt"
 
 
+# The fixed opening of the notice the hooks emit when retrieval errors. Matched as a phrase rather
+# than on a word like "failed", because a real pack can discuss a failure and must still be kept.
+_FAILURE_NOTICE_MARKERS = (
+    "retrieval was attempted for this prompt but failed",
+    "retrieval was attempted but failed",
+)
+
+
+def looks_like_failure_notice(text: str) -> bool:
+    """Is this the hook's retrieval-failure notice rather than a context pack?
+
+    The notice lands in the same variable a pack would occupy, so without this the cache stores it
+    and a later turn serves "retrieval failed" back as prior context -- which is worse than serving
+    nothing, because it reaches the agent labelled as history.
+    """
+    head = text[:400].lower()
+    return any(marker in head for marker in _FAILURE_NOTICE_MARKERS)
+
+
 def remember_context_pack(path: Path, text: str) -> None:
-    """Keep this pack, so a later turn that cannot reach the store still has something true."""
+    """Keep this pack, so a later turn that cannot reach the store still has something true.
+
+    A failure notice is refused: it occupies the same variable a pack does, and storing it would
+    hand a later turn "retrieval failed" as remembered history.
+    """
+    if looks_like_failure_notice(text):
+        return
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         # Write-then-rename: a turn that dies mid-write must not leave a torn pack behind for the

--- a/tools/test_a_failure_notice_is_never_remembered_as_a_pack.py
+++ b/tools/test_a_failure_notice_is_never_remembered_as_a_pack.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A failure notice is never remembered as a context pack.
+
+When retrieval errors, the Codex hook puts a plain-language notice in the same variable a pack
+would occupy:
+
+    "MatrixArk/TemporalStore retrieval was attempted for this prompt but failed. Use visible local
+     Codex context as authoritative for this turn. Failure: ..."
+
+The fallback remembered whatever was non-empty, so it stored those. Found on a live box as a cache
+file holding that sentence and nothing else. A later turn that could not reach the store would then
+serve "retrieval failed" back as PRIOR CONTEXT -- worse than serving nothing, because it reaches the
+agent labelled as remembered history.
+
+These tests cover the cache module's own guard, so both hooks get it and neither can drift.
+"""
+import os
+import tempfile
+import unittest
+
+import matrixark_hook_pack_cache as pack_cache
+
+
+class FailureNoticeIsNotAPackTest(unittest.TestCase):
+    def setUp(self):
+        self._dir = tempfile.TemporaryDirectory()
+        self._prev = os.environ.get("MATRIXARK_HOOK_PACK_CACHE_DIR")
+        os.environ["MATRIXARK_HOOK_PACK_CACHE_DIR"] = self._dir.name
+
+    def tearDown(self):
+        if self._prev is None:
+            os.environ.pop("MATRIXARK_HOOK_PACK_CACHE_DIR", None)
+        else:
+            os.environ["MATRIXARK_HOOK_PACK_CACHE_DIR"] = self._prev
+        self._dir.cleanup()
+
+    def test_a_failure_notice_is_recognised(self):
+        notice = (
+            "MatrixArk/TemporalStore retrieval was attempted for this prompt but failed. Use "
+            "visible local Codex context as authoritative for this turn. Failure: "
+            "matrixark_retrieve timed out at the Codex hook boundary after 300000ms"
+        )
+        self.assertTrue(
+            pack_cache.looks_like_failure_notice(notice),
+            "the notice the hook emits on a retrieval error must be recognised as such",
+        )
+
+    def test_a_real_pack_is_not_mistaken_for_one(self):
+        """The control: over-eager matching would throw away real context."""
+        pack = (
+            "Relevant context from earlier turns (MatrixArk memory):\\n"
+            "- user: why did the retrieval fail last night\\n"
+            "- assistant: the store did not answer within its deadline"
+        )
+        self.assertFalse(
+            pack_cache.looks_like_failure_notice(pack),
+            "a pack that merely mentions failure is still a pack",
+        )
+
+    def test_remembering_a_failure_notice_is_refused(self):
+        path = pack_cache.context_pack_cache_path("codex", "/work/project")
+        pack_cache.remember_context_pack(path, "a real pack worth keeping")
+        pack_cache.remember_context_pack(
+            path,
+            "MatrixArk/TemporalStore retrieval was attempted for this prompt but failed. "
+            "Use visible local Codex context as authoritative for this turn.",
+        )
+        self.assertEqual(
+            pack_cache.recover_context_pack(path, max_age_s=3600)[0],
+            "a real pack worth keeping",
+            "a failure notice must not overwrite the last pack that actually loaded",
+        )
+
+    def test_nothing_is_stored_when_the_first_write_is_a_notice(self):
+        path = pack_cache.context_pack_cache_path("codex", "/work/fresh")
+        pack_cache.remember_context_pack(
+            path, "MatrixArk/TemporalStore retrieval was attempted for this prompt but failed."
+        )
+        self.assertEqual(
+            pack_cache.recover_context_pack(path, max_age_s=3600)[0],
+            "",
+            "with only a notice to store, the cache must stay empty rather than serve it later",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The last-good-pack fallback remembered whatever the hook had put in `additional_context`. On a
retrieval error that variable does not hold a pack — it holds a plain-language notice:

```
MatrixArk/TemporalStore retrieval was attempted for this prompt but failed. Use visible local
Codex context as authoritative for this turn. Failure: matrixark_retrieve timed out ...
```

So the notice was cached, and a later turn that could not reach the store would serve it back
labelled as prior context. That is **worse than serving nothing**: the agent is told, as remembered
history, that retrieval failed. Found on a live box as a cache file holding that sentence and
nothing else.

The `error` guard existed on the recover path but not on the remember path.

### The change

- **The call site** (`matrixark_codex_hook.py`): when `error` is set, remember nothing.
- **The cache itself** (`matrixark_hook_pack_cache.py`): `remember_context_pack` refuses a failure
  notice outright. Two hooks share this module and are edited independently, and the cost of
  getting it wrong is not a lost optimisation but a false memory — so the refusal lives with the
  store, not only with the caller.

Matched on the notice's fixed opening phrase rather than on a word like "failed", because a real
pack can discuss a failure and must still be kept. That case is a test, not an aspiration.

### Tests

`test_a_failure_notice_is_never_remembered_as_a_pack.py`:

- the notice the hook emits is recognised
- **a real pack that merely mentions failure is not** — the control against over-eager matching
- a notice cannot overwrite the last pack that actually loaded
- with only a notice to store, the cache stays empty rather than serving it later

All 21 hook-cache tests pass together.

Live cache audited afterwards: one poisoned entry removed, twelve genuine packs left untouched.
