### PR TITLE
The inventory reads a boolean passed straight to a helper

### DIFF
--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -47,9 +47,9 @@ Anything else is blank, and a blank means go and look.
 | flags | count |
 |---|---|
 | total | 289 |
-| booleans whose default this could read off the source | 26 |
+| booleans whose default this could read off the source | 49 |
 | numbers whose default this could read off the source | 34 |
-| **defaulting on, and set by nothing** | 0 |
+| **defaulting on, and set by nothing** | 5 |
 | offered on the portal | 27 |
 | **that nothing in this repository sets** | 156 |
 | documented as keeping an older path alive | 5 |
@@ -69,7 +69,7 @@ Where this node is and what it talks to. Set by whoever provisions the node; not
 | `TS_RAFT_SHARD_ID` | — | harness, script | 3 | — |
 | `TS_RAFT_WAL_DIR` | — | config, harness, script | 3 | — |
 | `TS_SHARD_ID` | 1 | config, launch, script | 3 | — |
-| `TS_META_RAFT_NODES` | — | config | 2 | — |
+| `TS_META_RAFT_NODES` | off | config | 2 | — |
 | `TS_RAFT_BIND_ADDR` | — | harness, script | 2 | — |
 | `MATRIXARK_CONTEXT_EVENT_FANOUT_NODES` | 4 | nothing | 1 | — |
 | `MATRIXARK_TEMPORALSTORE_PROXY_ADDR` | — | nothing | 1 | — |
@@ -107,12 +107,12 @@ What the metaserver does about nodes it cannot reach -- conviction, freezing, re
 
 | flag | default | set by | files | keeps an older path |
 |---|---|---|---|---|
-| `TS_META_FORBID_SELF_CLEARING_CONVICTION` | — | nothing | 2 | — |
+| `TS_META_FORBID_SELF_CLEARING_CONVICTION` | off | nothing | 2 | — |
 | `MATRIXARK_TEMPORALSTORE_META_SYNC_DEADLINE_MS` | — | nothing | 1 | — |
-| `TS_AUTO_REBALANCE_DATA_MOVE` | — | script | 1 | — |
-| `TS_META_ADAPTIVE_FAILURE_DETECTOR` | — | nothing | 1 | — |
-| `TS_META_AUTO_REBALANCE` | — | config | 1 | — |
-| `TS_META_AUTO_REBALANCE_BALANCE` | — | nothing | 1 | — |
+| `TS_AUTO_REBALANCE_DATA_MOVE` | off | script | 1 | — |
+| `TS_META_ADAPTIVE_FAILURE_DETECTOR` | off | nothing | 1 | — |
+| `TS_META_AUTO_REBALANCE` | off | config | 1 | — |
+| `TS_META_AUTO_REBALANCE_BALANCE` | on | nothing | 1 | — |
 | `TS_META_CONVICT_ENABLED` | — | nothing | 1 | — |
 | `TS_META_CONVICT_ON_REBOOT` | — | nothing | 1 | — |
 | `TS_META_CONVICT_PROXIES` | — | nothing | 1 | — |
@@ -120,24 +120,24 @@ What the metaserver does about nodes it cannot reach -- conviction, freezing, re
 | `TS_META_FD_PHI_THRESHOLD` | — | nothing | 1 | — |
 | `TS_META_FD_SAMPLE_CAPACITY` | — | nothing | 1 | — |
 | `TS_META_FORBID_ORPHANING_SHARDS` | — | nothing | 1 | — |
-| `TS_META_FREEZE_AGING` | — | nothing | 1 | — |
+| `TS_META_FREEZE_AGING` | off | nothing | 1 | — |
 | `TS_META_MUTATION_LOG` | — | launch | 1 | — |
-| `TS_META_PLACEMENT_AWARE_REBALANCE` | — | nothing | 1 | — |
-| `TS_META_PROXY_CALIBRATION` | — | nothing | 1 | — |
+| `TS_META_PLACEMENT_AWARE_REBALANCE` | off | nothing | 1 | — |
+| `TS_META_PROXY_CALIBRATION` | off | nothing | 1 | — |
 | `TS_META_PROXY_FREEZE_COOLDOWN_MS` | — | nothing | 1 | — |
 | `TS_META_PROXY_FREEZE_MS` | — | nothing | 1 | — |
 | `TS_META_PROXY_RETENTION_MS` | — | nothing | 1 | — |
