### PR TITLE
A limited get_all answers with the newest memories, not the oldest

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -7806,7 +7806,11 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             limit = int(args.get("limit") or 0)
         except (TypeError, ValueError):
             raise MatrixArkError("limit must be an integer")
-        memories: list[Json] = []
+        # Select first, project second. Building the projected memory for every record and then
+        # slicing threw most of that work away: a subject with thousands of memories paid for all
+        # of them to answer `limit=10`. Order the cheap (time, record) pairs, cut, and build only
+        # the memories actually returned.
+        selected: list[tuple[int, Json]] = []
         for record in self.records_for_get_all(scope):
             if str(record.get("record_type") or "") != "context_event":
                 continue
@@ -7815,17 +7819,26 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 continue
             if user_hash and rec_user != user_hash:
                 continue
-            memories.append({
+            created_at_ms = record.get("updated_at_ms") or record.get("timestamp_key_ms")
+            selected.append((int(created_at_ms or 0), record))
+        selected.sort(key=lambda pair: pair[0])
+        if limit > 0:
+            # The NEWEST `limit`, not the oldest. Sorting ascending and taking the head handed back
+            # a subject's first memories and hid everything recent -- `get_all(limit=10)` on a
+            # thousand memories answered with the ten oldest. The listing itself stays in
+            # chronological order, which is what an unlimited call already returned.
+            selected = selected[-limit:]
+        memories: list[Json] = [
+            {
                 "id": record.get("event_id_hash"),
                 "memory": record.get("summary_text") or record.get("text") or "",
                 "text": record.get("text") or "",
                 "user_id": scope.get("user_id"),
                 "scope_key": record.get("scope_key") or canonical_scope_key(scope),
-                "created_at_ms": record.get("updated_at_ms") or record.get("timestamp_key_ms"),
-            })
-        memories.sort(key=lambda item: int(item.get("created_at_ms") or 0))
-        if limit > 0:
-            memories = memories[:limit]
+                "created_at_ms": created_at_ms,
+            }
+            for created_at_ms, record in selected
+        ]
         return {"memories": memories, "count": len(memories)}
 
     def reset(self, args: Json, hook: Json | None = None) -> Json:

--- a/tools/test_mem0_complete.py
+++ b/tools/test_mem0_complete.py
@@ -47,6 +47,41 @@ def _scope_for(user: str, *, tenant: str = "tenant_mem", session: str = "s1") ->
 # Layer 1: backend (local adapter through a real server)
 # --------------------------------------------------------------------------- #
 class GetUpdateHistoryBackendCase(unittest.TestCase):
+    def test_a_limited_get_all_returns_the_newest_memories_not_the_oldest(self) -> None:
+        """`get_all(limit=N)` must answer with the N most recent memories.
+
+        It sorted ascending and took the head, so a subject's FIRST memories came back and
+        everything recent was invisible -- `get_all(limit=10)` against a thousand memories answered
+        with the ten oldest. The listing itself stays in chronological order, which is what an
+        unlimited call already returned.
+        """
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+            adapter = mcp.MatrixArkLocalAdapter(Path(tmp) / "events.jsonl")
+            server = mcp.MatrixArkMcpServer(adapter, access_mode="dev")
+            self.addCleanup(server.close, timeout_s=1.0)
+            anchor = 1_780_000_000_000
+            for i in range(5):
+                server.call_tool("matrixark_ingest", {
+                    "messages": [{"role": "user", "content": f"FACT{i} recorded"}],
+                    "scope": _scope_for("limituser"),
+                    "ingestion_time_ms": anchor + i * 10_000,
+                })
+            everything = server.call_tool("matrixark_get_all", {"scope": _scope_for("limituser")})
+            self.assertEqual(5, everything["count"], "the fill must produce five memories")
+
+            limited = server.call_tool(
+                "matrixark_get_all", {"scope": _scope_for("limituser"), "limit": 2})
+            self.assertEqual(2, limited["count"])
+            texts = json.dumps(limited)
+            self.assertIn("FACT4", texts, "the newest memory must be in a limited listing")
+            self.assertIn("FACT3", texts)
+            self.assertNotIn("FACT0", texts, "the oldest must not crowd out the newest")
+
+            # Still chronological within the page, and an unlimited call is untouched.
+            stamps = [int(m["created_at_ms"]) for m in limited["memories"]]
+            self.assertEqual(sorted(stamps), stamps, "a page stays in chronological order")
+            self.assertEqual(5, len(everything["memories"]))
+
     def _ingest(self, server, user, text):
         return server.call_tool(
             "matrixark_ingest",


### PR DESCRIPTION
`get_all(limit=N)` answered with a subject's **oldest** N memories.

    memories.sort(key=lambda item: int(item.get("created_at_ms") or 0))   # ascending
    if limit > 0:
        memories = memories[:limit]                                        # the head

So `get_all(user_id="alice", limit=10)` against a thousand memories returned the ten she recorded
first, and everything recent was invisible. Nothing asserted which memories a limit returns, so it
had no coverage either way.

This is the same shape as the traversal cut that was fixed earlier -- sorted ascending, truncated
before use, so the most recently written became the first to disappear.

It now takes the newest `limit`. The page stays in chronological order, and an unlimited call is
byte-for-byte what it was.

## It also stopped paying for memories it discards

The projection ran over every record and the limit was applied afterwards, so answering `limit=10`
built a memory dict for every record the subject has. It now orders the cheap `(created_at_ms,
record)` pairs, cuts, and projects only what it returns.

## Behaviour change, stated plainly

A caller passing `limit` gets different memories than before -- the newest rather than the oldest.
That is the point of the change, but it is a change: anyone relying on `limit` to page from the
beginning of history was relying on the defect.

## Test

Five memories at known times, `limit=2` must contain the two newest and not the oldest, the page
must stay in chronological order, and the unlimited listing must still return all five.

Verified to FAIL without the change, with `'FACT4' not found in ...` and the response showing
FACT0 and FACT1.

The mem0 suites pass: 27 in test_mem0_complete, 8 in test_memory_ttl, 21 in test_memory_delete_forget.
