### PR TITLE
A record derives its own storage kind

### DIFF
--- a/tools/matrixark_mcp_temporal_append.py
+++ b/tools/matrixark_mcp_temporal_append.py
@@ -13,8 +13,10 @@ from typing import Any
 
 try:
     from tools.matrixark_mcp_core import Json, compact_latest_context_state_records, stable_hash
+    from tools.matrixark_mcp_storage_options import storage_record_kind
 except ModuleNotFoundError:  # Direct script execution from tools/.
     from matrixark_mcp_core import Json, compact_latest_context_state_records, stable_hash
+    from matrixark_mcp_storage_options import storage_record_kind
 
 
 # Keys of `storage_route` that are NOT recoverable from `storage_options`: where this record was
@@ -275,6 +277,45 @@ def slim_persisted_storage_options(record: Json) -> Json:
         slim = dict(slim if slim is not None else record)
         slim["envelope"] = trimmed_envelope
     return slim if slim is not None else record
+
+
+def slim_persisted_record_kind(record: Json) -> Json:
+    """Drop `storage_record_kind` / `storage_part` when the record already implies them.
+
+    `storage_record_kind(record)` maps a record_type to a kind -- `context_index` to `"index"`,
+    `context_summary` to `"summary"` -- but its FIRST line returns the stored field when one is
+    present, so the stored copy is usually the same string arrived at twice. Measured on the live
+    log the pair is **1.00%** of every byte written.
+
+    That first line also makes the field an override, not merely a cache: a caller could store a
+    kind the mapping would not produce. So this drops a field only when the record derives THAT
+    EXACT value without it. A genuine override fails the comparison and is kept, which makes this
+    lossless by construction rather than by what the corpus happens to contain today -- the same
+    conditional shape `slim_persisted_storage_route` uses for a derivable placement.
+
+    Verified on 11,393 live records with both fields stripped before deriving: 0 disagreements.
+    (Deriving WITHOUT stripping them compares the value to itself and matches 100% of the time,
+    which is what the first measurement of this did.)
+    """
+    if not isinstance(record, dict):
+        return record
+    kind = record.get("storage_record_kind")
+    part = record.get("storage_part")
+    if not isinstance(kind, str) and not isinstance(part, str):
+        return record
+    probe = {key: value for key, value in record.items()
+             if key not in ("storage_record_kind", "storage_part")}
+    derived = storage_record_kind(probe)
+    if isinstance(kind, str) and kind and kind != derived:
+        return record        # a kind the mapping would not produce: keep both, it is information
+    drop = [name for name, value in (("storage_record_kind", kind), ("storage_part", part))
+            if isinstance(value, str) and value == derived]
+    if not drop:
+        return record
+    slim = dict(record)
+    for name in drop:
+        slim.pop(name, None)
+    return slim
 
 
 def materialize_appended_records_locked(

--- a/tools/matrixark_temporal_direct_write.py
+++ b/tools/matrixark_temporal_direct_write.py
@@ -27,11 +27,13 @@ except ImportError:
 
 try:
     from tools.matrixark_mcp_temporal_append import (
+        slim_persisted_record_kind,
         slim_persisted_storage_options,
         slim_persisted_storage_route,
     )
 except ImportError:
     from matrixark_mcp_temporal_append import (
+        slim_persisted_record_kind,
         slim_persisted_storage_options,
         slim_persisted_storage_route,
     )
@@ -347,7 +349,8 @@ class _TemporalDirectWriteMixin:
             for bundle in self._record_bundles(records):
                 record_key, record_id = self._record_location(sequence)
                 payload_value: Json
-                slim = [slim_persisted_storage_options(slim_persisted_storage_route(record))
+                slim = [slim_persisted_record_kind(
+                            slim_persisted_storage_options(slim_persisted_storage_route(record)))
                         for record in bundle]
                 payload_value = slim[0] if len(slim) == 1 else {"record_bundle": slim}
                 payload = json.dumps(payload_value, sort_keys=True, separators=(",", ":"))

--- a/tools/test_matrixark_a_record_kind_that_derives_itself.py
+++ b/tools/test_matrixark_a_record_kind_that_derives_itself.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""`storage_record_kind` and `storage_part` are usually the same string arrived at twice.
+
+`storage_record_kind(record)` maps a record_type to a kind, but its first line returns the stored
+field when one is present. So the stored copy is normally redundant -- and on the live log the pair
+is 1.00% of every byte written -- while still being a real override for a caller who wants a kind
+the mapping would not produce.
+
+Hence the conditional: a field is dropped only when the record derives THAT EXACT value without it.
+`test_an_unmappable_kind_is_kept` is the test that makes this lossless by construction rather than
+by what the corpus happens to hold.
+
+A note on how this was nearly got wrong: deriving WITHOUT stripping the stored fields compares the
+value to itself and reports a 100% match whatever the truth is. The first measurement did exactly
+that and "proved" derivability on 11,398 records while proving nothing.
+"""
+import unittest
+
+try:
+    from tools.matrixark_mcp_temporal_append import slim_persisted_record_kind
+    from tools.matrixark_mcp_storage_options import storage_record_kind
+except ImportError:  # run from tools/
+    from matrixark_mcp_temporal_append import slim_persisted_record_kind
+    from matrixark_mcp_storage_options import storage_record_kind
+
+
+class RecordKindTests(unittest.TestCase):
+    def test_the_mapping_is_not_the_identity(self):
+        """Positive control: the mapping really does change some record types.
+
+        Without this, every other test here would still pass if `storage_record_kind` simply
+        echoed `record_type`, and the suite would be asserting nothing about the mapping.
+        """
+        self.assertEqual("summary", storage_record_kind({"record_type": "context_summary"}))
+        self.assertEqual("index", storage_record_kind({"record_type": "context_index"}))
+
+    def test_a_derivable_pair_is_dropped(self):
+        record = {"record_type": "context_summary", "storage_record_kind": "summary",
+                  "storage_part": "summary", "text": "x"}
+        slim = slim_persisted_record_kind(record)
+        self.assertNotIn("storage_record_kind", slim)
+        self.assertNotIn("storage_part", slim)
+        self.assertEqual("x", slim["text"])
+
+    def test_the_dropped_kind_comes_back(self):
+        """The invariant: a reader gets the same answer from the slimmed record."""
+        for record_type, kind in (("context_summary", "summary"), ("context_index", "index"),
+                                  ("context_event", "context_event"),
+                                  ("matrixark_idempotency", "matrixark_idempotency")):
+            record = {"record_type": record_type, "storage_record_kind": kind,
+                      "storage_part": kind}
+            slim = slim_persisted_record_kind(record)
+            self.assertEqual(kind, storage_record_kind(slim),
+                             f"{record_type} did not derive {kind} after slimming")
+
+    def test_an_unmappable_kind_is_kept(self):
+        """A kind the mapping would NOT produce is information, not a copy."""
+        record = {"record_type": "context_summary", "storage_record_kind": "something_else",
+                  "storage_part": "something_else"}
+        slim = slim_persisted_record_kind(record)
+        self.assertEqual("something_else", slim["storage_record_kind"])
+        self.assertEqual("something_else", slim["storage_part"])
+        self.assertEqual("something_else", storage_record_kind(slim))
+
+    def test_a_part_that_differs_from_the_kind_is_kept(self):
+        record = {"record_type": "context_summary", "storage_record_kind": "summary",
+                  "storage_part": "a_different_part"}
+        slim = slim_persisted_record_kind(record)
+        self.assertNotIn("storage_record_kind", slim)
+        self.assertEqual("a_different_part", slim["storage_part"])
+
+    def test_a_part_alone_is_handled(self):
+        record = {"record_type": "context_index", "storage_part": "index"}
+        self.assertNotIn("storage_part", slim_persisted_record_kind(record))
+        kept = {"record_type": "context_index", "storage_part": "not_index"}
+        self.assertEqual("not_index", slim_persisted_record_kind(kept)["storage_part"])
+
+    def test_a_record_with_neither_is_returned_as_is(self):
+        record = {"record_type": "context_event", "text": "x"}
+        self.assertIs(record, slim_persisted_record_kind(record))
+
+    def test_the_input_record_is_not_mutated(self):
+        record = {"record_type": "context_summary", "storage_record_kind": "summary",
+                  "storage_part": "summary"}
+        slim_persisted_record_kind(record)
+        self.assertEqual("summary", record["storage_record_kind"])
+        self.assertEqual("summary", record["storage_part"])
+
+    def test_a_non_dict_is_returned_as_is(self):
+        self.assertEqual("nope", slim_persisted_record_kind("nope"))
+
+    def test_the_envelope_kind_still_decides(self):
+        """The mapping consults envelope.kind, which must survive for the derivation to hold."""
+        record = {"record_type": "context_event", "envelope": {"kind": "feedback"},
+                  "storage_record_kind": "feedback", "storage_part": "feedback"}
+        slim = slim_persisted_record_kind(record)
+        self.assertNotIn("storage_record_kind", slim)
+        self.assertEqual("feedback", storage_record_kind(slim))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`storage_record_kind` maps a record type to a kind — `context_index` to `"index"`,
`context_summary` to `"summary"` — and `storage_part_for_record` just calls it. Both values are then
stored on the record, so each is usually the same string arrived at twice. On the live log the pair
is **1.00% of every byte written**, across 11,417 records.

## Dropped only when the record derives it

The first line of `storage_record_kind` is:

```python
explicit = str(record.get("storage_record_kind") or record.get("storage_part") or "")...
if explicit:
    return explicit
```

so the field is an **override**, not only a cache: a caller can store a kind the mapping would not
produce. Dropping it unconditionally would silently discard that.

So a field is dropped only when the record derives **that exact value** without it. A kind the
mapping would not produce fails the comparison and is kept, which makes this lossless *by
construction* rather than by what the corpus happens to hold today. It is the same conditional shape
`slim_persisted_storage_route` uses for a derivable placement.

## The measurement, and how it was nearly wrong

Deriving the kind **without stripping the stored fields first** compares the value to itself, because
of the `explicit` line above. Done that way it reports a 100% match whatever the truth is — the
first measurement of this "confirmed" derivability on 11,398 records and proved nothing.

Stripping both fields before deriving: **11,393 records, 0 disagreements.**

Running the real function over 150 log pieces, 92,616,751 bytes:

| | |
|---|---|
| records carrying either field | 11,417 |
| kept because the kind was not derivable | **0** |
| those records | 22,864,066 B -> 21,936,013 B |
| recovered | **928,053 B — 1.00% of the log** |

## Tests

`tools/test_matrixark_a_record_kind_that_derives_itself.py`, ten tests.
`test_the_mapping_is_not_the_identity` is the positive control: without it every other test would
still pass if the mapping merely echoed `record_type`, and the suite would assert nothing about the
mapping.

Mutation-checked with `__pycache__` cleared:

* drop unconditionally (remove the override guard) → breaks `test_an_unmappable_kind_is_kept`,
  `test_a_part_that_differs_from_the_kind_is_kept` and `test_a_part_alone_is_handled` — the three
  override-preservation tests, and nothing else
* slimmer made a no-op → breaks the four that assert the drop

Applied at the same single append chokepoint as mx#1048 and mx#1053.
