### PR TITLE
Every series this build emits has a panel, including the last three

### DIFF
--- a/docs/ops/matrixark-gateway-dashboard.json
+++ b/docs/ops/matrixark-gateway-dashboard.json
@@ -583,6 +583,82 @@
           "expr": "max(matrixark_gateway_datanode_probe_age_seconds{instance=~\"$instance\"})"
         }
       ]
+    },
+    {
+      "id": 16,
+      "type": "timeseries",
+      "title": "Worker resident memory",
+      "description": "Resident and peak memory of each gateway worker. Per worker, and deliberately not summed: resident sets share pages, so adding the workers together produces a figure larger than the machine is using. The `source` label says how the number was read -- /proc/self/status is exact, ru_maxrss is a peak only, and a series that switches between them is not comparable across the switch. Several gateway settings ask an operator to trade memory for speed -- the page and block index caches, the hot record cache, whether embeddings are stored at all -- and this is the half of that trade you can watch.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "matrixark_gateway_worker_resident_bytes",
+          "legendFormat": "resident {{source}} {{instance}}"
+        },
+        {
+          "refId": "B",
+          "expr": "matrixark_gateway_worker_peak_bytes",
+          "legendFormat": "peak {{source}} {{instance}}"
+        }
+      ]
+    },
+    {
+      "id": 17,
+      "type": "stat",
+      "title": "Workers",
+      "description": "How many workers this deployment was started with, as each one reports it. A live configuration write reaches the environment of whichever worker served the request and no other, so this is what says whether that matters here. More than one worker on a store that is not shared splits a tenant's memory across separate copies.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 32
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max(matrixark_gateway_workers)",
+          "legendFormat": "workers"
+        }
+      ]
     }
   ]
 }

--- a/tools/matrixark_gateway_metrics.py
+++ b/tools/matrixark_gateway_metrics.py
@@ -25,6 +25,7 @@ Two deliberate constraints:
 from __future__ import annotations
 
 import os
+import sys
 import threading
 from collections import deque
 import time
@@ -429,12 +430,107 @@ def config_change_lines() -> List[str]:
     ]
 
 
+def worker_resident() -> Json:
+    """This worker's resident memory, and where the number came from.
+
+    The source travels with the number because the two ways of asking do not agree about units:
+    `ru_maxrss` is kilobytes on Linux and BYTES on macOS, and a reader that picks wrong is out by a
+    factor of 1024 while looking entirely plausible. /proc is unambiguous, so it is preferred and
+    named.
+    """
+    try:
+        with open("/proc/self/status", encoding="utf-8") as handle:
+            fields: Json = {}
+            for line in handle:
+                if line.startswith(("VmRSS:", "VmHWM:")):
+                    key, value = line.split(":", 1)
+                    fields[key] = int(value.strip().split()[0]) * 1024
+        if fields.get("VmRSS"):
+            return {"resident_bytes": int(fields["VmRSS"]),
+                    "peak_bytes": int(fields.get("VmHWM") or fields["VmRSS"]),
+                    "source": "/proc/self/status"}
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import resource as _resource
+
+        raw = _resource.getrusage(_resource.RUSAGE_SELF).ru_maxrss
+        peak = int(raw) * (1 if sys.platform == "darwin" else 1024)
+        # Only the peak is available this way. Reporting it as "resident" would overstate a worker
+        # that has since given memory back.
+        return {"resident_bytes": None, "peak_bytes": peak, "source": "ru_maxrss"}
+    except Exception:  # pragma: no cover - a platform with neither
+        return {"resident_bytes": None, "peak_bytes": None, "source": "unavailable"}
+
+
+def worker_count(argv: Optional[List[str]] = None,
+                 env: Optional[Json] = None) -> int:
+    """How many workers this deployment was started with; 1 when nothing says otherwise.
+
+    Read from the command line, then WEB_CONCURRENCY.
+    """
+    argv = list(sys.argv if argv is None else argv)
+    env = dict(os.environ if env is None else env)
+    workers = 0
+    for index, token in enumerate(argv):
+        if token == "--workers" and index + 1 < len(argv):
+            try:
+                workers = int(argv[index + 1])
+            except ValueError:
+                workers = 0
+        elif token.startswith("--workers="):
+            try:
+                workers = int(token.split("=", 1)[1])
+            except ValueError:
+                workers = 0
+    if workers <= 0:
+        try:
+            workers = int(str(env.get("WEB_CONCURRENCY", "")).strip() or "0")
+        except ValueError:
+            workers = 0
+    return workers if workers > 0 else 1
+
+
+def worker_lines() -> List[str]:
+    """The footprint gauges, rendered here rather than appended by the route.
+
+    They were appended to the scrape from `/v1/metrics` itself, which put them outside every
+    renderer -- and `test_matrixark_dashboards` collects what this build emits BY RENDERING it. So
+    three series went out with no panel and no alert, and the rule that exists to catch exactly
+    that could not see them. A series that lives with the others is covered by that rule for free.
+    """
+    resident = worker_resident()
+    lines = [
+        "# HELP matrixark_gateway_worker_resident_bytes Resident memory of the worker that "
+        "served this scrape.",
+        "# TYPE matrixark_gateway_worker_resident_bytes gauge",
+        "# HELP matrixark_gateway_worker_peak_bytes Peak resident memory of that worker.",
+        "# TYPE matrixark_gateway_worker_peak_bytes gauge",
+        "# HELP matrixark_gateway_workers Workers this deployment was started with.",
+        "# TYPE matrixark_gateway_workers gauge",
+    ]
+    source = str(resident.get("source") or "unknown")
+    for field, series in (("resident_bytes", "matrixark_gateway_worker_resident_bytes"),
+                          ("peak_bytes", "matrixark_gateway_worker_peak_bytes")):
+        value = resident.get(field)
+        if value is None:
+            # Absent, not zero: a worker whose resident size could not be read is not one holding
+            # nothing, and a zero here would average into a fleet figure as though it were.
+            continue
+        # Labelled by source so a scrape taken through the fallback is distinguishable from one
+        # taken through /proc rather than silently comparable to it.
+        lines.append('%s{source="%s"} %d' % (series, source, int(value)))
+    lines.append("matrixark_gateway_workers %d" % worker_count())
+    return lines
+
+
 def prometheus_text(config_snapshot: Optional[Json] = None,
                     extra_lines: Optional[List[str]] = None) -> str:
     """The gateway's own metrics, plus config health, plus whatever the caller appends."""
     lines = METRICS.prometheus_lines()
     lines += config_health_lines(config_snapshot)
     lines += config_change_lines()
