### PR TITLE
One reader output budget, from the resolver the contract publishes

### DIFF
--- a/tools/run_locomo_ingest_once.py
+++ b/tools/run_locomo_ingest_once.py
@@ -1734,7 +1734,8 @@ class BenchmarkReader:
             candidate_first=self.config.candidate_first,
             candidate_only=self.config.candidate_only,
         )
-        max_tokens = int(os.environ.get("MATRIXARK_READER_MAX_TOKENS", "160"))
+        # The number the contract publishes for this run, not a literal beside it.
+        max_tokens = reader_max_tokens_from_env()
         payload = {
             "model": self.config.model,
             "temperature": 0,
@@ -1832,7 +1833,11 @@ class BenchmarkReader:
         candidate_hint = ""
         if self.config.include_extractive_hint and (self.config.candidate_only or self.config.candidate_hybrid):
             candidate_hint = extractive_reader_hint(question, blocks).strip()
-        max_tokens = int(os.environ.get("MATRIXARK_READER_MAX_TOKENS", "64"))
+        # The same resolver as the HTTP reader above. This defaulted to 64 where that one
+        # defaulted to 160, so with the variable unset the two backends of ONE reader wrote
+        # answers of different lengths -- and the shared-model contract, which requires both
+        # sides to use 'the same reader output-token budget', reported 160 for both.
+        max_tokens = reader_max_tokens_from_env()
         messages = [
             {"role": "system", "content": OSS_READER_SYSTEM_PROMPT},
             {

--- a/tools/test_numeric_defaults_agree.py
+++ b/tools/test_numeric_defaults_agree.py
@@ -32,6 +32,14 @@ it that way and computes no budgets. The MCP server's 30000 is a different layer
 waits for the tool call before abandoning it. Resolving the sentinel to 30000 would silently turn
 stage budgeting on for every unbudgeted request, so these must not be made to agree.
 
+`MATRIXARK_READER_MAX_TOKENS` is struck. It was not two reader paths that happened to differ:
+they are the HTTP and local-transformers backends of ONE reader, built from the same evidence
+bundle and the same prompts, defaulting to 160 and 64. With the variable unset the two wrote
+answers of different lengths, while the shared-model contract -- which requires both sides to
+use 'the same reader output-token budget' -- reported 160 for both. Both now call
+`reader_max_tokens_from_env()`, the resolver whose value the contract publishes, so there is
+one literal left and it belongs to the contract.
+
 The two TemporalStore SDK timeouts are struck. They were not a client/server difference: one option
 with one meaning, declared by three parsers, defaulting to 20000 in the backend resolver and 60000
 in both agent hooks. Every launcher supplies 60000 -- the three installers, the codex hook wrapper,
@@ -60,8 +68,6 @@ _READ = re.compile(
 KNOWN_DISAGREEMENTS: Dict[str, str] = {
     "MATRIXARK_HTTP_PORT":
         "servers bind 8080, the CLI paths use 0 (an ephemeral port)",
-    "MATRIXARK_READER_MAX_TOKENS":
-        "two reader paths in one benchmark script, 160 and 64",
     "MATRIXARK_RETRIEVAL_TIMEOUT_MS":
         "JUSTIFIED: the 0 is a sentinel, not a default -- no deadline was supplied for this "
         "request -- and the MCP server's 30000 is a different layer, how long it waits for the "


### PR DESCRIPTION
The fourth entry in `test_numeric_defaults_agree`'s unexamined list, listed as "two reader paths in
one benchmark script, 160 and 64".

They are not two paths that happen to differ. They are the **HTTP and local-transformers backends
of one reader**, in `run_locomo_ingest_once.py`, built from the same `reader_evidence_bundle` with
the same arguments, the same `OSS_READER_SYSTEM_PROMPT` and the same user template. The only thing
that differed was how long an answer each would write:

| backend | `max_tokens` when the variable is unset |
|---|---|
| OpenAI-compatible endpoint | 160 |
| local transformers | **64** |

### Why that is a defect rather than a preference

`reader_max_tokens_from_env()` lives in `run_locomo_benchmark_contract.py`, and the contract it
belongs to says in its own text that both sides must use

> the same OSS reader model, embedding/encoding model, retrieval block budget, adaptive retrieval
> policy, retrieval budget split, reader context budget, and reader **output-token budget**

The same script already **reports** that resolver's value as `reader_max_tokens` in the published
`benchmark_model_contract`, beside the prompts and the context budget. So with the variable unset
the contract recorded 160 for both backends while one of them wrote 64-token answers — a number
that was right for one reader and wrong for the other, in the document whose job is to say the two
sides were treated alike.

The project already knows this matters: `run_external_baseline_direct_retrieval.py` computes
`reader_output_budget_match` explicitly, comparing the two sides' output budgets.

### The fix

Both readers now call `reader_max_tokens_from_env()` — the resolver whose value the contract
publishes. One literal is left for this variable and it belongs to the contract module. Setting
`MATRIXARK_READER_MAX_TOKENS`, which `run_fair_oss_benchmark_suite.py` does for every real run,
behaves exactly as before.

### Checks

| | |
|---|---|
| `test_numeric_defaults_agree` | **4 passed**, entry struck, two left |
| resolver binds at both call sites | verified at runtime — the import is a star-import at the end of the file, and the name resolves, returning 160, and 96 when the variable is set |
| mutation — put the 64 back | **fails**: `MATRIXARK_READER_MAX_TOKENS (160, 64)` |
| `test_locomo_cross_session_retrieval` | passes |
| `test_locomo_reader_hints` | 2 failures, **name-diffed identical against `main`** — pre-existing |
