### PR TITLE
A message with no text needs no record of how its text was selected

### DIFF
--- a/tools/matrixark_agent_hook.py
+++ b/tools/matrixark_agent_hook.py
@@ -598,13 +598,21 @@ def hook_messages_from_payload(payload: Json, *, event: str, text: str) -> list[
         normalized_role = normalized_hook_message_role(role, event=event)
         selected_content = compact_for_role(normalized_role, content)
         message: Json = {"role": normalized_role, "content": selected_content}
+        original = content if original_content is None else original_content
         selection = codex_memory_selection_metadata(
             role=normalized_role,
             event=event,
             text=selected_content,
-            original_text=content if original_content is None else original_content,
+            original_text=original,
         )
-        if selection:
+        # 572 bytes of it, on a message with no content: selected_text_chars 0, original 0,
+        # dropped 0, retained ratio 1.0 -- a description of a selection that never happened. A hook
+        # event carrying no text produces exactly that, and mx#1065 made those the common case by
+        # stopping the envelope being used as the text.
+        #
+        # Only the both-empty case goes. A selection that had text and kept none of it is the one
+        # worth recording, so `original` alone is enough to keep the block.
+        if selection and (selected_content or original):
             message["metadata"] = {"codex_memory_selection": selection}
         return message
 

--- a/tools/test_matrixark_a_selection_of_nothing_needs_no_record.py
+++ b/tools/test_matrixark_a_selection_of_nothing_needs_no_record.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A message with no text carried 572 bytes describing how its text was selected.
+
+Every message the hook builds gets a `codex_memory_selection` block -- policy, policy_counts,
+selected and original char and line counts, ratios, stage. On a message with no content that block
+reads `selected_text_chars: 0`, `original_text_chars: 0`, `dropped_text_chars: 0`,
+`retained_text_ratio: 1.0`: a description of a selection that never happened.
+
+A hook event carrying no text produces exactly that, and mx#1065 made those the common case by
+stopping the event envelope from being used as the message text.
+
+Only the both-empty case is dropped. The block earns its bytes precisely when a selection HAD text
+and kept little or none of it, and `test_a_selection_that_dropped_everything_is_still_recorded` is
+what keeps that from being thrown away with it.
+"""
+import json
+import unittest
+
+try:
+    from tools.matrixark_agent_hook import hook_messages_from_payload
+except ImportError:  # run from tools/
+    from matrixark_agent_hook import hook_messages_from_payload
+
+
+def _only(payload, *, event, text):
+    messages = hook_messages_from_payload(payload, event=event, text=text)
+    assert len(messages) == 1, messages
+    return messages[0]
+
+
+class SelectionOfNothingTests(unittest.TestCase):
+    def test_an_empty_message_carries_no_selection_block(self):
+        message = _only({"cwd": "x", "hook_event_name": "SessionStart"},
+                        event="SessionStart", text="")
+        self.assertEqual("", message["content"])
+        self.assertNotIn("metadata", message)
+
+    def test_the_block_was_worth_removing(self):
+        """Positive control: it really is ~572 bytes, not a field or two."""
+        payload = {"cwd": "x", "hook_event_name": "SessionStart"}
+        message = _only(payload, event="SessionStart", text="some real text here")
+        block = json.dumps(message.get("metadata") or {}, separators=(",", ":"))
+        self.assertGreater(len(block), 300,
+                           "the selection block is small, so this change is not worth having")
+
+    def test_a_message_with_text_keeps_its_selection_block(self):
+        message = _only({"hook_event_name": "UserPromptSubmit"},
+                        event="UserPromptSubmit", text="please refactor the parser")
+        self.assertIn("please refactor", message["content"])
+        self.assertIn("codex_memory_selection", message.get("metadata", {}))
+
+    def test_a_selection_that_dropped_everything_is_still_recorded(self):
+        """The case the block exists for: text went in, nothing came out.
+
+        This must NOT be swept up with the empty-message case -- a lossy selection is exactly what
+        someone reading this telemetry later wants to find.
+        """
+        payload = {"hook_event_name": "PostToolUse",
+                   "messages": [{"role": "tool", "content": "   \\n   \\n  "}]}
+        messages = hook_messages_from_payload(payload, event="PostToolUse", text="")
+        for message in messages:
+            if not message.get("content"):
+                self.assertIn("metadata", message,
+                              "a selection with original text must still be described")
+
+    def test_the_role_and_content_are_unchanged(self):
+        message = _only({"cwd": "x", "hook_event_name": "SessionStart"},
+                        event="SessionStart", text="")
+        self.assertEqual({"role", "content"}, set(message))
+        self.assertEqual("user", message["role"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Every message the hook builds gets a `codex_memory_selection` block — policy, policy_counts,
selected and original char and line counts, ratios, stage. On a message with **no content** that
block reads:

```json
{"selected_text_chars": 0, "original_text_chars": 0, "dropped_text_chars": 0,
 "retained_text_ratio": 1.0, "selection_lossy": false, ...}
```

**572 bytes describing a selection that never happened.**

A hook event carrying no text produces exactly that, and mx#1065 made those the common case: it
stopped the event envelope being used as the message text, so a `SessionStart` now yields an
empty-content message — which then carried more metadata than content.

## Only the both-empty case

The block earns its bytes precisely when a selection **had** text and kept little or none of it —
that is the thing someone reading this telemetry later wants to find. So the condition is on the
original text as well as the selected text: a message keeps its block if either is non-empty, and
loses it only when there was nothing to select from.

`test_a_selection_that_dropped_everything_is_still_recorded` is what stops the lossy case being
swept up with the empty one.

## Tests

`tools/test_matrixark_a_selection_of_nothing_needs_no_record.py`, five tests:

* an empty message carries no selection block, and is left as exactly `{role, content}`
* a message with text keeps its block
* a selection that had text and produced none still records one
* `test_the_block_was_worth_removing` is the positive control — it asserts the block really is
  >300 bytes, so if it ever shrank to a field or two this change would be flagged as no longer
  worth having rather than silently kept

Mutation-checked with `__pycache__` cleared: attaching unconditionally again fails the two
empty-message tests and neither of the keep-it tests.

## About the hook suites

Ten of these suites are red on main: 66 failing names. With this change: the same 66, diffed by
name, with nothing appearing or disappearing on either side.
