### PR TITLE
The two ASGI fronts admit different callers, on purpose

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -5861,7 +5861,16 @@ def _build_server_from_env() -> Any:
 def create_v1_app() -> Callable[..., Awaitable[None]]:
     """Build the MatrixArk server from env and return the `/v1/*` gateway ASGI app.
 
-    Mirrors `matrixark_asgi.create_app` for `uvicorn matrixark_v1_gateway:application`.
+    The peer of `matrixark_asgi.create_app` for `uvicorn matrixark_v1_gateway:application`, and it
+    does NOT mirror it on the one default that decides who may call: this front resolves
+    MATRIXARK_ACCESS_MODE to "dev" and that one to "enforced". Both bind 0.0.0.0:8080 out of the
+    box, so an operator who sets nothing gets an anonymous dev_admin with every scope here, and a
+    401 there.
+
+    That is deliberate on this side and said in three places -- the DEV DEFAULT comment below, the
+    `require_auth` default, and the one-time `_NO_AUTH_WARNING` this front logs at startup when it
+    is open. What was not said is that the other front chose the opposite, which is why the word
+    "mirrors" is gone: the two are peers, not copies, and the difference is the security posture.
     """
     server = _build_server_from_env()
     app = make_v1_app(server, GatewayConfig.from_env())

--- a/tools/test_the_two_asgi_fronts_disagree_on_purpose.py
+++ b/tools/test_the_two_asgi_fronts_disagree_on_purpose.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The two ASGI fronts disagree about who may call, and that has to be on purpose.
+
+`matrixark_asgi` and `matrixark_v1_gateway` are peer uvicorn entry points. Both build a
+`MatrixArkMcpServer` from the environment, and both bind 0.0.0.0:8080 by default. They resolve
+MATRIXARK_ACCESS_MODE to different things when an operator sets nothing:
+
+    matrixark_asgi         -> "enforced"   an API key is required
+    matrixark_v1_gateway   -> "dev"        anonymous, role dev_admin, every scope
+
+In "dev" the access manager skips the scope check entirely and hands back an identity with
+`sorted(MATRIXARK_ALL_SCOPES)`. That is a deliberate developer-experience default on the gateway
+side, documented there and announced by a one-time startup warning. It is recorded here so that it
+stays a decision: a change to either default, in either direction, fails this until someone updates
+the table and says why.
+
+The literals are read from the source rather than by importing, because importing either module
+pulls in a server and its backends.
+"""
+from __future__ import annotations
+
+import os
+import re
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+
+#: entry point -> (default access mode, why it is that)
+DECLARED = {
+    "matrixark_asgi.py": (
+        "enforced",
+        "a network front with no anonymous story of its own: it builds the server and serves it, "
+        "so the safe end of the choice is the one that does not need a warning",
+    ),
+    "matrixark_v1_gateway.py": (
+        "dev",
+        "a deliberate developer-experience default so the API works with zero configuration, "
+        "carried with require_auth=False, a DEV DEFAULT comment, and the one-time "
+        "_NO_AUTH_WARNING logged at startup while the deployment is open",
+    ),
+}
+
+_READ = re.compile(
+    r'access_mode\s*=\s*os\.environ\.get\(\s*["\']MATRIXARK_ACCESS_MODE["\']\s*,\s*'
+    r'["\']([a-z]+)["\']\s*\)')
+
+
+def _default_in(name: str) -> str:
+    with open(os.path.join(TOOLS, name), encoding="utf-8") as handle:
+        found = _READ.findall(handle.read())
+    return found[0] if len(found) == 1 else "|".join(found) or "NONE"
+
+
+class TheTwoFrontsDisagreeOnPurpose(unittest.TestCase):
+
+    def test_each_front_still_resolves_the_variable_once(self) -> None:
+        """Assert this file's own extent: a moved read makes every check below vacuous."""
+        for name in DECLARED:
+            with self.subTest(entry_point=name):
+                found = _default_in(name)
+                self.assertIn(found, ("dev", "enforced"),
+                              "%s no longer resolves MATRIXARK_ACCESS_MODE to a single literal "
+                              "(found %r), so this file is asserting about something it can no "
+                              "longer see" % (name, found))
+
+    def test_the_defaults_are_the_declared_ones(self) -> None:
+        actual = {name: _default_in(name) for name in DECLARED}
+        expected = {name: value for name, (value, _) in DECLARED.items()}
+        self.assertEqual(
+            expected, actual,
+            "an ASGI front changed which callers it admits by default. In 'dev' the access "
+            "manager skips the scope check and returns role dev_admin with every scope, and both "
+            "fronts bind 0.0.0.0 by default, so this is who can reach a deployment that "
+            "configured nothing. Update the table above with the reason, or put the default back.")
+
+    def test_every_declared_default_gives_a_reason(self) -> None:
+        thin = sorted(name for name, (_, why) in DECLARED.items() if len(why.strip()) < 40)
+        self.assertEqual([], thin,
+                         "these are declared without a reason worth reading: %s" % thin)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`test_numeric_defaults_agree` covers numbers and `test_flag_readers_agree` covers booleans. A
**string** default is covered by neither, and drifts the same way — two readers agree on every value
anyone sets and part company for the deployment that sets nothing. Sweeping those found 70 variables
with a string default, 15 read with more than one.

Thirteen are legitimate by construction: the two agent hooks differ on identity
(`MATRIXARK_ACCOUNT_ID`, `MATRIXARK_TEAM`, `MATRIXARK_TENANT_ID`, the store prefix), and the
embedding and extraction providers differ on API base and key-variable name because that is what a
provider *is*.

One is worth writing down.

### The two ASGI fronts admit different callers

`matrixark_asgi` and `matrixark_v1_gateway` are peer uvicorn entry points. Both build a
`MatrixArkMcpServer` from the environment and both bind `0.0.0.0:8080` by default. They resolve the
same variable differently:

| entry point | `MATRIXARK_ACCESS_MODE` unset |
|---|---|
| `matrixark_asgi` | `enforced` — an API key is required |
| `matrixark_v1_gateway` | `dev` — anonymous, `role: dev_admin`, `sorted(MATRIXARK_ALL_SCOPES)` |

In `dev` the access manager skips the scope check outright (`if self.mode == "enforced" and
required_scopes`). So an operator who configures nothing gets a 401 from one front and full
anonymous admin from the other.

**This is not a defect on the gateway side and nothing about its behaviour changes here.** It is a
deliberate developer-experience default, said in three places: the `DEV DEFAULT` comment, the
`require_auth: False` default, and the one-time `_NO_AUTH_WARNING` logged at startup while the
deployment is open. The knob is offered on the portal, in the Access group.

What was wrong is that `create_v1_app`'s own docstring said it

> Mirrors `matrixark_asgi.create_app`

on the one default that decides who may call. That word is gone, and the docstring now says which
way each front goes and why this one goes that way.

### A guard, so it stays a decision

A new test declares each front's default with its reason and asserts the source still matches. A
change to either, **in either direction**, fails until someone updates the table. It reads the
literals from source rather than importing, because importing either module pulls in a server and
its backends, and it asserts its own extent first — if a front stops resolving the variable to a
single literal, that fails rather than the comparison quietly passing.

### Checks

| | |
|---|---|
| new guard | **3 passed** |
| mutation — gateway → `enforced` | **fails**, naming who can reach a deployment that configured nothing |
| mutation — asgi → `dev` | **fails** |
| restored | green |
