### PR TITLE
The kind inside the options block is the same string again

### DIFF
--- a/tools/matrixark_mcp_temporal_append.py
+++ b/tools/matrixark_mcp_temporal_append.py
@@ -301,7 +301,10 @@ def slim_persisted_record_kind(record: Json) -> Json:
         return record
     kind = record.get("storage_record_kind")
     part = record.get("storage_part")
-    if not isinstance(kind, str) and not isinstance(part, str):
+    options = record.get("storage_options")
+    inner = options if isinstance(options, dict) else {}
+    if not any(isinstance(value, str) for value in
+               (kind, part, inner.get("storage_record_kind"), inner.get("storage_part"))):
         return record
     probe = {key: value for key, value in record.items()
              if key not in ("storage_record_kind", "storage_part")}
@@ -310,11 +313,24 @@ def slim_persisted_record_kind(record: Json) -> Json:
         return record        # a kind the mapping would not produce: keep both, it is information
     drop = [name for name, value in (("storage_record_kind", kind), ("storage_part", part))
             if isinstance(value, str) and value == derived]
-    if not drop:
+    # normalize_storage_options writes the same pair INTO the options block, so a record held the
+    # kind up to four times: twice here and twice in there. Measured on the live log, 11,121 of
+    # 11,334 records carrying it held all four copies, and the inner pair alone is 0.98% of every
+    # byte written. Nothing reads them there -- every read of these names is on a record-shaped
+    # subject -- so the inner pair goes whenever the outer one could.
+    inner_drop = [name for name in ("storage_record_kind", "storage_part")
+                  if isinstance(inner.get(name), str) and inner[name] == derived]
+    if not drop and not inner_drop:
         return record
     slim = dict(record)
     for name in drop:
         slim.pop(name, None)
+    if inner_drop:
+        trimmed = {key: value for key, value in inner.items() if key not in inner_drop}
+        if trimmed:
+            slim["storage_options"] = trimmed
+        else:
+            slim.pop("storage_options", None)
     return slim
 
 

--- a/tools/test_matrixark_a_record_kind_that_derives_itself.py
+++ b/tools/test_matrixark_a_record_kind_that_derives_itself.py
@@ -100,5 +100,72 @@ class RecordKindTests(unittest.TestCase):
         self.assertEqual("feedback", storage_record_kind(slim))
 
 
+class KindInsideTheOptionsBlockTests(unittest.TestCase):
+    """normalize_storage_options writes the same pair into the options block.
+
+    A record therefore held the kind up to FOUR times -- twice at its top level and twice in there.
+    Nothing reads the inner pair: every read of these names in the tree is on a record-shaped
+    subject, and inside the block they are only ever written.
+    """
+
+    def test_the_inner_pair_is_dropped_too(self):
+        record = {"record_type": "context_index",
+                  "storage_record_kind": "index", "storage_part": "index",
+                  "storage_options": {"route": "default",
+                                      "storage_record_kind": "index", "storage_part": "index"}}
+        slim = slim_persisted_record_kind(record)
+        self.assertEqual({"route": "default"}, slim["storage_options"])
+        self.assertNotIn("storage_record_kind", slim)
+
+    def test_the_inner_pair_is_kept_on_an_override(self):
+        record = {"record_type": "context_index",
+                  "storage_record_kind": "custom", "storage_part": "custom",
+                  "storage_options": {"storage_record_kind": "custom"}}
+        slim = slim_persisted_record_kind(record)
+        self.assertEqual("custom", slim["storage_options"]["storage_record_kind"])
+        self.assertEqual("custom", slim["storage_record_kind"])
+
+    def test_the_inner_pair_goes_even_when_the_outer_is_absent(self):
+        record = {"record_type": "context_summary",
+                  "storage_options": {"route": "default", "storage_part": "summary"}}
+        slim = slim_persisted_record_kind(record)
+        self.assertEqual({"route": "default"}, slim["storage_options"])
+
+    def test_an_options_block_left_empty_is_removed(self):
+        record = {"record_type": "context_summary",
+                  "storage_options": {"storage_record_kind": "summary",
+                                      "storage_part": "summary"}}
+        self.assertNotIn("storage_options", slim_persisted_record_kind(record))
+
+    def test_the_other_option_fields_survive(self):
+        record = {"record_type": "context_summary",
+                  "storage_options": {"route": "default", "write_mode": "async",
+                                      "storage_record_kind": "summary"}}
+        slim = slim_persisted_record_kind(record)
+        self.assertEqual({"route": "default", "write_mode": "async"}, slim["storage_options"])
+
+    def test_the_callers_options_dict_is_not_mutated(self):
+        options = {"route": "default", "storage_record_kind": "summary"}
+        record = {"record_type": "context_summary", "storage_options": options}
+        slim_persisted_record_kind(record)
+        self.assertIn("storage_record_kind", options,
+                      "the caller's options dict was trimmed in place")
+
+    def test_the_kind_still_derives_after_all_four_copies_go(self):
+        record = {"record_type": "context_summary",
+                  "storage_record_kind": "summary", "storage_part": "summary",
+                  "storage_options": {"storage_record_kind": "summary",
+                                      "storage_part": "summary"}}
+        slim = slim_persisted_record_kind(record)
+        self.assertEqual("summary", storage_record_kind(slim))
+
+    def test_a_non_dict_options_value_is_left_alone(self):
+        record = {"record_type": "context_summary", "storage_record_kind": "summary",
+                  "storage_options": "not a dict"}
+        slim = slim_persisted_record_kind(record)
+        self.assertEqual("not a dict", slim["storage_options"])
+        self.assertNotIn("storage_record_kind", slim)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`normalize_storage_options` writes `storage_record_kind` and `storage_part` **into the options
block** as well as onto the record:

```python
normalized["storage_record_kind"] = record_kind
normalized["storage_part"] = record_kind
```

So a record held the same string up to four times. Measured on the live log, of the 11,334 records
carrying the kind at all, **11,121 held all four copies**. mx#1058 removed the two at the top level;
this removes the two inside the block.

| | |
|---|---|
| the pair inside the options block | 912,339 B — **0.98% of the log** |
| agrees with what the record derives | 11,197 |
| differs | **0** |

Running the slimmer over 150 pieces (92,974,249 B), both trims together recover **1,837,014 B —
1.98% of the log**, of which mx#1058 accounted for 1.00%.

## Why it is safe to drop there

Nothing reads them inside the block. Every read of these two names in the tree is on a
record-shaped subject — `record.get("storage_record_kind")` in `matrixark_mcp_indexing`,
`matrixark_mcp_serving_records` and `storage_record_kind()` itself. Inside the options block they
are only ever written, by the four `normalized[...] = record_kind` sites above.

The same conditional as mx#1058 still applies: a value is dropped only when the record derives that
exact string without it, so a kind the mapping would not produce is kept — in the block as well as
at the top level.

## A guard this change needed

The first version returned early when the top-level pair was absent, which skipped the options block
entirely on records that carried the kind only there. Three of the new tests failed on it, and the
guard now asks whether **any** of the four copies is present before returning early. That is the
whole reason `test_the_inner_pair_goes_even_when_the_outer_is_absent` and
`test_an_options_block_left_empty_is_removed` are in the suite.

## Tests

Eight added, 18 in the file. Beyond the drop and the override cases:

* an options block left empty by the trim is removed rather than stored as `{}`
* the caller's options dict is not trimmed in place — it is a nested dict, so copying the outer
  record alone would have shared it
* a non-dict `storage_options` is left alone
* after all four copies go, `storage_record_kind()` still returns the original value

77 tests pass across the write-path suites and both new files.
