### PR TITLE
The inventory said nothing sets twelve flags that something does

### DIFF
--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -51,7 +51,7 @@ Anything else is blank, and a blank means go and look.
 | numbers whose default this could read off the source | 34 |
 | **defaulting on, and set by nothing** | 0 |
 | offered on the portal | 27 |
-| **that nothing in this repository sets** | 168 |
+| **that nothing in this repository sets** | 156 |
 | documented as keeping an older path alive | 5 |
 | reaching more than two files | 15 |
 | whose doc comment is really about another flag | 43 |
@@ -62,13 +62,13 @@ Where this node is and what it talks to. Set by whoever provisions the node; not
 
 | flag | default | set by | files | keeps an older path |
 |---|---|---|---|---|
-| `TS_META_ADDR` | — | config, launch | 3 | — |
+| `TS_META_ADDR` | — | config, launch, script | 3 | — |
 | `TS_PROXY_ADDR` | — | launch, script | 3 | — |
 | `TS_RAFT_NODES` | — | harness, script | 3 | — |
 | `TS_RAFT_NODE_ID` | — | harness, script | 3 | — |
 | `TS_RAFT_SHARD_ID` | — | harness, script | 3 | — |
 | `TS_RAFT_WAL_DIR` | — | config, harness, script | 3 | — |
-| `TS_SHARD_ID` | 1 | config, launch | 3 | — |
+| `TS_SHARD_ID` | 1 | config, launch, script | 3 | — |
 | `TS_META_RAFT_NODES` | — | config | 2 | — |
 | `TS_RAFT_BIND_ADDR` | — | harness, script | 2 | — |
 | `MATRIXARK_CONTEXT_EVENT_FANOUT_NODES` | 4 | nothing | 1 | — |
@@ -81,21 +81,21 @@ Where this node is and what it talks to. Set by whoever provisions the node; not
 | `TS_MATRIXOBJECT_BUCKET` | — | config, launch | 1 | — |
 | `TS_MATRIXOBJECT_ENDPOINT` | — | config | 1 | — |
 | `TS_MATRIXOBJECT_STORE_DIR` | — | config | 1 | — |
-| `TS_META_BIND_ADDR` | — | config | 1 | — |
+| `TS_META_BIND_ADDR` | — | config, launch | 1 | — |
 | `TS_META_RAFT_NODE_ID` | — | nothing | 1 | — |
 | `TS_PAGE_STORE_DIR` | — | config, launch, script | 1 | — |
-| `TS_PROXY_ADVERTISED_ADDR` | — | config | 1 | — |
-| `TS_PROXY_BIND_ADDR` | — | config | 1 | — |
+| `TS_PROXY_ADVERTISED_ADDR` | — | config, launch | 1 | — |
+| `TS_PROXY_BIND_ADDR` | — | config, launch | 1 | — |
 | `TS_PROXY_LOCATION` | — | nothing | 1 | — |
 | `TS_REDIS_ADDR` | — | launch | 1 | — |
 | `TS_REDIS_BIND_ADDR` | — | config | 1 | — |
 | `TS_SERVER_ADDR` | — | launch | 1 | — |
-| `TS_SERVER_ADVERTISE_ADDR` | — | config, launch | 1 | — |
-| `TS_SERVER_BIND_ADDR` | — | config | 1 | — |
+| `TS_SERVER_ADVERTISE_ADDR` | — | config, launch, script | 1 | — |
+| `TS_SERVER_BIND_ADDR` | — | config, launch, script | 1 | — |
 | `TS_SERVER_LOCATION` | — | config | 1 | — |
 | `TS_SERVER_NODE_ID` | — | config, launch | 1 | — |
 | `TS_SHARD_URI` | — | test | 1 | — |