-| `TS_META_RAFT` | — | config, script | 1 | — |
+| `TS_META_RAFT` | off | config, script | 1 | — |
 | `TS_META_RAFT_ELECTION_TICK_MS` | — | nothing | 1 | — |
-| `TS_META_REBALANCE_LOCATION_SCOPED` | — | nothing | 1 | — |
-| `TS_META_REBALANCE_PER_TABLE` | — | nothing | 1 | — |
+| `TS_META_REBALANCE_LOCATION_SCOPED` | on | nothing | 1 | — |
+| `TS_META_REBALANCE_PER_TABLE` | on | nothing | 1 | — |
 | `TS_META_REBALANCE_SAFE_GAP` | — | nothing | 1 | — |
-| `TS_META_RETENTION_GC` | — | nothing | 1 | — |
+| `TS_META_RETENTION_GC` | off | nothing | 1 | — |
 | `TS_META_RETENTION_MS` | — | nothing | 1 | — |
 | `TS_META_SERVER_FREEZE_COOLDOWN_MS` | — | nothing | 1 | — |
 | `TS_META_SERVER_FREEZE_MS` | — | nothing | 1 | — |
 | `TS_META_SERVER_RETENTION_MS` | — | nothing | 1 | — |
-| `TS_META_SHARD_DIVERGENCE_CHECK` | — | nothing | 1 | — |
+| `TS_META_SHARD_DIVERGENCE_CHECK` | off | nothing | 1 | — |
 | `TS_META_SHARD_DIVERGENCE_REBOOT_GRACE_MS` | — | nothing | 1 | — |
 | `TS_META_SHARD_DIVERGENCE_SETTLE_GRACE_MS` | — | nothing | 1 | — |
 | `TS_META_SHARD_DIVERGENCE_WINDOW_MS` | — | nothing | 1 | — |
@@ -145,7 +145,7 @@ What the metaserver does about nodes it cannot reach -- conviction, freezing, re
 | `TS_META_TABLE_FREEZE_MS` | — | nothing | 1 | — |
 | `TS_META_TABLE_RETENTION_MS` | — | nothing | 1 | — |
 | `TS_META_TASK_SCHEDULER_BASE_POSTPONE_MS` | — | nothing | 1 | — |
-| `TS_RAFT_AUTO_FAILOVER` | — | config, script | 1 | — |
+| `TS_RAFT_AUTO_FAILOVER` | off | config, script | 1 | — |
 
 ## credential (5)
 
@@ -361,10 +361,10 @@ Everything else that changes what the engine does.
 | flag | default | set by | files | keeps an older path |
 |---|---|---|---|---|
 | `MATRIXARK_EAGER_CACHE_WARM_ON_LOAD` | on | config | 5 | — |
-| `TS_RAFT_ALLOW_PLAINTEXT` | — | harness, script | 4 | — |
+| `TS_RAFT_ALLOW_PLAINTEXT` | on | harness, script | 4 | — |
 | `MATRIXARK_BULK_INGEST` | off | config, test, portal | 3 | — |
 | `TS_RAFT_ELECTION_TICK_MS` | — | harness, script | 3 | — |
-| `TS_RAFT_ENABLE_LOCAL_ADMIN` | — | harness, script | 3 | — |
+| `TS_RAFT_ENABLE_LOCAL_ADMIN` | off | harness, script | 3 | — |
 | `TS_RAFT_RPC_DEADLINE_MS` | — | harness, script | 3 | — |
 | `TS_RAFT_RPC_RETRIES` | — | harness, script | 3 | — |
 | `MATRIXARK_BULK_INGEST_REPLAY_FROM_SEQUENCE` | — | config, test | 2 | — |
@@ -377,7 +377,7 @@ Everything else that changes what the engine does.
 | `MATRIXARK_TEMPORALSTORE_RUST_ROOT` | — | launch, script, test | 1 | — |
 | `TEMPORALSTORE_RUST_CODEX_EVENT_LOG` | — | launch | 1 | — |
 | `TEMPORALSTORE_RUST_CODEX_EVENT_LOG_ENABLE` | — | nothing | 1 | — |
-| `TS_BLOB_PEER_FETCH` | — | nothing | 1 | — |
+| `TS_BLOB_PEER_FETCH` | off | nothing | 1 | — |
 | `TS_BLOB_RUNTIME_THREADS` | — | nothing | 1 | — |
 | `TS_CACHE_DISK_TIER` | — | test | 1 | — |
 | `TS_COLD_SCAN_NO_CACHE_FILL` | on | config, test, portal | 1 | — |
