### PR TITLE
A context pack is cut between items, not mid-word

### DIFF
--- a/tools/matrixark_agent_hook.py
+++ b/tools/matrixark_agent_hook.py
@@ -1128,8 +1128,21 @@ def additional_context_from_retrieve(retrieve: Json | None, *, max_chars: int = 
     if not lines:
         return ""
     header = "Relevant context from earlier turns (MatrixArk memory):"
-    body = "\n".join(f"- {line}" for line in lines)
-    return (header + "\n" + body)[:max_chars]
+    # Cut BETWEEN items. Slicing the joined string to max_chars ends wherever the budget runs out,
+    # which on a live pack was mid-word -- the model's last remembered turn arrived as
+    # "...upgrading still costs cold-load time, but tha". A fragment that stops mid-clause is worse
+    # than not sending the item: it reads as a complete thought that changes meaning at the cut.
+    out = header
+    for line in lines:
+        entry = "\n- " + line
+        if len(out) + len(entry) > max_chars:
+            break
+        out += entry
+    if out == header:
+        # A single item longer than the whole budget: send the head of it rather than nothing, since
+        # dropping it would return "" and the caller reads that as "nothing was retrieved".
+        return (header + "\n- " + lines[0])[:max_chars]
+    return out
 
 
 def call_write_tool(

--- a/tools/test_matrixark_a_pack_is_cut_between_items.py
+++ b/tools/test_matrixark_a_pack_is_cut_between_items.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The injected context pack is cut between items, not mid-character.
+
+`additional_context_from_retrieve` joined every retrieved item and sliced the result to
+`max_chars`. The cut landed wherever the budget ran out. On a pack this hook actually injected it
+landed mid-word: the model's last remembered turn arrived as
+
+    "...upgrading still costs cold-load time, but tha"
+
+A fragment that stops mid-clause is worse than not sending the item at all -- it reads as a
+complete thought whose meaning changes at the cut, and the tokens are spent either way.
+
+The budget itself is unchanged. This only moves where the cut falls.
+"""
+import unittest
+
+try:
+    from tools.matrixark_agent_hook import additional_context_from_retrieve
+except ImportError:  # run from tools/
+    from matrixark_agent_hook import additional_context_from_retrieve
+
+HEADER = "Relevant context from earlier turns (MatrixArk memory):"
+
+
+def _retrieve(*texts):
+    return {"groups": [{"items": [{"text": t} for t in texts]}]}
+
+
+class PackCutTests(unittest.TestCase):
+    def test_no_item_is_cut_in_half(self):
+        items = ["x" * 300 for _ in range(10)]
+        # make each distinct so the flattener's dedupe keeps them all
+        items = [item + str(i) for i, item in enumerate(items)]
+        out = additional_context_from_retrieve(_retrieve(*items), max_chars=1000)
+        self.assertLessEqual(len(out), 1000)
+        for line in out.split("\n")[1:]:
+            self.assertTrue(line.startswith("- "))
+            body = line[2:]
+            self.assertIn(body, items, "an item was truncated mid-way")
+
+    def test_it_still_fills_the_budget(self):
+        """Cutting between items must not become an excuse to send almost nothing."""
+        items = [f"{i}" + "y" * 90 for i in range(40)]
+        out = additional_context_from_retrieve(_retrieve(*items), max_chars=1000)
+        self.assertGreater(len(out), 900, f"only used {len(out)} of 1000 chars")
+        self.assertLessEqual(len(out), 1000)
+
+    def test_the_budget_is_never_exceeded(self):
+        for cap in (120, 300, 1000, 8000):
+            items = [f"{i}" + "z" * 200 for i in range(60)]
+            out = additional_context_from_retrieve(_retrieve(*items), max_chars=cap)
+            self.assertLessEqual(len(out), cap, f"cap {cap} exceeded")
+
+    def test_one_oversized_item_is_still_sent(self):
+        """Returning "" here would read to the caller as 'nothing was retrieved'."""
+        out = additional_context_from_retrieve(_retrieve("q" * 5000), max_chars=200)
+        self.assertEqual(200, len(out))
+        self.assertTrue(out.startswith(HEADER))
+
+    def test_everything_fits_when_it_fits(self):
+        out = additional_context_from_retrieve(_retrieve("alpha", "beta"), max_chars=8000)
+        self.assertEqual(HEADER + "\n- alpha\n- beta", out)
+
+    def test_nothing_retrieved_is_still_empty(self):
+        """The fail-open contract: no items must mean "", not a bare header."""
+        self.assertEqual("", additional_context_from_retrieve(_retrieve(), max_chars=8000))
+        self.assertEqual("", additional_context_from_retrieve({}, max_chars=8000))
+        self.assertEqual("", additional_context_from_retrieve(None, max_chars=8000))
+
+    def test_duplicates_are_still_dropped(self):
+        out = additional_context_from_retrieve(_retrieve("same", "same", "other"), max_chars=8000)
+        self.assertEqual(HEADER + "\n- same\n- other", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`additional_context_from_retrieve` joined every retrieved item and sliced the result:

```python
body = "\n".join(f"- {line}" for line in lines)
return (header + "\n" + body)[:max_chars]
```

The cut lands wherever the 8,000-character budget runs out. On a pack this hook actually injected,
that was mid-word — the model's last remembered turn arrived as:

```
- ...current main ever has. So upgrading still costs cold-load time, but tha
```

A fragment that stops mid-clause is worse than not sending the item. It does not read as truncated;
it reads as a complete thought whose meaning changes at the cut, and the tokens are spent either
way.

## The change

Add items while they fit, stop when the next one would not. The budget is untouched — this only
moves where the cut falls, and the pack still fills it: on the test that packs 40 items into 1,000
characters the output is >900.

One case needed deciding rather than defaulting: a single item longer than the whole budget. Sending
nothing would return `""`, which the caller reads as "nothing was retrieved" and which then triggers
the last-good-pack fallback — a worse outcome than a head of the item. So that one case still slices,
deliberately, and `test_one_oversized_item_is_still_sent` pins it.

## Tests

`tools/test_matrixark_a_pack_is_cut_between_items.py`, seven tests: no item is cut in half, the
budget is never exceeded at four different caps, the budget is still filled, an oversized single item
is still sent, everything fits when it fits, duplicates are still dropped, and nothing retrieved is
still `""` (the fail-open contract).

Mutation-checked with `__pycache__` cleared: restoring the old slice fails
`test_no_item_is_cut_in_half` and **nothing else** — in particular the budget and fail-open tests
still pass, which is what says those are not what changed.

## About the hook suites

These ten suites are red on main: 66 failing names. With this change: the same 66, diffed by name
with nothing appearing or disappearing on either side.
