### PR TITLE
The suite does not read the configuration of the machine it runs on

### DIFF
--- a/tools/run_python_suite_ratchet.py
+++ b/tools/run_python_suite_ratchet.py
@@ -25,8 +25,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
+import tempfile
 import sys
 from pathlib import Path
 
@@ -48,16 +50,28 @@ def suite_result() -> tuple[set[str], set[str]]:
     was a skip -- five on a module absent from the repo, six on a native proxy binary CI does not
     build.
     """
-    result = subprocess.run(
-        [sys.executable, "-m", "unittest", "discover", "-v", "-s", ".", "-p", "test_*.py"],
-        cwd=str(Path(__file__).parent),
-        capture_output=True,
-        text=True,
-    )
+    # The suite runs against a runtime config file that does not exist, never the deployment's.
+    # `matrixark_gateway_config.config_path()` falls back to ~/.matrixark/runtime_config.json, and
+    # a configured box has 115 real settings in there. `apply_boot()` seeds them into the process
+    # environment when the gateway app is constructed -- correctly, it only declines to overwrite
+    # what was already set at boot -- so a test that sets MATRIXARK_AUDIT_MODE after import has it
+    # replaced by the stored value and asserts against the machine instead of against the change.
+    # CI has no such file and was green; the same commit was red on any real deployment.
+    with tempfile.TemporaryDirectory() as isolated:
+        environment = dict(os.environ)
+        environment["MATRIXARK_RUNTIME_CONFIG_FILE"] = os.path.join(isolated, "runtime.json")
+        result = subprocess.run(
+            [sys.executable, "-m", "unittest", "discover", "-v", "-s", ".", "-p", "test_*.py"],
+            cwd=str(Path(__file__).parent),
+            capture_output=True,
+            text=True,
+            env=environment,
+        )
+        text = result.stderr + result.stdout
     failing: set[str] = set()
     skipped: set[str] = set()
     started = ""
-    for line in (result.stderr + result.stdout).splitlines():
+    for line in text.splitlines():
         stripped = line.strip()
         found = NAME.match(stripped)
         if found:

--- a/tools/test_matrixark_gateway_portal.py
+++ b/tools/test_matrixark_gateway_portal.py
@@ -26,15 +26,25 @@ ADMIN = {"Authorization": "Bearer k-acme"}
 class _PortalTest(unittest.TestCase):
     def setUp(self) -> None:
         self.server = _FakeServer()
-        self.app = gw.make_v1_app(self.server, _cfg())
         self._saved_env = dict(os.environ)
         self._saved_boot = dict(cfgmod._BOOT_ENV)
+        # Derived from the registry rather than written down. The list here named four prefixes;
+        # the registry declares two, MATRIXARK_ for 98 settings and TS_ for 19, and TS_ was not
+        # one of the four. Those nineteen survived the isolation, so on a box that exports them --
+        # or one whose stored config seeds them through apply_boot -- this suite asserted against
+        # the machine it ran on. A written list drifts from the registry; a derived one cannot.
+        declared = {setting.env for setting in cfgmod.SETTINGS if setting.env}
         for name in list(os.environ):
-            if name.startswith(("MATRIXARK_", "DEEPSEEK_", "OPENAI_", "LOCAL_ENCODER_")):
+            if name in declared or name.startswith(("MATRIXARK_", "DEEPSEEK_", "OPENAI_",
+                                                    "LOCAL_ENCODER_")):
                 del os.environ[name]
         cfgmod._BOOT_ENV.clear()
         self._dir = tempfile.TemporaryDirectory()
         os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = os.path.join(self._dir.name, "runtime.json")
+        # After the isolation, not before. make_v1_app() calls apply_boot(), which seeds the
+        # stored document into the environment; building the app first meant seeding from
+        # whatever configuration the machine happened to have.
+        self.app = gw.make_v1_app(self.server, _cfg())
         # The metric registry is process-wide; start each test from zero so counts are assertable.
         metricsmod.METRICS.__init__()  # type: ignore[misc]
 

--- a/tools/test_matrixark_the_audit_log_can_be_read.py
+++ b/tools/test_matrixark_the_audit_log_can_be_read.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import tempfile
 import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -198,6 +199,23 @@ class AnEmptyListSaysWhichKindOfEmptyTest(unittest.TestCase):
                 os.environ["MATRIXARK_AUDIT_MODE"] = previous
 
         self.addCleanup(restore)
+        # Pinned at a file that does not exist, so apply_boot() has nothing to seed.
+        # make_v1_app() calls it, and on a configured box the stored document carries
+        # real values -- which would land in the environment after this isolation ran
+        # and be read as though the test had set them.
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        stored = os.environ.get("MATRIXARK_RUNTIME_CONFIG_FILE")
+
+        def restore_config() -> None:
+            if stored is None:
+                os.environ.pop("MATRIXARK_RUNTIME_CONFIG_FILE", None)
+            else:
+                os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = stored
+
+        self.addCleanup(restore_config)
+        os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = os.path.join(
+            directory.name, "runtime.json")
 
     def _payload(self, rows):
         _st, _h, body = _get(_app(_Server(rows=rows)), "/v1/admin/audit")

--- a/tools/test_matrixark_the_suite_does_not_read_the_deployments_configuration.py
+++ b/tools/test_matrixark_the_suite_does_not_read_the_deployments_configuration.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The suite must not read the configuration of the machine it runs on.
+
+`matrixark_gateway_config.config_path()` falls back to ~/.matrixark/runtime_config.json. On a
+configured box that file holds real values -- 115 of them on the deployment this was found on,
+including `audit.mode` and `behaviour.top_k_per_layer`. `apply_boot()` seeds them into the process
+environment when the gateway app is constructed. It is right to do so and it declines, correctly,
+to overwrite anything already present at boot; but a test sets its variables long after boot, so
+the stored value wins and the assertion is made against the machine rather than against the change.
+
+CI has no such file, so the suite was green there and red on any real deployment -- four failures
+that looked like a regression on main and were not. A gate whose answer depends on the box it runs
+on is not reporting on the change.
+
+Two separate holes produced those four, and each is guarded here:
+
+  * the runtime config file was read at all -- the ratchet now runs the suite against a path that
+    does not exist, and the three suites that manipulate these variables pin their own;
+  * the portal suite's environment isolation named four PREFIXES by hand. The registry declares
+    two, MATRIXARK_ for 98 settings and TS_ for 19, and TS_ was not among the four -- so nineteen
+    settings were never isolated at all. It is derived from the registry now.
+"""
+
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_gateway_config as cfgmod  # noqa: E402
+
+
+class TheRatchetRunsAgainstNoStoredConfiguration(unittest.TestCase):
+
+    def _captured_env(self) -> dict:
+        """Run suite_result() with the subprocess replaced, and return the env it would use."""
+        import run_python_suite_ratchet as ratchet
+
+        seen = {}
+
+        class _Result(object):
+            stderr = ""
+            stdout = "Ran 0 tests in 0.0s\n"
+
+        def fake_run(*args, **kwargs):
+            seen.update(kwargs.get("env") or {})
+            seen["__passed_env__"] = "env" in kwargs
+            return _Result()
+
+        real = ratchet.subprocess.run
+        ratchet.subprocess.run = fake_run
+        try:
+            ratchet.suite_result()
+        finally:
+            ratchet.subprocess.run = real
+        return seen
+
+    def test_it_passes_an_environment_at_all(self) -> None:
+        # Without this the next test passes for the wrong reason: an inherited environment has
+        # no key to look at, and `.get` on it returns None just as a pinned-but-wrong one would.
+        self.assertTrue(self._captured_env().get("__passed_env__"),
+                        "the suite subprocess inherits the environment unchanged")
+
+    def test_the_config_file_is_pinned_somewhere_that_does_not_exist(self) -> None:
+        pinned = self._captured_env().get("MATRIXARK_RUNTIME_CONFIG_FILE")
+        self.assertTrue(pinned, "the suite runs against whatever config the box has")
+        self.assertFalse(os.path.exists(pinned),
+                         "the suite would read a real file at %s" % pinned)
+
+    def test_it_is_not_the_deployment_path(self) -> None:
+        pinned = self._captured_env().get("MATRIXARK_RUNTIME_CONFIG_FILE") or ""
+        home = os.path.join(os.path.expanduser("~"), ".matrixark")
+        self.assertFalse(os.path.abspath(pinned).startswith(os.path.abspath(home)),
+                         "pinned inside the deployment's own directory")
+
+
+class ThePortalIsolationIsDerivedFromTheRegistry(unittest.TestCase):
+
+    @staticmethod
+    def _declared() -> set:
+        return {setting.env for setting in cfgmod.SETTINGS if setting.env}
+
+    def test_the_registry_declares_more_than_one_prefix(self) -> None:
+        # The floor that makes the rest meaningful. If every setting shared one prefix, a written
+        # list would be as good as a derived one and none of this would matter.
+        prefixes = {name.split("_", 1)[0] for name in self._declared()}
+        self.assertGreater(len(prefixes), 1, sorted(prefixes))
+        self.assertGreater(len(self._declared()), 100, len(self._declared()))
+
+    def test_no_declared_variable_survives_the_portal_setup(self) -> None:
+        import test_matrixark_gateway_portal as portal
+
+        declared = self._declared()
+        saved = dict(os.environ)
+        try:
+            for name in declared:
+                os.environ[name] = "sentinel-from-the-machine"
+            case = portal.ConfigExportTest("test_export_needs_a_key")
+            case.setUp()
+            try:
+                survivors = sorted(n for n in declared
+                                   if os.environ.get(n) == "sentinel-from-the-machine")
+            finally:
+                case.tearDown()
+            self.assertEqual([], survivors,
+                             "%d declared variables survived the isolation" % len(survivors))
+        finally:
+            os.environ.clear()
+            os.environ.update(saved)
+
+    def test_the_sentinel_check_can_see_a_survivor(self) -> None:
+        # The assertion above is an equality against the empty list, which is exactly what a
+        # detector that never looks at anything also returns. Prove it finds one when one is there.
+        declared = self._declared()
+        saved = dict(os.environ)
+        try:
+            for name in declared:
+                os.environ[name] = "sentinel-from-the-machine"
+            # A prefix list of the kind that was there before: it cannot reach the TS_ names.
+            for name in list(os.environ):
+                if name.startswith(("MATRIXARK_", "DEEPSEEK_", "OPENAI_", "LOCAL_ENCODER_")):
+                    del os.environ[name]
+            survivors = sorted(n for n in declared
+                               if os.environ.get(n) == "sentinel-from-the-machine")
+            self.assertTrue(survivors,
+                            "a hand-written prefix list left nothing behind, so this test "
+                            "proves nothing about the derived one")
+            self.assertTrue(all(n.startswith("TS_") for n in survivors), survivors)
+        finally:
+            os.environ.clear()
+            os.environ.update(saved)
+
+
+class TheSuitesThatSetTheseVariablesPinTheirOwn(unittest.TestCase):
+    """The ratchet covers CI. `python3 -m unittest <module>` is how anyone reads a failure, and
+    it has to give the same answer on a configured box as on a bare one."""
+
+    MODULES = (
+        "test_matrixark_gateway_portal.py",
+        "test_matrixark_user_policy.py",
+        "test_matrixark_the_audit_log_can_be_read.py",
+    )
+
+    def test_each_one_pins_the_runtime_config_file(self) -> None:
+        here = os.path.dirname(os.path.abspath(__file__))
+        for name in self.MODULES:
+            with io.open(os.path.join(here, name), encoding="utf-8") as handle:
+                source = handle.read()
+            self.assertIn("MATRIXARK_RUNTIME_CONFIG_FILE", source, name)
+            self.assertIn("tempfile", source, name)
+
+
+class OneSetUpLeavesTheProcessAsItFoundIt(unittest.TestCase):
+    """Measured before the fix: 109 variables gained from a single setUp/tearDown.
+
+    The saved-environment snapshot was taken after make_v1_app() had already called apply_boot(),
+    so the snapshot contained the seeded values and tearDown wrote them back into the process.
+    Every later test in that run then inherited a deployment's configuration from a suite that
+    had been careful to clear it.
+
+    A stored document is planted here so the check discriminates on a bare runner too: with no
+    file to seed from there is nothing to leak and the test would pass without proving anything.
+    """
+
+    WATCHED = ("MATRIXARK_", "TS_")
+
+    def _planted(self) -> str:
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        path = os.path.join(directory.name, "runtime.json")
+        with io.open(path, "w", encoding="utf-8") as handle:
+            json.dump({"values": {"audit.mode": "async",
+                                  "behaviour.top_k_per_layer": "8",
+                                  "storage_engine.cold_scan_no_cache_fill": "1"}}, handle)
+        return path
+
+    def _watched(self) -> set:
+        return {name for name in os.environ if name.startswith(self.WATCHED)}
+
+    def test_the_plant_would_seed_something(self) -> None:
+        """The control. If apply_boot cannot seed from this document, the next test is empty."""
+        saved = dict(os.environ)
+        try:
+            os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = self._planted()
+            cfgmod._BOOT_ENV.clear()
+            for name in list(os.environ):
+                if name.startswith(self.WATCHED) and name != "MATRIXARK_RUNTIME_CONFIG_FILE":
+                    del os.environ[name]
+            self.assertGreaterEqual(len(cfgmod.apply_boot()), 3)
+        finally:
+            os.environ.clear()
+            os.environ.update(saved)
+            cfgmod._BOOT_ENV.clear()
+            cfgmod._BOOT_ENV.update(saved)
+
+    def test_one_setup_and_teardown_gains_nothing(self) -> None:
+        import test_matrixark_gateway_portal as portal
+
+        saved = dict(os.environ)
+        try:
+            os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = self._planted()
+            before = self._watched()
+            case = portal.ConfigExportTest("test_export_needs_a_key")
+            case.setUp()
+            case.tearDown()
+            gained = sorted(self._watched() - before)
+            self.assertEqual([], gained,
+                             "%d variables leaked into the process" % len(gained))
+        finally:
+            os.environ.clear()
+            os.environ.update(saved)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_user_policy.py
+++ b/tools/test_matrixark_user_policy.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import os
 import sys
