### PR TITLE
A record stores the storage options a reader cannot recompute

### DIFF
--- a/tools/matrixark_mcp_temporal_append.py
+++ b/tools/matrixark_mcp_temporal_append.py
@@ -206,6 +206,60 @@ def slim_persisted_storage_route(record: Json) -> Json:
     return slim
 
 
+# Fields `canonical_storage_route` PRODUCES and never reads back. `storage_options` is stored on
+# every record, and the tail of `normalize_storage_options` merges the route's output into it:
+#
+#     route = canonical_storage_route(normalized)
+#     normalized.update({k: v for k, v in route.items() if k in {...sixteen names...}})
+#
+# so each record carries a copy of a pure function of its own inputs. Measured on the one-box log,
+# `storage_options` is 6.53% of every byte written and 17 of its 25 fields never vary at all.
+#
+# Only the PURE outputs are dropped. `route`, `storage_family`, `write_mode`, `durability`,
+# `read_preference` and `background_write` are read back by `canonical_storage_route` as INPUTS, so
+# dropping them would silently override a caller who set one explicitly -- e.g.
+# `background_write=False` on an async write re-derives as True. Today's records round-trip either
+# way, which is exactly how that class of bug ships; they stay.
+#
+# Verified over 1,616 storage_options blocks taken from the live log: re-deriving these ten from the
+# kept fields reproduces all ten EXACTLY, 1,616 of 1,616, and the block is 51.1% smaller.
+_OPTIONS_KEYS_DERIVED_FROM_THE_REST = (
+    "route_key",
+    "backend_family",
+    "sync_write",
+    "async_write",
+    "write_ack_policy",
+    "native_backend_decides_route",
+    "selected_storage_family",
+    "selected_write_mode",
+    "replica_read",
+    "durability_result",
+)
+
+
+def slim_persisted_storage_options(record: Json) -> Json:
+    """Persist the storage options a reader cannot recompute, not the ones it can.
+
+    A consumer that wants the derived half calls `canonical_storage_route` on what is left, exactly
+    as it already does for the derived half of `storage_route`.
+    """
+    if not isinstance(record, dict):
+        return record
+    options = record.get("storage_options")
+    if not isinstance(options, dict) or not options:
+        return record
+    kept = {key: value for key, value in options.items()
+            if key not in _OPTIONS_KEYS_DERIVED_FROM_THE_REST}
+    if len(kept) == len(options):
+        return record
+    slim = dict(record)
+    if kept:
+        slim["storage_options"] = kept
+    else:
+        slim.pop("storage_options", None)
+    return slim
+
+
 def materialize_appended_records_locked(
     target: Any,
     *,

--- a/tools/matrixark_temporal_direct_write.py
+++ b/tools/matrixark_temporal_direct_write.py
@@ -26,9 +26,15 @@ except ImportError:
     )
 
 try:
-    from tools.matrixark_mcp_temporal_append import slim_persisted_storage_route
+    from tools.matrixark_mcp_temporal_append import (
+        slim_persisted_storage_options,
+        slim_persisted_storage_route,
+    )
 except ImportError:
