### PR TITLE
The MCP servers http port is a mode, not a port

### DIFF
--- a/tools/matrixark_mcp_cli.py
+++ b/tools/matrixark_mcp_cli.py
@@ -35,6 +35,17 @@ def main() -> int:
     parser.add_argument(
         "--http-port",
         type=int,
+        # 0 is a MODE, not a port: it means "stay on stdio", and `if args.http_port` below is what
+        # reads it. So this is not a second opinion about the 8080 that the gateway, the shipped
+        # config, the container and the deployment unit all use -- that is a bind port for a
+        # process whose whole job is to bind one. The two must not be made to agree.
+        #
+        # They do share a NAME, which is the sharp edge worth knowing about: a deployment that
+        # exports MATRIXARK_HTTP_PORT globally, rather than per service, turns this server from an
+        # stdio MCP endpoint into a web portal, and the agent that expected to speak MCP to it
+        # simply finds nothing. Nothing ships that way -- the port is set in the cloud-api image,
+        # the compose file and the gateway config, none of which launch this -- but a hand-rolled
+        # environment can, and the failure looks like the MCP server never started.
         default=int(os.environ.get("MATRIXARK_HTTP_PORT", "0")),
         help="If non-zero, serve the browser portal and /api JSON facade instead of stdio MCP.",
     )

--- a/tools/matrixark_mcp_server.py
+++ b/tools/matrixark_mcp_server.py
@@ -713,6 +713,17 @@ def main() -> int:
     parser.add_argument(
         "--http-port",
         type=int,
+        # 0 is a MODE, not a port: it means "stay on stdio", and `if args.http_port` below is what
+        # reads it. So this is not a second opinion about the 8080 that the gateway, the shipped
+        # config, the container and the deployment unit all use -- that is a bind port for a
+        # process whose whole job is to bind one. The two must not be made to agree.
+        #
+        # They do share a NAME, which is the sharp edge worth knowing about: a deployment that
+        # exports MATRIXARK_HTTP_PORT globally, rather than per service, turns this server from an
+        # stdio MCP endpoint into a web portal, and the agent that expected to speak MCP to it
+        # simply finds nothing. Nothing ships that way -- the port is set in the cloud-api image,
+        # the compose file and the gateway config, none of which launch this -- but a hand-rolled
+        # environment can, and the failure looks like the MCP server never started.
         default=int(os.environ.get("MATRIXARK_HTTP_PORT", "0")),
         help="If non-zero, serve the browser portal and /api JSON facade instead of stdio MCP.",
     )

--- a/tools/test_numeric_defaults_agree.py
+++ b/tools/test_numeric_defaults_agree.py
@@ -16,11 +16,11 @@ schema used to quote the wrong one of those two numbers at callers, which is wha
 one layer up. Both readers now agree, so the entry goes: the rule below is that a list of known
 differences which is allowed to go stale is read as a description of the tree.
 
-The remaining three are NOT endorsed here. One looks like a deliberate difference between a client
-and the server it calls, and one is two reader paths in a benchmark. Neither has been examined, and
-this file does not pretend otherwise: it exists so the next one has to be looked at rather than
-joining them quietly. Strike an entry when its difference is either justified in the code or
-removed.
+Nothing is now listed unexamined. All five entries this file was written with have been looked at:
+three were made to agree and struck, and two are differences that are real and must stay, each with
+its reason recorded here and at the code that reads it. A new entry may be parked here unexamined --
+that is what the list is for, and better than a quiet disagreement -- but it should not stay that
+way, and the two kinds are told apart by whether the note begins JUSTIFIED.
 
 An entry is struck when the numbers are made to AGREE. One that has been examined and found
 justified stays listed -- the literals still differ, and this scan cannot tell a sentinel from a
