### PR TITLE
The retrieve deadline policy has one implementation

### DIFF
--- a/tools/matrixark_local_adapter_retrieve.py
+++ b/tools/matrixark_local_adapter_retrieve.py
@@ -320,35 +320,19 @@ class _LocalAdapterRetrieveMixin:
         # argument rather than a duplicated literal, and it is the only thing that differs.
         audit_mode, audit_sample_rate = _retrieve_planning.retrieval_audit_policy(
             args, default="off")
-        raw_deadline_ms = args.get("deadline_ms", ranking.get("deadline_ms", os.environ.get("MATRIXARK_RETRIEVAL_TIMEOUT_MS", 0)))
-        try:
-            deadline_ms = int(raw_deadline_ms or 0)
-        except (TypeError, ValueError):
-            raise MatrixArkError("deadline_ms must be an integer")
+        # Same resolution, same order, same error, from the same place -- args, then ranking, then
+        # the environment, and 0 for "this request was given no deadline".
+        deadline_ms = _retrieve_planning.retrieval_deadline_ms(args, ranking)
 
         def deadline_exceeded() -> bool:
             return deadline_ms > 0 and (time.perf_counter() - started_perf) * 1000.0 >= deadline_ms
 
         stage_names = ["query_understanding", "candidate_fetch", "node_traversal", "rerank_score", "pack", "audit"]
         explicit_stage_budgets = optional_object(args, "stage_budgets_ms") or optional_object(ranking, "stage_budgets_ms")
-        if deadline_ms > 0:
-            default_stage_budgets = {
-                "query_understanding": max(25, int(deadline_ms * 0.15)),
-                "candidate_fetch": max(25, int(deadline_ms * 0.20)),
-                "node_traversal": max(25, int(deadline_ms * 0.15)),
-                "rerank_score": max(25, int(deadline_ms * 0.30)),
-                "pack": max(25, int(deadline_ms * 0.15)),
-                "audit": max(10, int(deadline_ms * 0.05)),
-            }
-        else:
-            default_stage_budgets = {
-                "query_understanding": 500,
-                "candidate_fetch": 750,
-                "node_traversal": 500,
-                "rerank_score": 1000,
-                "pack": 500,
-                "audit": 250,
-            }
+        # And the same budgets: nineteen literals were restated here, character for character,
+        # including the split that decides how much of a deadline each stage may spend. Two copies
+        # of a policy agree until one is edited.
+        default_stage_budgets = _retrieve_planning.default_stage_budgets(deadline_ms)
         stage_budgets_ms: dict[str, int] = {}
         for stage in stage_names:
             value = explicit_stage_budgets.get(stage, ranking.get(f"{stage}_budget_ms", default_stage_budgets[stage]))