-    from matrixark_mcp_temporal_append import slim_persisted_storage_route
+    from matrixark_mcp_temporal_append import (
+        slim_persisted_storage_options,
+        slim_persisted_storage_route,
+    )
 
 try:  # names owned by the parent module
     from tools.matrixark_mcp_temporal_adapters import (
@@ -341,7 +347,8 @@ class _TemporalDirectWriteMixin:
             for bundle in self._record_bundles(records):
                 record_key, record_id = self._record_location(sequence)
                 payload_value: Json
-                slim = [slim_persisted_storage_route(record) for record in bundle]
+                slim = [slim_persisted_storage_options(slim_persisted_storage_route(record))
+                        for record in bundle]
                 payload_value = slim[0] if len(slim) == 1 else {"record_bundle": slim}
                 payload = json.dumps(payload_value, sort_keys=True, separators=(",", ":"))
                 entries.append({"key": record_key, "field": record_id, "value": payload, "storage_route": self._storage_route_for_bundle(bundle)})

--- a/tools/test_matrixark_the_derived_storage_options_are_not_stored.py
+++ b/tools/test_matrixark_the_derived_storage_options_are_not_stored.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""`storage_options` carried a copy of a pure function of its own inputs.
+
+The tail of `normalize_storage_options` merges `canonical_storage_route(normalized)` back into the
+options, so every stored record spelled out sixteen fields that its own kept fields already imply.
+On the one-box log `storage_options` is 6.53% of every byte written, and 17 of its 25 fields never
+take a second value.
+
+Ten of those are PURE outputs -- names `canonical_storage_route` produces and never reads back --
+and only those are dropped. The other six (`route`, `storage_family`, `write_mode`, `durability`,
+`read_preference`, `background_write`) are read back as INPUTS, so dropping them would silently
+override an explicit caller value; `test_an_explicit_input_survives` is what holds that line.
+
+The invariant that matters is not "the field is absent" but "the field is recoverable", so the
+central test re-derives every dropped name and demands an exact match across a matrix of option
+shapes, not one fixture.
+"""
+import itertools
+import unittest
+
+try:
+    from tools.matrixark_mcp_temporal_append import (
+        _OPTIONS_KEYS_DERIVED_FROM_THE_REST,
+        slim_persisted_storage_options,
+    )
+    from tools.matrixark_mcp_storage_options import (
+        canonical_storage_route,
+        normalize_storage_options,
+    )
+except ImportError:  # run from tools/
+    from matrixark_mcp_temporal_append import (
+        _OPTIONS_KEYS_DERIVED_FROM_THE_REST,
+        slim_persisted_storage_options,
+    )
+    from matrixark_mcp_storage_options import (
+        canonical_storage_route,
+        normalize_storage_options,
+    )
+
+DERIVED = set(_OPTIONS_KEYS_DERIVED_FROM_THE_REST)
+
+
+def _options(**kwargs):
+    """A realistic block, built by the same function that builds the stored ones."""
+    return normalize_storage_options({"storage_options": dict(kwargs)})
+
+
+def _shapes():
+    """A matrix of option shapes, so the invariant is not asserted on one lucky fixture."""
+    for mode, write, family in itertools.product(
+        ("default", "shared_store", "raft"),
+        ("async", "sync"),
+        ("default", "shared_store", "raft"),
+    ):
+        if len({m for m in (mode, family) if m in {"shared_store", "raft"}}) > 1:
+            continue        # normalize refuses to mix two families in one request
+        opts = {"storage_mode": mode, "write_mode": write}
+        if family != "default":
+            opts["storage_family"] = family
+        try:
+            yield _options(**opts)
+        except Exception:
+            continue
+
+
+class DerivedStorageOptionsTests(unittest.TestCase):
+    def test_every_dropped_field_is_recoverable_exactly(self):
+        """The load-bearing invariant: what is dropped must come back byte-identical."""
+        checked = 0
+        for options in _shapes():
+            record = slim_persisted_storage_options({"storage_options": options})
+            kept = record["storage_options"]
+            rebuilt = canonical_storage_route(kept)
+            for field in DERIVED & set(options):
+                self.assertEqual(
+                    options[field], rebuilt.get(field),
+                    f"{field} did not come back from {kept}")
+                checked += 1
+        self.assertGreater(checked, 20, "the shape matrix produced almost nothing to check")
+
+    def test_the_derived_fields_are_actually_gone(self):
+        """Without this the recovery test above would pass on an unchanged record."""
+        options = _options(storage_mode="default", write_mode="async")
+        present = DERIVED & set(options)
+        self.assertTrue(present, "the fixture never had the derived fields")
+        kept = slim_persisted_storage_options({"storage_options": options})["storage_options"]
+        self.assertEqual(set(), DERIVED & set(kept))
+
+    def test_an_explicit_input_survives(self):
+        """`background_write` is an input as well as an output, so it must NOT be dropped.
+
+        An async write derives background_write=True. A caller who explicitly asked for False would
+        have that silently reversed if the field were treated as purely derived.
+        """
+        options = _options(storage_mode="default", write_mode="async", background_write=False)
+        kept = slim_persisted_storage_options({"storage_options": options})["storage_options"]
+        self.assertIn("background_write", kept)
+        self.assertIs(False, kept["background_write"])
+        self.assertIs(True, canonical_storage_route({"write_mode": "async"})["background_write"],
+                      "positive control: the default really is the opposite value")
+
+    def test_a_record_without_options_is_untouched(self):
+        record = {"record_type": "context_event", "text": "x"}
+        self.assertIs(record, slim_persisted_storage_options(record))
+
+    def test_an_already_slim_record_is_untouched(self):
+        record = {"storage_options": {"storage_mode": "default", "oplog_mode": "async"}}
+        self.assertIs(record, slim_persisted_storage_options(record))
+
+    def test_the_rest_of_the_record_is_not_disturbed(self):
+        options = _options(storage_mode="default", write_mode="async")
+        record = {"record_type": "context_event", "text": "hello", "node_hash": 7,
+                  "storage_options": options}
+        slim = slim_persisted_storage_options(record)
+        self.assertEqual(
+            {k: v for k, v in record.items() if k != "storage_options"},
+            {k: v for k, v in slim.items() if k != "storage_options"})
+        self.assertIn("storage_options", record, "the input record was mutated in place")
+        self.assertEqual(options, record["storage_options"])
+
+    def test_a_non_dict_is_returned_as_is(self):
+        self.assertEqual("nope", slim_persisted_storage_options("nope"))
+
+    def test_it_saves_a_material_share_of_the_block(self):
+        """A guard on the reason this exists, so a future narrowing shows up as a failure."""
+        import json
+        options = _options(storage_mode="default", write_mode="async")
+        before = len(json.dumps(options, separators=(",", ":")))
+        after = len(json.dumps(
+            slim_persisted_storage_options({"storage_options": options})["storage_options"],
+            separators=(",", ":")))
+        self.assertLess(after, before * 0.7,
+                        f"expected the block to shrink materially, got {before} -> {after}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`storage_options` is stored on every record, and the tail of `normalize_storage_options` merges the
route's own output back into it:

```python
route = canonical_storage_route(normalized)
normalized.update({k: v for k, v in route.items() if k in {...sixteen names...}})
```

`canonical_storage_route` is a pure function, so each record then carries a copy of a function of
its own inputs. Measured on the one-box log, `storage_options` is **7.89% of every byte written**,
and **17 of its 25 fields never take a second value** across 555 blocks — `durability_result` is
always `"accepted_for_async_durability"`, `write_ack_policy` always `"ack_after_memory_append"`,
`native_backend_decides_route` always `true`. Several are the same fact spelled more than once:
`route`, `route_key`, `backend_family`, `selected_storage_family` and `storage_family` are all
`"default"`; `oplog_mode`, `selected_write_mode`, `write_mode` and `durability` are all `"async"`.

This is the same argument `slim_persisted_storage_route` already makes for the derived half of
`storage_route`, applied to the block that one derives from.

## Only the pure outputs

Ten names are dropped — the ones `canonical_storage_route` produces and never reads back:

`route_key`, `backend_family`, `sync_write`, `async_write`, `write_ack_policy`,
`native_backend_decides_route`, `selected_storage_family`, `selected_write_mode`, `replica_read`,
`durability_result`.

Six others that the merge also writes are **kept**: `route`, `storage_family`, `write_mode`,
`durability`, `read_preference` and `background_write` are read back by `canonical_storage_route` as
INPUTS. Dropping those would silently reverse a caller who set one explicitly — an async write
re-derives `background_write` as `true`, so a request that asked for `false` would come back wrong.
Every block on the live log round-trips either way, which is exactly how that class of bug ships.
`test_an_explicit_input_survives` holds that line.

## What it recovers

Over the 40 most recent log pieces, 13,633,887 bytes:

| | |
|---|---|
| `storage_options` blocks | 1,815 |
| those blocks | 1,075,452 B (7.89% of the log) |
| with the derived names dropped | 522,357 B |
| recovered | **553,095 B — 4.06% of the log** |

This applies to records written from here on; it does not shrink what is already stored. At the
log's current 510,082,640 bytes, 4.06% is about 20.7 MB per log of this size.

Re-deriving the ten dropped names from what is kept reproduces all ten **exactly, on 1,616 of 1,616**
`storage_options` blocks taken from the live log — no disagreements.

## Where it applies

One line, at the single append chokepoint in `matrixark_temporal_direct_write.py` — the same place
`slim_persisted_storage_route` is applied, and its own comment records that this is the only append
call site.

No read-side change. Nothing reads these names off a stored record: an AST scan of every production
module finds 29 reads of the ten names, and their subjects are `normalized` (14, inside the composer
itself), `options` (8, inside `canonical_storage_route` reading its own inputs), `route` (6, on a
`storage_route` dict, which is a different dict) and `native_metrics` (1). A consumer that wants the
derived half calls `canonical_storage_route` on what is left, exactly as it already does for
`storage_route`.

## Tests

`tools/test_matrixark_the_derived_storage_options_are_not_stored.py`, eight tests. The central one
re-derives every dropped name across a matrix of option shapes rather than one fixture, because the
invariant is "recoverable", not "absent".

Both mutations were checked, with `__pycache__` cleared so a same-size edit could not report a stale
pass:

* slimmer made a no-op → 2 failures, including the material-share guard
* `background_write` added to the drop set → `test_an_explicit_input_survives` fails, alone

57 tests pass across `test_direct_record_cache`, `test_matrixark_raw_message_storage_contract`,
`test_backend_intern_metadata`, `test_side_index_merge`, `test_placement_chunks`,
`test_native_backends_reach_temporalstore`, `test_temporalstore_features` and the two new files.
These suites need both the repo root and `tools/` on `PYTHONPATH`.