+import tempfile
 import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -32,9 +33,22 @@ class _PolicyTest(unittest.TestCase):
         tp.clear_tenant_policy_cache()
         self._saved = {name: os.environ.pop(knob.env)
                        for name, knob in tp.KNOBS.items() if knob.env in os.environ}
+        # Pinned at a file that does not exist, so apply_boot() has nothing to seed.
+        # make_v1_app() calls it, and on a configured box the stored document carries
+        # real values -- which would land in the environment after this isolation ran
+        # and be read as though the test had set them.
+        self._config_dir = tempfile.TemporaryDirectory()
+        self._saved_config = os.environ.get("MATRIXARK_RUNTIME_CONFIG_FILE")
+        os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = os.path.join(
+            self._config_dir.name, "runtime.json")
 
     def tearDown(self) -> None:
         tp.clear_tenant_policy_cache()
+        if self._saved_config is None:
+            os.environ.pop("MATRIXARK_RUNTIME_CONFIG_FILE", None)
+        else:
+            os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = self._saved_config
+        self._config_dir.cleanup()
         for name, value in self._saved.items():
             os.environ[tp.KNOBS[name].env] = value
 


### PR DESCRIPTION
Running the suite on this deployment reported four failures that do not exist on CI. They were not
a regression — they were the suite reading the configuration of the machine it ran on.