-| `TS_SHARED_STORE_CLUSTER_ID` | — | launch | 1 | — |
+| `TS_SHARED_STORE_CLUSTER_ID` | — | launch, script | 1 | — |
 | `TS_SHARED_STORE_DIR` | — | config, script | 1 | — |
 | `TS_SHARED_STORE_URI` | — | nothing | 1 | — |
 | `TS_STANDALONE` | — | config, launch, script | 1 | — |
@@ -109,7 +109,7 @@ What the metaserver does about nodes it cannot reach -- conviction, freezing, re
 |---|---|---|---|---|
 | `TS_META_FORBID_SELF_CLEARING_CONVICTION` | — | nothing | 2 | — |
 | `MATRIXARK_TEMPORALSTORE_META_SYNC_DEADLINE_MS` | — | nothing | 1 | — |
-| `TS_AUTO_REBALANCE_DATA_MOVE` | — | nothing | 1 | — |
+| `TS_AUTO_REBALANCE_DATA_MOVE` | — | script | 1 | — |
 | `TS_META_ADAPTIVE_FAILURE_DETECTOR` | — | nothing | 1 | — |
 | `TS_META_AUTO_REBALANCE` | — | config | 1 | — |
 | `TS_META_AUTO_REBALANCE_BALANCE` | — | nothing | 1 | — |
@@ -121,7 +121,7 @@ What the metaserver does about nodes it cannot reach -- conviction, freezing, re
 | `TS_META_FD_SAMPLE_CAPACITY` | — | nothing | 1 | — |
 | `TS_META_FORBID_ORPHANING_SHARDS` | — | nothing | 1 | — |
 | `TS_META_FREEZE_AGING` | — | nothing | 1 | — |
-| `TS_META_MUTATION_LOG` | — | nothing | 1 | — |
+| `TS_META_MUTATION_LOG` | — | launch | 1 | — |
 | `TS_META_PLACEMENT_AWARE_REBALANCE` | — | nothing | 1 | — |
 | `TS_META_PROXY_CALIBRATION` | — | nothing | 1 | — |
 | `TS_META_PROXY_FREEZE_COOLDOWN_MS` | — | nothing | 1 | — |
@@ -224,15 +224,15 @@ Sizes, ceilings and intervals. The tuning a deployment actually reaches for.
 | `MATRIXARK_RUST_PROXY_PAGE_COMPRESSION_MIN_BYTES` | 256 | test | 1 | — |
 | `MATRIXARK_TEMPORALSTORE_PROXY_CONNECT_TIMEOUT_MS` | — | nothing | 1 | — |
 | `MATRIXARK_TEMPORALSTORE_PROXY_IO_TIMEOUT_MS` | 30000 | nothing | 1 | — |
-| `TEMPORALSTORE_CONTEXT_BENCHMARK_MAX_EVENTS` | 32 | nothing | 1 | — |
+| `TEMPORALSTORE_CONTEXT_BENCHMARK_MAX_EVENTS` | 32 | script | 1 | — |
 | `TS_BLOB_CHUNK_BYTES` | — | config | 1 | — |
 | `TS_BLOB_PEER_FETCH_TIMEOUT_MS` | — | nothing | 1 | — |
-| `TS_BLOCK_INDEX_CACHE_BYTES` | 67108864 | config, portal | 1 | — |
+| `TS_BLOCK_INDEX_CACHE_BYTES` | 67108864 | config, test, portal | 1 | — |
 | `TS_BLOCK_SEGMENT_TARGET_BYTES` | — | nothing | 1 | — |
-| `TS_BLOCK_SLAB_TARGET_BYTES` | 1073741824 | config, portal | 1 | — |
+| `TS_BLOCK_SLAB_TARGET_BYTES` | 1073741824 | config, test, portal | 1 | — |
 | `TS_CACHE_MEMORY_BYTES` | — | config, launch | 1 | — |
