### PR TITLE
A write to a node stops carrying the node's history

### DIFF
--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1096,9 +1096,29 @@ pub(super) fn sync_context_pages_for_object(
         ("context_compression", &shard.context_compressions),
     ] {
         if let Some(points) = series.get(object_key) {
-            let live = unique_timestamped_kv_page_addresses(points);
-            if !live.is_empty() {
-                groups.push((kind, object_key.to_string(), live));
+            // Only the NEWEST page is filed. The loop below pops the last address and drops the
+            // rest -- these kinds carry no component, so the index holds one ref per object -- so
+            // finding the maximum is all this needs.
+            //
+            // Collecting every address the series ever held, into a HashSet and then a sorted Vec,
+            // made a write carry the node's whole history: 8,322 bytes to add a summary to a node
+            // holding 20, and 78,626 to add one to a node holding 320 -- 90.7% of the write, and
+            // still climbing. The same defect was already fixed one level down, in the loop that
+            // files these groups; the list it stopped filing was still being built here.
+            //
+            // The maximum of the series equals the last element of the deduplicated, sorted list,
+            // so this is the same address by the same ordering, without the set or the sort.
+            if let Some(newest) = points
+                .values()
+                .max_by(|left, right| {
+                    left.page_slab_id
+                        .cmp(&right.page_slab_id)
+                        .then(left.offset.cmp(&right.offset))
+                        .then(left.length.cmp(&right.length))
+                })
+                .cloned()
+            {
+                groups.push((kind, object_key.to_string(), vec![newest]));
             }
         }
     }

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -16931,3 +16931,62 @@ fn a_requested_bucket_list_reaches_the_lifecycle_planner() {
          otherwise a bucket that went clean undumped can never be covered and the log stays blocked"
     );
 }
+
+#[cfg(feature = "alloc-probe")]
+#[test]
+fn what_a_summary_write_costs_as_its_own_node_fills() {
+    // A summary write spends ~8.3 KB in `maintained_bucket_index`, which calls
+    // sync_context_pages_for_object -- and for a summary that walks the NODE's timestamped series.
+    // So the question is not whether the write carries the STORE (it does not) but whether it
+    // carries the node's own history. Same node, same summary, only the depth of its series varies.
+    const REPS: usize = 20;
+    let cost = |fill: usize| -> u64 {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            32 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        let write = |i: usize| Command::ContextUpsertSummary {
+            tenant_hash: 1,
+            summary: crate::types::ContextSummary {
+                node_hash: 42,
+                level: 1,
+                text: "a summary of the thing that happened".to_string(),
+                valid_from_ms: 1_700_000_000_000 + i as u64,
+                vector: Vec::new(),
+                embedding_model_hash: 0,
+            },
+        };
+        for i in 0..fill {
+            let out = engine.execute(ExecuteRequest { shard_id: 1, command: write(i) });
+            assert!(out.status.ok, "fill refused: {:?}", out.status);
+        }
+        let probe = crate::alloc_probe::Probe::start();
+        for i in fill..(fill + REPS) {
+            let out = engine.execute(ExecuteRequest { shard_id: 1, command: write(i) });
+            assert!(out.status.ok, "write refused: {:?}", out.status);
+        }
+        probe.stop().alloc_bytes / REPS as u64
+    };
+    let shallow = cost(20);
+    let deep = cost(320);
+    println!("  summary write, node holds  20 summaries: {shallow:>9} B");
+    println!("  summary write, node holds 320 summaries: {deep:>9} B");
+    let ratio = deep as f64 / shallow.max(1) as f64;
+    println!("  ratio {ratio:.2}x for 16x the node's own history");
+    println!("  A ratio near 1 means a write does not carry the node's history.");
+    // Maintenance collected every address the series held and then filed only the newest, so a
+    // write cost the node's whole history: 17,453 B at 20 summaries against 86,649 at 320, a
+    // 4.96x climb that does not stop. Finding the maximum instead of building the list makes it
+    // flat -- 12,221 and 11,113, 0.91x.
+    assert!(
+        ratio < 1.5,
+        "a summary write carries its node's history: {shallow} B at 20 summaries, {deep} B at 320 ({ratio:.2}x)"
+    );
+    // The floor is real work, not an empty measurement: a write that allocated nothing would make
+    // the ratio meaningless.
+    assert!(shallow > 1_000, "the shallow arm measured {shallow} B -- too small to be a real write");
+}


### PR DESCRIPTION
A write to a node carried the node's whole history.

`sync_context_pages_for_object` collected every live page address of a timestamped series --
through a `HashSet`, into a `Vec`, then sorted -- and the loop that files them keeps only the
newest. So adding one summary to a node built and threw away a list of every summary page that
node ever had.

The filing loop was already fixed for exactly this, and says so: "a node holding 850 events
re-filed 850 pages to add its 851st, so filling a node cost the square of its length". The list it
stopped filing was still being built one level up.

It now finds the maximum directly. The maximum of the series equals the last element of the
deduplicated, sorted list, so it selects the same address by the same ordering -- without the set,
the vector, or the sort. The other seven callers of the helper genuinely use the full list and are
untouched.

## Measured

Allocated bytes per summary write, same store, same node, same payload -- only the depth of that
node's own series varies:

| node holds | before | after |
|---|---|---|
| 20 summaries | 17,453 | 12,221 (-30%) |
| 320 summaries | **86,649** | **11,113 (-87.2%)** |
| ratio over 16x history | **4.96x** | **0.91x** |

The growth is gone, not reduced. Fitted, the old cost was ~231 bytes per summary the node already
held, so a node with 10,000 of them paid ~2.3 MB a write.

This is the command that dominates an ingest: UpsertSummary is 66,971 of a 109,990-byte message
ingest, across two calls.

## Test

The probe asserts the ratio stays under 1.5x over a 16x deepening, and that the shallow arm is a
real write (>1 KB) so a flat ratio cannot come from measuring nothing.

Verified to FAIL without the change: "a summary write carries its node's history: 17453 B at 20
summaries, 86649 B at 320 (4.96x)".

## Suite

The part4 module was run three times with the change and three times without, on the same tree.
With: one failure every run (`a_raft_apply_records_what_it_did_in_the_engine_log`). Without: the
same one twice, and four failures on the third run. That name is present in every run either way.
