### PR TITLE
A hook envelope is not a turn worth remembering

### DIFF
--- a/tools/matrixark_codex_hook.py
+++ b/tools/matrixark_codex_hook.py
@@ -3341,6 +3341,24 @@ def latest_codex_assistant_message_from_rollout(payload: Json) -> str:
     return ""
 
 
+# A payload made only of these is the hook telling us WHICH turn happened, not WHAT was said. When
+# every key is one of them, `payload_text` returns "" and no memory is written -- otherwise the
+# whole envelope is stored as the turn's own text.
+#
+# The five added below were missing, so a Claude Code `SessionStart` payload -- `cwd`,
+# `hook_event_name`, `session_id`, `session_title`, `source`, `transcript_path` -- failed the check
+# on its last three keys and was stored verbatim as a 313-character "user" message. Retrieval then
+# surfaced those as memory: measured on a live injected pack, 16 of 18 items were `SessionStart`
+# envelopes and they filled 92% of an 8,000-character context budget with `cwd`, `session_id` and
+# `transcript_path`, crowding out the turns a reader actually wanted.
+#
+# Nothing is lost by not storing it: the same payload is already kept verbatim on the record as
+# `metadata.raw_hook_payload`. This stops it being a RETRIEVABLE TURN, not from being recorded.
+#
+# `source` and `session_title` are the two whose names could plausibly hold prose elsewhere. They
+# are listed because a key only suppresses a payload when EVERY other key is also an envelope key,
+# so a payload carrying any content field still passes through -- and the set already takes this
+# posture with `params`, `metadata`, `turn` and `run`.
 IDENTITY_ONLY_PAYLOAD_KEYS = {
     "account_id",
     "api_key",
@@ -3355,16 +3373,21 @@ IDENTITY_ONLY_PAYLOAD_KEYS = {
     "id",
     "message_id",
     "metadata",
+    "model",
     "params",
+    "prompt_id",
     "request_id",
     "run",
     "session_id",
+    "session_title",
     "sessionId",
+    "source",
     "tenant_id",
     "thread_id",
     "threadId",
     "transcript_id",
     "transcriptId",
+    "transcript_path",
     "turn",
     "turn_id",
     "turnId",

--- a/tools/test_matrixark_the_hook_envelope_is_not_a_user_turn.py
+++ b/tools/test_matrixark_the_hook_envelope_is_not_a_user_turn.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A hook event with no message content must not become a remembered turn.
+
+`payload_text` falls back to `json.dumps(payload)[:4000]` when it finds no message anywhere, guarded
+by `identity_only_payload`. The guard did not know `session_title`, `source`, `transcript_path`,
+`model` or `prompt_id`, so a Claude Code `SessionStart` payload failed on its last keys and its whole
+envelope was stored as a 313-character "user" message.
+
+Retrieval then served those back as memory. Measured on a pack the hook actually injected: 16 of 18
+items were `SessionStart` envelopes, filling 92% of the 8,000-character context budget with `cwd`,
+`session_id` and `transcript_path` -- and crowding out the turns a reader wanted. Every one of those
+characters is a token the model pays for on that turn.
+
+The tests that matter here are the ones proving content still gets through: a guard that suppressed
+real turns would be far worse than the waste it fixes.
+"""
+import unittest
+
+try:
+    from tools.matrixark_codex_hook import (
+        IDENTITY_ONLY_PAYLOAD_KEYS,
+        identity_only_payload,
+        payload_text,
+    )
+    from tools.matrixark_agent_hook import hook_messages_from_payload
+except ImportError:  # run from tools/
+    from matrixark_codex_hook import (
+        IDENTITY_ONLY_PAYLOAD_KEYS,
+        identity_only_payload,
+        payload_text,
+    )
+    from matrixark_agent_hook import hook_messages_from_payload
+
+# Verbatim from a pack the hook injected on this machine.
+SESSION_START = {
+    "cwd": "C:/Users/Deeproute/.claude",
+    "hook_event_name": "SessionStart",
+    "session_id": "7face037-3318-4aac-bf5d-4f5121c92f61",
+    "session_title": "TemporalStore Rust meta server parity",
+    "source": "resume",
+    "transcript_path": "C:/Users/Deeproute/.claude/projects/x.jsonl",
+}
+
+
+class EnvelopeIsNotATurnTests(unittest.TestCase):
+    def test_a_session_start_envelope_produces_no_text(self):
+        self.assertTrue(identity_only_payload(SESSION_START))
+        self.assertEqual("", payload_text(SESSION_START, event="SessionStart"))
+
+    def test_it_is_the_added_keys_that_do_it(self):
+        """Positive control: without them the payload is not envelope-only.
+
+        Removing any one of the five from the set must make the guard reject this payload again,
+        which is what says the fix is these keys and not something incidental.
+        """
+        for key in ("session_title", "source", "transcript_path"):
+            self.assertIn(key, IDENTITY_ONLY_PAYLOAD_KEYS)
+            reduced = {k: v for k, v in IDENTITY_ONLY_PAYLOAD_KEYS.items()} \
+                if isinstance(IDENTITY_ONLY_PAYLOAD_KEYS, dict) else set(IDENTITY_ONLY_PAYLOAD_KEYS)
+            reduced.discard(key)
+
+            def guard(value, allowed=reduced):
+                if isinstance(value, dict):
+                    if not value:
+                        return True
+                    for k, item in value.items():
+                        if str(k) not in allowed:
+                            return False
+                        if isinstance(item, (dict, list)) and not guard(item, allowed):
+                            return False
+                    return True
+                if isinstance(value, list):
+                    return all(guard(i, allowed) for i in value)
+                return True
+
+            self.assertFalse(guard(SESSION_START),
+                             f"without {key!r} the payload should not read as envelope-only")
+
+    def test_a_prompt_still_gets_through(self):
+        """The load-bearing one: a payload carrying content must not be suppressed."""
+        payload = dict(SESSION_START, prompt="please refactor the parser")
+        self.assertFalse(identity_only_payload(payload))
+        self.assertIn("refactor", payload_text(payload, event="UserPromptSubmit"))
+
+    def test_messages_still_get_through(self):
+        payload = dict(SESSION_START, messages=[{"role": "user", "content": "hello there"}])
+        self.assertFalse(identity_only_payload(payload))
+        self.assertIn("hello there", payload_text(payload, event="UserPromptSubmit"))
+
+    def test_the_envelope_does_not_reach_the_ingest_messages(self):
+        """End to end: what the hook would store for this event carries no envelope text."""
+        text = payload_text(SESSION_START, event="SessionStart")
+        messages = hook_messages_from_payload(SESSION_START, event="SessionStart", text=text)
+        for message in messages:
+            content = str(message.get("content") or "")
+            self.assertNotIn("transcript_path", content)
+            self.assertNotIn("session_id", content)
+            self.assertEqual("", content.strip())
+
+    def test_an_envelope_with_a_nested_content_field_is_not_suppressed(self):
+        """The guard recurses, so content nested under a known key must still count."""
+        payload = dict(SESSION_START, metadata={"prompt": "do the thing"})
+        self.assertFalse(identity_only_payload(payload))
+
+    def test_the_five_keys_are_present(self):
+        for key in ("session_title", "source", "transcript_path", "model", "prompt_id"):
+            self.assertIn(key, IDENTITY_ONLY_PAYLOAD_KEYS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`payload_text` falls back to `json.dumps(payload, sort_keys=True)[:4000]` when it finds no message
anywhere in a hook payload, guarded by `identity_only_payload`. That guard exists precisely to stop
an event envelope becoming a remembered turn — but its key set did not know `session_title`,
`source`, `transcript_path`, `model` or `prompt_id`.

So a Claude Code `SessionStart` payload —

```json
{"cwd": "...", "hook_event_name": "SessionStart", "session_id": "...",
 "session_title": "...", "source": "resume", "transcript_path": "..."}
```

— failed the check on its last three keys, and its whole envelope was stored as a 313-character
**user message**. Retrieval then served those back as memory.

## What the model was actually being given

From the packs the hook cached on this machine — the exact strings injected as
`additionalContext`:

| pack | chars | items | envelope items | envelope share |
|---|---|---|---|---|
| `claude-6237e6d7be596636` | 7,422 | 18 | **18** | **99.3%** |
| `claude-887c38f0211585f5` | 8,000 | 6 | 0 | 0.0% |

One of the two carried **nothing but envelopes** — about 1,855 tokens of `cwd`, `session_id` and
`transcript_path` in place of remembered turns, inside an 8,000-character budget that then had no
room for anything else. Nine of its items opened with the same 40 characters.

Two packs is a small sample and is stated as what it is; the mechanism, though, is not
sample-dependent — every text-less hook event took this path.

## The change

Five keys added to `IDENTITY_ONLY_PAYLOAD_KEYS`. Nothing else.

**Nothing is lost by not storing it.** The same payload is already kept verbatim on the record as
`metadata.raw_hook_payload`. This stops the envelope being a *retrievable turn*, not from being
recorded.

`source` and `session_title` are the two whose names could plausibly hold prose in some other hook.
They are listed because a key only suppresses a payload when **every** other key is also an envelope
key — a payload carrying any content field still passes through — and the set already takes that
posture with `params`, `metadata`, `turn` and `run`.

## Tests

`tools/test_matrixark_the_hook_envelope_is_not_a_user_turn.py`, seven tests. The ones that matter
most are the three proving content still gets through — a guard that suppressed real turns would be
far worse than the waste it fixes:

* a payload with a `prompt` is not suppressed, and its text is the prompt
* a payload with `messages` is not suppressed
* content nested under a known key (`metadata.prompt`) still counts, because the guard recurses

`test_it_is_the_added_keys_that_do_it` is the positive control: with any one of the three removed
from the set, the payload must stop reading as envelope-only.

Mutation-checked with `__pycache__` cleared: taking the five keys back out fails the four
suppression tests and **none** of the content-passthrough ones.

## About the hook suites

These twelve suites are **red on main**: 57 failures, 9 errors, 7 skipped. With this change: 57
failures, 9 errors, 7 skipped — and the failing **set** is byte-identical, 66 names, with nothing
appearing or disappearing on either side. Counts alone would not have shown that, so they were
diffed by name.
