### PR TITLE
The environment floor measures the snapshot, not the machine

### DIFF
--- a/tools/test_matrixark_a_clone_runs_what_the_source_ran.py
+++ b/tools/test_matrixark_a_clone_runs_what_the_source_ran.py
@@ -201,10 +201,46 @@ class TheSuitePutsTheEnvironmentBackTest(Case):
         self._restore()
         self.assertEqual(before, os.environ.get(variable))
 
-    def test_the_snapshot_covers_more_than_one_variable(self) -> None:
+    def test_the_snapshot_covers_every_variable_that_was_there(self) -> None:
         """The floor: restoring a single name would pass the test above and still leak the other
-        hundred a preset writes."""
-        self.assertGreater(len(self._environ), 5)
+        hundred a preset writes.
+
+        Counting what the machine happens to export is not that floor. The first version asserted
+        `len(self._environ) > 5`, which passes on any developer box and fails under `env -i`,
+        where there are three variables -- it measured the environment rather than the snapshot,
+        so it was strongest exactly where the environment was richest and the leak least likely
+        to matter. Plant the names and the count is of the mechanism.
+        """
+        planted = {"MATRIXARK_SNAPSHOT_PROBE_%d" % index: str(index) for index in range(6)}
+        saved = dict(os.environ)
+        try:
+            os.environ.update(planted)
+            # A second instance, set up while the planted names are present: the snapshot under
+            # test is the one `setUp` takes, and this test's own was taken before they existed.
+            probe = type(self)(self._testMethodName)
+            probe.setUp()
+            try:
+                missing = sorted(name for name in planted if name not in probe._environ)
+                self.assertEqual([], missing,
+                                 "the snapshot missed %d of the names that were set" % len(missing))
+                self.assertEqual(planted, {name: probe._environ[name] for name in planted})
+                # And it is a copy. A snapshot that aliased os.environ would satisfy everything
+                # above and restore nothing, because it would change with the thing it records.
+                os.environ["MATRIXARK_SNAPSHOT_PROBE_0"] = "changed-after-the-snapshot"
+                self.assertEqual("0", probe._environ["MATRIXARK_SNAPSHOT_PROBE_0"])
+                # A name that did not exist when the snapshot was taken. Putting the snapshot
+                # back is only half of restoring: without clearing first, everything the test
+                # ADDED survives, and a preset write adds about a hundred.
+                os.environ["MATRIXARK_SNAPSHOT_PROBE_ADDED"] = "added-during-the-test"
+            finally:
+                probe.doCleanups()
+            # doCleanups ran _restore, which is what puts the changed name back.
+            self.assertEqual("0", os.environ.get("MATRIXARK_SNAPSHOT_PROBE_0"))
+            self.assertIsNone(os.environ.get("MATRIXARK_SNAPSHOT_PROBE_ADDED"),
+                              "the snapshot went back but what the test added stayed")
+        finally:
+            os.environ.clear()
+            os.environ.update(saved)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The floor added in #1078 measures the wrong thing.

```python
def test_the_snapshot_covers_more_than_one_variable(self):
    self.assertGreater(len(self._environ), 5)
```

It is meant to say "the whole environment is snapshotted, not just the one variable this suite
sets" — the distinction that mattered, because the first version of that suite restored only the
config path and turned 229 sibling tests red. But `len(self._environ)` counts **what the machine
exports**, not what the snapshot covers. It passes on any developer box and fails under `env -i`,
where there are three variables and nothing is wrong.

So it is strongest exactly where the environment is richest — which is where a leak is least likely
to matter — and weakest in a bare container, where it fails for a reason that has nothing to do with
the claim.

### What it says now

Plant six names, set up a second instance of the case while they are present, and measure **its**
snapshot. Three things follow that the count could not reach:

- every planted name is in the snapshot, with its value — not merely six of something
- the snapshot is a **copy**: change the environment afterwards and the snapshot must not move. An
  alias would satisfy completeness perfectly and restore nothing, because it changes with the thing
  it records
- restoring **clears** first. Putting the snapshot back is only half of it; without the clear,
  everything the test *added* survives, and a preset write adds about a hundred names

The second instance is the point: the snapshot under test has to be the one `setUp` takes, and this
test's own was taken before the planted names existed.

```
the snapshot aliases the environment instead of copying   -> FAIL
only the config path is snapshotted (the 229-red bug)     -> FAIL
restore stops clearing what the test added                -> FAIL
```

The third mutation **survived** the first version of this rewrite — I had covered completeness and
copy-semantics and not the clear — and the check for a name added during the test is what kills it.

Green under a normal environment and under `env -i`, which is the whole point.

Found while running the settings guards under `env -i` during the #1050 rebase: this was the single
failure, and it was the harness, not the branch. Same defect class as #1098 — a test whose answer
depends on the box it runs on.