`matrixark_gateway_config.config_path()` falls back to `~/.matrixark/runtime_config.json`. On a
configured box that file holds real values — **115** of them here, including `audit.mode: 'off'` and
`behaviour.top_k_per_layer: '8'`, which are precisely the two values the failures reported.
`make_v1_app()` calls `apply_boot()`, which seeds them into the process environment.

**`apply_boot` is right.** It declines to overwrite anything already present at boot, exactly as
documented. But a test sets its variables long after boot, so the stored value wins and the
assertion is made against the machine instead of against the change. CI has no such file and was
green; the same commit was red on any real deployment. A gate whose answer depends on the box is
not reporting on the change.

### Two independent causes

**The config file was read at all.** The ratchet now runs the suite against a path that does not
exist, and the three suites that manipulate these variables pin their own — so
`python3 -m unittest <module>`, which is how anyone actually reads a failure, gives the same answer
on a configured box as on a bare one.

**The portal suite's isolation was written, not derived.** It stripped four prefixes:
`MATRIXARK_`, `DEEPSEEK_`, `OPENAI_`, `LOCAL_ENCODER_`. The registry declares **two** —
`MATRIXARK_` for 98 settings and `TS_` for 19 — and `TS_` was not among the four, so nineteen
settings were never isolated. Confirmed independent: with the config pinned to an empty path but
`TS_*` exported, the export test still failed. It is derived from the registry now, which cannot
drift from it.

