### PR TITLE
Exporting a configuration and importing it hands the clone the same settings

### DIFF
--- a/tools/test_matrixark_a_clone_runs_what_the_source_ran.py
+++ b/tools/test_matrixark_a_clone_runs_what_the_source_ran.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Exporting a configuration and importing it hands the clone the same settings.
+
+`export_settings()` produces a patch body meant to be POSTed at another deployment. Nothing tested
+the trip: export, import into a fresh config, and compare. These do, for every setting at once.
+
+**What this does NOT establish.** It is tempting to say this catches a declared default that
+disagrees with the build -- the defect several earlier fixes were about, since
+`include_defaults=True` writes each declared default into the target as an explicit value. It does
+not, and a mutation proved it: disabling `_apply_build_defaults` leaves these tests green, because
+source and target compute effective values the same way, so a wrong default is wrong *identically*
+on both sides. Whether a declared default matches the build is
+`test_matrixark_the_portal_declares_the_budget_the_build_runs`'s question, and it stays there.
+
+What these do catch, each shown by a mutation that reddens them: a secret exported instead of
+omitted, an export that drops the settings nobody set, and a config path that stops honouring its
+override.
+
+**Isolation matters here.** These functions read and WRITE the runtime configuration file, and a
+settings test in this repository has twice now written to a live one -- the second time because a
+mutation disabled `config_path()`'s override and the suite was then run against it, which sent
+every write to the real file. Every case points `MATRIXARK_RUNTIME_CONFIG_FILE` at a
+`TemporaryDirectory` and asserts it took effect; that assertion is the one worth keeping, and
+mutating the mechanism it guards is not a test worth running against a live box.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+import matrixark_gateway_config as cfg  # noqa: E402
+
+PATH_VARIABLE = "MATRIXARK_RUNTIME_CONFIG_FILE"
+
+
+class Case(unittest.TestCase):
+    """Each test gets its own directory, the real config file is never in reach, and the whole
+    environment is put back afterwards.
+
+    `update()` says it "applies to the live process environment unconditionally" -- a portal write
+    is meant to take effect without a restart, so it sets `os.environ` as well as the file. In a
+    test process that makes every `update()` here a change to the configuration every LATER test
+    in the same process runs under. The first version of this suite restored only the config path
+    and turned 229 sibling tests red in the ratchet: it did not fail, it reconfigured everything
+    that came after it.
+
+    So the whole environment is snapshotted and restored, not the one variable this suite sets.
+    """
+
+    def setUp(self) -> None:
+        self._environ = dict(os.environ)
+        self._work = tempfile.TemporaryDirectory(prefix="matrixark-clone-")
+        self.addCleanup(self._work.cleanup)
+        self.addCleanup(self._restore)
+
+    def _restore(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._environ)
+
+    def at(self, name: str) -> str:
+        """Point the module at a config file of this name, and return the path."""
+        path = os.path.join(self._work.name, name)
+        os.environ[PATH_VARIABLE] = path
+        return path
+
+    def effective(self) -> dict:
+        """What the deployment this file describes is actually running, per setting."""
+        stored = {k: str(v) for k, v in (cfg.load().get("values") or {}).items()}
+        return {s.key: cfg._effective(s, stored)[0] for s in cfg.SETTINGS}
+
+
+class AConfiguredDeploymentClonesExactlyTest(Case):
+
+    def test_what_was_set_comes_back_with_the_value_it_went_out_with(self) -> None:
+        self.at("source.json")
+        cfg.apply_preset("voyage", actor="test")
+        cfg.update({"skills.shared_skill_budget_ratio": "0.30",
+                    "retrieval.default_max_context_tokens": "250000"}, actor="test")
+        sent = cfg.export_settings()["settings"]
+
+        self.at("target.json")
+        cfg.update(dict(sent), actor="test")
+        back = cfg.export_settings()["settings"]
+
+        self.assertEqual(sent, back)
+
+    def test_the_export_carried_something(self) -> None:
+        """The floor: two empty documents compare equal, and would say nothing at all."""
+        self.at("source.json")
+        cfg.apply_preset("voyage", actor="test")
+        sent = cfg.export_settings()["settings"]
+        self.assertGreaterEqual(len(sent), 3, "the export carried %d settings" % len(sent))
+
+
+class ADefaultExportCarriesEverySettingTest(Case):
+    """Exporting WITH defaults writes every declared default into the target as an explicit value.
+
+    That the two sides then AGREE is what is checked here, and it is a weaker claim than it looks:
+    a declared default that disagrees with the build is wrong identically on both, so this passes.
+    It catches the trip losing or altering a value, not the value being wrong to begin with.
+    """
+
+    def test_the_clone_runs_the_same_values(self) -> None:
+        self.at("source.json")           # a deployment that has configured nothing
+        source = self.effective()
+        exported = cfg.export_settings(include_defaults=True)["settings"]
+
+        self.at("target.json")           # a fresh one, handed the export
+        cfg.update(dict(exported), actor="test")
+        target = self.effective()
+
+        differ = {key: (source[key], target.get(key))
+                  for key in source if source[key] != target.get(key)}
+        self.assertEqual({}, differ,
+                         "these run a different value on the clone: %s" % differ)
+
+    def test_it_compared_every_setting(self) -> None:
+        """The floor: an empty comparison passes. Whatever the registry holds must be in it."""
+        self.at("source.json")
+        self.assertEqual(len(cfg.SETTINGS), len(self.effective()))
+        self.assertGreater(len(cfg.SETTINGS), 50)
+
+    def test_the_default_export_carries_more_than_the_sparse_one(self) -> None:
+        """`include_defaults` must actually include them, or the risky path is untested.
+
+        Stated as a superset rather than a margin: `_effective` counts an environment variable as
+        a set value, and a machine that already exports a hundred of them makes the "sparse"
+        export anything but. The property that matters holds on both -- everything the sparse
+        export carries is in the full one, and the full one carries more.
+        """
+        self.at("source.json")
+        sparse = cfg.export_settings()["settings"]
+        full = cfg.export_settings(include_defaults=True)["settings"]
+        self.assertTrue(set(full) >= set(sparse),
+                        "the full export dropped %s" % sorted(set(sparse) - set(full)))
+        self.assertGreater(len(full), len(sparse))
+
+
+class ASecretIsNeverExportedTest(Case):
+    """A blank would be a WRITE that clears the target's working key, so an import that applied
+    everything would break the deployment it was meant to configure."""
+
+    def test_a_stored_secret_is_omitted_and_named(self) -> None:
+        secrets = [s for s in cfg.SETTINGS if s.secret]
+        if not secrets:
+            self.skipTest("no secret settings in this build")
+        self.at("source.json")
+        cfg.update({secrets[0].key: "a-real-looking-value"}, actor="test")
+        exported = cfg.export_settings(include_defaults=True)
+        self.assertNotIn(secrets[0].key, exported["settings"])
+        self.assertIn(secrets[0].key, exported["secrets_omitted"])
+
+    def test_the_value_appears_nowhere_in_the_document(self) -> None:
+        secrets = [s for s in cfg.SETTINGS if s.secret]
+        if not secrets:
+            self.skipTest("no secret settings in this build")
+        self.at("source.json")
+        cfg.update({secrets[0].key: "a-real-looking-value"}, actor="test")
+        self.assertNotIn("a-real-looking-value",
+                         repr(cfg.export_settings(include_defaults=True)))
+
+
+class TheTestsTouchNoRealConfigTest(Case):
+    """The hazard this suite is written around, asserted rather than assumed."""
+
+    def test_the_path_points_inside_the_temporary_directory(self) -> None:
+        path = self.at("source.json")
+        self.assertEqual(path, cfg.config_path())
+        self.assertTrue(cfg.config_path().startswith(self._work.name))
+
+    def test_writing_creates_the_file_there_and_nowhere_else(self) -> None:
+        path = self.at("source.json")
+        cfg.update({"skills.shared_skill_budget_ratio": "0.30"}, actor="test")
+        self.assertTrue(os.path.isfile(path))
+        self.assertEqual([os.path.basename(path)],
+                         [n for n in os.listdir(self._work.name) if n.endswith(".json")])
+
+
+class TheSuitePutsTheEnvironmentBackTest(Case):
+    """The hazard this suite is written around, asserted rather than assumed.
+
+    A test that leaves `os.environ` changed does not fail -- it changes the answer for every test
+    that runs after it, in a different file, and the failure is reported against them.
+    """
+
+    def test_an_update_here_does_not_outlive_the_test(self) -> None:
+        key = "skills.shared_skill_budget_ratio"
+        variable = cfg.SETTINGS_BY_KEY[key].env
+        before = os.environ.get(variable)
+        self.at("source.json")
+        cfg.update({key: "0.42"}, actor="test")
+        self.assertEqual("0.42", os.environ.get(variable),
+                         "update() is supposed to apply to the process environment")
+        # The cleanup this class installs is what puts it back; run it here to prove it does.
+        self._restore()
+        self.assertEqual(before, os.environ.get(variable))
+
+    def test_the_snapshot_covers_more_than_one_variable(self) -> None:
+        """The floor: restoring a single name would pass the test above and still leak the other
+        hundred a preset writes."""
+        self.assertGreater(len(self._environ), 5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`export_settings()` produces a patch body "ready to POST at another deployment". Nothing tested the
trip: export, import into a fresh configuration, compare. These do, for every setting at once.

```
115 settings exported with defaults included
0 of 117 settings run a different value on the clone
```

### What this does not establish, and why I nearly claimed it did

It is tempting to say this catches a **declared default that disagrees with the build** — the defect
behind several earlier fixes, since `include_defaults=True` writes each declared default into the
target as an explicit value, so cloning a deployment reconfigured it.

**It does not, and a mutation proved it.** Disabling `_apply_build_defaults(SETTINGS)` — the thing
that corrects those defaults — left every one of these tests green, because source and target
compute effective values the same way, so a wrong default is wrong *identically* on both sides. That
question belongs to `test_matrixark_the_portal_declares_the_budget_the_build_runs`, and it stays
there. I wrote the suite believing otherwise and the mutation run corrected me; the docstring now
says so rather than overclaiming.

What the mutations *did* show it catches:

```
a secret is exported instead of omitted          -> FAIL (2 tests)
the default export drops the settings nobody set -> FAIL
the config path stops honouring the override     -> FAIL (2 tests)
```

The secret property is the one with no guard today and a documented hazard behind it: a blank in the
export would be a **write** that clears the target's working key, so an import that "just applied
everything" would break the deployment it was meant to configure. Two tests check the key is omitted
*and* named in `secrets_omitted`, and that its value appears nowhere in the document at all.

### A mutation I ran once and will not run again

`config_path()` honouring `MATRIXARK_RUNTIME_CONFIG_FILE` is what keeps this suite off the live
runtime configuration. Mutating it is a fair test of the isolation assertions — and when I did, the
harness then ran the whole suite against the mutated code, so **every write in it went to this box's
live config**: the encoder was switched from a local endpoint to Voyage with "require a real model"
on, two budgets moved, and an API key that had never been set was given a probe value.

Recovered in full from the config's own `history`, which records `from` and `to` per key, so the
previous values were read rather than guessed. Nothing had consumed them — no gateway process was
running.

The lesson is in the suite's docstring: a mutation that disables a sandbox does not fail safely, it
redirects every write at whatever the sandbox was protecting. The isolation assertions stay; the
mutation against them belongs in a container, not on a live box.

Every case points `MATRIXARK_RUNTIME_CONFIG_FILE` at a `TemporaryDirectory` and **asserts it took
effect** before writing anything, and a final pair checks the file lands there and nowhere else.


### The ratchet caught the suite poisoning its siblings

The first push went red with **229 new failures** — none of them in this file. `update()` says in as
many words that it *"applies to the live process environment unconditionally"*: a portal write is
meant to take effect without a restart, so it sets `os.environ` as well as the file. In a test
process that makes every `update()` here a change to the configuration **every later test in the
same process runs under**, in other files, and the failures are reported against them.

The suite restored only the config path. It now snapshots and restores the whole environment, with
a test that proves the cleanup puts a written variable back and a floor that the snapshot covers
more than one name. Verified in both orders — this suite first, then the config siblings, and the
siblings first, then this — because a leak only shows in one of them.

That is the same hazard as a suite inheriting a sibling's environment, from the other side: this one
was the sibling.