--- a/tools/test_the_retrieve_stage_policy_has_one_implementation.py
+++ b/tools/test_the_retrieve_stage_policy_has_one_implementation.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The retrieve deadline policy has ONE implementation.
+
+`matrixark_local_adapter_retrieve` restated, character for character, both halves of the policy
+that `matrixark_mcp_retrieve_planning` already exports: the deadline resolution -- args, then
+ranking, then the environment, then 0 -- and the stage-budget split that decides how much of a
+deadline each stage may spend. Nineteen literals in two places. The comment above them in the
+adapter already said the audit policy had been consolidated "rather than a duplicated literal";
+these two were left.
+
+Two copies of a policy agree until one is edited, and this one is invisible when it drifts: the
+budgets are reported, not enforced, so a wrong split shows up as telemetry that quietly stops
+matching the path it describes.
+
+The check is on the SPLIT rather than on an import, because an import can be present while a
+second copy sits beside it. The proportions are what must exist once.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(TOOLS)
+
+#: The proportional split, in the order the policy writes it. Matched as a sequence so a module
+#: that merely mentions 0.15 somewhere is not accused of restating the policy.
+SPLIT = ["0.15", "0.20", "0.15", "0.30", "0.15", "0.05"]
+
+#: The absolute budgets used when a request carries no deadline.
+FLOOR = ["500", "750", "500", "1000", "500", "250"]
+
+#: The module the policy belongs to.
+OWNER = "tools/matrixark_mcp_retrieve_planning.py"
+
+
+def _production_sources() -> list:
+    listed = subprocess.run(["git", "ls-files", "tools/*.py"], cwd=REPO,
+                            capture_output=True, text=True).stdout.split()
+    return [path for path in listed if not os.path.basename(path).startswith("test_")]
+
+
+def _modules_carrying(sequence: list) -> list:
+    # Decimals and integers are scanned SEPARATELY. The split is written as
+    # max(25, int(deadline_ms * 0.15)), so a scan over every numeric token sees the 25s
+    # interleaved and never finds the proportions next to each other -- which is what the extent
+    # assertion below caught when this was written against one pattern.
+    decimal = "." in sequence[0]
+    pattern = re.compile(r"\d+\.\d+" if decimal else r"(?<![\d.])\d+(?![\d.])")
+    carrying = []
+    for path in _production_sources():
+        try:
+            with open(os.path.join(REPO, path), encoding="utf-8", errors="replace") as handle:
+                numbers = pattern.findall(handle.read())
+        except OSError:
+            continue
+        for start in range(len(numbers) - len(sequence) + 1):
+            if numbers[start:start + len(sequence)] == sequence:
+                carrying.append(path)
+                break
+    return sorted(carrying)
+
+
+class TheRetrieveStagePolicyHasOneImplementation(unittest.TestCase):
+
+    def test_the_owner_still_carries_the_split(self) -> None:
+        """Assert this scan's own extent: if the policy is rewritten, the checks below are empty."""
+        self.assertIn(OWNER, _modules_carrying(SPLIT),
+                      "the proportional split is no longer in %s, so this file is asserting that "
+                      "nothing restates a policy it can no longer find" % OWNER)
+        self.assertIn(OWNER, _modules_carrying(FLOOR),
+                      "the no-deadline budgets are no longer in %s" % OWNER)
+
+    def test_only_one_module_carries_the_proportional_split(self) -> None:
+        carrying = _modules_carrying(SPLIT)
+        self.assertEqual(
+            [OWNER], carrying,
+            "the stage-budget split is written in more than one place: %s. It decides how much of "
+            "a deadline each stage may spend, and the budgets are REPORTED rather than enforced, "
+            "so a copy that drifts shows up as telemetry that stops matching the path it "
+            "describes. Call matrixark_mcp_retrieve_planning.default_stage_budgets instead."
+            % carrying)
+
+    def test_only_one_module_carries_the_no_deadline_budgets(self) -> None:
+        carrying = _modules_carrying(FLOOR)
+        self.assertEqual(
+            [OWNER], carrying,
+            "the budgets used when a request carries no deadline are written in more than one "
+            "place: %s" % carrying)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`matrixark_local_adapter_retrieve` restated both halves of a policy that
`matrixark_mcp_retrieve_planning` already exports — the deadline resolution and the stage-budget
split — character for character. The comment immediately above them says the audit policy was
consolidated for exactly this reason:

> The same policy the other retrieve paths use, from one implementation. […] that difference is now
> the argument rather than a duplicated literal

These two were left. **Nineteen numeric literals in two places**, in the same order.

### Why this copy is a bad one to have

The stage budgets are **reported, not enforced** — `over_budget` and `over_budget_stages` are
telemetry, and the only thing that aborts a retrieve is `deadline_exceeded()`. So a drifted copy
does not fail: it produces telemetry that quietly stops describing the path it is attached to. That
is the kind of duplication that survives a long time.

### Verified by equivalence, because nothing tests it

The backend-policy suites that name `deadline_ms` and `stage_budgets` **skip at import** —
`run_matrixark_rust_scale_report` is absent from this repository — so no test exercises either
path, here or on `main`. Rather than infer equivalence from the literals matching, both were run
against the old inline code:

| | |
|---|---|
| deadline resolution | **84 cases** — env unset/empty/`0`/`5000`/`30000`/`1`/non-numeric × four `args` shapes × three `ranking` shapes — **0 mismatches**, including the case that raises `deadline_ms must be an integer` identically |
| stage budgets | **208 deadline values**, 0–199 plus 1000/5000/20000/30000/60000/300000 and two negatives — **0 mismatches** |

### The guard

A new test asserts the split lives in exactly one module. It checks the **proportions**, not an
import, because an import can sit beside a second copy.

It also asserts its own extent — and that assertion earned its place immediately. The first version
scanned every numeric token, which never finds `0.15, 0.20, 0.15, …` adjacent because
`max(25, int(deadline_ms * 0.15))` interleaves the `25`s. The extent check failed rather than the
scan silently matching nothing and reporting a clean tree. Decimals and integers are now scanned
separately.

### Checks

| | |
|---|---|
| new guard | **3 passed** |
| mutation — restore the duplicated dicts | **fails both assertions**, naming both modules |
| restored | green |
| `test_numeric_defaults_agree` | passes — the variable still reads `0` and `30000`, one reader fewer |
| `test_pipeline_task_slim`, `test_matrixark_popular_agent_hooks` | pass |