+    lines += worker_lines()
     if extra_lines:
         lines += extra_lines
     return "\n".join(lines) + "\n"

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -3412,26 +3412,7 @@ def _worker_count(argv: Optional[list] = None, env: Optional[dict] = None) -> in
     configuration write has its own reason to care -- a live setting is applied to the environment
     of whichever worker served the request, and no other.
     """
-    argv = list(sys.argv if argv is None else argv)
-    env = dict(os.environ if env is None else env)
-    workers = 0
-    for index, token in enumerate(argv):
-        if token == "--workers" and index + 1 < len(argv):
-            try:
-                workers = int(argv[index + 1])
-            except ValueError:
-                workers = 0
-        elif token.startswith("--workers="):
-            try:
-                workers = int(token.split("=", 1)[1])
-            except ValueError:
-                workers = 0
-    if workers <= 0:
-        try:
-            workers = int(str(env.get("WEB_CONCURRENCY", "")).strip() or "0")
-        except ValueError:
-            workers = 0
-    return workers if workers > 0 else 1
+    return _gwmetrics.worker_count(argv, env)
 
 
 def _single_writer_warning(
@@ -4120,36 +4101,9 @@ def _engine_footprint(text: Optional[str]) -> Json:
 
 
 def _worker_resident() -> Json:
-    """This worker's resident memory, and where the number came from.
-
-    The source is reported because the two ways of asking do not agree about units:
-    `ru_maxrss` is kilobytes on Linux and BYTES on macOS, and a panel that picks wrong is out by a
-    factor of 1024 while looking entirely plausible. /proc is unambiguous, so it is preferred and
-    named.
-    """
-    try:
-        with open("/proc/self/status", encoding="utf-8") as handle:
-            fields: Json = {}
-            for line in handle:
-                if line.startswith(("VmRSS:", "VmHWM:")):
-                    key, value = line.split(":", 1)
-                    fields[key] = int(value.strip().split()[0]) * 1024
-        if fields.get("VmRSS"):
-            return {"resident_bytes": int(fields["VmRSS"]),
-                    "peak_bytes": int(fields.get("VmHWM") or fields["VmRSS"]),
-                    "source": "/proc/self/status"}
-    except (OSError, ValueError, IndexError):
-        pass
-    try:
-        import resource as _resource
-
-        raw = _resource.getrusage(_resource.RUSAGE_SELF).ru_maxrss
-        peak = int(raw) * (1 if sys.platform == "darwin" else 1024)
-        # Only the peak is available this way. Reporting it as "resident" would overstate a worker
-        # that has since given memory back.
-        return {"resident_bytes": None, "peak_bytes": peak, "source": "ru_maxrss"}
-    except Exception:  # pragma: no cover - a platform with neither
-        return {"resident_bytes": None, "peak_bytes": None, "source": "unavailable"}
+    """This worker's resident memory. The measurement lives with the other metrics now, so the
+    gauges built from it are rendered where `test_matrixark_dashboards` can see them."""
+    return _gwmetrics.worker_resident()
 
 
 def _footprint_summary(cfg: GatewayConfig, text: Optional[str] = None) -> Json:
@@ -5061,25 +5015,10 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                 config_snapshot = _model_config_snapshot()
             except Exception:
                 config_snapshot = None
-            try:
-                resident = _worker_resident()
-                extra.append("# HELP matrixark_gateway_worker_resident_bytes Resident memory of "
-                             "the worker that served this scrape.")
-                extra.append("# TYPE matrixark_gateway_worker_resident_bytes gauge")
-                # Labelled by source so a scrape taken through the fallback is distinguishable
-                # from one taken through /proc, rather than silently comparable to it.
-                for field, series in (("resident_bytes", "matrixark_gateway_worker_resident_bytes"),
-                                      ("peak_bytes", "matrixark_gateway_worker_peak_bytes")):
-                    value = resident.get(field)
-                    if value is None:
-                        continue
-                    if series.endswith("peak_bytes"):
-                        extra.append("# TYPE matrixark_gateway_worker_peak_bytes gauge")
-                    extra.append('%s{source="%s"} %d'
-                                 % (series, resident.get("source", "unknown"), int(value)))
-                extra.append("matrixark_gateway_workers %d" % _worker_count())
-            except Exception:  # pragma: no cover - the scrape is worth more than this figure
-                pass
+            # The footprint gauges are rendered by `prometheus_text` itself now. Appending
+            # them here put them outside every renderer, and the rule that checks each emitted
+            # series has a panel collects what this build emits by RENDERING it -- so they went
+            # out uncharted and unalerted with nothing to notice.
             body = _gwmetrics.prometheus_text(config_snapshot, extra)
             return await _text(send, 200, body, content_type="text/plain; version=0.0.4")
 

--- a/tools/test_matrixark_every_series_this_build_emits_has_a_panel.py
+++ b/tools/test_matrixark_every_series_this_build_emits_has_a_panel.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Every series this build emits has a panel, including the ones added last.
+
+`test_matrixark_dashboards` already asserts that. It collects what the build emits **by rendering
+it** -- calling the renderers and reading the series names out of the text -- which is the right
+way to ask, and it worked until three gauges were emitted from somewhere no renderer runs.
+
+The worker footprint gauges were appended to the `/v1/metrics` response inside the route:
+
+    extra.append("# TYPE matrixark_gateway_worker_resident_bytes gauge")
+
+So they reached every scrape and no renderer, the rule could not see them, and they shipped with no
+panel and no alert -- silently, because a rule that cannot see a series reports nothing rather than
+a gap.
+
+They are rendered by `prometheus_text` now, which is what makes the existing rule cover them. This
+suite pins the property that made the gap possible: the scrape is what the renderers produce, and
+the route adds nothing of its own.
+"""
+from __future__ import annotations
+
+import ast
+import json
+import os
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+import matrixark_gateway_metrics as gwm  # noqa: E402
+
+DASHBOARD = os.path.abspath(
+    os.path.join(TOOLS, os.pardir, "docs", "ops", "matrixark-gateway-dashboard.json"))
+FOOTPRINT = ("matrixark_gateway_worker_resident_bytes",
+             "matrixark_gateway_worker_peak_bytes",
+             "matrixark_gateway_workers")
+
+
+def rendered() -> str:
+    return gwm.prometheus_text(
+        {"extraction": {"provider": "deterministic"},
+         "embedding": {"provider": "deterministic"}, "warnings": []})
+
+
+class TheGaugesComeFromTheRendererTest(unittest.TestCase):
+
+    def test_each_one_is_in_what_the_renderer_produces(self) -> None:
+        text = rendered()
+        for series in FOOTPRINT:
+            with self.subTest(series=series):
+                self.assertIn(series, text)
+
+    def test_each_carries_a_type(self) -> None:
+        """A series with no TYPE is one a scraper takes a guess at, and the rule that collects
+        emitted names reads HELP and TYPE lines."""
+        text = rendered()
+        for series in FOOTPRINT:
+            with self.subTest(series=series):
+                self.assertIn("# TYPE %s gauge" % series, text)
+
+    def test_the_route_appends_none_of_them(self) -> None:
+        """The property that made the gap possible. Anything the route appends to the scrape is
+        outside every renderer, and therefore outside the rule that checks for a panel."""
+        with open(os.path.join(TOOLS, "matrixark_v1_gateway.py"), encoding="utf-8") as handle:
+            source = handle.read()
+        for series in FOOTPRINT:
+            with self.subTest(series=series):
+                self.assertNotIn('extra.append("# TYPE %s' % series, source)
+                self.assertNotIn('extra.append("%s' % series, source)
+
+    def test_the_route_still_appends_something(self) -> None:
+        """The floor: `extra` is how the ingestion registry's lines get in, so a rule that
+        forbade appending altogether would be wrong as well as untested."""
+        with open(os.path.join(TOOLS, "matrixark_v1_gateway.py"), encoding="utf-8") as handle:
+            source = handle.read()
+        self.assertIn("extra = _jobs.prometheus_text()", source)
+
+
+class ADeadReadingIsAbsentNotZeroTest(unittest.TestCase):
+    """A worker whose resident size could not be read is not one holding nothing, and a zero here
+    would average into a fleet figure as though it were."""
+
+    def test_an_unreadable_measurement_emits_no_sample(self) -> None:
+        original = gwm.worker_resident
+        gwm.worker_resident = lambda: {"resident_bytes": None, "peak_bytes": None,
+                                       "source": "unavailable"}
+        try:
+            lines = gwm.worker_lines()
+        finally:
+            gwm.worker_resident = original
+        samples = [line for line in lines if not line.startswith("#")]
+        self.assertEqual(["matrixark_gateway_workers %d" % gwm.worker_count()], samples)
+
+    def test_a_readable_one_does(self) -> None:
+        """The floor: a renderer that emitted nothing ever would satisfy the test above."""
+        samples = [line for line in gwm.worker_lines() if not line.startswith("#")]
+        self.assertGreater(len(samples), 1)
+
+    def test_the_source_travels_with_the_number(self) -> None:
+        """kilobytes on Linux and bytes on macOS: two readings that are not comparable, so which
+        one this is has to be on the sample."""
+        for line in gwm.worker_lines():
+            if line.startswith("matrixark_gateway_worker_"):
+                with self.subTest(line=line):
+                    self.assertIn('source="', line)
+
+
+class TheDashboardShowsThemTest(unittest.TestCase):
+
+    def queried(self) -> set:
+        with open(DASHBOARD, encoding="utf-8") as handle:
+            doc = json.load(handle)
+        found = set()
+        for panel in doc.get("panels", []):
+            for target in panel.get("targets", []):
+                found.update(part for part in FOOTPRINT if part in target.get("expr", ""))
+        return found
+
+    def test_all_three_are_charted(self) -> None:
+        self.assertEqual(set(FOOTPRINT), self.queried())
+
+    def test_the_panels_explain_why_they_are_not_summed(self) -> None:
+        """Per worker, and the panel has to say so: adding resident sets together produces a
+        number larger than the machine is using."""
+        with open(DASHBOARD, encoding="utf-8") as handle:
+            doc = json.load(handle)
+        text = " ".join(panel.get("description", "") for panel in doc["panels"]).lower()
+        self.assertIn("not summed", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_the_portal_shows_the_footprint_it_asks_you_to_trade.py
+++ b/tools/test_matrixark_the_portal_shows_the_footprint_it_asks_you_to_trade.py
@@ -221,11 +221,25 @@ class TheScrapeCarriesItTooTest(unittest.TestCase):
     """A figure that exists only on a page cannot be alerted on or watched over time, which is
     most of what a footprint is for."""
 
-    def test_the_metrics_route_exports_the_worker_gauge(self) -> None:
-        with open(os.path.join(TOOLS, "matrixark_v1_gateway.py"), encoding="utf-8") as handle:
-            source = handle.read()
-        self.assertIn("matrixark_gateway_worker_resident_bytes", source)
-        self.assertIn("matrixark_gateway_workers", source)
+    def test_the_scrape_carries_the_worker_gauges(self) -> None:
+        """Asked of the scrape, not of a file.
+
+        This used to grep `matrixark_v1_gateway.py` for the series names, because that is where
+        the route appended them. Appending them there is exactly what kept them out of every
+        renderer and therefore out of the rule that checks each emitted series has a panel -- so
+        the string moved, and a test pinned to the file it used to be in went red for the change
+        that fixed the problem. What the name claims is that the scrape carries them; that is what
+        it asks now, and it holds wherever they are rendered.
+        """
+        try:
+            from tools import matrixark_gateway_metrics as gwm  # type: ignore
+        except ImportError:
+            import matrixark_gateway_metrics as gwm  # type: ignore
+        text = gwm.prometheus_text(
+            {"extraction": {"provider": "deterministic"},
+             "embedding": {"provider": "deterministic"}, "warnings": []})
+        self.assertIn("matrixark_gateway_worker_resident_bytes", text)
+        self.assertIn("matrixark_gateway_workers", text)
 
 
 class ThePageDrawsItTest(unittest.TestCase):


### PR DESCRIPTION
`test_matrixark_dashboards` already asserts that every series this build emits has a panel or an
alert. It works the right way — it collects what the build emits **by rendering it**, calling the
renderers and reading the series names out of the text.

Three gauges were emitted from somewhere no renderer runs:

```python
# in the /v1/metrics route
extra.append("# TYPE matrixark_gateway_worker_resident_bytes gauge")
extra.append('%s{source="%s"} %d' % (series, resident.get("source", "unknown"), int(value)))
extra.append("matrixark_gateway_workers %d" % _worker_count())
```

So they reached every scrape and no renderer. The rule could not see them, and they shipped in
[#1029](https://github.com/matrixarkai/TemporalStore/pull/1029) with **no panel and no alert** —
silently, because a rule that cannot see a series reports nothing rather than a gap.

That is my own change, and the guard was right to have been unable to help.

### The fix is where they live, not a new rule

`worker_resident()` and `worker_count()` move into `matrixark_gateway_metrics`, and `worker_lines()`
renders the three gauges from `prometheus_text`. The gateway keeps the names its six call sites use
and delegates. Teaching the dashboard rule about the route would have been the other option — a new
exemption for a series that lives somewhere odd. Putting the series where every other series lives
means the existing rule covers it for free, and covers the next one too.

The moment they became visible, the rule failed:

```
'matrixark_gateway_worker_peak_bytes' : emitted and shown nowhere -- add a panel or an alert:
['matrixark_gateway_worker_peak_bytes', 'matrixark_gateway_worker_resident_bytes',
 'matrixark_gateway_workers']
```

The gateway dashboard now carries a **Worker resident memory** timeseries and a **Workers** stat.
Both descriptions say the figures are per worker and deliberately not summed: resident sets share
pages, so adding the workers together produces a number larger than the machine is using.

### Two things the samples must not do

**Report a dead reading as zero.** A worker whose resident size cannot be read is not one holding
nothing, and a zero would average into a fleet figure as though it were. No sample is emitted, and
a mutation that emits `0` instead is caught.

**Lose the source.** `ru_maxrss` is kilobytes on Linux and bytes on macOS; a series that switches
between that and `/proc/self/status` is not comparable across the switch. The `source` label travels
on every sample.

```
the gauges leave the renderer again              -> FAIL
an unreadable measurement is emitted as zero     -> FAIL
the source label is dropped                      -> FAIL
the TYPE lines go away                           -> FAIL
the memory panel is removed from the dashboard   -> FAIL
the panel stops explaining why it is not summed  -> FAIL
```

### One test of mine needed repairing, and it was the same mistake in miniature

`test_the_metrics_route_exports_the_worker_gauge` grepped `matrixark_v1_gateway.py` for the series
names — because that is where the route appended them. Appending them there is precisely what caused
this, so the string moved and a test pinned to the file went red for the change that fixed the
problem. What its name claims is that the **scrape** carries them. That is what it asks now, and it
holds wherever they are rendered.

9 new tests, plus 75 across the dashboard, monitoring-asset, footprint and readiness suites.
