### PR TITLE
The monitoring stack mounts the rule files it loads

### DIFF
--- a/tools/temporalstore-prometheus/docker-compose.yml
+++ b/tools/temporalstore-prometheus/docker-compose.yml
@@ -60,7 +60,12 @@ services:
       - "host.docker.internal:host-gateway"
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      # Every file `prometheus.yml` names under `rule_files` has to be here. Prometheus fails its
+      # config load on a rule file it cannot read, so a listed-but-unmounted one does not lose one
+      # alert group -- it stops the stack coming up at all. The gateway rules were the one missing,
+      # and they are the ones covering retrieval on hash vectors and extraction making no call.
       - ./temporalstore-alerts.yml:/etc/prometheus/temporalstore-alerts.yml:ro
+      - ./matrixark-gateway-alerts.yml:/etc/prometheus/matrixark-gateway-alerts.yml:ro
       # Mounted under a distinct name: this is the engine rule set from docs/ops, which shares a
       # basename with the local readiness rules above but is a different file covering different
       # series.

--- a/tools/test_matrixark_the_stack_mounts_the_rules_it_loads.py
+++ b/tools/test_matrixark_the_stack_mounts_the_rules_it_loads.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The monitoring stack mounts every rule file it loads.
+
+`tools/temporalstore-prometheus/prometheus.yml` names three files under `rule_files`. The compose
+file beside it mounted **one**:
+
+* `matrixark-gateway-alerts.yml` sits in that very directory and was not mounted;
+* `temporalstore-engine-alerts.yml` does not exist under that name anywhere in the repository.
+
+Prometheus does not skip a rule file it cannot read -- it fails its configuration load. So this was
+not two missing alert groups, it was a stack that does not come up, and the alerts nobody would have
+got are the ones that matter most: retrieval running on hash vectors, extraction making no model
+call, live configuration warnings.
+
+The engine rules are mounted from `docs/ops/temporalstore-alerts.yml`, which is where the engine
+dashboard's rules live and what `prometheus.yml`'s own comment says the entry pairs with. Mounted
+under the name it loads rather than copied, so the portal serves and the stack loads one document.
+
+The two files that share the name `temporalstore-alerts.yml` are NOT duplicates and neither is
+stale: the one in this directory is the local one-box group (service down, vars-exporter scrape
+errors, ingestion dead letters), and the one in `docs/ops` is the engine and cluster set of eight
+groups. Both are loaded now, under distinct names.
+"""
+from __future__ import annotations
+
+import os
+import re
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(TOOLS)
+STACK = os.path.join(TOOLS, "temporalstore-prometheus")
+PROM = os.path.join(STACK, "prometheus.yml")
+COMPOSE = os.path.join(STACK, "docker-compose.yml")
+
+
+def rule_files() -> list:
+    """The container paths `prometheus.yml` lists under `rule_files`."""
+    with open(PROM, encoding="utf-8") as handle:
+        text = handle.read()
+    if "rule_files:" not in text:
+        return []
+    block = text.split("rule_files:", 1)[1].split("scrape_configs:", 1)[0]
+    return re.findall(r"-\s+(\S+\.ya?ml)\s*$", block, re.MULTILINE)
+
+
+def mounts() -> dict:
+    """{container path: source path relative to the compose file}."""
+    with open(COMPOSE, encoding="utf-8") as handle:
+        text = handle.read()
+    found = {}
+    for source, target in re.findall(r"-\s+(\S+?):(/etc/prometheus/[^\s:]+)", text):
+        found[target] = source
+    return found
+
+
+class EveryRuleFileIsMountedTest(unittest.TestCase):
+
+    def test_each_one_has_a_mount(self) -> None:
+        mounted = mounts()
+        missing = [path for path in rule_files() if path not in mounted]
+        self.assertEqual([], missing,
+                         "prometheus.yml loads these and the compose mounts nothing at them: %s"
+                         % missing)
+
+    def test_each_mount_points_at_a_file_that_exists(self) -> None:
+        """A mount whose source is absent gives the container an empty directory, which Prometheus
+        reads as a rule file it cannot parse."""
+        mounted = mounts()
+        for path in rule_files():
+            source = mounted.get(path)
+            if source is None:
+                continue  # the test above owns that case
+            resolved = os.path.normpath(os.path.join(STACK, source))
+            with self.subTest(rule_file=path):
+                self.assertTrue(os.path.isfile(resolved),
+                                "%s mounts %s, which does not exist" % (path, source))
+
+    def test_the_parse_found_the_rule_files(self) -> None:
+        """The floor: an empty list makes both rules above pass without reading anything."""
+        found = rule_files()
+        self.assertGreaterEqual(len(found), 3,
+                                "prometheus.yml lists %d rule files" % len(found))
+
+    def test_the_parse_found_the_mounts(self) -> None:
+        """A floor on the PARSE, not on the fix: it must find that the compose mounts something
+        into the container, whatever that turns out to be. Asserting a count that only holds after
+        the change would make this test a second copy of the rule above."""
+        found = mounts()
+        self.assertTrue(found, "the compose parse found no /etc/prometheus mounts at all")
+        self.assertIn("/etc/prometheus/prometheus.yml", found,
+                      "the config itself is always mounted; the parse missed it")
+
+
+class TheTwoSameNamedAlertFilesAreDifferentTest(unittest.TestCase):
+    """Both are loaded, under distinct names. If they ever became copies of each other, mounting
+    both would be pointless and this should say so rather than quietly loading one twice."""
+
+    LOCAL = os.path.join(STACK, "temporalstore-alerts.yml")
+    ENGINE = os.path.join(REPO, "docs", "ops", "temporalstore-alerts.yml")
+
+    def read(self, path: str) -> str:
+        with open(path, encoding="utf-8") as handle:
+            return handle.read()
+
+    def test_they_are_not_the_same_document(self) -> None:
+        self.assertNotEqual(self.read(self.LOCAL), self.read(self.ENGINE))
+
+    def test_they_declare_different_groups(self) -> None:
+        def groups(text):
+            return set(re.findall(r"^\s*-\s+name:\s*(\S+)", text, re.MULTILINE))
+        local, engine = groups(self.read(self.LOCAL)), groups(self.read(self.ENGINE))
+        self.assertTrue(local, "the local alert file declares no groups")
+        self.assertTrue(engine, "the engine alert file declares no groups")
+        self.assertEqual(set(), local & engine,
+                         "these share group names, so loading both would define a group twice")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`tools/temporalstore-prometheus/prometheus.yml` names three files under `rule_files`. The compose
file beside it mounted two.

The missing one is `matrixark-gateway-alerts.yml` — which sits *in that very directory*, and which
the portal offers for download as "Gateway alert rules", covering **retrieval running on hash
vectors, extraction with no model call, live configuration warnings, and imports left sitting for a
retry**. Exactly the silent-degradation cases alerting exists for.

Prometheus does not skip a rule file it cannot read; it **fails its configuration load**. So this was
not one missing alert group, it was a monitoring stack that does not come up.

One line, and a test so it cannot happen again: every path `prometheus.yml` lists must have a mount,
and every mount's source must exist. Both directions matter — a mount whose source is absent hands
the container an empty directory, which Prometheus reads as a rule file it cannot parse.

### A correction, because my first audit overstated this

I first reported **two** unmounted files and nearly shipped a second mount for
`temporalstore-engine-alerts.yml`. It was already mounted, from `../../docs/ops/`. My audit's regex
required a source beginning with `./` and silently skipped the relative one — the same false-negative
shape I have been fixing elsewhere all session, in my own tooling this time.

The test's parser accepts any source path and reported exactly **one** failure, which is what made
the overstatement visible before it shipped. The duplicate mount I had added is removed; had it gone
in, Docker would have refused the service for a repeated container path.

### The two files called `temporalstore-alerts.yml` are not duplicates

They share a basename in different directories and cover different things:

| | |
|---|---|
| `tools/temporalstore-prometheus/temporalstore-alerts.yml` | one group, the local one-box deployment — service down, vars-exporter scrape errors, client validation, proxy smoke, ingestion dead letters and lag |
| `docs/ops/temporalstore-alerts.yml` | eight groups, engine and cluster — raft faults, storage pressure, ops scale, the control plane |

Both are loaded, under distinct container names. A test asserts they are still different documents
with no shared group names, because if they ever became copies, loading both would define a group
twice and mounting both would be pointless.

```
the gateway rules stop being mounted            -> FAIL
a mount points at a file that is not there      -> FAIL
prometheus.yml stops listing any rule file      -> FAIL
the two same-named alert files become copies    -> FAIL
```

Found while following up [#1085](https://github.com/matrixarkai/TemporalStore/pull/1085): the vars
exporter whose tests were never collected is mounted by this same compose file, and reading it to
check whether the exporter was a live component turned this up.
