### PR TITLE
A tracked fixture carries no local path, and the gate says so before CI does

### DIFF
--- a/tools/test_matrixark_the_hook_envelope_is_not_a_user_turn.py
+++ b/tools/test_matrixark_the_hook_envelope_is_not_a_user_turn.py
@@ -33,14 +33,16 @@ except ImportError:  # run from tools/
     )
     from matrixark_agent_hook import hook_messages_from_payload
 
-# Verbatim from a pack the hook injected on this machine.
+# The shape of a pack the hook injected, with the paths neutralised: this file is tracked in
+# a public repository and `validate_open_source_readiness` refuses a local one. Nothing here
+# reads them -- the assertions are about which KEYS the payload carries, not where it ran.
 SESSION_START = {
-    "cwd": "C:/Users/Deeproute/.claude",
+    "cwd": "/home/agent/.claude",
     "hook_event_name": "SessionStart",
     "session_id": "7face037-3318-4aac-bf5d-4f5121c92f61",
     "session_title": "TemporalStore Rust meta server parity",
     "source": "resume",
-    "transcript_path": "C:/Users/Deeproute/.claude/projects/x.jsonl",
+    "transcript_path": "/home/agent/.claude/projects/x.jsonl",
 }
 
 

--- a/tools/test_validate_open_source_readiness.py
+++ b/tools/test_validate_open_source_readiness.py
@@ -33,5 +33,37 @@ class OpenSourceReadinessTest(unittest.TestCase):
                         readiness.validate_no_private_paths()
 
 
+class TheTrackedTreeCarriesNoLocalPathTest(unittest.TestCase):
+    """The same check the CI job runs, run here.
+
+    Everything above exercises the scanner on a fixture: it rejects what it should and skips what
+    it should. Nothing asked it about the repository, so a local path could be committed, pass
+    every local suite, and fail only in `oss-readiness` -- which is how
+    `C:/Users/<name>/.claude` reached `main` in a test fixture and turned every open pull
+    request's gate red for a reason none of them caused.
+
+    The scan takes well under a second. There is no reason the answer should arrive from CI first.
+    """
+
+    def test_no_tracked_file_carries_a_private_path(self) -> None:
+        try:
+            readiness.validate_no_private_paths()
+        except SystemExit as exit_error:
+            self.fail(str(exit_error))
+
+    def test_the_scan_actually_looked_at_the_tree(self) -> None:
+        """The floor: an empty file list makes the rule above pass without reading anything, and
+        `repository_files()` falls back to a directory walk when git is unavailable -- exactly the
+        condition under which a silent zero would look like a clean tree."""
+        tracked = readiness.repository_files()
+        self.assertGreater(len(tracked), 200,
+                           "the scan found %d tracked files" % len(tracked))
+
+    def test_the_tokens_it_looks_for_are_still_there(self) -> None:
+        """And it must still be looking for something. A rule with an empty token list would pass
+        on any tree at all."""
+        self.assertGreaterEqual(len(readiness.PRIVATE_PATH_TOKENS), 3)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Every open pull request has a red `oss-readiness` gate**, for a reason none of them caused:

```
tracked files contain local/private path markers:
tools/test_matrixark_the_hook_envelope_is_not_a_user_turn.py: <contributor name>
```

[#1065](https://github.com/matrixarkai/TemporalStore/pull/1065) landed a test fixture holding two
literal home-directory paths from the machine that recorded it. This repository is public, so that
is a contributor's local path in the open as well as a broken gate.

The fixture keeps its shape and loses the paths. **Nothing reads them** — every assertion in that
file is about which *keys* the payload carries, not where it ran — so neutralising them changes no
behaviour and the seven tests there still pass.

### Why nothing caught it locally

The gate had a test already, and it is a good one: it feeds the scanner a fixture and checks it
rejects what it should and skips what it should. But **it never asks the scanner about the
repository**. So a local path could be committed, pass every suite anyone runs, and fail only in a
CI job — which is exactly what happened, and it took every other pull request down with it.

It runs over the tracked tree now. The scan is well under a second; there is no reason the answer
should arrive from CI first.

```
a local path comes back into a tracked fixture  -> FAIL
the token list is emptied                       -> FAIL
```

Two floors, because this rule is easy to make vacuous in the direction that passes:

- **the scan must have found files** — `repository_files()` falls back to a directory walk when git
  is unavailable, and a silent zero would look exactly like a clean tree;
- **the token list must still hold something** — an empty one passes on any tree at all.

Both were mutation-tested. My first attempt at the second mutation wrote `PRIVATE_PATH_TOKENS = []
or [...]`, which is not empty, and it survived — the test was fine, the mutation was wrong.