-| `TS_COMPACTION_WATERMARK_BYTES` | 268435456 | config, portal | 1 | — |
-| `TS_CONTEXT_PAGE_TARGET_BYTES` | 65536 | config, portal | 1 | — |
+| `TS_COMPACTION_WATERMARK_BYTES` | 268435456 | config, test, portal | 1 | — |
+| `TS_CONTEXT_PAGE_TARGET_BYTES` | 65536 | config, test, portal | 1 | — |
 | `TS_DATA_RAFT_BOUNDED_STALE_MAX_INDEX_LAG` | — | nothing | 1 | — |
 | `TS_DATA_RAFT_READ_INDEX_TIMEOUT_MS` | — | nothing | 1 | — |
 | `TS_DISTRIBUTED_RAFT_CATCHUP_TIMEOUT_SECS` | 30 | nothing | 1 | — |
@@ -266,11 +266,11 @@ Sizes, ceilings and intervals. The tuning a deployment actually reaches for.
 | `TS_META_TASK_SCHEDULER_MAX_POSTPONE_MS` | — | nothing | 1 | — |
 | `TS_META_TASK_SCHEDULER_MAX_RETRY_TIMES` | — | nothing | 1 | — |
 | `TS_METRICS_MAX_SLOT_SERIES` | 1024 | portal | 1 | — |
-| `TS_PAGE_INDEX_CACHE_BYTES` | 67108864 | config, portal | 1 | — |
+| `TS_PAGE_INDEX_CACHE_BYTES` | 67108864 | config, test, portal | 1 | — |
 | `TS_PROXY_AUTO_REGISTER_MIN_INTERVAL_MS` | — | nothing | 1 | — |
 | `TS_PROXY_CONNECT_TIMEOUT_MS` | — | config | 1 | — |
 | `TS_PROXY_DROP_PERCENT` | — | nothing | 1 | — |
-| `TS_PROXY_HEARTBEAT_INTERVAL_MS` | — | nothing | 1 | — |
+| `TS_PROXY_HEARTBEAT_INTERVAL_MS` | — | launch | 1 | — |
 | `TS_PROXY_HEARTBEAT_TIMEOUT_MS` | — | nothing | 1 | — |
 | `TS_PROXY_IO_TIMEOUT_MS` | — | config | 1 | — |
 | `TS_PROXY_MAX_INFLIGHT_REQUESTS` | — | nothing | 1 | — |
@@ -282,12 +282,12 @@ Sizes, ceilings and intervals. The tuning a deployment actually reaches for.
 | `TS_RAFT_AUTO_FAILOVER_IO_TIMEOUT_MS` | — | nothing | 1 | — |
 | `TS_RAFT_MAX_APPLIED_LOG_BYTES` | — | nothing | 1 | — |
 | `TS_RAFT_MAX_INFLIGHTS_REPLICATE` | — | test | 1 | — |
-| `TS_SERVER_HEARTBEAT_INTERVAL_MS` | 3000 | config | 1 | — |
+| `TS_SERVER_HEARTBEAT_INTERVAL_MS` | 3000 | config, script | 1 | — |
 | `TS_SERVER_MAX_BACKGROUND_QUEUE_DEPTH` | — | config | 1 | — |
 | `TS_SERVER_MAX_QUEUE_DEPTH` | — | config | 1 | — |
 | `TS_SHARED_STORE_MAX_PENDING` | 50000 | nothing | 1 | yes |
-| `TS_STORAGE_ZONE_SIZE` | 1073741824 | config, portal | 1 | — |
-| `TS_STREAM_MAX_BLOB_SIZE` | 10485760 | config, portal | 1 | — |
+| `TS_STORAGE_ZONE_SIZE` | 1073741824 | config, test, portal | 1 | — |
+| `TS_STREAM_MAX_BLOB_SIZE` | 10485760 | config, test, portal | 1 | — |
 
 ## context (23)
 
