### PR TITLE
The envelope keeps its own copy of the derived storage options

### DIFF
--- a/tools/matrixark_mcp_temporal_append.py
+++ b/tools/matrixark_mcp_temporal_append.py
@@ -237,27 +237,44 @@ _OPTIONS_KEYS_DERIVED_FROM_THE_REST = (
 )
 
 
-def slim_persisted_storage_options(record: Json) -> Json:
-    """Persist the storage options a reader cannot recompute, not the ones it can.
-
-    A consumer that wants the derived half calls `canonical_storage_route` on what is left, exactly
-    as it already does for the derived half of `storage_route`.
-    """
-    if not isinstance(record, dict):
-        return record
-    options = record.get("storage_options")
+def _slim_options_block(holder: Json) -> Json | None:
+    """`holder` with its `storage_options` trimmed, or None when there is nothing to trim."""
+    if not isinstance(holder, dict):
+        return None
+    options = holder.get("storage_options")
     if not isinstance(options, dict) or not options:
-        return record
+        return None
     kept = {key: value for key, value in options.items()
             if key not in _OPTIONS_KEYS_DERIVED_FROM_THE_REST}
     if len(kept) == len(options):
-        return record
-    slim = dict(record)
+        return None
+    slim = dict(holder)
     if kept:
         slim["storage_options"] = kept
     else:
         slim.pop("storage_options", None)
     return slim
+
+
+def slim_persisted_storage_options(record: Json) -> Json:
+    """Persist the storage options a reader cannot recompute, not the ones it can.
+
+    A consumer that wants the derived half calls `canonical_storage_route` on what is left, exactly
+    as it already does for the derived half of `storage_route`.
+
+    A record carries the block in TWO places -- its own top level and inside its `envelope` -- and
+    trimming only the first left the second spelling out the same derived fields. That is the shape
+    that keeps recurring here: one routine reaches a nested copy and its sibling does not.
+    """
+    if not isinstance(record, dict):
+        return record
+    slim = _slim_options_block(record)
+    envelope = (slim or record).get("envelope")
+    trimmed_envelope = _slim_options_block(envelope)
+    if trimmed_envelope is not None:
+        slim = dict(slim if slim is not None else record)
+        slim["envelope"] = trimmed_envelope
+    return slim if slim is not None else record
 
 
 def materialize_appended_records_locked(

--- a/tools/test_matrixark_the_derived_storage_options_are_not_stored.py
+++ b/tools/test_matrixark_the_derived_storage_options_are_not_stored.py
@@ -135,5 +135,58 @@ class DerivedStorageOptionsTests(unittest.TestCase):
                         f"expected the block to shrink materially, got {before} -> {after}")
 
 
+class EnvelopeStorageOptionsTests(unittest.TestCase):
+    """The block lives in two places on a record; trimming one is not trimming it."""
+
+    def setUp(self):
+        self.options = _options(storage_mode="default", write_mode="async")
+        self.assertTrue(DERIVED & set(self.options), "fixture has no derived fields")
+
+    def test_the_envelopes_own_block_is_trimmed(self):
+        record = {"record_type": "context_event",
+                  "envelope": {"messages": [], "storage_options": dict(self.options)}}
+        slim = slim_persisted_storage_options(record)
+        self.assertEqual(set(), DERIVED & set(slim["envelope"]["storage_options"]))
+
+    def test_the_envelopes_dropped_fields_are_recoverable(self):
+        record = {"envelope": {"storage_options": dict(self.options)}}
+        kept = slim_persisted_storage_options(record)["envelope"]["storage_options"]
+        rebuilt = canonical_storage_route(kept)
+        for field in DERIVED & set(self.options):
+            self.assertEqual(self.options[field], rebuilt.get(field), field)
+
+    def test_both_copies_are_trimmed_together(self):
+        record = {"storage_options": dict(self.options),
+                  "envelope": {"storage_options": dict(self.options)}}
+        slim = slim_persisted_storage_options(record)
+        self.assertEqual(set(), DERIVED & set(slim["storage_options"]))
+        self.assertEqual(set(), DERIVED & set(slim["envelope"]["storage_options"]))
+
+    def test_the_input_record_is_not_mutated(self):
+        envelope = {"storage_options": dict(self.options)}
+        record = {"envelope": envelope}
+        slim_persisted_storage_options(record)
+        self.assertTrue(DERIVED & set(envelope["storage_options"]),
+                        "the caller's envelope was trimmed in place")
+        self.assertIs(envelope, record["envelope"])
+
+    def test_the_rest_of_the_envelope_survives(self):
+        record = {"envelope": {"messages": [{"role": "user"}], "metadata": {"a": 1},
+                               "storage_options": dict(self.options)}}
+        slim = slim_persisted_storage_options(record)
+        self.assertEqual([{"role": "user"}], slim["envelope"]["messages"])
+        self.assertEqual({"a": 1}, slim["envelope"]["metadata"])
+
+    def test_a_record_with_neither_block_is_returned_as_is(self):
+        record = {"record_type": "context_event", "envelope": {"messages": []}}
+        self.assertIs(record, slim_persisted_storage_options(record))
+
+    def test_a_non_dict_envelope_is_ignored(self):
+        record = {"storage_options": dict(self.options), "envelope": "not a dict"}
+        slim = slim_persisted_storage_options(record)
+        self.assertEqual("not a dict", slim["envelope"])
+        self.assertEqual(set(), DERIVED & set(slim["storage_options"]))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A record carries `storage_options` in two places — its own top level and inside its `envelope` —
and `slim_persisted_storage_options` (mx#1048) only reached the first. The envelope's copy went on
spelling out the same ten derived fields.

This is the shape that keeps recurring in this code: one routine reaches a nested copy and its
sibling does not. It is the same defect as the placement head in mx#1042, found the same way — by
looking at what the live log actually contains after the change, rather than at whether the change
was applied.

## What it recovers

Over 30 recent log pieces, 10,703,272 bytes:

| | |
|---|---|
| envelope `storage_options` blocks | 40 (36 at `record_bundle.envelope`, 4 at `envelope`) |
| those blocks | 18,980 B |
| trimmed | 8,235 B |
| recovered | **10,745 B — 0.100% of the log** |

Small, and stated as measured rather than rounded up. It is worth doing because the inconsistency
is the bug: a reader of `slim_persisted_storage_options` reasonably expects it to have trimmed the
record, and until now it had trimmed part of it.

Re-deriving the dropped names from what is kept reproduces them **exactly on all 35** envelope
blocks that carried the derived half — no mismatches.

## The change

The trimming moves into `_slim_options_block(holder)`, applied to the record and then to its
envelope. Same drop set as mx#1048, so the same argument holds: only the ten names
`canonical_storage_route` produces and never reads back, never the six it consults as inputs.

The caller's record and envelope are not mutated — `test_the_input_record_is_not_mutated` holds
that, since the envelope is a nested dict and copying the outer record alone would have shared it.

## Tests

Seven added to `tools/test_matrixark_the_derived_storage_options_are_not_stored.py`, 15 in the file
now. Mutation-checked with `__pycache__` cleared: removing the envelope reach fails
`test_the_envelopes_own_block_is_trimmed` and `test_both_copies_are_trimmed_together`, and **no
record-level test**, so the new tests are aimed at the envelope specifically rather than restating
what mx#1048 already covers.
