### PR TITLE
A knob the portal offers is read by something

### DIFF
--- a/tools/test_matrixark_a_knob_the_portal_offers_is_read_by_something.py
+++ b/tools/test_matrixark_a_knob_the_portal_offers_is_read_by_something.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A knob the portal offers should be read by something.
+
+Every ``behaviour.*`` setting on the portal is a tenant-policy knob. Setting one writes a value the
+resolver returns and the history records -- and for eleven of them, that is the end of it. Their only
+accessor lives in ``matrixark_index_growth_bound``, in a function no production code calls, and no
+other module reads the variable. The operator gets a control, a stored value and a confirmation,
+and the deployment behaves identically either way.
+
+The live deployment this was found on had ``behaviour.summary_levels``,
+``behaviour.recall_reinforcement`` and ``behaviour.generate_l1_summaries`` all set. None of them
+did anything.
+
+**Two ways a knob is read, and both count.** Either something calls its accessor -- which requires
+that accessor to be reachable from a production entry point, not merely to exist -- or some module
+reads the environment variable directly. Seven of the unreachable accessors are in the second
+group: ``top_k_per_layer``'s accessor is dead while ``matrixark_mcp_core`` reads
+MATRIXARK_TOP_K_PER_LAYER on its own. Those knobs work. Counting them as dead would be wrong, and
+grepping for the accessor name alone would have done exactly that.
+
+**The list below may only shrink.** It is not a skip list: a name in it that turns out to BE read
+fails ``test_the_list_holds_nobody_who_is_read``, so wiring one up forces its removal. What the
+list prevents is the set growing quietly.
+"""
+from __future__ import annotations
+
+import ast
+import io
+import os
+import re
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+import matrixark_tenant_policy as tp  # noqa: E402
+
+GROWTH_BOUND = "matrixark_index_growth_bound.py"
+
+# Where a knob is DECLARED rather than used. A mention here is not a consumer.
+DECLARING = {GROWTH_BOUND, "matrixark_tenant_policy.py", "matrixark_gateway_config.py"}
+
+# Offered by the portal, resolved by the policy, read by nothing. Measured 2026-09-06.
+OFFERED_AND_UNREAD = frozenset({
+    "embed_node_path_prefix",
+    "generate_l1_summaries",
+    "max_event_text_chars",
+    "max_summary_text_chars",
+    "recall_reinforcement",
+    "return_all_candidate_threshold",
+    "return_all_candidates",
+    "skill_description_always",
+    "summarize_aggregation_only_nodes",
+    "summary_levels",
+    # This one appears EXACTLY ONCE in the repository -- the line that declares it. It defaults
+    # to on, so an operator turning secondary index writes off to hold down index growth gets a
+    # stored value, a confirmation, and the same number of records as before.
+    "write_secondary_index",
+})
+
+
+_SOURCES_CACHE = {}
+_REACHABLE_CACHE = set()
+_UNREAD_CACHE = set()
+
+
+def _production_sources() -> dict:
+    if _SOURCES_CACHE:
+        return _SOURCES_CACHE
+    out = {}
+    for name in sorted(os.listdir(TOOLS)):
+        if not name.endswith(".py") or name.startswith("test_") or name in DECLARING:
+            continue
+        try:
+            out[name] = io.open(os.path.join(TOOLS, name), encoding="utf-8").read()
+        except OSError:
+            continue
+    _SOURCES_CACHE.update(out)
+    return out
+
+
+def _reads_the_variable(sources: dict, variable: str) -> list:
+    pattern = re.compile(r'["\']%s["\']' % re.escape(variable))
+    return sorted(name for name, src in sources.items() if pattern.search(src))
+
+
+def _reachable_accessors() -> set:
+    """Growth-bound functions reachable from a call made outside that module.
+
+    Reachability, not existence: ``summary_levels`` IS called -- by ``node_summary_plan``, which
+    nothing calls. A caller count would have reported it live.
+    """
+    if _REACHABLE_CACHE:
+        return _REACHABLE_CACHE
+    tree = ast.parse(io.open(os.path.join(TOOLS, GROWTH_BOUND), encoding="utf-8").read())
+    defs = {n.name: n for n in tree.body if isinstance(n, ast.FunctionDef)}
+
+    graph = {}
+    for name, node in defs.items():
+        inner = set()
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Call):
+                called = getattr(sub.func, "id", None) or getattr(sub.func, "attr", None)
+                if called in defs:
+                    inner.add(called)
+        graph[name] = inner
+
+    entries = set()
+    for name in sorted(os.listdir(TOOLS)):
+        if not name.endswith(".py") or name.startswith("test_") or name == GROWTH_BOUND:
+            continue
+        try:
+            outer = ast.parse(io.open(os.path.join(TOOLS, name), encoding="utf-8").read())
+        except (OSError, SyntaxError):
+            continue
+        for node in ast.walk(outer):
+            if isinstance(node, ast.Call):
+                called = getattr(node.func, "id", None) or getattr(node.func, "attr", None)
+                if called in defs:
+                    entries.add(called)
+
+    reachable, stack = set(entries), list(entries)
+    while stack:
+        for nxt in graph.get(stack.pop(), ()):
+            if nxt not in reachable:
+                reachable.add(nxt)
+                stack.append(nxt)
+    _REACHABLE_CACHE.update(reachable)
+    return reachable
+
+
+def _resolved_by_name() -> set:
+    """Knob names passed as a string to the policy resolver.
+
+    The third way a knob is read, and the one this file first missed: `enforce_secondary_index_bounds`
+    is reachable and asks for `max_secondary_index_records_per_tenant` by NAME, never touching the
+    variable and never calling an accessor of that name. Four knobs were reported dead on that
+    omission alone.
+    """
+    asked = set()
+    for name, src in _production_sources().items():
+        for match in re.finditer(r'resolve(?:_tenant_policy)?\(\s*["\']([a-z0-9_]+)["\']', src):
+            asked.add(match.group(1))
+    # ...and from the reachable half of the growth-bound module itself.
+    reachable = _reachable_accessors()
+    tree = ast.parse(io.open(os.path.join(TOOLS, GROWTH_BOUND), encoding="utf-8").read())
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef) or node.name not in reachable:
+            continue
+        for sub in ast.walk(node):
+            if not isinstance(sub, ast.Call):
+                continue
+            called = getattr(sub.func, "id", None) or getattr(sub.func, "attr", None)
+            if called in ("resolve", "resolve_tenant_policy") and sub.args:
+                first = sub.args[0]
+                if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                    asked.add(first.value)
+    return asked
+
+
+def _unread_knobs() -> set:
+    if _UNREAD_CACHE:
+        return _UNREAD_CACHE
+    sources = _production_sources()
+    reachable = _reachable_accessors()
+    by_name = _resolved_by_name()
+    unread = set()
+    for name, knob in tp.KNOBS.items():
+        if not knob.env:
+            continue
+        if _reads_the_variable(sources, knob.env):
+            continue
+        if name in reachable or (name + "_enabled") in reachable:
+            continue
+        if name in by_name:
+            continue
+        unread.add(name)
+    _UNREAD_CACHE.update(unread)
+    return unread
+
+
+class TheKnobsThePortalOffersAreReadBySomething(unittest.TestCase):
+
+    def test_the_set_has_not_grown(self) -> None:
+        new = sorted(_unread_knobs() - OFFERED_AND_UNREAD)
+        self.assertEqual([], new,
+                         "%d knob(s) became unread: the portal offers them, the policy resolves "
+                         "them, and nothing reads the result" % len(new))
+
+    def test_the_list_holds_nobody_who_is_read(self) -> None:
+        """So the list can only shrink. Wire one up and this fails until it is removed."""
+        wired = sorted(OFFERED_AND_UNREAD - _unread_knobs())
+        self.assertEqual([], wired,
+                         "%s is read now -- take it out of OFFERED_AND_UNREAD" % (wired,))
+
+    def test_every_name_in_the_list_is_a_real_knob(self) -> None:
+        self.assertEqual([], sorted(n for n in OFFERED_AND_UNREAD if n not in tp.KNOBS))
+
+
+class TheDetectorWorks(unittest.TestCase):
+    """Every assertion above is an equality against an empty list, which is also what a detector
+    that finds nothing produces."""
+
+    def test_it_finds_the_knobs_that_are_read(self) -> None:
+        read = {name for name in tp.KNOBS if name not in _unread_knobs()}
+        self.assertGreater(len(read), len(OFFERED_AND_UNREAD), sorted(read)[:5])
+
+    def test_a_variable_nothing_mentions_is_reported_unread(self) -> None:
+        sources = _production_sources()
+        self.assertGreater(len(sources), 100, len(sources))
+        self.assertEqual([], _reads_the_variable(sources, "MATRIXARK_NO_SUCH_VARIABLE_AT_ALL"))
+
+    def test_a_variable_that_is_read_is_reported_read(self) -> None:
+        self.assertTrue(_reads_the_variable(_production_sources(), "MATRIXARK_TOP_K_PER_LAYER"),
+                        "the reader check found nothing for a variable known to be read")
+
+    def test_reachability_is_narrower_than_existence(self) -> None:
+        """The distinction the whole file turns on: ``summary_levels`` exists and is called, and is
+        still unreachable, because its only caller is unreachable too."""
+        reachable = _reachable_accessors()
+        self.assertGreater(len(reachable), 5, sorted(reachable))
+        self.assertNotIn("summary_levels", reachable)
+        self.assertNotIn("node_summary_plan", reachable)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Every `behaviour.*` control on the portal is a tenant-policy knob. Setting one writes a value the
resolver returns and the history records — and for **eleven** of them, that is the end of it. The
operator gets a control, a stored value and a confirmation, and the deployment behaves identically
either way.

The live deployment this was found on has `behaviour.summary_levels`, `behaviour.recall_reinforcement`
and `behaviour.generate_l1_summaries` all set. None of them do anything.

```
embed_node_path_prefix            max_summary_text_chars        return_all_candidates
generate_l1_summaries             recall_reinforcement          skill_description_always
max_event_text_chars              return_all_candidate_threshold summarize_aggregation_only_nodes
summary_levels                    write_secondary_index
```

`write_secondary_index` is the one worth reading twice: it appears **exactly once in the
repository**, on the line that declares it, and defaults to on. An operator turning secondary index
writes off to hold down index growth gets the same number of records as before.

### Three ways a knob is read, and I missed two of them in turn

This is why the file leans on the distinction rather than on a grep.

**Reachability, not existence.** `summary_levels()` *is* called — by `node_summary_plan()`, which
nothing calls. A caller count reports it live; only walking the call graph from a real production
entry point shows the whole branch is detached. 25 of the 42 public functions in
`matrixark_index_growth_bound` are unreachable that way.

**The variable, read directly.** Seven of those unreachable accessors sit over knobs that work
anyway: `top_k_per_layer`'s accessor is dead while `matrixark_mcp_core` reads
`MATRIXARK_TOP_K_PER_LAYER` on its own. Calling those dead would have been wrong, and grepping for
the accessor name would have done it.

**Resolved by name.** My first version reported 14, and the four extra were a bug in the detector,
not knobs: `enforce_secondary_index_bounds` is reachable and asks for
`max_secondary_index_records_per_tenant` by *name*, touching neither the variable nor an accessor.
The test itself caught this — it failed with four names I could not justify, and three of them were
genuinely read.

### The list may only shrink

It is not a skip list. A name in it that turns out to be read fails
`test_the_list_holds_nobody_who_is_read`, so wiring one up forces its removal; what the list
prevents is the set growing quietly.

```
a dead knob is dropped from the recorded list   -> FAIL
a WIRED knob is added to the list               -> FAIL
a name that is not a knob is added              -> FAIL
the variable check stops finding readers        -> FAIL
reachability becomes mere existence             -> FAIL
the resolve-by-name route is dropped            -> FAIL
```

Four of the seven tests exist to keep the other three honest: they assert equality against an empty
list, which is also what a detector that looks at nothing returns.

4.1s, down from 195s once the two scans were memoised.

### What this does not do

It does not wire any of the eleven up, or remove them. Whether `summary_levels` should gate the
summariser or stop being offered is a product decision; this makes the set visible and stops it
growing. Clean negatives found alongside, recorded rather than turned into work: no offered *choice*
value is dead — all 7 choice settings' values are named by live code — and `summary.provider`'s
blank option behaves exactly as documented on all three paths (`update()` removes the variable, the
file stores `''`, `apply_boot` skips it), so the summariser follows the extraction provider every
time.