@@ -385,10 +385,10 @@ Everything else that changes what the engine does.
 | `TS_EVICT_SAMPLES` | — | nothing | 1 | — |
 | `TS_EVICT_SCAN_TURNS` | — | nothing | 1 | — |
 | `TS_MALLOC_TRIM` | on | test, portal | 1 | — |
-| `TS_MATRIXOBJECT_CHECKPOINT_ON_START` | — | nothing | 1 | — |
+| `TS_MATRIXOBJECT_CHECKPOINT_ON_START` | on | nothing | 1 | — |
 | `TS_MATRIXOBJECT_FLUSH_BATCH` | — | nothing | 1 | — |
-| `TS_MATRIXOBJECT_NETWORKED_CHECKPOINT_ON_START` | — | nothing | 1 | — |
-| `TS_MATRIXOBJECT_SYNC_FLUSH` | — | nothing | 1 | — |
+| `TS_MATRIXOBJECT_NETWORKED_CHECKPOINT_ON_START` | on | nothing | 1 | — |
+| `TS_MATRIXOBJECT_SYNC_FLUSH` | off | nothing | 1 | — |
 | `TS_PROXY_BACKEND_CONTINUOUS_FAILED_TIME_MS` | — | nothing | 1 | — |
 | `TS_PROXY_CONFIG_VERSION` | — | nothing | 1 | — |
 | `TS_PROXY_ENFORCE_INGESTION_ACCOUNT` | — | nothing | 1 | — |
@@ -407,8 +407,8 @@ Everything else that changes what the engine does.
 | `TS_RAFT_SECURITY_MODE` | — | nothing | 1 | — |
 | `TS_RAFT_TRANSPORT_SECURITY` | — | nothing | 1 | — |
 | `TS_SCRATCH_SWEEP` | on | portal | 1 | — |
-| `TS_SERVER_JOIN_EMPTY` | — | script | 1 | — |
-| `TS_SERVER_RAFT` | — | nothing | 1 | — |
+| `TS_SERVER_JOIN_EMPTY` | off | script | 1 | — |
+| `TS_SERVER_RAFT` | off | nothing | 1 | — |
 | `TS_SERVER_RAFT_READ_MODE` | — | nothing | 1 | — |
 | `TS_SERVER_READONLY` | — | nothing | 1 | — |
 | `TS_SERVER_WORKER_THREADS` | — | config | 1 | — |

--- a/tools/build_engine_flag_inventory.py
+++ b/tools/build_engine_flag_inventory.py
@@ -419,6 +419,49 @@ def literal_consts(bodies):
     return found
 
 
