### PR TITLE
The portal plots what it has only ever tabulated

### DIFF
--- a/tools/matrixark_gateway_metrics.py
+++ b/tools/matrixark_gateway_metrics.py
@@ -124,6 +124,13 @@ def bucket_quantile(buckets: List[float], quantile: float, observed_max_s: float
     return observed_max_s
 
 
+# How often the rolling series takes a sample, and how many it keeps. Fifteen seconds over four
+# hours is 960 tuples of five numbers -- a few tens of kilobytes, bounded like the failure ring
+# above and for the same reason: this is a process-lifetime structure on a hot path.
+SERIES_INTERVAL_S = 15.0
+SERIES_SAMPLES = 960
+
+
 class GatewayMetrics:
     """Process-wide edge counters. Every method is cheap and lock-guarded; recording never raises,
     because a metrics bug must not be able to fail a customer request."""
@@ -155,6 +162,14 @@ class GatewayMetrics:
         # Not probed here -- a metrics endpoint that opens an outbound connection is one that can
         # hang, and scraping would put the datanode's health check on Prometheus's cadence times
         # every worker.
+        # A rolling series, so the portal can PLOT traffic rather than only tabulate a total.
+        # Each entry is CUMULATIVE at the moment it was taken -- (when, requests, errors, latency
+        # sum, latency count) -- so a rate is the difference between two samples. Storing rates
+        # directly would mean a missed sample silently invents or erases traffic; a difference
+        # between two totals cannot.
+        self._series: Deque[Tuple[float, int, int, float, int]] = deque(maxlen=SERIES_SAMPLES)
+        self._series_at = 0.0
+
         self._datanode: Optional[Tuple[str, float]] = None
 
     # ---- recording -----------------------------------------------------------------------------
@@ -204,8 +219,26 @@ class GatewayMetrics:
                 self._req_bytes[route] = self._req_bytes.get(route, 0) + int(request_bytes)
             if response_bytes:
                 self._resp_bytes[route] = self._resp_bytes.get(route, 0) + int(response_bytes)
+            try:
+                self._sample_locked(time.time())
+            except Exception:  # pragma: no cover - the promise above, kept
+                pass
             if status >= 400:
                 self._failures.append((time.time(), route, method, status, incident))
+
+    def _sample_locked(self, now: float) -> None:
+        """Append one cumulative sample, at most once per interval. The lock is already held."""
+        if now - self._series_at < SERIES_INTERVAL_S:
+            return
+        self._series_at = now
+        self._series.append((
+            now,
+            sum(self._requests.values()),
+            sum(count for (_route, _method, status), count in self._requests.items()
+                if status >= 400),
+            sum(self._sum.values()),
+            sum(self._count.values()),
+        ))
 
     def note_datanode(self, state: str) -> None:
         """Record what the readiness probe just found."""
@@ -213,6 +246,41 @@ class GatewayMetrics:
             self._datanode = (str(state), time.time())
 
     # ---- reading -------------------------------------------------------------------------------
+    def series(self) -> Json:
+        """Per-interval rates, derived from consecutive cumulative samples.
+
+        Deliberately NOT part of `snapshot()`: that goes into the live frame every two seconds to
+        every open tab, and an hour of history in it would be paid for on every tick by every
+        viewer. This is asked for once, by the page that draws it.
+
+        `mean_ms` is the mean over ITS interval, not since the process started. A lifetime mean
+        flattens every spike a plot exists to show.
+        """
+        with self._lock:
+            samples = list(self._series)
+        points = []
+        for (t0, r0, e0, s0, c0), (t1, r1, e1, s1, c1) in zip(samples, samples[1:]):
+            span = t1 - t0
+            if span <= 0:  # pragma: no cover - a clock that went backwards
+                continue
+            calls = c1 - c0
+            points.append({
+                "at": round(t1, 3),
+                "requests_per_s": round(max(0, r1 - r0) / span, 4),
+                "errors_per_s": round(max(0, e1 - e0) / span, 4),
+                "mean_ms": round((s1 - s0) / calls * 1000.0, 3) if calls > 0 else None,
+            })
+        return {
+            "interval_s": SERIES_INTERVAL_S,
+            "points": points,
+            # n samples make n-1 intervals, so one sample plots nothing. Saying how much is
+            # covered is the difference between "quiet" and "only just started watching".
+            "covers_s": round(samples[-1][0] - samples[0][0], 1) if len(samples) > 1 else 0.0,
+            # Every worker keeps its own. Two workers do not add up to the deployment's traffic
+            # any more than two workers' resident memory adds up to its footprint.
+            "worker_scoped": True,
+        }
+
     def snapshot(self) -> Json:
         """A JSON view for the portal's metrics panel (the same numbers Prometheus scrapes)."""
         with self._lock:

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1647,6 +1647,14 @@ def _model_picker_body(target: str) -> Json:
     return body
 
 
+def _metrics_series() -> Json:
+    """The rolling traffic series, for the page to plot. Never fatal to the overview."""
+    try:
+        return _gwmetrics.METRICS.series()
+    except Exception:  # pragma: no cover - a metrics bug must not fail the page
+        return {"interval_s": 0, "points": [], "covers_s": 0.0, "worker_scoped": True}
+
+
 def _latency_summary() -> Json:
     """Which control actually decides how long a retrieve can take.
 
@@ -4850,6 +4858,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                 "traffic": traffic,
                 "footprint": footprint,
                 "latency": _latency_summary(),
+                "metrics_series": _metrics_series(),
                 "imports": imports,
                 "config": config_snapshot,
             })

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -127,6 +127,9 @@
   pre{background:var(--panel-2);border:1px solid var(--line);border-radius:7px;padding:12px 14px;
       overflow-x:auto;font-size:12.5px;margin:0;line-height:1.5}
   .empty{color:var(--faint);font-size:14px;padding:6px 0}
+.spark{margin:0 0 10px}
+.spark figcaption{font-size:12px;color:var(--faint);margin-bottom:2px}
+.spark svg{width:100%;height:56px;display:block;opacity:.85}
   .enc{border:1px solid var(--line);border-radius:8px;padding:12px 14px;margin-bottom:9px;
        background:var(--panel-2)}
   .enc.active{border-color:var(--accent);background:var(--accent-soft)}

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -1126,6 +1126,16 @@ SETUP_BODY = """
       the store, so a single slow call runs to the transport timeout whatever the deadline says.</p>
     <div id="latency"><div class="empty">Loading&hellip;</div></div>
   </section>
+
+  <section>
+    <h2>Traffic over time</h2>
+    <p class="hint" style="margin-top:0">The counters this page tabulates, drawn. Sampled every
+      fifteen seconds on the request path, so the shape is there whether or not anyone had this
+      page open &mdash; and it survives a reload, which a series built in the browser would not.
+      One worker&rsquo;s: two workers no more add up to the deployment&rsquo;s traffic than their
+      resident memory adds up to its footprint.</p>
+    <div id="trend"><div class="empty">Loading&hellip;</div></div>
+  </section>
   </section>
 
   <section class="pane" role="tabpanel" aria-labelledby="tab-deployment" id="pane-deployment" hidden>
@@ -2430,6 +2440,56 @@ SETUP_JS = r"""
     $("latency").innerHTML = "<table><tbody>" + rows + "</tbody></table>";
   }
 
+  /* ---------- traffic over time ---------- */
+  function sparkline(points, pick, label, unit) {
+    var W = 320, H = 56, PAD = 3;
+    var values = points.map(pick);
+    var real = values.filter(function (v) { return v !== null && v !== undefined; });
+    if (!real.length) { return ""; }
+    var top = Math.max.apply(null, real);
+    /* A flat line at the bottom of an empty chart and a flat line at the bottom of a real one look
+       identical, so a zero maximum gets a nominal scale and the label still says 0. */
+    var scale = top > 0 ? top : 1;
+    var step = values.length > 1 ? (W - PAD * 2) / (values.length - 1) : 0;
+    var drawn = [];
+    values.forEach(function (v, i) {
+      if (v === null || v === undefined) { return; }
+      var x = PAD + i * step;
+      var y = H - PAD - (v / scale) * (H - PAD * 2);
+      drawn.push(x.toFixed(1) + "," + y.toFixed(1));
+    });
+    if (drawn.length < 2) { return ""; }
+    return '<figure class="spark"><figcaption>' + label
+         + ' <span class="aux">peak ' + (Math.round(top * 100) / 100) + " " + unit
+         + '</span></figcaption>'
+         + '<svg viewBox="0 0 ' + W + " " + H + '" role="img" aria-label="' + label + '">'
+         + '<polyline fill="none" stroke="currentColor" stroke-width="1.5" points="'
+         + drawn.join(" ") + '"/></svg></figure>';
+  }
+
+  function renderTrend(series) {
+    if (!series || !series.points) {
+      $("trend").innerHTML = '<div class="empty">Not available.</div>';
+      return;
+    }
+    var points = series.points;
+    if (points.length < 2) {
+      /* Not an empty chart: an empty chart reads as "no traffic", and this is "not enough
+         samples yet". Two samples make one interval, and one interval is not a line. */
+      $("trend").innerHTML = '<div class="empty">Watching. A line needs two intervals &mdash; '
+        + "about " + Math.round((series.interval_s || 15) * 2) + " seconds of traffic.</div>";
+      return;
+    }
+    var minutes = Math.round((series.covers_s || 0) / 60);
+    $("trend").innerHTML =
+      sparkline(points, function (p) { return p.requests_per_s; }, "Requests", "/s")
+      + sparkline(points, function (p) { return p.errors_per_s; }, "Errors", "/s")
+      + sparkline(points, function (p) { return p.mean_ms; }, "Mean latency", "ms")
+      + '<p class="hint">' + points.length + " intervals of "
+      + series.interval_s + "s" + (minutes ? ", covering about " + minutes + " minutes" : "")
+      + ". This worker only.</p>";
+  }
+
   function loadFootprint() {
     fetch("/v1/admin/overview", { headers: auth() })
       .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
@@ -2439,12 +2499,14 @@ SETUP_JS = r"""
         renderFootprint(d.footprint);
         renderBudgets((((d.config || {}).skills) || {}).budgets);
         renderLatency(d.latency);
+        renderTrend(d.metrics_series);
       })
       .catch(function () {
         $("footprint").innerHTML =
           '<div class="msg err">Could not read the footprint.</div>';
         $("budgets").innerHTML = '<div class="msg err">Could not read the budget.</div>';
         $("latency").innerHTML = '<div class="msg err">Could not read the timing.</div>';
+        $("trend").innerHTML = '<div class="msg err">Could not read the traffic series.</div>';
       });
   }
 

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -127,6 +127,9 @@
   pre{background:var(--panel-2);border:1px solid var(--line);border-radius:7px;padding:12px 14px;
       overflow-x:auto;font-size:12.5px;margin:0;line-height:1.5}
   .empty{color:var(--faint);font-size:14px;padding:6px 0}
