### PR TITLE
A limited child query answers with the newest children

### DIFF
--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -3331,7 +3331,18 @@ pub(crate) fn execute_on_shard(
             let object_key = context_child_key(tenant_hash, parent_hash);
             let mut refs = load_context_children(cache, page_store, shard_id, shard, &object_key);
             refs.sort_by_key(|child_ref| (child_ref.updated_at_ms, child_ref.child_hash));
-            refs.truncate(context_limit(limit));
+            // Keep the NEWEST `limit`, not the oldest. Sorting ascending and truncating handed back
+            // a parent's first children and hid everything recently added -- five children with
+            // limit 2 answered with the two oldest, and the newest was unreachable by any query.
+            //
+            // The same cut, in the same direction, is what traversal was fixed for: the most
+            // recently ingested were the first to become invisible, which is the opposite of what
+            // a store keyed on time should do. The listing stays in chronological order, which is
+            // what an unlimited query already returned.
+            let keep = context_limit(limit);
+            if refs.len() > keep {
+                refs.drain(..refs.len() - keep);
+            }
             CommandResponse::ContextChildRefs {
                 object_key,
                 refs,

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -16990,3 +16990,61 @@ fn what_a_summary_write_costs_as_its_own_node_fills() {
     // the ratio meaningless.
     assert!(shallow > 1_000, "the shallow arm measured {shallow} B -- too small to be a real write");
 }
+
+#[test]
+fn which_children_a_limited_query_returns() {
+    // ContextQueryChildren sorts ascending on updated_at_ms and truncates to the limit, so a
+    // limited query answers with a parent's OLDEST children and the most recently added are
+    // invisible. Same shape as the traversal age-cut and the mem0 get_all limit.
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        8 * 1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    for i in 0..5u64 {
+        let out = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextUpsertChildRef {
+                tenant_hash: 1,
+                child_ref: crate::types::ContextChildRef {
+                    parent_hash: 9,
+                    child_hash: 100 + i,
+                    updated_at_ms: 1_700_000_000_000 + i * 10_000,
+                },
+            },
+        });
+        assert!(out.status.ok, "seed refused: {:?}", out.status);
+    }
+    let ask = |limit: Option<usize>| -> Vec<u64> {
+        let out = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextQueryChildren { tenant_hash: 1, parent_hash: 9, limit },
+        });
+        assert!(out.status.ok, "query refused: {:?}", out.status);
+        match out.response {
+            CommandResponse::ContextChildRefs { refs, .. } => {
+                refs.iter().map(|r| r.child_hash).collect()
+            }
+            other => panic!("unexpected response: {other:?}"),
+        }
+    };
+    let all = ask(None);
+    let limited = ask(Some(2));
+    println!("  all children:      {all:?}");
+    println!("  limit=2 returned:  {limited:?}");
+    let newest = *all.iter().max().expect("children exist");
+    println!("  newest child {newest}, present in the limited answer: {}", limited.contains(&newest));
+
+    assert_eq!(5, all.len(), "the fill must produce five children, or the limit proves nothing");
+    assert_eq!(2, limited.len(), "the limit must bind");
+    assert!(
+        limited.contains(&newest),
+        "a limited child query hid the newest child: asked for 2 of {all:?} and got {limited:?}"
+    );
+    assert_eq!(vec![103, 104], limited, "the two newest, in chronological order");
+    // The unlimited answer is untouched, and still oldest-first.
+    assert_eq!(vec![100, 101, 102, 103, 104], all, "an unlimited query is unchanged");
+}


### PR DESCRIPTION
`ContextQueryChildren` sorted a parent's children ascending on `updated_at_ms` and truncated to the
limit, so a limited query answered with the OLDEST children and the most recently added were
invisible.

    refs.sort_by_key(|child_ref| (child_ref.updated_at_ms, child_ref.child_hash));
    refs.truncate(context_limit(limit));

Five children, `limit: 2` -> `[100, 101]`, and child 104 could not be reached by any query.

It now keeps the newest `limit`. The listing stays in chronological order, and an unlimited query
is unchanged.

## The same cut, in the same direction, twice before

This is the third place this shape has been found in this codebase:

* traversal cut its children by age before scoring, ascending, so the most recently ingested were
  the first to become invisible -- fixed earlier;
* mem0's `get_all(limit=N)` sorted ascending and took the head, answering with a subject's oldest
  memories;
* and this.

It was found by sweeping for the shape rather than by a failure: nothing errors, the count is
right, the order is sensible -- only the wrong end of the range comes back. `ContextCompressEvents`
has the same sort-then-truncate and is CORRECT, because compression should consume the oldest
events and it reports `truncated_source_events`, so the shape is a search heuristic and not a
verdict.

## Test

Five children at known times. `limit: 2` must contain the newest, must be exactly `[103, 104]` in
chronological order, and an unlimited query must still return all five oldest-first. The fill size
and the bound limit are asserted too, so the assertions cannot pass against an empty or unbounded
answer.

Verified to FAIL without the change: "a limited child query hid the newest child: asked for 2 of
[100, 101, 102, 103, 104] and got [100, 101]".

## Suite

10 failures against 9 on this tree with the change removed. The one name that differs,
`wal::tests::rolling_adds_no_durability_barriers`, passes 3/3 alone with the change, and the whole
wal module reports the same 9 failures with the change and without it.
