### PR TITLE
The config guard compares numbers the engine states in a helper call

### DIFF
--- a/tools/test_config_says_when_it_overrides.py
+++ b/tools/test_config_says_when_it_overrides.py
@@ -37,9 +37,14 @@ KNOWN_OVERRIDES: Dict[str, str] = {
         "read is served",
 }
 
-# The same, for keys whose value is a number. Empty today: all six comparable numeric keys restate
-# the engine default. A new entry here is a deployment decision and its reason belongs beside it in
-# the file, exactly as for the booleans above.
+# The same, for keys whose value is a number. Empty today: all EIGHT comparable numeric keys
+# restate the engine default. A new entry here is a deployment decision and its reason belongs
+# beside it in the file, exactly as for the booleans above.
+#
+# Six of them until the extractor below learned the engine's other way of stating a number --
+# as the argument of env_u64/env_usize rather than in an .unwrap_or written after the name.
+# Two more keys became comparable and both restate, so the list stays empty; what changed is
+# that it is now empty about more of the file.
 KNOWN_NUMERIC_OVERRIDES: Dict[str, str] = {}
 
 _LINE = re.compile(


### PR DESCRIPTION
`test_config_says_when_it_overrides` compares each shipped-config key against the engine default it
names, so a key that CONTRADICTS one is listed as a deployment decision and a key that restates one
is documentation. For numbers it could only make that comparison for **six** keys, because it read
the engine default through `numeric_default_of_statement` — which reads `.unwrap_or(N)` written
after the name.

mx#1071 taught the generator the engine's other way of stating a number, as the argument of a
helper:

```rust
env_u64("TS_RAFT_SNAPSHOT_CHECK_INTERVAL_MS", 30_000)
```

This guard now reads both. Comparable numeric keys go **6 → 8**, and both new ones restate the
engine default, so `KNOWN_NUMERIC_OVERRIDES` stays empty — the list is now empty about more of the
file, which is the only thing that changed and the comment says so.

### Checks

| | |
|---|---|
| `test_config_says_when_it_overrides` | **9 passed** |
| comparable numeric pairs | 6 → **8**, disagreements **0** |
| mutation — move a config value off the engine default | **fails** |
| restored | green |