+.spark{margin:0 0 10px}
+.spark figcaption{font-size:12px;color:var(--faint);margin-bottom:2px}
+.spark svg{width:100%;height:56px;display:block;opacity:.85}
   .enc{border:1px solid var(--line);border-radius:8px;padding:12px 14px;margin-bottom:9px;
        background:var(--panel-2)}
   .enc.active{border-color:var(--accent);background:var(--accent-soft)}

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -127,6 +127,9 @@
   pre{background:var(--panel-2);border:1px solid var(--line);border-radius:7px;padding:12px 14px;
       overflow-x:auto;font-size:12.5px;margin:0;line-height:1.5}
   .empty{color:var(--faint);font-size:14px;padding:6px 0}
+.spark{margin:0 0 10px}
+.spark figcaption{font-size:12px;color:var(--faint);margin-bottom:2px}
+.spark svg{width:100%;height:56px;display:block;opacity:.85}
   .enc{border:1px solid var(--line);border-radius:8px;padding:12px 14px;margin-bottom:9px;
        background:var(--panel-2)}
   .enc.active{border-color:var(--accent);background:var(--accent-soft)}

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -127,6 +127,9 @@
   pre{background:var(--panel-2);border:1px solid var(--line);border-radius:7px;padding:12px 14px;
       overflow-x:auto;font-size:12.5px;margin:0;line-height:1.5}
   .empty{color:var(--faint);font-size:14px;padding:6px 0}
