### PR TITLE
An entity ref need not say its type twice

### DIFF
--- a/tools/matrixark_local_adapter_ingest.py
+++ b/tools/matrixark_local_adapter_ingest.py
@@ -4068,7 +4068,7 @@ class _LocalAdapterIngestMixin:
                 ref_type = "summary"
                 ref_hash = record.get("summary_hash") or record.get("node_hash")
             elif record_type == "context_entity":
-                text = f"{record.get('entity_type', '')}: {record.get('entity_name', '')} = {record.get('state', '')}"
+                text = entity_ref_text(record)
                 ref_type = "entity"
                 ref_hash = record.get("entity_hash")
             elif record_type == "context_segment":

--- a/tools/matrixark_local_adapter_retrieve.py
+++ b/tools/matrixark_local_adapter_retrieve.py
@@ -2211,7 +2211,7 @@ class _LocalAdapterRetrieveMixin:
                 secondary_index_matched_count += 1
             if not admit_candidate_for_node(record):
                 continue
-            text = f"{record.get('entity_type', '')}: {record.get('entity_name', '')} = {record.get('state', '')}"
+            text = entity_ref_text(record)
             entity_metadata = embedding_metadata_by_ref.get(("entity", record.get("entity_hash")), {})
             source_entity_hashes = record.get("source_entity_hashes", [])
             source_session_ids = record.get("source_session_ids", [])
@@ -2734,7 +2734,7 @@ class _LocalAdapterRetrieveMixin:
                 profile_current_value = first_explicit_bool("profile_entity_current", record, entity_metadata)
                 if profile_current_value is False:
                     continue
-                text = f"{record.get('entity_type', '')}: {record.get('entity_name', '')} = {record.get('state', '')}"
+                text = entity_ref_text(record)
                 if not text.strip(" :=	"):
                     continue
                 source_entity_hashes = record.get("source_entity_hashes", [])
@@ -2964,7 +2964,7 @@ class _LocalAdapterRetrieveMixin:
                     profile_current_value = first_explicit_bool("profile_entity_current", record, entity_metadata)
                     if profile_current_value is False:
                         continue
-                    text = f"{record.get('entity_type', '')}: {record.get('entity_name', '')} = {record.get('state', '')}"
+                    text = entity_ref_text(record)
                     if not text.strip(" :=\t"):
                         continue
                     source_entity_hashes = record.get("source_entity_hashes", [])
@@ -3447,7 +3447,7 @@ class _LocalAdapterRetrieveMixin:
                 profile_current_value = first_explicit_bool("profile_entity_current", record, entity_metadata)
                 if profile_current_value is False:
                     continue
-                text = f"{record.get('entity_type', '')}: {record.get('entity_name', '')} = {record.get('state', '')}"
+                text = entity_ref_text(record)
                 if not text.strip(" :=	"):
                     continue
                 ref_tokens = max(1, token_count(text))

--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -3076,6 +3076,30 @@ STORAGE_ROUTE_PRESETS: dict[str, Json] = {
 }
 
 
+def entity_ref_text(record: Json) -> str:
+    """The one line an entity ref shows in a context pack.
+
+    Rendered as ``f"{entity_type}: {entity_name} = {state}"`` at five call sites, which spelled the
+    type twice whenever the name already carried it -- and it usually does. Measured over 448 entity
+    refs in the live log: 195 had ``entity_name == entity_type`` ("assistant_decision:
+    assistant_decision = ...") and another 186 had the name prefixed with the type
+    ("codex_validation: codex_validation:ran_159_tests = ..."). 381 of 448.
+
+    Dropping the repeat is 8.8% off the rendered length of those refs, about 1,827 tokens across
+    that sample -- and every one of them is a token the model pays for on the turn the pack is
+    injected into.
+
+    A name unrelated to the type still shows both: that pairing is information.
+    """
+    entity_type = str(record.get("entity_type", "") or "")
+    entity_name = str(record.get("entity_name", "") or "")
+    state = str(record.get("state", "") or "")
+    if entity_name and entity_type:
+        if entity_name == entity_type or entity_name.startswith(entity_type + ":"):
+            return f"{entity_name} = {state}"
+    return f"{entity_type}: {entity_name} = {state}"
+
+
 def canonical_storage_route(storage_options: Json | None) -> Json:
     options = storage_options if isinstance(storage_options, dict) else {}
     storage_mode = str(options.get("storage_mode") or "default")