+#: A boolean read by a direct helper call rather than through an accessor:
+#:
+#:     if env_bool("TS_AUTO_REBALANCE_DATA_MOVE", false) {
+#:
+#: `default_of` wants a one-flag function returning bool and `default_of_statement` wants one of
+#: the shapes an inline `env::var` chain takes -- `matches!`, `.is_ok()`, `unwrap_or(true)`. A
+#: helper call has none of them: the default is simply its second argument, and 22 flags were
+#: reported as having no readable default because nothing looked there.
+#:
+#: The unit is the CALL, bounded by its own parentheses, so there is no window to size and no
+#: negation sitting outside it.
+#:
+#: A `true`/`false` LITERAL is required, and that is what keeps this honest twice over. The same
+#: helper is declared in two shapes -- `env_bool(name, default)` in three binaries and
+#: `env_bool(name)` in two others, which supplies no default at all -- and requiring the literal
+#: reads the first without ever guessing at the second. It also declines
+#: `env_bool(NAME, defaults.convict_enabled)`, where following the answer would mean evaluating
+#: Rust; those six stay blank, which is the honest report.
+_BOOL_HELPER = re.compile(r"\benv_bool\s*\(")
+
+
+def bool_helper_default(lines, read_line):
+    """"on", "off", or "" -- the literal second argument of the env_bool call around the read."""
+    text = NEWLINE.join(lines)
+    offset = sum(len(line) + 1 for line in lines[:read_line])
+    match = FLAG_READ.search(text, offset)
+    if not match:
+        return ""
+    helper = None
+    for found in _BOOL_HELPER.finditer(text, max(0, match.start() - 2000)):
+        if found.start() > match.start():
+            break
+        helper = found
+    if helper is None:
+        return ""
+    open_paren = helper.end() - 1
+    close = _balanced(text, open_paren)
+    if close < 0 or not open_paren < match.start() < close:
+        return ""
+    tail = _last_argument(text[open_paren + 1:close]).strip()
+    return {"true": "on", "false": "off"}.get(tail, "")
+
+
 def numeric_default_of_statement(lines, read_line, consts):
     r"""A number, as text, or "" -- the default of a flag whose read states one.
 
@@ -517,6 +560,8 @@ for rel, text in prod.items():
             entry["default"] = default_of(body, len(set(FLAG_READ.findall(body))))
         if not entry["default"]:
             entry["default"] = default_of_statement(lines, line_no)
+        if not entry["default"]:
+            entry["default"] = bool_helper_default(lines, line_no)
         if not entry["default"]:
             entry["default"] = numeric_default_of_statement(lines, line_no, CONSTS)
         if entry["doc"]:

--- a/tools/test_a_two_path_flag_says_why.py
+++ b/tools/test_a_two_path_flag_says_why.py
@@ -14,6 +14,12 @@ written down; the set is asserted exactly, so a NEW one fails here until somebod
 and one that stops qualifying fails too rather than sitting in a list that has quietly become
 fiction.
 
+A flag defaulting ON that nothing sets is the shape worth looking hardest at -- the summary calls
+it a branch with one live side. Three of the entries below show why that is a question and not a
+verdict: they default ON and are read INSIDE a feature that is off, so their off side is reached by
+anyone who turns the parent on. Nesting is not visible in a default-and-setter pair, and reading the
+read site is what tells them apart.
+
 What the reasons have in common is the test that settled them: does the other arm let this build
 DO or READ something the live arm cannot? A diagnostic that surfaces suppressed fields does. A
 benchmark mode that the serving path never reaches does, for the harness. A branch that produces
@@ -45,6 +51,63 @@ KNOWN_TWO_PATH_FLAGS: Dict[str, str] = {
     # default, so the published field is always false. The branch is what gives those refusals
     # something to refuse, and it is the only way to measure the ceiling a real retrieval is
     # scored against, so it stays.
+    # --- surfaced when the inventory learned to read a helper's default ------------------------
+    # These fifteen were invisible while their default read as unknown. Every one is a real
+    # switch and none is a dead branch; the engine states the reason for each beside the read,
+    # and the short version is here so the list can be scanned.
+    #
+    # Three of them default ON and are read INSIDE a feature that is off:
+    "TS_META_AUTO_REBALANCE_BALANCE":
+        "a sub-option of auto-rebalance, read inside `if env_bool(TS_META_AUTO_REBALANCE, false)`. "
+        "Its off side is reached by anyone who turns the parent on, so ON-and-unset does not make "
+        "it one-sided",
+    "TS_META_REBALANCE_LOCATION_SCOPED":
+        "an AutoRebalanceOptions field on the same off-by-default path: honours each table's "
+        "preferred location when planning a move",
+    "TS_META_REBALANCE_PER_TABLE":
+        "the other AutoRebalanceOptions field, balancing per table rather than on total shard "
+        "counts; same parent, same argument",
+    # Two default ON and are documented OPT-OUTS:
+    "TS_MATRIXOBJECT_CHECKPOINT_ON_START":
+        "publishes this node's state as a checkpoint at start so a later recovery replays only "
+        "the tail; the engine calls it an opt-out, and turning it off is how an operator declines "
+        "that cost",
+    "TS_MATRIXOBJECT_NETWORKED_CHECKPOINT_ON_START":
+        "the networked half of the same checkpoint, so a future owner can follow it lazily; the "
+        "same opt-out",
+    # The rest default OFF. Retiring one of those deletes a hatch rather than a dead arm, and each
+    # is a behaviour an operator asks for:
+    "TS_BLOB_PEER_FETCH":
+        "cross-peer blob availability -- a local miss fetches from a peer instead of failing. "
+        "Opt-in, and the engine says so at the read",
+    "TS_MATRIXOBJECT_SYNC_FLUSH":
+        "switches the durability writer from async batching to a synchronous flush, so an "
+        "acknowledgement waits on the matrixobject append. A durability posture, not a tidy-up",
+    "TS_META_ADAPTIVE_FAILURE_DETECTOR":
+        "judges each datanode against its own heartbeat cadence instead of one fixed threshold. "
+        "The engine explains what the fixed one costs -- it convicts the fleet when the metaserver "
+        "stalls, and freezes a rack when the rack faults -- so this arm exists to be turned on",
+    "TS_META_FORBID_SELF_CLEARING_CONVICTION":
+        "a conviction policy, and the read is deliberately duplicated on the raft path because "
+        "`from_env` returns before reaching the single-node one, where it used to do nothing",
+    "TS_META_FREEZE_AGING":
+        "drops a resource that has been frozen longer than its cooldown so retention can forget "
+        "it. Off because a frozen resource staying frozen is the safe end",
+    "TS_META_PLACEMENT_AWARE_REBALANCE":
+        "off because it changes which server a shard lands on, which the engine calls "
+        "behaviour-visible -- the reason is written at the read",
+    "TS_META_PROXY_CALIBRATION":
+        "keeps each proxy group at its target by attaching idle proxies and releasing surplus; "
+        "off because it reassigns which namespace a proxy serves",
+    "TS_META_RETENTION_GC":
+        "ages out the tombstones a dropped server, proxy or table leaves behind, which otherwise "
+        "grow for the lifetime of the cluster. Off because forgetting a resource is irreversible",
+    "TS_META_SHARD_DIVERGENCE_CHECK":
+        "compares the owner map against what each datanode reports serving and re-places the "
+        "difference. Off because it moves shards",
+    "TS_SERVER_RAFT":
+        "the gate on the whole per-shard raft path in the datanode; `start_server_raft_from_env` "
+        "returns None without it",
     "TEMPORALSTORE_CONTEXT_BENCHMARK_DIRECT_SOURCE_SCORING": "benchmark ceiling, refused when published",
 }
 


### PR DESCRIPTION
The inventory could read a boolean's default only when the flag sat in a dedicated accessor —
a one-flag function returning `bool` — or when an inline read carried one of the shapes an
`env::var` chain takes (`matches!`, `.is_ok()`, `unwrap_or(true)`).

A knob passed straight to a helper has neither:

```rust
if env_bool("TS_AUTO_REBALANCE_DATA_MOVE", false) {
```

The default is right there as the second argument. **Twenty-two flags read as having no readable
default because nothing looked at it.**

| | before | after |
|---|---|---|
| booleans whose default the generator can read | 26 | **49** |
| **defaulting on, and set by nothing** | 0 | **5** |

That second line is the one the document exists for. Its own text calls a flag nothing sets "a
branch with one live side, and the other side can go" — and it had been counting zero because it
could not see the defaults.

### Why a literal is required

The unit is the **call**, bounded by its own parentheses, so there is no window to size and no
negation sitting outside it. Requiring a `true`/`false` literal keeps it honest twice:

- `env_bool` is declared in **two shapes** — `env_bool(name, default)` in three binaries and
  `env_bool(name)` in two others, which supplies no default at all. The literal reads the first
  and never guesses at the second.
- It declines `env_bool(NAME, defaults.convict_enabled)`, where following the answer would mean
  evaluating Rust. Those six stay blank, which is the honest report.

### The fifteen it surfaced, decided

Making them visible made them undecided, and `test_a_two_path_flag_says_why` said so. Each is now
recorded with its reason, taken from what the engine states beside the read. None is a dead branch:

- **Three default ON and are read inside a feature that is off.** `TS_META_AUTO_REBALANCE_BALANCE`
  sits inside `if env_bool("TS_META_AUTO_REBALANCE", false)`, with the two `AutoRebalanceOptions`
  fields beside it. Their off side is reached by anyone who turns the parent on.
- **Two default ON and are documented opt-outs** — the matrixobject start-up checkpoints, local and
  networked.
- **Ten default OFF**, each a behaviour an operator asks for, and the engine says why it is off:
  placement-aware rebalance "changes which server a shard lands on"; retention GC is off "because
  forgetting a resource" is irreversible; the adaptive failure detector exists because a fixed
  threshold "convicts the entire fleet if the metaserver itself stalls".

That first group is worth stating as a rule, and the guard's docstring now does: **ON-and-unset is a
question, not a verdict.** Nesting is invisible in a default-and-setter pair, and only the read site
tells them apart.

### Checks

| | |
|---|---|
| mutation — unwire the reader, keep the document | **fails** `test_regenerating_produces_the_same_document` |
| mutation — drop one of the fifteen decisions | **fails**, naming `TS_SERVER_RAFT` |
| restored | green |
| eight flag guards | all pass |
