### PR TITLE
Three audit modes, three vocabularies, one of them offered

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -554,6 +554,35 @@ SETTINGS: List[Setting] = [
             "MATRIXARK_TIME_COMPRESSION_MAX_RAW_EVENTS_PER_NODE",
             "Raw events kept per node", "int", "256", "restart",
             "The ceiling on raw events one node keeps before compression is forced."),
+    # ---- three audit modes, three vocabularies ---------------------------------------------------
+    # `audit.mode` above governs the ACCESS layer. These two govern different layers and take
+    # different words, which is the sharp edge: `sync` and `full` appear in more than one of them
+    # meaning different things, and a value borrowed from the wrong one is rejected outright.
+    Setting("retrieval.context_audit_mode", "retrieval",
+            "MATRIXARK_CONTEXT_AUDIT_MODE",
+            "Retrieval audit mode", "str", "telemetry_only", "live",
+            "Whether a retrieve records what it did. off keeps nothing; telemetry_only keeps the "
+            "shape of the answer; full keeps the evidence, which is what makes a pack "
+            "reconstructable afterwards and what makes the record log grow. "
+            "This is NOT the access-layer audit above and does not take its words: async and "
+            "sync are refused here. "
+            "With nothing set the answer depends on which path served the retrieve -- the request "
+            "path and the direct read use telemetry_only, the local adapter uses off -- so "
+            "setting this is how a deployment makes them agree.",
+            ("off", "telemetry_only", "full")),
+    Setting("retrieval.context_audit_sample_rate", "retrieval",
+            "MATRIXARK_CONTEXT_AUDIT_SAMPLE_RATE",
+            "Retrieval audit sample rate", "float", "0.01", "live",
+            "What fraction of retrieves the mode above applies to. Selecting full raises this to "
+            "1.0 for the retrieves it keeps evidence for, so a deployment that wants full "
+            "auditing on a sample sets both."),
+    Setting("limits.direct_audit_mode", "limits",
+            "MATRIXARK_DIRECT_AUDIT_MODE",
+            "Store audit write mode", "str", "buffered", "restart",
+            "How audit records reach the store. buffered writes them off the request path; sync "
+            "makes each durable before the call returns; drop discards them and logs that it did. "
+            "A third vocabulary: off and full are not words this one knows.",
+            ("buffered", "sync", "drop")),
     Setting("retrieval.hook_max_context_tokens", "retrieval",
             "MATRIXARK_HOOK_MAX_CONTEXT_TOKENS",
             "Agent hook context budget (tokens)", "int", "128000", "live",

--- a/tools/test_matrixark_one_audit_policy_two_declared_defaults.py
+++ b/tools/test_matrixark_one_audit_policy_two_declared_defaults.py
@@ -136,18 +136,35 @@ class TheCallersDeclareWhatTheyTakeTest(unittest.TestCase):
         source = self._source("matrixark_mcp_retrieve_request.py")
         self.assertIn("retrieval_audit_policy(args)", source)
 
+    #: Where the variable is DECLARED rather than resolved. The settings registry names every
+    #: variable the portal can write, so it mentions this one without deciding anything with it --
+    #: and a scan that counts declarations as readers grows by one the first time the setting is
+    #: offered on a screen, which is what happened.
+    DECLARING = ("matrixark_gateway_config.py",)
+
     def test_only_one_module_reads_the_variable_for_this_decision(self) -> None:
         """The direct-read path has its own resolution with its own fallback-on-invalid, so it is
         not folded in here; this pins the count so a fourth copy cannot appear unnoticed."""
         readers = []
         for name in sorted(os.listdir(TOOLS)):
-            if not name.endswith(".py") or name.startswith("test_"):
+            if not name.endswith(".py") or name.startswith("test_") or name in self.DECLARING:
                 continue
             with open(os.path.join(TOOLS, name), encoding="utf-8") as handle:
                 if "MATRIXARK_CONTEXT_AUDIT_MODE" in handle.read():
                     readers.append(name)
         self.assertEqual(["matrixark_mcp_retrieve_planning.py",
                           "matrixark_temporal_direct_read.py"], readers, readers)
+
+    def test_the_declaring_module_really_does_declare_it(self) -> None:
+        """The exclusion above is only safe while it names a module that DECLARES the variable.
+        If the registry ever stopped mentioning it, the exclusion would be hiding nothing and
+        should go -- and if it started resolving it, this file would be excusing a third copy."""
+        source = self._source("matrixark_gateway_config.py")
+        self.assertIn("MATRIXARK_CONTEXT_AUDIT_MODE", source)
+        self.assertIn("Setting(\"retrieval.context_audit_mode\"", source)
+        # Declaring is naming it in the registry. Resolving is reading it back out of the
+        # environment to decide something, which is what the two real readers do.
+        self.assertNotIn("os.environ.get(\"MATRIXARK_CONTEXT_AUDIT_MODE\"", source)
 
 
 if __name__ == "__main__":

--- a/tools/test_matrixark_three_audit_modes_three_vocabularies.py
+++ b/tools/test_matrixark_three_audit_modes_three_vocabularies.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Three audit modes, three vocabularies, and only one of them was offered.
+
+`MATRIXARK_AUDIT_MODE` governs the access layer and the portal offers it: off, async, full, sync.
+Two more exist and neither was offered:
+
+* `MATRIXARK_CONTEXT_AUDIT_MODE` decides whether a retrieve records what it did, and takes
+  ``off``, ``telemetry_only`` or ``full`` -- **it refuses the access layer's words outright**.
+* `MATRIXARK_DIRECT_AUDIT_MODE` decides how audit records reach the store, and takes ``buffered``,
+  ``sync`` or ``drop``.
+
+So a customer reasoning by analogy from the one setting they could see -- "audit mode is async" --
+gets `audit_mode must be full, telemetry_only, or off` from a retrieve. `sync` and `full` appear in
+more than one of the three meaning different things.
+
+And the retrieval one had a consequence beyond being unreachable: **with nothing set, whether a
+retrieve records anything depends on which path served it.** The request path and the direct read
+default to ``telemetry_only``; the local adapter passes ``off``. Setting it is how a deployment
+makes them agree, which is what the setting is for.
+
+The choices are DERIVED here from the code that validates them, not restated. Two vocabularies that
+drift apart silently is how this got confusing in the first place.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import re
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+import matrixark_gateway_config as cfg  # noqa: E402
+import matrixark_mcp_retrieve_planning as planning  # noqa: E402
+import matrixark_mcp_runtime_config as runtime  # noqa: E402
+
+CONTEXT_KEY = "retrieval.context_audit_mode"
+RATE_KEY = "retrieval.context_audit_sample_rate"
+DIRECT_KEY = "limits.direct_audit_mode"
+ACCESS_KEY = "audit.mode"
+
+
+def validated_set(filename: str, variable: str) -> set:
+    """The set a module checks a value against: `if <variable> not in {...}: raise`."""
+    with open(os.path.join(TOOLS, filename), encoding="utf-8") as handle:
+        tree = ast.parse(handle.read(), filename=filename)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Compare) or len(node.ops) != 1:
+            continue
+        if not isinstance(node.ops[0], ast.NotIn):
+            continue
+        if not (isinstance(node.left, ast.Name) and node.left.id == variable):
+            continue
+        target = node.comparators[0]
+        if isinstance(target, (ast.Set, ast.Tuple, ast.List)):
+            return {e.value for e in target.elts
+                    if isinstance(e, ast.Constant) and isinstance(e.value, str)}
+    return set()
+
+
+def compared_literals(filename: str, attribute: str) -> set:
+    """Every string a module compares one attribute against: `self.<attribute> == "x"`."""
+    path = os.path.join(TOOLS, filename)
+    # Named, so it can go missing. mx#1080 deleted the orphaned copy of this branching while it
+    # was live in another module, and a bare FileNotFoundError out of here says nothing about
+    # which claim broke. If it moves again, the message should name what was being looked for.
+    if not os.path.exists(path):
+        raise AssertionError(
+            "%s is not in tools/ any more; find where `self.%s` is compared and point this at "
+            "it, or the choices below are derived from nothing" % (filename, attribute))
+    with open(path, encoding="utf-8") as handle:
+        tree = ast.parse(handle.read(), filename=filename)
+    found = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Compare) or not node.comparators:
+            continue
+        left = node.left
+        if not (isinstance(left, ast.Attribute) and left.attr == attribute):
+            continue
+        for element in node.comparators:
+            if isinstance(element, ast.Constant) and isinstance(element.value, str):
+                found.add(element.value)
+    return found
+
+
+class Case(unittest.TestCase):
+    def setUp(self) -> None:
+        self._saved = os.environ.get("MATRIXARK_CONTEXT_AUDIT_MODE")
+        os.environ.pop("MATRIXARK_CONTEXT_AUDIT_MODE", None)
+
+    def tearDown(self) -> None:
+        if self._saved is None:
+            os.environ.pop("MATRIXARK_CONTEXT_AUDIT_MODE", None)
+        else:
+            os.environ["MATRIXARK_CONTEXT_AUDIT_MODE"] = self._saved
+
+
+class TheChoicesAreWhatTheCodeAcceptsTest(unittest.TestCase):
+
+    def test_the_retrieval_choices_come_from_its_validator(self) -> None:
+        accepted = validated_set("matrixark_mcp_retrieve_planning.py", "audit_mode")
+        self.assertEqual(accepted, set(cfg.SETTINGS_BY_KEY[CONTEXT_KEY].choices))
+
+    def test_the_validator_was_actually_found(self) -> None:
+        """The floor: an empty set would make the rule above compare nothing to nothing."""
+        self.assertEqual({"full", "telemetry_only", "off"},
+                         validated_set("matrixark_mcp_retrieve_planning.py", "audit_mode"))
+
+    def test_the_store_choices_come_from_what_it_branches_on(self) -> None:
+        branched = compared_literals("matrixark_temporal_direct_write.py", "_audit_mode")
+        self.assertEqual(branched, set(cfg.SETTINGS_BY_KEY[DIRECT_KEY].choices))
+
+    def test_that_branching_was_actually_found(self) -> None:
+        self.assertEqual({"drop", "sync", "buffered"},
+                         compared_literals("matrixark_temporal_direct_write.py", "_audit_mode"))
+
+
+class TheThreeVocabulariesAreDistinctTest(unittest.TestCase):
+    """The reason each help text warns about the others."""
+
+    def sets(self):
+        return {key: set(cfg.SETTINGS_BY_KEY[key].choices)
+                for key in (ACCESS_KEY, CONTEXT_KEY, DIRECT_KEY)}
+
+    def test_no_two_are_the_same(self) -> None:
+        values = list(self.sets().values())
+        for index, first in enumerate(values):
+            for second in values[index + 1:]:
+                self.assertNotEqual(first, second)
+
+    def test_they_overlap_which_is_the_hazard(self) -> None:
+        """If they were disjoint the confusion would be obvious. They are not: `sync` and `full`
+        each appear in two of the three, meaning different things."""
+        sets = self.sets()
+        self.assertIn("sync", sets[ACCESS_KEY])
+        self.assertIn("sync", sets[DIRECT_KEY])
+        self.assertIn("full", sets[ACCESS_KEY])
+        self.assertIn("full", sets[CONTEXT_KEY])
+
+    def test_each_help_names_a_word_it_refuses(self) -> None:
+        """Substance, not a keyword. A reader arriving from the one setting that was already
+        offered needs to see the word they were about to type, said to be wrong here -- so each
+        help must NAME at least one value that belongs to another of the three and not to it."""
+        sets = self.sets()
+        for key in (CONTEXT_KEY, DIRECT_KEY):
+            others = set().union(*(v for k, v in sets.items() if k != key))
+            foreign = others - sets[key]
+            help_text = cfg.SETTINGS_BY_KEY[key].help.lower()
+            named = [word for word in foreign if word in help_text]
+            with self.subTest(setting=key):
+                self.assertTrue(named,
+                                "%s warns about none of %s" % (key, sorted(foreign)))
+
+    def test_there_are_foreign_words_to_warn_about(self) -> None:
+        """The floor: if the three vocabularies stopped overlapping, the rule above would be
+        satisfiable by saying nothing."""
+        sets = self.sets()
+        for key in (CONTEXT_KEY, DIRECT_KEY):
+            others = set().union(*(v for k, v in sets.items() if k != key))
+            self.assertTrue(others - sets[key])
+
+
+class AWordFromAnotherVocabularyIsRefusedTest(Case):
+
+    def test_the_access_layers_words_are_not_accepted_here(self) -> None:
+        for word in ("async", "sync"):
+            with self.subTest(word=word):
+                os.environ["MATRIXARK_CONTEXT_AUDIT_MODE"] = word
+                with self.assertRaises(Exception):
+                    planning.retrieval_audit_policy({})
+
+    def test_its_own_words_are(self) -> None:
+        """The floor: a validator that refused everything would satisfy the test above."""
+        for word in cfg.SETTINGS_BY_KEY[CONTEXT_KEY].choices:
+            with self.subTest(word=word):
+                os.environ["MATRIXARK_CONTEXT_AUDIT_MODE"] = word
+                mode, _rate = planning.retrieval_audit_policy({})
+                self.assertEqual(word, mode)
+
+
+class SettingItMakesThePathsAgreeTest(Case):
+    """The consequence of it being unreachable, and the reason to reach it."""
+
+    def test_with_nothing_set_the_paths_disagree(self) -> None:
+        request_path, _ = planning.retrieval_audit_policy({})
+        local_adapter, _ = planning.retrieval_audit_policy({}, default="off")
+        self.assertNotEqual(request_path, local_adapter)
+        self.assertEqual("telemetry_only", request_path)
+        self.assertEqual("off", local_adapter)
+
+    def test_setting_it_makes_them_agree(self) -> None:
+        for word in ("off", "telemetry_only", "full"):
+            with self.subTest(word=word):
+                os.environ["MATRIXARK_CONTEXT_AUDIT_MODE"] = word
+                self.assertEqual(planning.retrieval_audit_policy({}),
+                                 planning.retrieval_audit_policy({}, default="off"))
+
+    def test_the_help_says_so(self) -> None:
+        help_text = cfg.SETTINGS_BY_KEY[CONTEXT_KEY].help
+        self.assertIn("depends on which path", help_text)
+
+
+class TheDeclaredDefaultsAreWhatTheBuildRunsTest(unittest.TestCase):
+
+    def test_the_store_audit_default(self) -> None:
+        self.assertEqual(runtime.DIRECT_AUDIT_MODE, cfg.SETTINGS_BY_KEY[DIRECT_KEY].default)
+
+    def test_the_sample_rate_default(self) -> None:
+        """Read out of the module that reads it, rather than retyped here."""
+        with open(os.path.join(TOOLS, "matrixark_mcp_retrieve_planning.py"),
+                  encoding="utf-8") as handle:
+            source = handle.read()
+        match = re.search(r'MATRIXARK_CONTEXT_AUDIT_SAMPLE_RATE",\s*([0-9.]+)', source)
+        self.assertIsNotNone(match, "the sample-rate default is not where this looked")
+        self.assertEqual(float(match.group(1)),
+                         float(cfg.SETTINGS_BY_KEY[RATE_KEY].default))
+
+    def test_two_are_live_and_one_is_not(self) -> None:
+        """Not a stylistic split. The two retrieval controls are read inside the call that uses
+        them, so a change lands on the next retrieve; the store one is bound when its module is
+        imported, so it does not. The labels say which, and `test_matrixark_gateway_config_audit`
+        derives that from where each read is -- it caught both of these labelled restart."""
+        self.assertEqual("live", cfg.SETTINGS_BY_KEY[CONTEXT_KEY].applies)
+        self.assertEqual("live", cfg.SETTINGS_BY_KEY[RATE_KEY].applies)
+        self.assertEqual("restart", cfg.SETTINGS_BY_KEY[DIRECT_KEY].applies)
+
+    def test_the_retrieval_default_is_the_one_two_of_three_paths_use(self) -> None:
+        """There is no single build default -- that is the defect. The declared one is what the
+        request path and the direct read do, and the help names the exception."""
+        self.assertEqual("telemetry_only", cfg.SETTINGS_BY_KEY[CONTEXT_KEY].default)
+        self.assertEqual("telemetry_only", planning.retrieval_audit_policy({})[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
There are **three** audit modes in this build, with **three different vocabularies**, and the portal
offered one of them.

| variable | takes | layer | offered before |
|---|---|---|---|
| `MATRIXARK_AUDIT_MODE` | `off` `async` `full` `sync` | access | yes |
| `MATRIXARK_CONTEXT_AUDIT_MODE` | `off` `telemetry_only` `full` | retrieval | **no** |
| `MATRIXARK_DIRECT_AUDIT_MODE` | `buffered` `sync` `drop` | store writes | **no** |

`sync` and `full` each appear in two of the three, meaning different things. So a customer reasoning
by analogy from the only one they could see — *"audit mode is async"* — gets

```
MatrixArkError: audit_mode must be full, telemetry_only, or off
```

from a retrieve. All three are offered now, each with its own list and each help naming a word the
others use that **this** one refuses.

### The retrieval one had a consequence beyond being unreachable

With nothing set, whether a retrieve records anything **depends on which path served it**:

```
the request path / direct read   ->  ('telemetry_only', 0.01)
the local adapter                ->  ('off', 0.01)
```

That difference is deliberate and documented in the adapter. What was missing is the way to resolve
it: setting `MATRIXARK_CONTEXT_AUDIT_MODE` makes both paths agree, on any of the three values, and
until now a deployment could not set it from the portal. The declared default is
`telemetry_only` — what two of the three paths do — and the help names the exception rather than
pretending there is one answer.

### Derived, not restated

The choices are read out of the code that validates them:

- `retrieval.context_audit_mode`'s list is parsed from `if audit_mode not in {…}: raise` in
  `matrixark_mcp_retrieve_planning`.
- `limits.direct_audit_mode`'s list is collected from every `self._audit_mode == "…"` branch in
  `matrixark_mcp_temporal_audit`.

Two vocabularies drifting apart silently is how this got confusing; a list retyped here would drift
the same way. Each derivation has a floor asserting it actually found the set, since an empty one
would compare nothing to nothing.

The "warn about the other words" rule is derived too. It does not grep for a keyword — it computes
which values belong to the *other* two vocabularies and not to this one, and requires the help to
name at least one of them. With a floor: if the three ever stopped overlapping, that rule would be
satisfiable by saying nothing.

```
a choice the code accepts is dropped from the list     -> FAIL
a word from another vocabulary is offered here         -> FAIL
the store's choices stop matching what it branches on  -> FAIL
the help stops naming a word it refuses                -> FAIL
the store default drifts from the build                -> FAIL
the sample rate drifts from the build                  -> FAIL
the declared retrieval default is the local adapter's  -> FAIL
the validator stops refusing a foreign word            -> FAIL
```

### Two labels the audit corrected

I filed all three as `restart`. `test_matrixark_gateway_config_audit` failed twice, and it was right
both times: the two retrieval controls are read *inside* the call that uses them, so a change lands
on the next retrieve. They are `live`. The store one is bound when its module is imported and stays
`restart`. A test now states that asymmetry, because it is a fact about where the read is rather
than a style choice.

17 tests, plus 70 across the suites that police the registry. Stacked on
[#1050](https://github.com/matrixarkai/TemporalStore/pull/1050).
