### PR TITLE
The backend's allocations were being counted as the proxy's

### DIFF
--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -3801,6 +3801,73 @@ mod tests {
         let counts = probe.stop();
         rows.push(("POST /execute, backend ANSWERS", counts.allocs / ITERS as u64, counts.alloc_bytes / ITERS as u64));
 
+        // The SAME forward against a backend that allocates nothing, because the rows above do not
+        // measure only this process's work.
+        //
+        // `alloc_probe` counts GLOBAL atomics, and the stub backend runs on its own thread. While
+        // the client blocks in `read()`, that thread is parsing the request and serialising a
+        // reply, and every allocation it makes lands inside the probe's window. Measured: a round
+        // trip costs 11 allocations against the JSON stub and 2 against a listener that writes a
+        // constant response -- so NINE of the eleven were the backend's.
+        //
+        // A/B numbers taken across these rows are still sound, since both arms pay the same
+        // backend. The ABSOLUTE figure is what needs this row: it is the one an optimisation
+        // budget gets set from.
+        let quiet = test_addr(18_640);
+        let quiet_thread = quiet.clone();
+        std::thread::spawn(move || {
+            let listener = match std::net::TcpListener::bind(&quiet_thread) {
+                Ok(listener) => listener,
+                Err(_) => return,
+            };
+            let canned = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\n{}";
+            for stream in listener.incoming().flatten() {
+                let mut stream = stream;
+                let mut scratch = [0u8; 4096];
+                loop {
+                    use std::io::{Read as _, Write as _};
+                    match stream.read(&mut scratch) {
+                        Ok(0) | Err(_) => break,
+                        Ok(_) => {
+                            if stream.write_all(canned).is_err() {
+                                break;
+                            }
+                            let _ = stream.flush();
+                        }
+                    }
+                }
+            }
+        });
+        wait_for_http(&quiet);
+        let quiet_serving = scoped_proxy(ProxyOptions::default());
+        quiet_serving
+            .client()
+            .insert_cached_route_for_test(1, quiet.clone());
+        let (code, _) = quiet_serving.handle(crate::proxy::HttpRequest {
+            method: "POST".to_string(),
+            path: "/execute".to_string(),
+            body: execute_body.clone(),
+        });
+        assert_eq!(
+            code, 200,
+            "the quiet listener must answer, or this row measures the error tail"
+        );
+        let probe = crate::alloc_probe::Probe::start();
+        for _ in 0..ITERS {
+            let out = quiet_serving.handle(crate::proxy::HttpRequest {
+                method: "POST".to_string(),
+                path: "/execute".to_string(),
+                body: execute_body.clone(),
+            });
+            std::hint::black_box(&out);
+        }
+        let counts = probe.stop();
+        rows.push((
+            "POST /execute, backend allocates NOTHING",
+            counts.allocs / ITERS as u64,
+            counts.alloc_bytes / ITERS as u64,
+        ));
+
         // What the forward above is made of, so the next person optimising it knows which part to
         // look at rather than guessing from the total.
         let probe = crate::alloc_probe::Probe::start();


### PR DESCRIPTION
The backend-answering rows in `what_a_proxy_request_allocates` do not measure only this process's work, and I quoted one of them as the proxy's cost in #1054.

`alloc_probe` counts **global atomics**, and the stub backend runs on **its own thread**. While the client blocks in `read()`, that thread is parsing the request and serialising a reply — and every allocation it makes lands inside the probe's window.

Measured, one round trip:

| against | allocs | bytes |
|---|---|---|
| the JSON stub backend | 11 | 1110 |
| a listener that writes a constant response | **2** | **243** |

**Nine of the eleven were the backend's.** End to end:

| POST /execute, end to end | allocs | bytes |
|---|---|---|
| stub backend (what the row reported) | 20 | 1711 |
| **backend that allocates nothing** | **15** | **781** |

So the proxy's own cost per forward is 15 allocations and 781 bytes, not 20 and 1711.

## What this does and does not invalidate

**A/B numbers across these rows are still sound.** Both arms pay the same backend, so a delta measured between them is real — #1054's four allocations are client-side and stand. What needed fixing is the **absolute** figure, because that is the one an optimisation budget gets set from, and mine was ~25% high.

This adds a `POST /execute, backend allocates NOTHING` row beside the existing one, with the reason written where the rows are, so the next reader does not have to rediscover it.

## Why this keeps happening

Third time in this work that a row measured something other than what it was quoted as. #1007 found these rows measuring a **400 rejection** because the body never parsed. The comment in this file already warns that the unreachable-backend rows measure a failure. Now the reachable-backend rows turn out to include the backend.

The pattern is the same each time: the number is real, and the sentence beside it names the wrong thing. Hence a row that states its own condition in its label rather than in prose someone has to read.
