### PR TITLE
A backfill tool read a metaserver spelling nothing sets

### DIFF
--- a/tools/matrixark_context_backfill.py
+++ b/tools/matrixark_context_backfill.py
@@ -2456,7 +2456,18 @@ def run_verify_manifest(args: argparse.Namespace) -> Json:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description='Backfill MatrixArk context records from MatrixArk raw ingestion logs.')
-    parser.add_argument('--metaserver', default=os.environ.get('MATRIXARK_METASERVER', '127.0.0.1:65000'))
+    # MATRIXARK_TEMPORALSTORE_METASERVER first: that is the spelling the shipped config, the
+    # compose file and every deploy document use, and the one the running processes carry.
+    # This read only ever saw the bare MATRIXARK_METASERVER, which nothing sets, so an
+    # operator who configured the documented variable changed nothing here and the tool dialled
+    # 127.0.0.1:65000 -- a port that does not listen, in a deployment whose live value is
+    # "local". The bare name is still ACCEPTED, because accepting an old spelling costs
+    # nothing and refusing it breaks whoever set it; it is emitting one that loses.
+    parser.add_argument(
+        '--metaserver',
+        default=(os.environ.get('MATRIXARK_TEMPORALSTORE_METASERVER')
+                 or os.environ.get('MATRIXARK_METASERVER')
+                 or '127.0.0.1:18000'))
     # The namespace and table the shipped config declares for these two variables, which is also
     # what the running processes carry. These defaulted to 'matrixark' and 'context', and nothing
     # else in the repository names either -- so a backfill run without --namespace addressed a

--- a/tools/run_matrixark_context_backfill_ubuntu22.sh
+++ b/tools/run_matrixark_context_backfill_ubuntu22.sh
@@ -17,7 +17,9 @@ PARTIAL_USER_IDS="${PARTIAL_USER_IDS:-}"
 PARTIAL_SESSION_IDS="${PARTIAL_SESSION_IDS:-}"
 PARTIAL_FILTER_JSON="${PARTIAL_FILTER_JSON:-}"
 PARTIAL_REQUIRE_BOUNDED="${PARTIAL_REQUIRE_BOUNDED:-1}"
-METASERVER="${METASERVER:-${MATRIXARK_METASERVER:-127.0.0.1:65000}}"
+# The documented spelling first, then the bare one, then the value the shipped config
+# declares. This wrapper defaulted to 127.0.0.1:65000, which no deployment listens on.
+METASERVER="${METASERVER:-${MATRIXARK_TEMPORALSTORE_METASERVER:-${MATRIXARK_METASERVER:-127.0.0.1:18000}}}"
 NAMESPACE="${NAMESPACE:-${MATRIXARK_NAMESPACE:-matrixark}}"
 TABLE="${TABLE:-${MATRIXARK_TABLE:-context}}"
 PROM_OUTPUT="${PROM_OUTPUT:-/tmp/matrixark_context_backfill_${JOB_ID}.prom}"

--- a/tools/test_matrixark_context_backfill.py
+++ b/tools/test_matrixark_context_backfill.py
@@ -2008,5 +2008,119 @@ class MatrixArkContextBackfillTest(unittest.TestCase):
             self.assertIn('file="shadow_wave_0000.sh",check="matches_plan"} 0', prom_text)
 
 
