### PR TITLE
The portal offers the serving knobs the config file does

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -471,6 +471,89 @@ SETTINGS: List[Setting] = [
             "MATRIXARK_TEMPORALSTORE_IO_TIMEOUT_MS",
             "Transport I/O timeout (ms)", "int", "60000", "live",
             "The I/O timeout underneath the request timeout above. Same story, same fix."),
+    # ---- offered by the config file since it existed; the portal caught up ----------------------
+    Setting("limits.backend_readiness_timeout_ms", "limits",
+            "MATRIXARK_BACKEND_READINESS_TIMEOUT_MS",
+            "Backend readiness timeout (ms)", "int", "30000", "restart",
+            "How long to keep waiting for the store to answer a readiness probe before giving up "
+            "on it. A cold store with a large log takes tens of seconds to load, so a timeout "
+            "below that turns a slow start into a failed one."),
+    Setting("limits.backend_readiness_backoff_ms", "limits",
+            "MATRIXARK_BACKEND_READINESS_BACKOFF_MS",
+            "Backend readiness retry gap (ms)", "int", "200", "restart",
+            "How long to wait between readiness probes while the store is still coming up."),
+    Setting("limits.direct_record_bundle_max_bytes", "limits",
+            "MATRIXARK_DIRECT_RECORD_BUNDLE_MAX_BYTES",
+            "Record bundle ceiling (bytes)", "int", "65536", "restart",
+            "The largest bundle of records fetched in one round trip. Bigger bundles mean fewer "
+            "round trips and more memory held per request."),
+    Setting("limits.direct_record_hot_cache_max_records", "limits",
+            "MATRIXARK_DIRECT_RECORD_HOT_CACHE_MAX_RECORDS",
+            "Hot record cache (records)", "int", "20000", "restart",
+            "How many records the read path keeps hot. This is resident memory traded for read "
+            "latency, and the footprint panel is where you can see what it costs."),
+    Setting("retrieval.cross_session_max_candidates", "retrieval",
+            "MATRIXARK_CROSS_SESSION_MAX_CANDIDATES",
+            "Cross-session candidates", "int", "24", "restart",
+            "How many candidates a retrieve may draw from sessions other than the current one "
+            "before ranking them. Each one costs a read."),
+    Setting("retrieval.cross_session_min_score", "retrieval",
+            "MATRIXARK_CROSS_SESSION_MIN_SCORE",
+            "Cross-session score floor", "float", "0.20", "restart",
+            "The score a candidate from another session must reach to be considered at all. "
+            "Raising it makes long-term memory pickier rather than smaller."),
+    Setting("retrieval.cross_session_parallelism", "retrieval",
+            "MATRIXARK_CROSS_SESSION_PARALLELISM",
+            "Cross-session parallelism", "int", "4", "restart",
+            "How many other sessions are searched at once. Raising it shortens a retrieve and "
+            "raises the load one retrieve puts on the store."),
+    Setting("retrieval.cross_session_profile_max_sessions", "retrieval",
+            "MATRIXARK_CROSS_SESSION_PROFILE_MAX_SESSIONS",
+            "Profile sessions searched", "int", "6", "restart",
+            "How many past sessions a profile query reaches into. The durable profile is meant to "
+            "answer most of these without a scan, so this is the fallback breadth."),
+    Setting("retrieval.max_children_scored_per_parent", "retrieval",
+            "MATRIXARK_MAX_CHILDREN_SCORED_PER_PARENT",
+            "Children scored per parent", "int", "100000", "restart",
+            "How many children of one node a traversal will score. Scoring a child costs a page "
+            "read, so this is the ceiling on what one branch can cost."),
+    Setting("retrieval.shared_context_min_score", "retrieval",
+            "MATRIXARK_SHARED_CONTEXT_MIN_SCORE",
+            "Shared content score floor", "float", "0.20", "restart",
+            "The score a shared skill or resource chunk must reach before it may take part of the "
+            "pack. The share settings decide how much room it has; this decides whether it "
+            "deserves any."),
+    Setting("retrieval.mode_dependent_quota", "retrieval",
+            "MATRIXARK_MODE_DEPENDENT_QUOTA",
+            "Mode-dependent quota", "bool", "0", "restart",
+            "Off, every caller gets the same cross-session share. On, the share follows the "
+            "context source mode: a caller that already has the current session in its own prompt "
+            "gets the budget spent on long-term memory instead. Shipped off pending a measured "
+            "comparison."),
+    Setting("extraction.entity_merge_operator", "extraction",
+            "MATRIXARK_ENTITY_MERGE_OPERATOR",
+            "Entity merge operator", "str", "EUA_MERGE", "restart",
+            "Which operator decides that two extracted entities are the same one. EUA_MERGE "
+            "applies field patches deterministically, in the serving path, with no model call. "
+            "LLM_MERGE asks the extraction model instead -- and it needs the setting below turned "
+            "on as well: with that off, choosing LLM_MERGE silently gets you EUA_MERGE, which is "
+            "why the two are offered together. Confirmations and corrections always use LATEST "
+            "whatever is set here, so it is not offered as a choice.",
+            ("EUA_MERGE", "LLM_MERGE")),
+    Setting("extraction.enable_llm_merge_operator", "extraction",
+            "MATRIXARK_ENABLE_LLM_MERGE_OPERATOR",
+            "Ask the model to merge entities", "bool", "0", "restart",
+            "Off, entities are merged by the deterministic operator above. On, the extraction "
+            "model is asked as well, which costs a call per ambiguous pair."),
+    Setting("extraction.time_compression_min_events", "extraction",
+            "MATRIXARK_TIME_COMPRESSION_MIN_EVENTS",
+            "Events before compressing a window", "int", "8", "restart",
+            "How many events must gather in a window before they are compressed into a summary. "
+            "Lower compresses sooner and loses raw detail sooner."),
+    Setting("extraction.time_compression_max_raw_events_per_node", "extraction",
+            "MATRIXARK_TIME_COMPRESSION_MAX_RAW_EVENTS_PER_NODE",
+            "Raw events kept per node", "int", "256", "restart",
+            "The ceiling on raw events one node keeps before compression is forced."),
     Setting("retrieval.hook_max_context_tokens", "retrieval",
             "MATRIXARK_HOOK_MAX_CONTEXT_TOKENS",
             "Agent hook context budget (tokens)", "int", "128000", "live",

--- a/tools/test_matrixark_the_portal_offers_what_the_config_file_does.py
+++ b/tools/test_matrixark_the_portal_offers_what_the_config_file_does.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The portal offers what the config file does.
+
+`matrixark_load_config.ENV_MAP` maps 131 config-file keys to environment variables. The portal
+offered 117 settings, and **77 of the file's variables were not among them** -- so which controls a
+customer could reach depended on how they had configured the deployment, and nobody had decided
+that: it was two lists maintained separately.
+
+Most of the 77 are right to leave alone. A bootstrap setting -- the bind address, the port, the API
+key file, the cluster's meta address -- is a launcher decision, and the portal already says so about
+the ones it does show. That distinction is **derivable**: the config file puts them in its own
+sections, so this rule exempts a section rather than a list of names, and a knob added to a serving
+section is covered from the moment it is added.
+
+Sixteen were serving knobs, every one of them read by production code. Fifteen are offered now. The
+sixteenth is an alias for a setting the portal already has, and offering it would have created a
+second way to set one thing -- the same trap as emitting a compatibility name.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+import matrixark_gateway_config as cfg  # noqa: E402
+import matrixark_load_config as loader  # noqa: E402
+
+# Sections of the config file a deployment settles before it serves anything. The portal reports
+# these where it reports them at all, and does not change them.
+BOOTSTRAP_SECTIONS = ("gateway", "auth", "server", "recovery", "replication",
+                      "wal", "storage", "raft", "meta", "proxy", "cluster")
+
+# The one serving variable deliberately not offered, and why.
+ALIASES = {
+    "MATRIXARK_EMBED_BASE_URL": "MATRIXARK_EMBEDDING_API_BASE",
+}
+
+
+def env_map():
+    return dict(getattr(loader, "ENV_MAP", {}))
+
+
+def offered():
+    return {s.env: s for s in cfg.SETTINGS if s.env}
+
+
+def serving_only_in_the_file():
+    """Config-file keys in a serving section that the portal does not offer."""
+    have = offered()
+    missing = {}
+    for key, variable in env_map().items():
+        if variable in have or variable in ALIASES:
+            continue
+        if key.split(".", 1)[0] in BOOTSTRAP_SECTIONS:
+            continue
+        missing[key] = variable
+    return missing
+
+
+class TheTwoSurfacesAgreeTest(unittest.TestCase):
+
+    def test_every_serving_knob_in_the_file_is_on_the_portal(self) -> None:
+        missing = serving_only_in_the_file()
+        self.assertEqual(
+            {}, missing,
+            "a config file can set these and the portal cannot:\n  "
+            + "\n  ".join("%s (%s)" % (k, v) for k, v in sorted(missing.items())))
+
+    def test_the_rule_is_comparing_something(self) -> None:
+        """The rule above passes if the map goes empty or every section is called bootstrap. Both
+        would read exactly like agreement."""
+        mapped = env_map()
+        self.assertGreater(len(mapped), 100, "the config map has %d entries" % len(mapped))
+        serving = [k for k in mapped if k.split(".", 1)[0] not in BOOTSTRAP_SECTIONS]
+        self.assertGreater(len(serving), 40,
+                           "only %d config keys are in a serving section" % len(serving))
+
+    def test_the_exemptions_are_the_minority(self) -> None:
+        """A section list that swallowed the file would make this vacuous with nothing to notice."""
+        mapped = env_map()
+        exempt = [k for k in mapped if k.split(".", 1)[0] in BOOTSTRAP_SECTIONS]
+        self.assertLess(len(exempt), len(mapped) - len(exempt) + len(exempt) // 1,
+                        "%d of %d keys are exempt" % (len(exempt), len(mapped)))
+        self.assertLess(len(exempt) / float(len(mapped)), 0.75)
+
+
+class TheAliasIsReallyAnAliasTest(unittest.TestCase):
+    """Exempting a name is the weakest kind of rule, so the reason is checked rather than trusted."""
+
+    def test_the_setting_it_defers_to_is_offered(self) -> None:
+        have = offered()
+        for alias, primary in ALIASES.items():
+            with self.subTest(alias=alias):
+                self.assertIn(primary, have,
+                              "%s is exempt because %s is offered; it is not" % (alias, primary))
+
+    def test_they_are_read_in_the_same_breath(self) -> None:
+        """An alias is a fallback beside the name it defers to. If it ever became an independent
+        control it would need offering like any other."""
+        with open(os.path.join(TOOLS, "matrixark_v1_gateway.py"), encoding="utf-8") as handle:
+            source = handle.read()
+        for alias, primary in ALIASES.items():
+            with self.subTest(alias=alias):
+                line = next((ln for ln in source.splitlines() if alias in ln), "")
+                self.assertIn(primary, line,
+                              "%s is not read beside %s any more" % (alias, primary))
+
+
+class TheNewSettingsAreRealTest(unittest.TestCase):
+    """Offering a knob that nothing reads is the defect this repository keeps finding. Every one of
+    these was checked against the code before it was offered; this keeps that true."""
+
+    ADDED = (
+        "limits.backend_readiness_timeout_ms",
+        "limits.backend_readiness_backoff_ms",
+        "limits.direct_record_bundle_max_bytes",
+        "limits.direct_record_hot_cache_max_records",
+        "retrieval.cross_session_max_candidates",
+        "retrieval.cross_session_min_score",
+        "retrieval.cross_session_parallelism",
+        "retrieval.cross_session_profile_max_sessions",
+        "retrieval.max_children_scored_per_parent",
+        "retrieval.shared_context_min_score",
+        "retrieval.mode_dependent_quota",
+        "extraction.entity_merge_operator",
+        "extraction.enable_llm_merge_operator",
+        "extraction.time_compression_min_events",
+        "extraction.time_compression_max_raw_events_per_node",
+    )
+
+    def test_each_one_is_registered(self) -> None:
+        for key in self.ADDED:
+            with self.subTest(setting=key):
+                self.assertIn(key, cfg.SETTINGS_BY_KEY)
+
+    def test_each_names_the_variable_the_config_file_maps(self) -> None:
+        mapped = env_map()
+        for key in self.ADDED:
+            with self.subTest(setting=key):
+                self.assertIn(key, mapped, "%s is not in the config map" % key)
+                self.assertEqual(mapped[key], cfg.SETTINGS_BY_KEY[key].env)
+
+    def test_each_variable_is_read_by_the_build(self) -> None:
+        """A knob nothing reads is worse than a missing one: it reports as configured."""
+        sources = []
+        for name in sorted(os.listdir(TOOLS)):
+            if not name.endswith(".py") or name.startswith("test_"):
+                continue
+            if name in ("matrixark_gateway_config.py", "matrixark_load_config.py"):
+                continue
+            with open(os.path.join(TOOLS, name), encoding="utf-8", errors="replace") as handle:
+                sources.append(handle.read())
+        blob = "\n".join(sources)
+        for key in self.ADDED:
+            variable = cfg.SETTINGS_BY_KEY[key].env
+            with self.subTest(setting=key):
+                self.assertIn(variable, blob, "%s is offered and nothing reads it" % variable)
+
+    def test_the_group_matches_the_config_file_section(self) -> None:
+        """The two surfaces name the same thing the same way, which is what makes the rule above
+        checkable at all."""
+        for key in self.ADDED:
+            with self.subTest(setting=key):
+                self.assertEqual(key.split(".", 1)[0], cfg.SETTINGS_BY_KEY[key].group)
+
+    def test_none_of_them_claims_to_be_live(self) -> None:
+        """They are bound at import in `matrixark_mcp_runtime_config`, so `restart` is the honest
+        label. Making them live is a separate change with its own evidence."""
+        for key in self.ADDED:
+            with self.subTest(setting=key):
+                self.assertEqual("restart", cfg.SETTINGS_BY_KEY[key].applies)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`matrixark_load_config.ENV_MAP` maps **131** config-file keys to environment variables. The portal
offered **117** settings. **77 of the file's variables were not among them** — so which controls a
customer could reach depended on how they had configured the deployment, and nobody decided that.
It was two lists maintained separately.

Most of the 77 are right to leave alone, and that is **derivable rather than a judgement**: the
config file puts bootstrap settings in their own sections. A bind address, a port, an API key file,
the cluster's meta address — those are launcher decisions, and the portal already says so about the
ones it does display. Exempting a *section* means a knob added to a serving section is covered from
the moment it is added, without anyone remembering to add it here.

That splits cleanly:

| | |
|---|---|
| bootstrap sections (`gateway`, `auth`, `server`, `recovery`, `replication`, …) | 61 — correctly not on the portal |
| **serving sections** (`retrieval`, `extraction`, `limits`) | **16** |

Sixteen serving knobs a config-file customer could set and a portal customer could not. **Every one
of them is read by production code** — I checked before offering any, because offering a knob that
nothing reads is the defect this repository keeps finding, and it is worse than a missing one: it
reports as configured.

Fifteen are offered now:

- `limits.backend_readiness_timeout_ms`, `…_backoff_ms` — a cold store with a large log takes tens
  of seconds to load, so a timeout below that turns a slow start into a failed one
- `limits.direct_record_bundle_max_bytes`, `…_hot_cache_max_records` — resident memory traded for
  read latency, and the footprint panel is now where you can see what it costs
- `retrieval.cross_session_max_candidates`, `…_min_score`, `…_parallelism`,
  `…_profile_max_sessions`, `max_children_scored_per_parent`, `shared_context_min_score`
- `retrieval.mode_dependent_quota` — the whole mode-dependent quota scheme, shipped off
- `extraction.entity_merge_operator`, `enable_llm_merge_operator`, `time_compression_min_events`,
  `…_max_raw_events_per_node`

### The sixteenth, and a correction

`MATRIXARK_EMBED_BASE_URL` is **not** offered, on purpose: it is a fallback read beside
`MATRIXARK_EMBEDDING_API_BASE`, which the portal already has. Offering it would create a second way
to set one thing — the same trap as emitting a compatibility name rather than merely accepting it.

Worth recording how close that came to being wrong. My first sweep reported it as read by
**nothing**, which would have made it a dead knob on a live surface. The sweep only scanned
`tools/*.py`; the Rust engine reads it at `crates/temporalstore-rust/src/bin/server.rs:252`. Exactly
one name is exempted here, and two tests check the *reason* rather than trusting it: that the setting
it defers to is offered, and that the two are still read in the same expression.

### A dependency that fails silently

`entity_merge_operator` takes `EUA_MERGE` or `LLM_MERGE` — and choosing `LLM_MERGE` **silently gets
you `EUA_MERGE`** unless `enable_llm_merge_operator` is also on (`normalize_entity_operator` falls
back without a word). It is offered as a two-value choice with that dependency spelled out, and the
two settings sit next to each other. A free-text field there would have invited exactly the
one-character typo that #964 was about.

```
one of the fifteen is taken off the portal again          -> FAIL
a setting names a variable the config file does not map   -> FAIL
a setting is filed under the wrong group                  -> FAIL
one of them claims to take effect live                    -> FAIL
a declared default drifts from the build                  -> FAIL
the bootstrap list swallows the whole config file         -> FAIL
the alias defers to a setting the portal does not offer   -> FAIL
```

10 tests, plus 86 across the suites that police the registry. The declared-default sweep compares
all fifteen defaults against the constants the build runs, so a wrong number here fails a test
rather than reconfiguring somebody's clone.

All fifteen are labelled `restart`, which is the honest label: they are bound at import in
`matrixark_mcp_runtime_config`. Making them live is a separate change with its own evidence, and a
test asserts none of them claims otherwise in the meantime.