### A third change I nearly shipped on assertion alone

Moving `make_v1_app()` to *after* the isolation looked obviously right, so it went into the mutation
run — and **survived**: reverting the order still passed everything. Rather than keep it on the
strength of the argument I measured what it does. Under the old order a single `setUp`/`tearDown`
leaves **109 extra variables in the process**: the saved-environment snapshot is taken after
`apply_boot()` has already seeded, so `tearDown` writes the seeded values back and every later test
in the run inherits a deployment's configuration from a suite that had been careful to clear it.
Zero under the new order. That is the contamination shape that turned 229 sibling tests red in
#1078.

So it stays, now with a test — one that plants a stored document so it discriminates on a bare
runner too (with nothing to seed from there is nothing to leak and the check would pass without
proving anything), plus a control asserting the plant would in fact seed.

```
the ratchet stops passing an environment           -> FAIL
the ratchet pins the deployment's own file         -> FAIL
the ratchet pins a file that already exists        -> FAIL
the portal goes back to a written prefix list      -> FAIL
the app is built BEFORE the isolation again        -> FAIL (2 tests)
```

The first version of that last mutation *deleted* app construction rather than *moving* it, so
nothing seeded and it survived for a reason that said nothing about the test. Corrected, it reddens
two.

### Verification

| | |
|---|---|
| full login environment, live config present | **150/150** (was 4 failures) |
| pristine environment, as CI sees it | **150/150** |
| `run_python_suite_ratchet.py`, login environment | **no new failures**, exit 0 (was 4) |

The negative assertions carry controls throughout: `test_it_passes_an_environment_at_all` exists
because an inherited environment has no key to look at and `.get` returns `None` on it just as a
mispinned one would, and `test_the_sentinel_check_can_see_a_survivor` reproduces the old
hand-written prefix list and requires the detector to find the `TS_` names it leaves behind.

Found while checking whether #1038 had broken `main` after it merged without ever running this
gate — see #1092, which is the reason it could merge that way. It had not.
