### PR TITLE
Return the mcp entrypoint to its line budget

### DIFF
--- a/tools/matrixark_mcp_server.py
+++ b/tools/matrixark_mcp_server.py
@@ -713,19 +713,9 @@ def main() -> int:
     parser.add_argument(
         "--http-port",
         type=int,
-        # 0 is a MODE, not a port: it means "stay on stdio", and `if args.http_port` below is what
-        # reads it. So this is not a second opinion about the 8080 that the gateway, the shipped
-        # config, the container and the deployment unit all use -- that is a bind port for a
-        # process whose whole job is to bind one. The two must not be made to agree.
-        #
-        # They do share a NAME, which is the sharp edge worth knowing about: a deployment that
-        # exports MATRIXARK_HTTP_PORT globally, rather than per service, turns this server from an
-        # stdio MCP endpoint into a web portal, and the agent that expected to speak MCP to it
-        # simply finds nothing. Nothing ships that way -- the port is set in the cloud-api image,
-        # the compose file and the gateway config, none of which launch this -- but a hand-rolled
-        # environment can, and the failure looks like the MCP server never started.
+        # 0 is a MODE (stdio), not a bind port -- test_numeric_defaults_agree, JUSTIFIED entry.
         default=int(os.environ.get("MATRIXARK_HTTP_PORT", "0")),
-        help="If non-zero, serve the browser portal and /api JSON facade instead of stdio MCP.",
+        help="If non-zero, serve the browser portal and /api JSON facade instead of stdio MCP. Exporting MATRIXARK_HTTP_PORT globally rather than per service turns this server into a portal and an MCP client finds nothing.",
     )
     parser.add_argument(
         "--http-root",


### PR DESCRIPTION
`test_mcp_entrypoint_stays_small` asserts the entrypoint stays at or under 750 lines. It is at 759,
so the check is failing on main and every pull request inherits it -- the ratchet reports it as a
new failure and refuses to merge.

#1046 added an eleven-line comment at the `--http-port` argument explaining that its 0 is a mode
rather than a port, and that the name is shared with the gateway's 8080. Every word of that is
worth keeping, and all of it is already kept: `test_numeric_defaults_agree` carries the same
reasoning as its second JUSTIFIED entry, which is the list that exists to hold exactly this. The
copy in the entrypoint was a duplicate of the authoritative note.

So the comment now states the two facts an eye passing over the argument needs -- 0 is a mode, and
the variable is shared -- and points at the entry that explains why. The consequence an operator
would actually meet moves into the `--help` text, where someone reading `--help` will see it, which
the comment could never do.

The entrypoint is 749 lines. Nothing about the flag's behaviour changes: `--help` still builds and
still prints `--http-port`, and the JUSTIFIED entry is untouched.