+.spark{margin:0 0 10px}
+.spark figcaption{font-size:12px;color:var(--faint);margin-bottom:2px}
+.spark svg{width:100%;height:56px;display:block;opacity:.85}
   .enc{border:1px solid var(--line);border-radius:8px;padding:12px 14px;margin-bottom:9px;
        background:var(--panel-2)}
   .enc.active{border-color:var(--accent);background:var(--accent-soft)}

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -127,6 +127,9 @@
   pre{background:var(--panel-2);border:1px solid var(--line);border-radius:7px;padding:12px 14px;
       overflow-x:auto;font-size:12.5px;margin:0;line-height:1.5}
   .empty{color:var(--faint);font-size:14px;padding:6px 0}
+.spark{margin:0 0 10px}
+.spark figcaption{font-size:12px;color:var(--faint);margin-bottom:2px}
+.spark svg{width:100%;height:56px;display:block;opacity:.85}
   .enc{border:1px solid var(--line);border-radius:8px;padding:12px 14px;margin-bottom:9px;
        background:var(--panel-2)}
   .enc.active{border-color:var(--accent);background:var(--accent-soft)}

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -127,6 +127,9 @@
   pre{background:var(--panel-2);border:1px solid var(--line);border-radius:7px;padding:12px 14px;
       overflow-x:auto;font-size:12.5px;margin:0;line-height:1.5}
   .empty{color:var(--faint);font-size:14px;padding:6px 0}
+.spark{margin:0 0 10px}
+.spark figcaption{font-size:12px;color:var(--faint);margin-bottom:2px}
+.spark svg{width:100%;height:56px;display:block;opacity:.85}
   .enc{border:1px solid var(--line);border-radius:8px;padding:12px 14px;margin-bottom:9px;
        background:var(--panel-2)}
   .enc.active{border-color:var(--accent);background:var(--accent-soft)}
@@ -622,6 +625,16 @@
       of them can stop a slow call. The deadline is checked between stages, never around a call to
       the store, so a single slow call runs to the transport timeout whatever the deadline says.</p>
     <div id="latency"><div class="empty">Loading&hellip;</div></div>
