### PR TITLE
The block store borrows the page it is given

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -417,7 +417,10 @@ pub struct BlockStoreOptions {
     pub compression_level: i32,
 }
 
-pub type BlockAppendRecord = (Vec<u8>, Option<u64>, Option<u32>);
+/// The payload is BORROWED. A caller already holds the encoded page -- it keeps it for the
+/// cache put, or it holds the buffer it published from -- so owning it here forced every
+/// caller to hand over a clone of a page that is several times its own payload.
+pub type BlockAppendRecord<'a> = (&'a [u8], Option<u64>, Option<u32>);
 
 impl Default for BlockStoreOptions {
     fn default() -> Self {

--- a/crates/temporalstore-rust/src/block_store/append.rs
+++ b/crates/temporalstore-rust/src/block_store/append.rs
@@ -120,7 +120,7 @@ impl LocalBlockStore {
 
     pub fn append_batch_with_page_metadata(
         &self,
-        records: Vec<BlockAppendRecord>,
+        records: Vec<BlockAppendRecord<'_>>,
     ) -> Result<Vec<BlockAddress>, BlockStoreError> {
         let mut inner = self.inner.lock().expect("block store lock poisoned");
         if records.is_empty() {
@@ -140,7 +140,7 @@ impl LocalBlockStore {
             let mut page_id = inner.next_page_id;
             let mut band_id = band_id_for_slab(inner.page_slab_id);
             let mut record = encode_page_record(
-                &bytes,
+                bytes,
                 page_id,
                 object_id,
                 routing_bucket,

--- a/crates/temporalstore-rust/src/engine/packed_pages.rs
+++ b/crates/temporalstore-rust/src/engine/packed_pages.rs
@@ -268,15 +268,19 @@ fn append_timestamped_kv_pages_inner(
     let mut refs = Vec::new();
     let chunks = chunk_timestamped_kv_points(points);
     if !async_storage {
-        let mut writes = Vec::with_capacity(chunks.len());
         let mut chunk_points = Vec::with_capacity(chunks.len());
         let mut encoded_pages = Vec::with_capacity(chunks.len());
         for chunk in chunks {
-            let packed = encode_feature_page(&chunk);
-            writes.push((packed.clone(), Some(object_id), Some(routing_bucket)));
-            encoded_pages.push(packed);
+            encoded_pages.push(encode_feature_page(&chunk));
             chunk_points.push(chunk);
         }
+        // Hand the store a slice of each page instead of a clone of it. The page is kept anyway,
+        // for the cache put below, so the clone was a second full copy of a JSON page -- and a
+        // page is several times its payload, because a value is written as decimal numbers.
+        let writes: Vec<crate::block_store::BlockAppendRecord<'_>> = encoded_pages
+            .iter()
+            .map(|packed| (packed.as_slice(), Some(object_id), Some(routing_bucket)))
+            .collect();
         let addresses = block_store.append_batch_with_page_metadata(writes)?;
         if addresses.len() != chunk_points.len() {
             return Err(BlockStoreError::Io(std::io::Error::new(

--- a/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
+++ b/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
@@ -727,8 +727,10 @@ impl TemporalEngine {
         }
         let append_records = publish_records
             .iter()
+            // `publish_records` owns these bytes and outlives the append, so the store can
+            // borrow them rather than take a copy of every page being published.
             .map(|(_, _, bytes, object_id, routing_bucket)| {
-                (bytes.clone(), *object_id, *routing_bucket)
+                (bytes.as_slice(), *object_id, *routing_bucket)
             })
             .collect::<Vec<BlockAppendRecord>>();
         let published_addresses = self


### PR DESCRIPTION
`BlockAppendRecord` owned its payload, so both callers handed the store a clone of a page they
already held.

- `append_timestamped_kv_pages_inner` keeps the encoded page for the cache put, and cloned it for
  the store.
- The visibility publish path holds its buffers in `publish_records`, which outlives the append,
  and cloned each one for the store.

A page is JSON and a point carries its value as a `Vec<u8>`, which serde_json writes as an array
of decimal numbers, so a page is several times the payload it carries and each of those clones is
a full copy of it.

The record now borrows: `pub type BlockAppendRecord<'a> = (&'a [u8], Option<u64>, Option<u32>)`.
Nothing inside the store needed ownership -- `encode_page_record` already took `&[u8]`.

## Measured

Allocated bytes, 20 writes, alloc probe, A/B on this base:

| | before | after |
|---|---|---|
| summary write, 384-dim vector | 34,346 | 31,485 (-8.3%) |
| summary write, 1024-dim vector | 68,243 | 60,109 (-11.9%) |
| whole message ingest | 112,423 | 109,990 (-2.2%) |

A summary write is 61% of a message ingest. The saving matches what the copy cost when the append
path was split by stage: 2,853 bytes measured for the clone, 2,861 recovered.

With the two page changes before it, a summary write is down from 43,225 to 31,485 -- 27.2% -- and
an ingest from 119,839 to 109,990.

## Suite

17 failures against 18 on this base with the change removed; the one name that differs
(`async_hot_page_survives_memory_eviction_via_spill`) passes 3/3 alone with the change and also
fails in the baseline set, so it is the same environment racing seen across this branch. Two
baseline failures cleared.