+
+class TheConnectionDefaultsAddressTheDeployment(unittest.TestCase):
+    """Run with no flags, this tool must address the store the deployment runs.
+
+    All three of its connection defaults pointed elsewhere. The namespace and table defaulted to
+    "matrixark" and "context" while config/temporalstore.toml declares deploy_ns and deploy_table
+    for those exact variables, and nothing else in the repository names either value. The
+    metaserver was read only as MATRIXARK_METASERVER -- a spelling nothing sets -- and defaulted to
+    127.0.0.1:65000, a port no deployment listens on.
+
+    A backfill that addresses an empty namespace does not fail. It writes, reports what it wrote,
+    and the deployment reads none of it, which is why these are asserted rather than left to be
+    noticed.
+    """
+
+    def _defaults(self, env: dict) -> argparse.Namespace:
+        import os
+
+        keys = ("MATRIXARK_TEMPORALSTORE_METASERVER", "MATRIXARK_METASERVER",
+                "MATRIXARK_NAMESPACE", "MATRIXARK_TABLE")
+        saved = {key: os.environ.get(key) for key in keys}
+        for key in keys:
+            os.environ.pop(key, None)
+        os.environ.update(env)
+        try:
+            return backfill.build_parser().parse_args([])
+        finally:
+            for key, value in saved.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+
+    def test_the_namespace_and_table_are_the_ones_the_config_declares(self) -> None:
+        args = self._defaults({})
+        self.assertEqual("deploy_ns", args.namespace)
+        self.assertEqual("deploy_table", args.table)
+
+    def test_the_documented_metaserver_spelling_is_honoured(self) -> None:
+        """The one the config, the compose file and the deploy documents all use."""
+        args = self._defaults({"MATRIXARK_TEMPORALSTORE_METASERVER": "local"})
+        self.assertEqual("local", args.metaserver,
+                         "the tool ignored the variable the running processes carry")
+
+    def test_the_older_spelling_is_still_accepted(self) -> None:
+        """Accepting an old name costs nothing; refusing it breaks whoever set it."""
+        args = self._defaults({"MATRIXARK_METASERVER": "127.0.0.1:19000"})
+        self.assertEqual("127.0.0.1:19000", args.metaserver)
+
+    def test_the_documented_spelling_wins_when_both_are_set(self) -> None:
+        args = self._defaults({"MATRIXARK_TEMPORALSTORE_METASERVER": "local",
+                               "MATRIXARK_METASERVER": "127.0.0.1:19000"})
+        self.assertEqual("local", args.metaserver)
+
+    def test_unset_falls_back_to_what_the_config_declares(self) -> None:
+        self.assertEqual("127.0.0.1:18000", self._defaults({}).metaserver)
+
+
+class TheConnectionDefaultsAddressTheDeployment(unittest.TestCase):
+    """Run with no flags, this tool must address the store the deployment runs.
+
+    All three of its connection defaults pointed elsewhere. The namespace and table defaulted to
+    "matrixark" and "context" while config/temporalstore.toml declares deploy_ns and deploy_table
+    for those exact variables, and nothing else in the repository names either value. The
+    metaserver was read only as MATRIXARK_METASERVER -- a spelling nothing sets -- and defaulted to
+    127.0.0.1:65000, a port no deployment listens on.
+
+    A backfill that addresses an empty namespace does not fail. It writes, reports what it wrote,
+    and the deployment reads none of it, which is why these are asserted rather than left to be
+    noticed.
+    """
+
+    def _defaults(self, env: dict) -> argparse.Namespace:
+        import os
+
+        keys = ("MATRIXARK_TEMPORALSTORE_METASERVER", "MATRIXARK_METASERVER",
+                "MATRIXARK_NAMESPACE", "MATRIXARK_TABLE")
+        saved = {key: os.environ.get(key) for key in keys}
+        for key in keys:
+            os.environ.pop(key, None)
+        os.environ.update(env)
+        try:
+            return backfill.build_parser().parse_args([])
+        finally:
+            for key, value in saved.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+
+    def test_the_namespace_and_table_are_the_ones_the_config_declares(self) -> None:
+        args = self._defaults({})
+        self.assertEqual("deploy_ns", args.namespace)
+        self.assertEqual("deploy_table", args.table)
+
+    def test_the_documented_metaserver_spelling_is_honoured(self) -> None:
+        """The one the config, the compose file and the deploy documents all use."""
+        args = self._defaults({"MATRIXARK_TEMPORALSTORE_METASERVER": "local"})
+        self.assertEqual("local", args.metaserver,
+                         "the tool ignored the variable the running processes carry")
+
+    def test_the_older_spelling_is_still_accepted(self) -> None:
+        """Accepting an old name costs nothing; refusing it breaks whoever set it."""
+        args = self._defaults({"MATRIXARK_METASERVER": "127.0.0.1:19000"})
+        self.assertEqual("127.0.0.1:19000", args.metaserver)
+
+    def test_the_documented_spelling_wins_when_both_are_set(self) -> None:
+        args = self._defaults({"MATRIXARK_TEMPORALSTORE_METASERVER": "local",
+                               "MATRIXARK_METASERVER": "127.0.0.1:19000"})
+        self.assertEqual("local", args.metaserver)
+
+    def test_unset_falls_back_to_what_the_config_declares(self) -> None:
+        self.assertEqual("127.0.0.1:18000", self._defaults({}).metaserver)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/validate_codex_mcp_conformance.py
+++ b/tools/validate_codex_mcp_conformance.py
@@ -119,7 +119,11 @@ def validate_rust_cli_smoke() -> dict[str, object]:
     env.setdefault("CARGO_TARGET_DIR", "/tmp/temporalstore-mcp-parity-target")
     request = {
         "op": "put_string",
-        "metaserver": os.environ.get("MATRIXARK_METASERVER", "127.0.0.1:18000"),
+        # The documented spelling first; the bare one stays accepted. Same order as the
+        # backfill tool, so a deployment configures one variable and both honour it.
+        "metaserver": (os.environ.get("MATRIXARK_TEMPORALSTORE_METASERVER")
+                       or os.environ.get("MATRIXARK_METASERVER")
+                       or "127.0.0.1:18000"),
         "namespace": os.environ.get("MATRIXARK_NAMESPACE", "deploy_ns"),
         "table": os.environ.get("MATRIXARK_TABLE", "deploy_table"),
         "key": "matrixark:mcp:parity",


### PR DESCRIPTION
The third of `matrixark_context_backfill`'s connection defaults. #1056 pointed its namespace and
table at the store the deployment runs; this is the metaserver, and it was wrong in a different way.

### It read a spelling nothing sets

There are two names for the metaserver:

| name | who uses it |
|---|---|
| `MATRIXARK_TEMPORALSTORE_METASERVER` | the shipped config, the compose file, `INSTALL.md`, both deploy guides, the cloud API document — and **7 running processes**, which carry `=local` |
| `MATRIXARK_METASERVER` | three places: this tool, its shell wrapper, and the conformance validator |

**Zero processes carry the bare name.** So an operator who configured the documented variable
changed nothing here, and the tool fell through to `127.0.0.1:65000` — a port nothing listens on, in
a deployment whose `MATRIXARK_LOCAL_MODE` is `no-metaserver` and whose live value for that setting
is the string `local`.

Both spellings are now read, documented one first, defaulting to the `127.0.0.1:18000` the config
declares. The old name stays **accepted**: accepting a superseded spelling costs nothing, and
refusing it breaks whoever set it — it is *emitting* one that loses silently. The wrapper script and
the conformance validator take the same order, so a deployment configures one variable and all three
honour it.

### Why the failure is quiet

A backfill pointed at a store nobody reads does not error. It connects or fails to connect, writes
what it can, and reports what it wrote. Together with #1056 all three of this tool's connection
defaults — metaserver, namespace, table — addressed somewhere the deployment is not.

### Verified against the running system

| | |
|---|---|
| processes carrying `MATRIXARK_TEMPORALSTORE_METASERVER` | **7**, all `=local` |
| processes carrying `MATRIXARK_METASERVER` | **0** |
| ports 18000 / 65000 listening | neither |
| `MATRIXARK_LOCAL_MODE` in those processes | `no-metaserver` |

### Checks

Five new tests pin what the tool resolves with no flags passed.

| | |
|---|---|
| `test_matrixark_context_backfill` | **47 passed** |
| documented spelling honoured, old one accepted, documented wins when both set, unset → config value | asserted |
| mutation — read only the bare spelling again | **3 fail**, including the one that says the tool ignored what the processes carry |
| restored | green |