@@ -299,7 +299,7 @@ The memory pipeline: what gets extracted, embedded, drained and packed. The surf
 | `MATRIXARK_BACKFILL_FLUSH_EVERY_ACCEPTED` | 10000 | nothing | 1 | — |
 | `MATRIXARK_BACKFILL_FLUSH_EVERY_SESSION` | — | nothing | 1 | — |
 | `MATRIXARK_BACKFILL_GLOBAL_SESSION` | — | nothing | 1 | — |
-| `MATRIXARK_BACKFILL_RAW_FIRST` | — | nothing | 1 | — |
+| `MATRIXARK_BACKFILL_RAW_FIRST` | — | launch | 1 | — |
 | `MATRIXARK_BACKFILL_SKIP_COVERED_SESSIONS` | — | nothing | 1 | — |
 | `MATRIXARK_BACKFILL_SUB_BATCH` | 250 | nothing | 1 | — |
 | `MATRIXARK_CONTEXT_COMPRESSION_ENABLED` | — | nothing | 1 | — |
@@ -307,13 +307,13 @@ The memory pipeline: what gets extracted, embedded, drained and packed. The surf
 | `MATRIXARK_CONTEXT_COMPRESSION_WINDOW` | — | nothing | 1 | — |
 | `MATRIXARK_CONTEXT_EVENT_QUERY_OVERFETCH` | 2 | nothing | 1 | — |
 | `MATRIXARK_CONTEXT_EVENT_SCAN_CAP` | 64 | nothing | 1 | — |
-| `MATRIXARK_EMBEDDING_MODEL` | — | config, script, test, portal | 1 | — |
+| `MATRIXARK_EMBEDDING_MODEL` | — | config, launch, script, test, portal | 1 | — |
 | `MATRIXARK_EMBED_API_KEY_ENV` | — | nothing | 1 | — |
 | `MATRIXARK_EMBED_BASE_URL` | — | config, script | 1 | — |
 | `MATRIXARK_EMBED_DRAINER` | off | config, launch, test, portal | 1 | — |
 | `MATRIXARK_EMBED_DRAINER_BATCH` | — | config, portal | 1 | — |
 | `MATRIXARK_HOOK_ADDITIONAL_CONTEXT_CHAR_LIMIT` | 40000 | launch | 1 | — |
-| `MATRIXARK_REQUIRE_MODEL_EMBEDDINGS` | off | config, portal | 1 | — |
+| `MATRIXARK_REQUIRE_MODEL_EMBEDDINGS` | off | config, test, portal | 1 | — |
 | `MATRIXARK_REQUIRE_MODEL_SUMMARIES` | off | config, portal | 1 | — |
 | `MATRIXARK_RETRIEVAL_TRAVERSAL_TOP_K` | — | nothing | 1 | — |
 | `TS_PROXY_CONTEXT_FIRST_SHARD` | — | nothing | 1 | — |
@@ -329,7 +329,7 @@ Who the caller is, not what the engine does. Supplied per request or per process
 | `MATRIXARK_AGENT_NAME` | — | launch | 2 | — |
 | `MATRIXARK_TENANT_ID` | — | launch | 2 | — |
 | `MATRIXARK_USER_ID` | — | launch, test | 2 | — |
-| `TEMPORALSTORE_AGENT_NAME` | — | launch | 2 | — |
+| `TEMPORALSTORE_AGENT_NAME` | — | launch, test | 2 | — |
 | `MATRIXARK_SESSION_ID` | — | nothing | 1 | — |
 
 ## diagnostic (2)
@@ -347,12 +347,12 @@ Read only by the benchmark harnesses. Never consulted on a serving path.
 
 | flag | default | set by | files | keeps an older path |
 |---|---|---|---|---|