@@ -31,6 +31,11 @@ answers "what deadline was THIS request given", 0 means none was, and `default_s
 it that way and computes no budgets. The MCP server's 30000 is a different layer -- how long it
 waits for the tool call before abandoning it. Resolving the sentinel to 30000 would silently turn
 stage budgeting on for every unbudgeted request, so these must not be made to agree.
+
+`MATRIXARK_HTTP_PORT` is the second JUSTIFIED entry, and its note had guessed wrong: the 0 is not an
+ephemeral port. `if args.http_port` is what reads it, so 0 means "stay on stdio" and any non-zero
+value means "serve the portal instead". The gateway's 8080 is a bind port. Reading a note rather
+than the code is how a difference stays unexamined while looking examined.
 
 `MATRIXARK_READER_MAX_TOKENS` is struck. It was not two reader paths that happened to differ:
 they are the HTTP and local-transformers backends of ONE reader, built from the same evidence
@@ -67,7 +72,9 @@ _READ = re.compile(
 # unset. The note says what the difference looks like, not that it is right.
 KNOWN_DISAGREEMENTS: Dict[str, str] = {
     "MATRIXARK_HTTP_PORT":
-        "servers bind 8080, the CLI paths use 0 (an ephemeral port)",
+        "JUSTIFIED: the 0 in the two MCP entry points is a MODE -- stay on stdio -- and not an "
+        "ephemeral port as this note first guessed. The 8080 is a bind port for the gateway, "
+        "which exists to bind one. Said in the code at both --http-port arguments.",
     "MATRIXARK_RETRIEVAL_TIMEOUT_MS":
         "JUSTIFIED: the 0 is a sentinel, not a default -- no deadline was supplied for this "
         "request -- and the MCP server's 30000 is a different layer, how long it waits for the "


### PR DESCRIPTION
The last entry in `test_numeric_defaults_agree`'s unexamined list, and the note describing it was
wrong.

It read: *"servers bind 8080, the CLI paths use 0 (an ephemeral port)"*. The `0` is not an ephemeral
port. Both MCP entry points read it as a **mode**:

```python
parser.add_argument("--http-port", type=int,
                    default=int(os.environ.get("MATRIXARK_HTTP_PORT", "0")),
                    help="If non-zero, serve the browser portal and /api JSON facade instead of stdio MCP.")
...
if args.http_port:
    mcp_server.serve_http(...)
```

`0` means *stay on stdio*. The gateway's `8080` is a bind port for a process whose whole job is to
bind one. They are not two opinions about a number and must not be made to agree, so the entry stays
listed with its reason, now marked `JUSTIFIED:`.

### The sharp edge worth naming

The two meanings share a **name**. A deployment that exports `MATRIXARK_HTTP_PORT` globally rather
than per service turns the MCP server from an stdio endpoint into a web portal, and the agent that
expected to speak MCP to it simply finds nothing — a failure that looks like the server never
started.

Nothing ships that way, and I checked rather than assumed: the port is set in the cloud-api image,
the compose file, the commented-out unit line and the gateway config, none of which launch an MCP
server. The MCP server also never loads `config/temporalstore.toml`, so the loader — which *does*
write resolved keys into `os.environ`, and maps `gateway.http_port` onto this variable — cannot
reach it in-process. A hand-rolled environment can. That is now written at both argument sites.

### The list is now fully examined

All five entries this file was written with have been looked at, three of them in the last few
changes:

| entry | outcome |
|---|---|
| `MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS` | struck earlier |
| `MATRIXARK_TEMPORALSTORE_REQUEST_TIMEOUT_MS` | made to agree, struck |
| `MATRIXARK_TEMPORALSTORE_IO_TIMEOUT_MS` | made to agree, struck |
| `MATRIXARK_READER_MAX_TOKENS` | made to agree, struck |
| `MATRIXARK_RETRIEVAL_TIMEOUT_MS` | real difference — sentinel vs deadline, `JUSTIFIED` |
| `MATRIXARK_HTTP_PORT` | real difference — mode vs bind port, `JUSTIFIED` |

The docstring said "the remaining three are NOT endorsed here"; that is no longer true and now says
what is. A new entry may still be parked unexamined — that is what the list is for, and better than
a quiet disagreement — but the two kinds are told apart by whether the note begins `JUSTIFIED`.

### Checks

| | |
|---|---|
| `test_numeric_defaults_agree` | **4 passed** |
| both entries carry a reason | verified by importing the module and reading the dict |
| `matrixark_mcp_server.py --help` | builds and prints `--http-port` |