--- a/tools/test_matrixark_an_entity_ref_need_not_say_its_type_twice.py
+++ b/tools/test_matrixark_an_entity_ref_need_not_say_its_type_twice.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""An entity ref in a context pack said its type twice.
+
+Five call sites rendered a ref as ``f"{entity_type}: {entity_name} = {state}"``, and the name
+usually already carries the type. From a live injected pack:
+
+    tool_evidence: tool_evidence = tool: Exit code: 0; Ran 159 tests
+    codex_validation: codex_validation:ran_159_tests = tool validation: Ran 159 tests
+
+Measured over 448 entity refs in the log, 195 had ``entity_name == entity_type`` and another 186
+had the name prefixed with it -- 381 of 448. Dropping the repeat is 8.8% off their rendered length,
+about 1,827 tokens, and each of those is a token the model pays for on the turn the pack lands in.
+
+Only an EXACT match or a ``type + ":"`` prefix counts. ``session`` / ``session_memory`` keeps both,
+because that pairing is information rather than a repeat.
+"""
+import ast
+import os
+import unittest
+
+try:
+    from tools.matrixark_mcp_core import entity_ref_text
+except ImportError:  # run from tools/
+    from matrixark_mcp_core import entity_ref_text
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+class EntityRefTextTests(unittest.TestCase):
+    def test_a_name_equal_to_the_type_is_not_repeated(self):
+        self.assertEqual(
+            "assistant_decision = chose the batch path",
+            entity_ref_text({"entity_type": "assistant_decision",
+                             "entity_name": "assistant_decision",
+                             "state": "chose the batch path"}))
+
+    def test_a_name_prefixed_by_the_type_is_not_repeated(self):
+        self.assertEqual(
+            "codex_validation:ran_159_tests = tool validation: Ran 159 tests",
+            entity_ref_text({"entity_type": "codex_validation",
+                             "entity_name": "codex_validation:ran_159_tests",
+                             "state": "tool validation: Ran 159 tests"}))
+
+    def test_an_unrelated_name_still_shows_both(self):
+        """The pairing is information when the name does not carry the type."""
+        self.assertEqual(
+            "session: session_memory = active",
+            entity_ref_text({"entity_type": "session", "entity_name": "session_memory",
+                             "state": "active"}))
+
+    def test_an_underscore_is_not_a_prefix_match(self):
+        """Only `type + ':'` counts -- `session_memory` is a different name, not `session` again."""
+        out = entity_ref_text({"entity_type": "session", "entity_name": "session_memory",
+                               "state": "x"})
+        self.assertTrue(out.startswith("session: "))
+
+    def test_nothing_is_lost(self):
+        """Whatever the shape, the name and the state must both survive."""
+        for record in (
+            {"entity_type": "a", "entity_name": "a", "state": "s"},
+            {"entity_type": "a", "entity_name": "a:b", "state": "s"},
+            {"entity_type": "a", "entity_name": "zzz", "state": "s"},
+        ):
+            out = entity_ref_text(record)
+            self.assertIn(record["entity_name"], out)
+            self.assertIn(record["state"], out)
+
+    def test_missing_fields_do_not_raise(self):
+        # Unchanged from the original rendering, empty parts and all -- this pins that the
+        # helper did not quietly alter the degenerate case while fixing the repeat.
+        self.assertEqual(":  = ", entity_ref_text({}))
+        self.assertEqual("a:  = ", entity_ref_text({"entity_type": "a"}))
+        self.assertEqual(": b = ", entity_ref_text({"entity_name": "b"}))
+
+    def test_every_call_site_uses_the_helper(self):
+        """The five sites were identical copies; a sixth must not reappear.
+
+        Counted as ast.Call nodes rather than by grepping, so a mention in a comment or a docstring
+        cannot make this pass.
+        """
+        inline = 0
+        calls = 0
+        for name in ("matrixark_local_adapter_retrieve.py", "matrixark_local_adapter_ingest.py"):
+            path = os.path.join(HERE, name)
+            source = open(path, encoding="utf-8").read()
+            tree = ast.parse(source)
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call):
+                    fn = node.func
+                    if isinstance(fn, ast.Name) and fn.id == "entity_ref_text":
+                        calls += 1
+                # an f-string still spelling the old rendering
+                if isinstance(node, ast.JoinedStr):
+                    rendered = "".join(
+                        part.value for part in node.values
+                        if isinstance(part, ast.Constant) and isinstance(part.value, str))
+                    if rendered.startswith(": ") and " = " in rendered:
+                        inline += 1
+        self.assertEqual(5, calls, "expected all five sites to call the helper")
+        self.assertEqual(0, inline, "an inline copy of the old rendering is still there")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
An entity ref is rendered into a context pack as:

```python
text = f"{record.get('entity_type', '')}: {record.get('entity_name', '')} = {record.get('state', '')}"
```

written out identically at **five call sites**. The name usually already carries the type, so the
line says it twice. From a pack this hook actually injected:

```
 - [1] ref
   tool_evidence: tool_evidence = tool: Exit code: 0; Ran 159 tests
 - [2] ref
   codex_validation: codex_validation:ran_159_tests = tool validation: Ran 159 tests
```

## What it costs

Over 448 entity refs in the live log:

| | |
|---|---|
| `entity_name` == `entity_type` | 195 |
| `entity_name` starts with `entity_type + ":"` | 186 |
| unrelated (both kept) | 67 |
| rendered today | 83,334 chars |
| without the repeat | 76,026 chars |
| | **8.8% shorter, ~1,827 tokens** |

**381 of 448.** Every one of those characters is a token the model pays for on the turn the pack is
injected into, and the pack is bounded — so a character spent restating the type is one not spent on
a remembered turn.

Nothing durable changes: these five sites render a ref for the pack out of fields that are already
stored separately (`entity_type`, `entity_name`, `state`). The stored record is untouched.

## What stays

Only an exact match or a `type + ":"` prefix counts as a repeat. `session` / `session_memory` keeps
both, because a name that merely resembles the type is a different name and the pairing is
information. `test_an_underscore_is_not_a_prefix_match` holds that line.

## The five copies become one

The expression was duplicated verbatim four times in `matrixark_local_adapter_retrieve.py` and once
in `matrixark_local_adapter_ingest.py`. It is now `entity_ref_text()` in `matrixark_mcp_core`, which
both modules already star-import.

## Tests

`tools/test_matrixark_an_entity_ref_need_not_say_its_type_twice.py`, seven tests, including:

* `test_nothing_is_lost` — whatever the shape, the name and the state both survive
* `test_missing_fields_do_not_raise` — pins the degenerate rendering as **unchanged**, empty parts
  and all, so the helper cannot have quietly altered it while fixing the repeat
* `test_every_call_site_uses_the_helper` — counts `ast.Call` nodes, not grep hits, and also fails if
  an f-string spelling the old rendering reappears

Mutation-checked with `__pycache__` cleared: making the helper always render both fails the two
not-repeated tests and nothing else.

34 retrieve, ingest, entity, pack and pipeline suites pass — 0 failures, name-diffed against main.