+  </section>
+
+  <section>
+    <h2>Traffic over time</h2>
+    <p class="hint" style="margin-top:0">The counters this page tabulates, drawn. Sampled every
+      fifteen seconds on the request path, so the shape is there whether or not anyone had this
+      page open &mdash; and it survives a reload, which a series built in the browser would not.
+      One worker&rsquo;s: two workers no more add up to the deployment&rsquo;s traffic than their
+      resident memory adds up to its footprint.</p>
+    <div id="trend"><div class="empty">Loading&hellip;</div></div>
   </section>
   </section>
 
@@ -2145,6 +2158,56 @@ function liveStream(options) {
     $("latency").innerHTML = "<table><tbody>" + rows + "</tbody></table>";
   }
 
+  /* ---------- traffic over time ---------- */
+  function sparkline(points, pick, label, unit) {
+    var W = 320, H = 56, PAD = 3;
+    var values = points.map(pick);
+    var real = values.filter(function (v) { return v !== null && v !== undefined; });
+    if (!real.length) { return ""; }
+    var top = Math.max.apply(null, real);
+    /* A flat line at the bottom of an empty chart and a flat line at the bottom of a real one look
+       identical, so a zero maximum gets a nominal scale and the label still says 0. */
+    var scale = top > 0 ? top : 1;
+    var step = values.length > 1 ? (W - PAD * 2) / (values.length - 1) : 0;
+    var drawn = [];
+    values.forEach(function (v, i) {
+      if (v === null || v === undefined) { return; }
+      var x = PAD + i * step;
+      var y = H - PAD - (v / scale) * (H - PAD * 2);
+      drawn.push(x.toFixed(1) + "," + y.toFixed(1));
+    });
+    if (drawn.length < 2) { return ""; }
+    return '<figure class="spark"><figcaption>' + label
+         + ' <span class="aux">peak ' + (Math.round(top * 100) / 100) + " " + unit
+         + '</span></figcaption>'
+         + '<svg viewBox="0 0 ' + W + " " + H + '" role="img" aria-label="' + label + '">'
+         + '<polyline fill="none" stroke="currentColor" stroke-width="1.5" points="'
+         + drawn.join(" ") + '"/></svg></figure>';
+  }
+
+  function renderTrend(series) {
+    if (!series || !series.points) {
+      $("trend").innerHTML = '<div class="empty">Not available.</div>';
+      return;
+    }
+    var points = series.points;
+    if (points.length < 2) {
+      /* Not an empty chart: an empty chart reads as "no traffic", and this is "not enough
+         samples yet". Two samples make one interval, and one interval is not a line. */
+      $("trend").innerHTML = '<div class="empty">Watching. A line needs two intervals &mdash; '
+        + "about " + Math.round((series.interval_s || 15) * 2) + " seconds of traffic.</div>";
+      return;
+    }
+    var minutes = Math.round((series.covers_s || 0) / 60);
+    $("trend").innerHTML =
+      sparkline(points, function (p) { return p.requests_per_s; }, "Requests", "/s")
+      + sparkline(points, function (p) { return p.errors_per_s; }, "Errors", "/s")
+      + sparkline(points, function (p) { return p.mean_ms; }, "Mean latency", "ms")
+      + '<p class="hint">' + points.length + " intervals of "
+      + series.interval_s + "s" + (minutes ? ", covering about " + minutes + " minutes" : "")
+      + ". This worker only.</p>";
+  }
+
   function loadFootprint() {
     fetch("/v1/admin/overview", { headers: auth() })
       .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
@@ -2154,12 +2217,14 @@ function liveStream(options) {
         renderFootprint(d.footprint);
         renderBudgets((((d.config || {}).skills) || {}).budgets);
         renderLatency(d.latency);
+        renderTrend(d.metrics_series);
       })
       .catch(function () {
         $("footprint").innerHTML =
           '<div class="msg err">Could not read the footprint.</div>';
         $("budgets").innerHTML = '<div class="msg err">Could not read the budget.</div>';
         $("latency").innerHTML = '<div class="msg err">Could not read the timing.</div>';
+        $("trend").innerHTML = '<div class="msg err">Could not read the traffic series.</div>';
       });
   }
 