-| `TEMPORALSTORE_CONTEXT_BENCHMARK_ALL_SOURCE_REPLAY` | off | nothing | 1 | — |
-| `TEMPORALSTORE_CONTEXT_BENCHMARK_DIRECT_SOURCE_SCORING` | off | nothing | 1 | — |
-| `TEMPORALSTORE_CONTEXT_BENCHMARK_EXTERNAL_ONLY` | off | nothing | 1 | — |
+| `TEMPORALSTORE_CONTEXT_BENCHMARK_ALL_SOURCE_REPLAY` | off | script | 1 | — |
+| `TEMPORALSTORE_CONTEXT_BENCHMARK_DIRECT_SOURCE_SCORING` | off | script | 1 | — |
+| `TEMPORALSTORE_CONTEXT_BENCHMARK_EXTERNAL_ONLY` | off | script | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_JSONL` | — | script | 1 | — |
-| `TEMPORALSTORE_CONTEXT_BENCHMARK_SELECTED_ID_LIMIT` | 128 | nothing | 1 | — |
-| `TEMPORALSTORE_CONTEXT_BENCHMARK_SOURCE_ORDER_RANKING` | off | nothing | 1 | — |
+| `TEMPORALSTORE_CONTEXT_BENCHMARK_SELECTED_ID_LIMIT` | 128 | script | 1 | — |
+| `TEMPORALSTORE_CONTEXT_BENCHMARK_SOURCE_ORDER_RANKING` | off | script | 1 | — |
 
 ## behaviour (61)
 
@@ -371,7 +371,7 @@ Everything else that changes what the engine does.
 | `TEMPORALSTORE_RUST_CODEX_HOOK_ROOT` | — | launch | 2 | — |
 | `TS_PAGE_STORE_COMPRESSION_ENABLED` | — | config, launch, test | 2 | — |
 | `TS_PAGE_STORE_COMPRESSION_LEVEL` | — | config, test | 2 | — |
-| `MATRIXARK_RUST_PROXY_ASYNC_STORAGE` | off | launch, test | 1 | — |
+| `MATRIXARK_RUST_PROXY_ASYNC_STORAGE` | off | launch, script, test | 1 | — |
 | `MATRIXARK_RUST_PROXY_PAGE_COMPRESSION_ENABLED` | — | test | 1 | — |
 | `MATRIXARK_RUST_PROXY_PAGE_COMPRESSION_LEVEL` | — | test | 1 | — |
 | `MATRIXARK_TEMPORALSTORE_RUST_ROOT` | — | launch, script, test | 1 | — |
@@ -380,7 +380,7 @@ Everything else that changes what the engine does.
 | `TS_BLOB_PEER_FETCH` | — | nothing | 1 | — |
 | `TS_BLOB_RUNTIME_THREADS` | — | nothing | 1 | — |
 | `TS_CACHE_DISK_TIER` | — | test | 1 | — |
-| `TS_COLD_SCAN_NO_CACHE_FILL` | on | config, portal | 1 | — |
+| `TS_COLD_SCAN_NO_CACHE_FILL` | on | config, test, portal | 1 | — |
 | `TS_DATA_RAFT_READ_MODE` | — | config | 1 | — |
 | `TS_EVICT_SAMPLES` | — | nothing | 1 | — |
 | `TS_EVICT_SCAN_TURNS` | — | nothing | 1 | — |
@@ -393,7 +393,7 @@ Everything else that changes what the engine does.
 | `TS_PROXY_CONFIG_VERSION` | — | nothing | 1 | — |
 | `TS_PROXY_ENFORCE_INGESTION_ACCOUNT` | — | nothing | 1 | — |
 | `TS_PROXY_INGESTION_ACCOUNT` | — | nothing | 1 | — |
-| `TS_PROXY_NAMESPACE` | — | nothing | 1 | — |
+| `TS_PROXY_NAMESPACE` | — | launch | 1 | — |
 | `TS_PROXY_PIN_PRIMARY_READS` | — | nothing | 1 | — |
 | `TS_PROXY_REFRESH_ROUTE_ON_BACKEND_ERROR` | — | nothing | 1 | — |
 | `TS_PROXY_ROUTE_CACHE_TTL_MS` | — | nothing | 1 | — |
@@ -407,7 +407,7 @@ Everything else that changes what the engine does.
 | `TS_RAFT_SECURITY_MODE` | — | nothing | 1 | — |
 | `TS_RAFT_TRANSPORT_SECURITY` | — | nothing | 1 | — |
 | `TS_SCRATCH_SWEEP` | on | portal | 1 | — |
-| `TS_SERVER_JOIN_EMPTY` | — | nothing | 1 | — |
+| `TS_SERVER_JOIN_EMPTY` | — | script | 1 | — |
 | `TS_SERVER_RAFT` | — | nothing | 1 | — |
 | `TS_SERVER_RAFT_READ_MODE` | — | nothing | 1 | — |
 | `TS_SERVER_READONLY` | — | nothing | 1 | — |

--- a/tools/build_engine_flag_inventory.py
+++ b/tools/build_engine_flag_inventory.py
@@ -21,6 +21,7 @@ against the source with a rule simpler than this one, and states how much source
 """
 import io
 import pathlib
+import ast
 import re
 import sys
 
@@ -562,7 +563,23 @@ SETTERS = [
     ("script", re.compile(r'(?:environ(?:\.setdefault)?|env)\s*[\[(]\s*"%s"\s*[\])]?\s*(?:,|=[^=])'
                           % NAME)),
 ]
+#: SHELL ONLY. An assignment without `export` still sets the variable for the command it prefixes,
+#: and that is how the deploy script passes half of what it passes:
+#:
+#:     TS_META_MUTATION_LOG="$DATA_DIR/meta/mutation-log.jsonl" \\
+#:
+#: Kept out of the Python scan because there the same characters are a KEYWORD ARGUMENT:
+#: `MATRIXARK_SESSION_ID=item.session_id` passes a value to a function and sets no environment.
+#: Anchored on a boundary so `${TS_X:-...}`, a read, does not match, and followed by a lookahead
+#: for something a value can start with -- `TS_MATRIXOBJECT_ENDPOINT=<host:port>` inside an echo is
+#: telling an operator the shape, and `<` cannot begin a value.
+SHELL_SETTERS = [
+    ("launch", re.compile(r"""(?:^|[\s;&|(])%s=(?=["'$A-Za-z0-9_./~-])""" % NAME, re.M)),
+]
 CONFIG_NAME = re.compile(NAME)
+#: The same name, anchored, for asking whether a dict KEY is a flag rather than
+#: whether a line mentions one.
+FLAG_NAME_ONLY = re.compile(r"^" + NAME + r"$")
 SET_ROOTS = [
     (ROOT / "crates" / "temporalstore-rust" / "src", (".rs",)),
     (ROOT / "crates" / "temporalstore-rust" / "tests", (".rs",)),
@@ -570,6 +587,73 @@ SET_ROOTS = [
     (ROOT / "tools", (".sh", ".py")),
     (ROOT / "deploy", (".sh", ".yml", ".yaml", ".env")),
 ]
+
+
+# A Python launcher hands a child process a DICT, not a subscript assignment:
+#
+#     env.update({"TEMPORALSTORE_CONTEXT_BENCHMARK_EXTERNAL_ONLY": "1", ...})
+#     subprocess.run(cmd, env={"TS_SHARD_ID": "1", ...})
+#
+# The pattern above matches `environ["NAME"] =` and misses every one of these, which is why the
+# column said "nothing" for flags a shipped harness sets on every run.
+#
+# It is read from the AST rather than by pattern, and the reason is a defect this repository has
+# already had. A decision list writes `{"TS_X": "why it is kept"}` and an env dict writes
+# `{"TS_X": "1"}` -- the same shape. A guard that matched the shape once fed itself its own list
+# and went red on merge (mx#910). So the question asked here is not what the dict LOOKS like but
+# what it IS: assigned to a name meaning environment, passed as `env=`, merged into one, the value
+# of an "env" key, or built inside or handed to a function whose own name says environment.
+def _env_dict_keys(node):
+    if not isinstance(node, ast.Dict):
+        return []
+    return [key.value for key in node.keys
+            if isinstance(key, ast.Constant) and isinstance(key.value, str)
+            and FLAG_NAME_ONLY.match(key.value)]
+
+
+def _looks_like_env(node):
+    if isinstance(node, ast.Name):
+        return "env" in node.id.lower()
+    if isinstance(node, ast.Attribute):
+        return "env" in node.attr.lower()
+    return False
+
+
+def _env_dict_names(body):
+    try:
+        tree = ast.parse(body)
+    except (SyntaxError, ValueError):
+        return set()
+    found = set()
+    for fn in ast.walk(tree):
+        if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)) and "env" in fn.name.lower():
+            for inner in ast.walk(fn):
+                found.update(_env_dict_keys(inner))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(_looks_like_env(t) for t in node.targets):
+            found.update(_env_dict_keys(node.value))
+        if isinstance(node, ast.AnnAssign) and _looks_like_env(node.target) and node.value:
+            found.update(_env_dict_keys(node.value))
+        if isinstance(node, ast.Call):
+            for keyword in node.keywords:
+                if keyword.arg and "env" in keyword.arg.lower():
+                    found.update(_env_dict_keys(keyword.value))
+            if isinstance(node.func, ast.Attribute) and node.func.attr in ("update", "setdefault"):
+                receiver = node.func.value
+                if _looks_like_env(receiver) or (isinstance(receiver, ast.Attribute)
+                                                 and "environ" in receiver.attr):
+                    for arg in node.args:
+                        found.update(_env_dict_keys(arg))
+            callee = (node.func.attr if isinstance(node.func, ast.Attribute)
+                      else getattr(node.func, "id", ""))
+            if "env" in str(callee).lower():
+                for arg in node.args:
+                    found.update(_env_dict_keys(arg))
+        if isinstance(node, ast.Dict):
+            for key, value in zip(node.keys, node.values):
+                if isinstance(key, ast.Constant) and key.value == "env":
+                    found.update(_env_dict_keys(value))
+    return found
 
 
 def _setters_by_name():
@@ -600,8 +684,19 @@ def _setters_by_name():
             # script pattern matches a Python test's os.environ assignment identically, so without
             # this every flag a unit test touches was reported as one a script sets -- and adding a
             # test that names a flag rewrote this document with a claim about deployments.
+            # A COMMENT is not a setting, in either language. A deploy script spells an
+            # assignment out in its usage text to show an operator what to type, and this file
+            # spells one out to explain that -- so without this the generator credited a flag to
+            # the very comment describing the problem, which is the self-reference that made an
+            # earlier guard feed on its own output.
+            body = "\n".join(line for line in body.splitlines()
+                              if not line.lstrip().startswith("#"))
             is_test = path.name.startswith("test_") or "tests" in path.parts
-            for label, pattern in SETTERS:
+            if path.suffix == ".py":
+                for name in _env_dict_names(body):
+                    found.setdefault(name, set()).add("test" if is_test else "script")
+            patterns = SETTERS + (SHELL_SETTERS if path.suffix == ".sh" else [])
+            for label, pattern in patterns:
                 label = "test" if is_test else label
                 for name in pattern.findall(body):
                     found.setdefault(name, set()).add(label)

--- a/tools/test_a_two_path_flag_says_why.py
+++ b/tools/test_a_two_path_flag_says_why.py
@@ -157,7 +157,16 @@ def _unselected() -> List[str]:
     assigned = _assigned_values()
     out = []
     for name, _default, set_by in _rows():
-        if name in assigned and _reaches_the_other_arm(assigned[name], _default):
+        if name in assigned:
+            # The sweep above knows what VALUE is assigned; the inventory's `set by` column knows
+            # only that somewhere assigns one. Where they disagree the sweep wins, because the
+            # question here is whether anything reaches the OTHER arm and pinning a flag to the
+            # value it already has reaches nothing. The column started reporting the harness that
+            # sets TEMPORALSTORE_CONTEXT_BENCHMARK_DIRECT_SOURCE_SCORING to "0" -- its own default
+            # -- and without this that decision read as settled.
+            if _reaches_the_other_arm(assigned[name], _default):
+                continue
+            out.append(name)
             continue
         if set_by == "nothing" or set(part.strip() for part in set_by.split(",")) <= {
                 "test", "harness"}:


### PR DESCRIPTION
The engine flag inventory's `set by` column is the evidence for the retirement question. Its own
text says so: a flag that nothing sets "is not a switch anyone throws — it is a branch with one live
side, and the other side can go."

It said **nothing** for 168 of 289 flags. Twelve of those were wrong, and wrong in the direction
that licenses a removal.

### What it could not see

The column is built from patterns, and two shapes were missing.

**A Python launcher hands a child process a dict, not a subscript assignment.** The pattern matched
`environ["NAME"] =` and missed every one of these:

```python
env.update({"TEMPORALSTORE_CONTEXT_BENCHMARK_EXTERNAL_ONLY": "1", ...})
start("dnc", ..., dn_env(9, ...)) ...  {"TS_SERVER_JOIN_EMPTY": "1"}
```

`run_locomo_rust_harness` sets seven flags that way on every run, and
`rebalance_add_drop_validation` fourteen.

**A shell assignment without `export` still sets the variable for the command it prefixes**, and
that is how the deploy script passes half of what it passes:

```bash
TS_META_MUTATION_LOG="$DATA_DIR/meta/mutation-log.jsonl" \
```

### The dict is read from the AST, and the reason is a defect this repo has had

A decision list writes `{"TS_X": "why it is kept"}` and an env dict writes `{"TS_X": "1"}` — the
same shape. A guard that matched the shape once fed itself its own list and went red on merge
(mx#910). So the question asked is not what the dict *looks like* but what it **is**: assigned to a
name meaning environment, passed as `env=`, merged into one, the value of an `"env"` key, or built
inside or handed to a function whose own name says environment.

Verified against the four decision-list files in `tools/` — none is picked up.

### Three false positives, each caught and removed

Writing this produced exactly the errors it is about, which is why each is now handled explicitly:

| what matched | why it is not a setting |
|---|---|
| `#   TS_MATRIXOBJECT_ENDPOINT=10.0.0.20:17200` | a **comment** — a deploy script's usage text showing an operator what to type. And this file's own comment explaining that, which credited the flag to the sentence describing the problem |
| `TS_MATRIXOBJECT_ENDPOINT=<host:port>` in an `echo` | `<` cannot begin a shell value; a lookahead now requires one that can |
| `MATRIXARK_SESSION_ID=item.session_id` | a Python **keyword argument**. The bare-assignment shape is shell-only and no longer runs over `.py` |

Each of those errs toward reporting a flag as *set*, which keeps a branch alive rather than
licensing its removal — the safe direction, but still wrong, and the column is only worth reading if
it is right.

### One decision had to be defended against the improvement

`TEMPORALSTORE_CONTEXT_BENCHMARK_DIRECT_SOURCE_SCORING` is now correctly reported as set by a
script — and its entry in `test_a_two_path_flag_says_why` went stale, because the guard consulted
the column. But the harness sets it to `"0"`, its own default, which reaches no second arm; that is
the whole reason it was listed (#1031). The column cannot express a value, so where the two
disagree the value-aware sweep now wins, and says why.

### Checks

| | |
|---|---|
| `set by nothing` | **168 → 156**, 42 rows changed |
| mutation — remove the env-dict scan, keep the document | **fails** `test_regenerating_produces_the_same_document` |
| nine flag guards | all pass, including the four that read this document |