--- a/tools/portal/trend_panel_harness.js
+++ b/tools/portal/trend_panel_harness.js
@@ -1,0 +1,159 @@
+/* Run the Setup page, hand it a traffic series, and read the chart it drew.
+ *
+ * A chart is the easiest panel to make lie. An empty one and a quiet one look the same; a missing
+ * sample drawn as zero is a dip that never happened; a series too short to plot rendered as a flat
+ * line reads as "no traffic" rather than "not watching long enough". None of that is visible in a
+ * diff, so the page is run and the SVG is read.
+ *
+ * Usage: node trend_panel_harness.js <setup_portal.html> [full|short|absent|gaps]
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const mode = process.argv[3] || "full";
+const scripts = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+function points(n) {
+  const out = [];
+  for (let i = 0; i < n; i += 1) {
+    out.push({
+      at: 1788600000 + i * 15,
+      requests_per_s: 1 + (i % 4),
+      errors_per_s: i === 3 ? 2 : 0,
+      /* An interval in which nothing completed has no mean. Drawing it as 0 would show a latency
+         dip that never happened. */
+      mean_ms: (mode === "gaps" && i % 2 === 1) ? null : 12 + i,
+    });
+  }
+  return out;
+}
+
+const SERIES = mode === "absent" ? undefined : {
+  interval_s: 15,
+  points: mode === "short" ? points(1) : points(8),
+  covers_s: mode === "short" ? 0 : 105,
+  worker_scoped: true,
+};
+
+const OVERVIEW = {
+  status: "ok",
+  footprint: { worker: { resident_bytes: 1048576, peak_bytes: 1048576,
+                         source: "/proc/self/status", workers: 1 },
+               engine: { available: false } },
+  latency: { available: true, deadline_ms: 0, deadline_is_cooperative: true,
+             transport_request_timeout_ms: 60000, transport_io_timeout_ms: 60000,
+             bounds_a_slow_call: "transport_request_timeout_ms",
+             worst_case_single_call_ms: 60000, deadline_can_be_overrun_by_ms: 0 },
+  metrics_series: SERIES,
+  config: { skills: { budgets: { available: false } } },
+};
+
+const els = new Map();
+function makeEl(id) {
+  return {
+    id: id || "", hidden: false, textContent: "",
+    value: id === "key" ? "k-admin" : "", checked: true, className: "",
+    style: {}, dataset: {}, files: [], options: [], children: [], _html: "",
+    get innerHTML() { return this._html; },
+    set innerHTML(v) { this._html = String(v); },
+    addEventListener() {}, removeEventListener() {}, appendChild() {}, removeChild() {},
+    setAttribute() {}, getAttribute() { return null; }, closest() { return null; },
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    scrollIntoView() {}, focus() {}, click() {},
+    classList: { add() {}, remove() {}, toggle() {} }
+  };
+}
+function el(id) {
+  if (!els.has(id)) { els.set(id, makeEl(id)); }
+  return els.get(id);
+}
+
+const win = {
+  document: {
+    getElementById: (id) => el(id),
+    querySelector: () => makeEl(), querySelectorAll: () => [],
+    createElement: () => makeEl(), addEventListener() {}, body: makeEl(), hidden: false
+  },
+  addEventListener() {},
+  location: { origin: "http://localhost", href: "http://localhost", reload() {} },
+  sessionStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  localStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  navigator: {},
+  setTimeout: () => 0, setInterval: () => 0, clearInterval() {},
+  Number, JSON, String, Math, Date, Object, Array, Promise, RegExp, Error, isNaN,
+  encodeURIComponent, decodeURIComponent, parseInt, parseFloat,
+  TextDecoder: function () { this.decode = (v) => Buffer.from(v || []).toString("utf8"); },
+  AbortController: function () { this.abort = () => {}; this.signal = {}; },
+  FileReader: function () {}, Blob: function () {},
+  URL: { createObjectURL: () => "", revokeObjectURL() {} },
+  fetch: (url) => {
+    const u = String(url);
+    if (u.indexOf("/v1/admin/overview") >= 0) {
+      return Promise.resolve({ ok: true, status: 200,
+                               json: () => Promise.resolve(OVERVIEW),
+                               text: () => Promise.resolve(JSON.stringify(OVERVIEW)) });
+    }
+    if (u.indexOf("/v1/admin/events") >= 0) {
+      return Promise.resolve({ ok: true, status: 200,
+                               body: { getReader: () => ({ read: () => new Promise(() => {}) }) },
+                               json: () => Promise.resolve({}), text: () => Promise.resolve("") });
+    }
+    return Promise.resolve({ ok: true, status: 200,
+                             json: () => Promise.resolve({ settings: {} }),
+                             text: () => Promise.resolve("") });
+  }
+};
+win.window = win;
+
+const names = Object.keys(win);
+const values = names.map((k) => win[k]);
+scripts.forEach((body, index) => {
+  try { new Function(...names, body)(...values); }
+  catch (e) { console.log("FAIL script " + index + " threw: " + e.message); failures += 1; }
+});
+
+setTimeout(function () {
+  const html = el("trend").innerHTML;
+  ok("the panel was drawn at all", !/Loading/.test(html), html.slice(0, 160));
+
+  if (mode === "absent") {
+    /* An older worker that does not publish a series must not render an empty chart, which would
+       read as a deployment serving nothing. */
+    ok("a missing series says so rather than drawing zero",
+       /Not available/.test(html) && !/<svg/.test(html), html.slice(0, 300));
+  } else if (mode === "short") {
+    ok("one interval is not plotted as a line", !/<svg/.test(html), html.slice(0, 300));
+    ok("and the page says what it is waiting for",
+       /needs two intervals/.test(html), html.slice(0, 300));
+    ok("it does not read as an idle deployment", !/no traffic/i.test(html), html.slice(0, 300));
+  } else {
+    ok("three charts were drawn", (html.match(/<svg/g) || []).length === 3, html.slice(0, 400));
+    ok("each is a polyline with points",
+       (html.match(/<polyline[^>]*points="[^"]+"/g) || []).length === 3, html.slice(0, 400));
+    ok("requests, errors and latency are all labelled",
+       /Requests/.test(html) && /Errors/.test(html) && /Mean latency/.test(html),
+       html.slice(0, 400));
+    ok("the peak of each series is stated", /peak /.test(html), html.slice(0, 400));
+    ok("the window is described", /intervals of 15s/.test(html), html.slice(0, 900));
+    ok("and it says whose traffic this is", /This worker only/.test(html), html.slice(0, 900));
+
+    if (mode === "gaps") {
+      /* Four of the eight latency samples are null. The line must have four vertices, not eight
+         with four of them at the floor. */
+      const latency = html.slice(html.indexOf("Mean latency"));
+      const pts = (latency.match(/points="([^"]+)"/) || ["", ""])[1].trim().split(/\s+/);
+      ok("an interval with no calls is skipped, not drawn as zero",
+         pts.length === 4, "vertices: " + pts.length + " -> " + pts.join(" "));
+    }
+  }
+
+  console.log(failures ? "\n" + failures + " failed" : "\nall ok");
+  process.exit(failures ? 1 : 0);
+}, 60);

--- a/tools/test_matrixark_the_portal_plots_what_it_tabulates.py
+++ b/tools/test_matrixark_the_portal_plots_what_it_tabulates.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The portal plots what it has only ever tabulated.
+
+The gateway counted every request and timed every route, and the portal showed a table. Across all
+five portal pages there was **not one chart** -- no SVG, no canvas, no line -- so the shape of a
+deployment's traffic, which is the thing a table cannot show, was visible only to somebody who had
+stood up Prometheus and imported a dashboard.
+
+The collector keeps a rolling series now and the setup page draws it.
+
+Two decisions are load-bearing and are what this suite mostly checks:
+
+* **Samples are cumulative, not rates.** A rate is the difference between two samples. Storing
+  rates directly means a missed sample silently invents or erases traffic; a difference between two
+  totals cannot.
+* **The series is not in the live frame.** That frame goes to every open tab every two seconds, and
+  four hours of history in it would be paid for on every tick by every viewer. It is asked for once,
+  by the page that draws it.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+import matrixark_gateway_metrics as gwm  # noqa: E402
+import matrixark_v1_gateway as gateway  # noqa: E402
+
+PORTAL = os.path.join(TOOLS, "portal")
+
+
+def collector() -> "gwm.GatewayMetrics":
+    return gwm.GatewayMetrics()
+
+
+def force_sample(metrics) -> None:
+    """Take the next sample now rather than waiting for the interval to elapse."""
+    metrics._series_at = 0.0
+
+
+class TheSeriesIsHonestAboutWhatItHasTest(unittest.TestCase):
+
+    def test_a_collector_nobody_called_plots_nothing(self) -> None:
+        series = collector().series()
+        self.assertEqual([], series["points"])
+        self.assertEqual(0.0, series["covers_s"])
+
+    def test_one_sample_is_not_a_rate(self) -> None:
+        """Two samples make one interval. A single sample rendered as a point would be a rate
+        computed against the beginning of time."""
+        metrics = collector()
+        for _ in range(5):
+            metrics.record("/v1/retrieve", "POST", 200, 0.01)
+        self.assertEqual(1, len(metrics._series))
+        self.assertEqual([], metrics.series()["points"])
+
+    def test_two_samples_make_one_point(self) -> None:
+        metrics = collector()
+        metrics.record("/v1/retrieve", "POST", 200, 0.01)
+        force_sample(metrics)
+        for _ in range(9):
+            metrics.record("/v1/retrieve", "POST", 200, 0.01)
+        self.assertEqual(1, len(metrics.series()["points"]))
+
+    def test_a_sample_holds_the_running_total_of_requests(self) -> None:
+        """Cumulative, and cumulative of the right thing.
+
+        Monotonicity alone is too weak to pin this: the number of distinct (route, method, status)
+        keys also only ever grows, and a mutation storing THAT passed a monotonic check while
+        making every plotted rate wrong. The count is asserted exactly.
+        """
+        metrics = collector()
+        metrics.record("/v1/retrieve", "POST", 200, 0.01)   # first sample: 1 request so far
+        self.assertEqual(1, metrics._series[-1][1])
+        force_sample(metrics)
+        for _ in range(4):
+            metrics.record("/v1/retrieve", "POST", 500, 0.01)
+        # The second sample is taken on the first of those four, so it sees two.
+        self.assertEqual(2, metrics._series[-1][1])
+        self.assertEqual(1, metrics._series[-1][2], "the error count is not the request count")
+        force_sample(metrics)
+        metrics.record("/v1/retrieve", "POST", 200, 0.01)
+        self.assertEqual(6, metrics._series[-1][1])
+        totals = [sample[1] for sample in metrics._series]
+        self.assertEqual(sorted(totals), totals, "samples are not cumulative")
+
+    def test_an_interval_with_no_calls_has_no_mean(self) -> None:
+        """None, not zero. A zero would draw a latency dip that never happened."""
+        metrics = collector()
+        metrics.record("/v1/retrieve", "POST", 200, 0.01)
+        # A second sample with nothing recorded between the two.
+        force_sample(metrics)
+        metrics._sample_locked(metrics._series[-1][0] + 15.0)
+        point = metrics.series()["points"][-1]
+        self.assertIsNone(point["mean_ms"])
+        self.assertEqual(0.0, point["requests_per_s"])
+
+    def test_it_says_whose_traffic_it_is(self) -> None:
+        self.assertTrue(collector().series()["worker_scoped"])
+
+
+class TheSamplingIsCheapAndBoundedTest(unittest.TestCase):
+
+    def test_many_requests_in_one_interval_take_one_sample(self) -> None:
+        metrics = collector()
+        for _ in range(500):
+            metrics.record("/v1/retrieve", "POST", 200, 0.001)
+        self.assertEqual(1, len(metrics._series))
+
+    def test_the_window_cannot_grow_without_bound(self) -> None:
+        """A process-lifetime structure on a hot path. The failure mode of an unbounded one only
+        shows up on the deployments having the worst day."""
+        metrics = collector()
+        self.assertEqual(gwm.SERIES_SAMPLES, metrics._series.maxlen)
+        for _ in range(gwm.SERIES_SAMPLES + 50):
+            force_sample(metrics)
+            metrics.record("/v1/retrieve", "POST", 200, 0.001)
+        self.assertEqual(gwm.SERIES_SAMPLES, len(metrics._series))
+
+    def test_the_window_is_hours_not_minutes(self) -> None:
+        """The floor: a maxlen of 2 would satisfy the bound above and plot nothing useful."""
+        self.assertGreaterEqual(gwm.SERIES_SAMPLES * gwm.SERIES_INTERVAL_S, 3600)
+
+    def test_recording_still_cannot_raise(self) -> None:
+        """This module's own promise: a metrics bug must not be able to fail a customer request."""
+        metrics = collector()
+        metrics._series = None  # type: ignore[assignment]
+        try:
+            metrics.record("/v1/retrieve", "POST", 200, 0.01)
+        except Exception as exc:  # pragma: no cover - the point of the test
+            self.fail("recording raised: %r" % (exc,))
+
+
+class TheLiveFrameDoesNotCarryItTest(unittest.TestCase):
+    """The frame is sent to every open tab every two seconds. History belongs in the request that
+    draws it, not in the one that keeps a forgotten tab up to date."""
+
+    def test_the_snapshot_has_no_series(self) -> None:
+        metrics = collector()
+        for _ in range(3):
+            force_sample(metrics)
+            metrics.record("/v1/retrieve", "POST", 200, 0.01)
+        snapshot = metrics.snapshot()
+        self.assertNotIn("series", snapshot)
+        self.assertNotIn("points", snapshot)
+
+    def test_but_the_series_is_reachable(self) -> None:
+        """The floor: a collector that had no series at all would pass the test above."""
+        metrics = collector()
+        force_sample(metrics)
+        metrics.record("/v1/retrieve", "POST", 200, 0.01)
+        self.assertIn("points", metrics.series())
+
+
+class TheOverviewCarriesItTest(unittest.TestCase):
+
+    def test_the_gateway_publishes_a_series(self) -> None:
+        series = gateway._metrics_series()
+        for field in ("interval_s", "points", "covers_s", "worker_scoped"):
+            with self.subTest(field=field):
+                self.assertIn(field, series)
+
+    def test_the_overview_route_includes_it(self) -> None:
+        with open(os.path.join(TOOLS, "matrixark_v1_gateway.py"), encoding="utf-8") as handle:
+            source = handle.read()
+        block = source[source.index('path == "/v1/admin/overview"'):]
+        block = block[:block.index('"config": config_snapshot')]
+        self.assertIn('"metrics_series": _metrics_series()', block)
+
+
+class ThePageDrawsItTest(unittest.TestCase):
+    """A chart is the easiest panel to make lie: an empty one and a quiet one look the same, and a
+    missing sample drawn as zero is a dip that never happened. So the page is run."""
+
+    def setUp(self) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    def harness(self, mode: str) -> str:
+        out = subprocess.run(["node", "trend_panel_harness.js", "setup_portal.html", mode],
+                             cwd=PORTAL, capture_output=True, text=True, timeout=600)
+        return out.stdout + out.stderr
+
+    def test_a_full_series_is_three_charts(self) -> None:
+        self.assertIn("all ok", self.harness("full"), self.harness("full"))
+
+    def test_one_interval_is_not_a_line(self) -> None:
+        self.assertIn("all ok", self.harness("short"), self.harness("short"))
+
+    def test_an_absent_series_does_not_draw_zero(self) -> None:
+        self.assertIn("all ok", self.harness("absent"), self.harness("absent"))
+
+    def test_a_missing_sample_is_a_gap_not_a_dip(self) -> None:
+        self.assertIn("all ok", self.harness("gaps"), self.harness("gaps"))
+
+
+class ThePageHadNoChartsBeforeTest(unittest.TestCase):
+    """The premise, kept honest. If the portal grew a charting library, this panel's argument --
+    that there was nowhere at all to see the shape of traffic -- would need restating."""
+
+    def test_this_is_the_only_hand_rolled_chart(self) -> None:
+        """One `<polyline` in the SOURCE -- the template inside `sparkline`. Three appear at
+        runtime, which is the harness's business, not this file's: counting rendered output here
+        would be reading the page instead of running it."""
+        with open(os.path.join(PORTAL, "setup_portal.html"), encoding="utf-8") as handle:
+            page = handle.read()
+        self.assertEqual(1, page.count("<polyline"),
+                         "something other than the trend panel is drawing a line")
+        self.assertNotIn("<canvas", page)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The gateway counts every request and times every route. The portal showed a table. Across all five
portal pages there was **not one chart** — no `<svg>`, no `<canvas>`, no line — so the shape of a
deployment's traffic, which is the one thing a table cannot show, was visible only to somebody who
had stood up Prometheus and imported a dashboard.

The collector keeps a rolling series now, and the setup page draws it: requests/s, errors/s and mean
latency, as three inline SVG sparklines built from the response the page **already fetches**.

### Two decisions that carry the whole thing

**Samples are cumulative, not rates.** Each entry is `(when, requests, errors, latency_sum,
latency_count)` *as of that moment*, and a rate is the difference between two of them. Storing rates
directly means a missed sample silently invents or erases traffic; a difference between two running
totals cannot. Sampled on the request path under the lock it already holds — so a deployment nobody
is watching still accumulates history, and a reloaded page does not start from nothing, which a
series built in the browser would.

**It is not in the live frame.** That frame goes to every open tab every two seconds; four hours of
history in it would be paid for on every tick by every viewer. `series()` is deliberately separate
from `snapshot()`, and a test asserts the snapshot does not carry it — with a floor, because a
collector that had no series at all would pass that too.

Bounded at 960 samples × 15s = 4 hours, the same way the failure ring is bounded and for the same
reason: this is a process-lifetime structure on a hot path.

### Three ways a chart can lie, each pinned

| | what it must not do |
|---|---|
| **no series** (older worker) | draw an empty chart, which reads as *serving nothing* — it says "not available" |
| **one interval** | draw a flat line, which reads as *no traffic* — it says what it is waiting for |
| **an interval with no calls** | plot `mean_ms` as 0, a latency dip that never happened — the vertex is skipped |

The third is checked by counting SVG vertices: eight samples with four null means must produce a
**four**-vertex line, not eight with four on the floor.

```
the series stores rates instead of running totals    -> FAIL
every request takes a sample                         -> FAIL
the window grows without bound                       -> FAIL
an interval with no calls reports a mean of zero     -> FAIL
one sample is plotted as a point                     -> FAIL
the sampling can fail a customer request again       -> FAIL
the history rides in the two-second live frame       -> FAIL
the overview stops publishing the series             -> FAIL
a missing series is drawn as an empty chart          -> FAIL
one interval is drawn as a line                      -> FAIL
a missing sample is drawn at the floor               -> FAIL
```

### Two things my own tests caught

**I broke the module's promise.** `GatewayMetrics` says in as many words that "recording never
raises, because a metrics bug must not be able to fail a customer request" — and sampling is the
first thing in `record()` that does more than a dict update. A test written from that docstring
failed, and the sample is wrapped now. A plot is not worth a 500.

**A monotonic assertion was too weak.** The mutation that stored the wrong cumulative value —
`len(self._requests)`, the number of distinct route/method/status keys — **survived**, because that
number also only ever grows. Monotonicity does not pin "cumulative of the right thing". The test
asserts exact counts now, and the mutation dies.

19 tests. The page is run, not read: a Node harness executes its scripts against a stubbed DOM in
four states and reads the SVG that comes out. The style rule went into
`ingestion_portal.html`, which is where the shared stylesheet is extracted from — putting it in the
generator would have been overwritten by the next extraction.

Stacked on [#1038](https://github.com/matrixarkai/TemporalStore/pull/1038).
