### PR TITLE
The select shows the provider the deployment is running

### DIFF
--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -1326,9 +1326,27 @@ SETUP_JS = r"""
         '<option value="1"' + (f.value === "1" ? " selected" : "") + ">on</option></select>";
     }
     if (f.choices && f.choices.length) {
-      return "<select" + attr + ">" + f.choices.map(function (c) {
-        return '<option value="' + esc(c) + '"' + (c === f.value ? " selected" : "") + ">" +
-          esc(c) + "</option>";
+      /* The value a deployment is RUNNING is not always one of the offered choices. The provider
+         readers accept aliases this list does not carry -- summary_provider() maps oss,
+         open_source, local_llm and oss_llm onto openai_compatible, and the extraction reader
+         takes oss and oss_with_fallback. Rendering only the offered list leaves nothing
+         selected, so the browser shows the FIRST option: the screen then reports a provider the
+         deployment is not using, and saving the form makes that report true. Carry the running
+         value as its own option, marked, so the screen is honest and a save is a no-op.
+
+         The empty choice gets a label too. Rendered bare it is a blank row, which tells the
+         reader exactly as much as it looks like it does -- and on summary.provider that blank
+         is the DEFAULT, so it is the row most people see selected. */
+      var running = f.value == null ? "" : String(f.value);
+      var offered = f.choices.slice();
+      if (offered.indexOf(running) < 0) { offered.push(running); }
+      return "<select" + attr + ">" + offered.map(function (c) {
+        var label;
+        if (c === "") { label = "(not set)"; }
+        else if (f.choices.indexOf(c) < 0) { label = c + " (in use, not offered)"; }
+        else { label = c; }
+        return '<option value="' + esc(c) + '"' + (c === running ? " selected" : "") + ">" +
+          esc(label) + "</option>";
       }).join("") + "</select>";
     }
     return '<input type="text"' + attr + ' spellcheck="false" value="' + esc(f.value || "") + '">';

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -1041,9 +1041,27 @@ function liveStream(options) {
         '<option value="1"' + (f.value === "1" ? " selected" : "") + ">on</option></select>";
     }
     if (f.choices && f.choices.length) {
-      return "<select" + attr + ">" + f.choices.map(function (c) {
-        return '<option value="' + esc(c) + '"' + (c === f.value ? " selected" : "") + ">" +
-          esc(c) + "</option>";
+      /* The value a deployment is RUNNING is not always one of the offered choices. The provider
+         readers accept aliases this list does not carry -- summary_provider() maps oss,
+         open_source, local_llm and oss_llm onto openai_compatible, and the extraction reader
+         takes oss and oss_with_fallback. Rendering only the offered list leaves nothing
+         selected, so the browser shows the FIRST option: the screen then reports a provider the
+         deployment is not using, and saving the form makes that report true. Carry the running
+         value as its own option, marked, so the screen is honest and a save is a no-op.
+
+         The empty choice gets a label too. Rendered bare it is a blank row, which tells the
+         reader exactly as much as it looks like it does -- and on summary.provider that blank
+         is the DEFAULT, so it is the row most people see selected. */
+      var running = f.value == null ? "" : String(f.value);
+      var offered = f.choices.slice();
+      if (offered.indexOf(running) < 0) { offered.push(running); }
+      return "<select" + attr + ">" + offered.map(function (c) {
+        var label;
+        if (c === "") { label = "(not set)"; }
+        else if (f.choices.indexOf(c) < 0) { label = c + " (in use, not offered)"; }
+        else { label = c; }
+        return '<option value="' + esc(c) + '"' + (c === running ? " selected" : "") + ">" +
+          esc(label) + "</option>";
       }).join("") + "</select>";
     }
     return '<input type="text"' + attr + ' spellcheck="false" value="' + esc(f.value || "") + '">';

--- a/tools/portal/summary_provider_select_harness.js
+++ b/tools/portal/summary_provider_select_harness.js
@@ -41,11 +41,39 @@ ok("a chosen provider is the one selected",
 ok("and blank is still offered, so it is not a one-way door",
    chosen.indexOf('<option value=""') >= 0, chosen);
 
-/* The comparison: a list WITHOUT the blank cannot express "same as extraction". */
+/* The blank is the DEFAULT on this setting, so it is the row most people see selected. Rendered
+   bare it was an empty line in the dropdown. */
+ok("the blank reads as something rather than nothing",
+   blank.indexOf(">(not set)</option>") >= 0, blank);
+
+/* A list WITHOUT the blank used to mean nothing was selected and the browser showed the first --
+   the screen then reported a provider the deployment was not running, and saving made it true.
+   The running value is carried now, whatever the list holds. */
 const withoutBlank = controlHtml(Object.assign({}, field,
   { choices: ["deterministic", "openai_compatible"] }));
-ok("FLOOR: without the blank, nothing is selected and the browser shows the first",
-   withoutBlank.indexOf("selected") < 0, withoutBlank);
+ok("a running value the list does not hold is still selected",
+   /<option value="" selected>/.test(withoutBlank), withoutBlank);
+ok("and it is not silently presented as an offered choice",
+   withoutBlank.indexOf("(not set)") >= 0, withoutBlank);
+
+/* The case this is really for. summary_provider() maps oss, open_source, local_llm and oss_llm
+   onto openai_compatible, and none of them are offered here, so a deployment configured with one
+   is a deployment whose provider is not in this list. */
+const alias = controlHtml(Object.assign({}, field, { value: "oss" }));
+ok("an accepted alias is shown as the running value",
+   /<option value="oss" selected>/.test(alias), alias);
+ok("and is marked as one the list does not offer",
+   alias.indexOf("oss (in use, not offered)") >= 0, alias);
+ok("without dropping any offered choice",
+   ["", "deterministic", "openai_compatible"].every(function (c) {
+     return alias.indexOf('<option value="' + c + '"') >= 0;
+   }), alias);
+ok("and exactly one option is selected",
+   (alias.match(/ selected>/g) || []).length === 1, alias);
+
+/* The floor for all of the above: an offered value must NOT be marked. */
+ok("FLOOR: a value the list does offer carries no marking",
+   chosen.indexOf("not offered") < 0, chosen);
 
 console.log(failures ? "\n" + failures + " failure(s)" : "\nall good");
 process.exit(failures ? 1 : 0);

--- a/tools/test_matrixark_a_knob_the_portal_offers_is_read_by_something.py
+++ b/tools/test_matrixark_a_knob_the_portal_offers_is_read_by_something.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A knob the portal offers should be read by something.
+
+Every ``behaviour.*`` setting on the portal is a tenant-policy knob. Setting one writes a value the
+resolver returns and the history records -- and for eleven of them, that is the end of it. Their only
+accessor lives in ``matrixark_index_growth_bound``, in a function no production code calls, and no
+other module reads the variable. The operator gets a control, a stored value and a confirmation,
+and the deployment behaves identically either way.
+
+The live deployment this was found on had ``behaviour.summary_levels``,
+``behaviour.recall_reinforcement`` and ``behaviour.generate_l1_summaries`` all set. None of them
+did anything.
+
+**Two ways a knob is read, and both count.** Either something calls its accessor -- which requires
+that accessor to be reachable from a production entry point, not merely to exist -- or some module
+reads the environment variable directly. Seven of the unreachable accessors are in the second
+group: ``top_k_per_layer``'s accessor is dead while ``matrixark_mcp_core`` reads
+MATRIXARK_TOP_K_PER_LAYER on its own. Those knobs work. Counting them as dead would be wrong, and
+grepping for the accessor name alone would have done exactly that.
+
+**The list below may only shrink.** It is not a skip list: a name in it that turns out to BE read
+fails ``test_the_list_holds_nobody_who_is_read``, so wiring one up forces its removal. What the
+list prevents is the set growing quietly.
+"""
+from __future__ import annotations
+
+import ast
+import io
+import os
+import re
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+import matrixark_tenant_policy as tp  # noqa: E402
+
+GROWTH_BOUND = "matrixark_index_growth_bound.py"
+
+# Where a knob is DECLARED rather than used. A mention here is not a consumer.
+DECLARING = {GROWTH_BOUND, "matrixark_tenant_policy.py", "matrixark_gateway_config.py"}
+
+# Offered by the portal, resolved by the policy, read by nothing. Measured 2026-09-06.
+OFFERED_AND_UNREAD = frozenset({
+    "embed_node_path_prefix",
+    "generate_l1_summaries",
+    "max_event_text_chars",
+    "max_summary_text_chars",
+    "recall_reinforcement",
+    "return_all_candidate_threshold",
+    "return_all_candidates",
+    "skill_description_always",
+    "summarize_aggregation_only_nodes",
+    "summary_levels",
+    # This one appears EXACTLY ONCE in the repository -- the line that declares it. It defaults
+    # to on, so an operator turning secondary index writes off to hold down index growth gets a
+    # stored value, a confirmation, and the same number of records as before.
+    "write_secondary_index",
+})
+
+
+_SOURCES_CACHE = {}
+_REACHABLE_CACHE = set()
+_UNREAD_CACHE = set()
+
+
+def _production_sources() -> dict:
+    if _SOURCES_CACHE:
+        return _SOURCES_CACHE
+    out = {}
+    for name in sorted(os.listdir(TOOLS)):
+        if not name.endswith(".py") or name.startswith("test_") or name in DECLARING:
+            continue
+        try:
+            out[name] = io.open(os.path.join(TOOLS, name), encoding="utf-8").read()
+        except OSError:
+            continue
+    _SOURCES_CACHE.update(out)
+    return out
+
+
+def _reads_the_variable(sources: dict, variable: str) -> list:
+    pattern = re.compile(r'["\']%s["\']' % re.escape(variable))
+    return sorted(name for name, src in sources.items() if pattern.search(src))
+
+
+def _reachable_accessors() -> set:
+    """Growth-bound functions reachable from a call made outside that module.
+
+    Reachability, not existence: ``summary_levels`` IS called -- by ``node_summary_plan``, which
+    nothing calls. A caller count would have reported it live.
+    """
+    if _REACHABLE_CACHE:
+        return _REACHABLE_CACHE
+    tree = ast.parse(io.open(os.path.join(TOOLS, GROWTH_BOUND), encoding="utf-8").read())
+    defs = {n.name: n for n in tree.body if isinstance(n, ast.FunctionDef)}
+
+    graph = {}
+    for name, node in defs.items():
+        inner = set()
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Call):
+                called = getattr(sub.func, "id", None) or getattr(sub.func, "attr", None)
+                if called in defs:
+                    inner.add(called)
+        graph[name] = inner
+
+    entries = set()
+    for name in sorted(os.listdir(TOOLS)):
+        if not name.endswith(".py") or name.startswith("test_") or name == GROWTH_BOUND:
+            continue
+        try:
+            outer = ast.parse(io.open(os.path.join(TOOLS, name), encoding="utf-8").read())
+        except (OSError, SyntaxError):
+            continue
+        for node in ast.walk(outer):
+            if isinstance(node, ast.Call):
+                called = getattr(node.func, "id", None) or getattr(node.func, "attr", None)
+                if called in defs:
+                    entries.add(called)
+
+    reachable, stack = set(entries), list(entries)
+    while stack:
+        for nxt in graph.get(stack.pop(), ()):
+            if nxt not in reachable:
+                reachable.add(nxt)
+                stack.append(nxt)
+    _REACHABLE_CACHE.update(reachable)
+    return reachable
+
+
+def _resolved_by_name() -> set:
+    """Knob names passed as a string to the policy resolver.
+
+    The third way a knob is read, and the one this file first missed: `enforce_secondary_index_bounds`
+    is reachable and asks for `max_secondary_index_records_per_tenant` by NAME, never touching the
+    variable and never calling an accessor of that name. Four knobs were reported dead on that
+    omission alone.
+    """
+    asked = set()
+    for name, src in _production_sources().items():
+        for match in re.finditer(r'resolve(?:_tenant_policy)?\(\s*["\']([a-z0-9_]+)["\']', src):
+            asked.add(match.group(1))
+    # ...and from the reachable half of the growth-bound module itself.
+    reachable = _reachable_accessors()
+    tree = ast.parse(io.open(os.path.join(TOOLS, GROWTH_BOUND), encoding="utf-8").read())
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef) or node.name not in reachable:
+            continue
+        for sub in ast.walk(node):
+            if not isinstance(sub, ast.Call):
+                continue
+            called = getattr(sub.func, "id", None) or getattr(sub.func, "attr", None)
+            if called in ("resolve", "resolve_tenant_policy") and sub.args:
+                first = sub.args[0]
+                if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                    asked.add(first.value)
+    return asked
+
+
+def _unread_knobs() -> set:
+    if _UNREAD_CACHE:
+        return _UNREAD_CACHE
+    sources = _production_sources()
+    reachable = _reachable_accessors()
+    by_name = _resolved_by_name()
+    unread = set()
+    for name, knob in tp.KNOBS.items():
+        if not knob.env:
+            continue
+        if _reads_the_variable(sources, knob.env):
+            continue
+        if name in reachable or (name + "_enabled") in reachable:
+            continue
+        if name in by_name:
+            continue
+        unread.add(name)
+    _UNREAD_CACHE.update(unread)
+    return unread
+
+
+class TheKnobsThePortalOffersAreReadBySomething(unittest.TestCase):
+
+    def test_the_set_has_not_grown(self) -> None:
+        new = sorted(_unread_knobs() - OFFERED_AND_UNREAD)
+        self.assertEqual([], new,
+                         "%d knob(s) became unread: the portal offers them, the policy resolves "
+                         "them, and nothing reads the result" % len(new))
+
+    def test_the_list_holds_nobody_who_is_read(self) -> None:
+        """So the list can only shrink. Wire one up and this fails until it is removed."""
+        wired = sorted(OFFERED_AND_UNREAD - _unread_knobs())
+        self.assertEqual([], wired,
+                         "%s is read now -- take it out of OFFERED_AND_UNREAD" % (wired,))
+
+    def test_every_name_in_the_list_is_a_real_knob(self) -> None:
+        self.assertEqual([], sorted(n for n in OFFERED_AND_UNREAD if n not in tp.KNOBS))
+
+
+class TheDetectorWorks(unittest.TestCase):
+    """Every assertion above is an equality against an empty list, which is also what a detector
+    that finds nothing produces."""
+
+    def test_it_finds_the_knobs_that_are_read(self) -> None:
+        read = {name for name in tp.KNOBS if name not in _unread_knobs()}
+        self.assertGreater(len(read), len(OFFERED_AND_UNREAD), sorted(read)[:5])
+
+    def test_a_variable_nothing_mentions_is_reported_unread(self) -> None:
+        sources = _production_sources()
+        self.assertGreater(len(sources), 100, len(sources))
+        self.assertEqual([], _reads_the_variable(sources, "MATRIXARK_NO_SUCH_VARIABLE_AT_ALL"))
+
+    def test_a_variable_that_is_read_is_reported_read(self) -> None:
+        self.assertTrue(_reads_the_variable(_production_sources(), "MATRIXARK_TOP_K_PER_LAYER"),
+                        "the reader check found nothing for a variable known to be read")
+
+    def test_reachability_is_narrower_than_existence(self) -> None:
+        """The distinction the whole file turns on: ``summary_levels`` exists and is called, and is
+        still unreachable, because its only caller is unreachable too."""
+        reachable = _reachable_accessors()
+        self.assertGreater(len(reachable), 5, sorted(reachable))
+        self.assertNotIn("summary_levels", reachable)
+        self.assertNotIn("node_summary_plan", reachable)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_the_portal_offers_the_summary_model.py
+++ b/tools/test_matrixark_the_portal_offers_the_summary_model.py
@@ -22,6 +22,7 @@ does.
 """
 from __future__ import annotations
 
+import io
 import json
 import os
 import subprocess
@@ -183,10 +184,16 @@ class TheHelpTextIsTrueTest(unittest.TestCase):
 class TheSelectHonoursTheBlankTest(unittest.TestCase):
     """Asserting that "" is in `choices` proves what the registry says, not what the page draws.
 
-    The page renders a `choices` setting as a `<select>`, and a list without the blank leaves NO
-    option selected -- the browser then shows the first, and saving pins it. This runs the shipped
-    `controlHtml` to check the blank is drawn, is selected when the value is blank, and is still
-    offered once a provider has been picked.
+    The page renders a `choices` setting as a `<select>`. A running value the list does not hold
+    used to leave NO option selected -- the browser then showed the first, the screen reported a
+    provider the deployment was not using, and saving made that report true. This runs the shipped
+    `controlHtml` to check the blank is drawn and selected, is still offered once a provider has
+    been picked, and that a value outside the list is carried and marked rather than dropped.
+
+    The last part is not hypothetical: `summary_provider()` maps `oss`, `open_source`, `local_llm`
+    and `oss_llm` onto `openai_compatible`, and the extraction reader takes `oss` and
+    `oss_with_fallback`. None of those are offered here, so a deployment configured with one had a
+    dropdown that did not contain its own provider.
     """
 
     HARNESS = os.path.join(TOOLS, "portal", "summary_provider_select_harness.js")
@@ -208,8 +215,21 @@ class TheSelectHonoursTheBlankTest(unittest.TestCase):
     def test_it_is_not_a_one_way_door(self) -> None:
         out = self._run().stdout
         self.assertIn("ok   and blank is still offered, so it is not a one-way door", out)
-        self.assertIn("ok   FLOOR: without the blank, nothing is selected and the browser shows "
-                      "the first", out)
+
+    def test_the_blank_reads_as_something(self) -> None:
+        """It is the default on this setting, so it is the row most people see selected, and it
+        used to be an empty line."""
+        self.assertIn("ok   the blank reads as something rather than nothing", self._run().stdout)
+
+    def test_a_value_outside_the_list_is_carried_and_marked(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   a running value the list does not hold is still selected", out)
+        self.assertIn("ok   an accepted alias is shown as the running value", out)
+        self.assertIn("ok   and is marked as one the list does not offer", out)
+        self.assertIn("ok   without dropping any offered choice", out)
+        self.assertIn("ok   and exactly one option is selected", out)
+        # The floor: an offered value must NOT pick up the marking, or the mark means nothing.
+        self.assertIn("ok   FLOOR: a value the list does offer carries no marking", out)
 
 
 class TheControlsAreNotDecorativeTest(unittest.TestCase):
@@ -229,6 +249,47 @@ class TheControlsAreNotDecorativeTest(unittest.TestCase):
                         readers.append(entry)
             with self.subTest(setting=key, variable=name):
                 self.assertTrue(readers, "%s is offered and nothing reads %s" % (key, name))
+
+
+class TheTwoCopiesOfTheControlAgreeTest(unittest.TestCase):
+    """`controlHtml` exists twice: in the shipped page and in the builder that writes pages.
+
+    The harness runs the PAGE's copy, so an edit made to only one of them passes every test here
+    while the next generated page carries the old behaviour. They were identical before this
+    change and have to stay that way.
+    """
+
+    FILES = (os.path.join(TOOLS, "portal", "setup_portal.html"),
+             os.path.join(TOOLS, "portal", "build_portal_pages.py"))
+
+    @staticmethod
+    def _control(path: str) -> str:
+        text = io.open(path, encoding="utf-8").read()
+        start = text.find("function controlHtml(f)")
+        if start < 0:
+            raise AssertionError("controlHtml is not in %s" % os.path.basename(path))
+        depth = 0
+        for index in range(text.index("{", start), len(text)):
+            if text[index] == "{":
+                depth += 1
+            elif text[index] == "}":
+                depth -= 1
+                if depth == 0:
+                    return text[start:index + 1]
+        raise AssertionError("controlHtml is not closed in %s" % os.path.basename(path))
+
+    def test_both_files_still_hold_one(self) -> None:
+        # The floor: if the reader stops finding them, the equality below is "" == "".
+        for path in self.FILES:
+            body = self._control(path)
+            self.assertGreater(len(body), 400, os.path.basename(path))
+            self.assertIn("f.choices", body, os.path.basename(path))
+
+    def test_they_are_the_same_function(self) -> None:
+        page, builder = (self._control(path) for path in self.FILES)
+        self.assertEqual(page, builder,
+                         "the page and the builder disagree about how a control is drawn; the "
+                         "harness only exercises the page")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A choice setting renders as a `<select>` built from the offered list. Two things go wrong when the
value a deployment is actually running is not in that list.

**The screen reports a provider the deployment is not using.** No option carries `selected`, so the
browser shows the first one. **And saving the form makes that report true** — the operator opens the
page to change something else, saves, and the provider silently becomes whatever happened to be
listed first.

This is not hypothetical. `summary_provider()` maps `oss`, `open_source`, `local_llm` and `oss_llm`
onto `openai_compatible`, and the extraction reader takes `oss` and `oss_with_fallback`. None of
those are offered. A deployment configured with any of them had a dropdown that did not contain its
own provider.

The running value is carried as its own option now — selected, and marked `(in use, not offered)` so
it is not mistaken for something the portal is recommending. The screen tells the truth and a save
is a no-op.

**The blank read as nothing.** `summary.provider` offers `""`, meaning "follow the extraction
provider", and it is that setting's **default** — so it is the row most people see selected. Rendered
bare it was an empty line in the dropdown. It says `(not set)` now.

### While checking, two clean negatives

Both looked like bugs and are not, so they are recorded rather than "fixed":

- **Booleans render correctly.** The control shows `on` only when the value is exactly `"1"`, and 22
  settings default to on — but `snapshot()` sends the *effective* value, so an untouched
  default-on boolean arrives as `"1"` and draws as `on`.
- **The blank choice behaves as documented on all three paths.** `update()` *removes* the variable
  rather than blanking it, the file stores `''`, and `apply_boot` skips empty values — so the
  `os.environ.get(NAME, DEFAULT)` trap (present-but-empty returns `""`, not the default) never
  fires, and the summariser follows the extraction provider every time. Measured, not reasoned.

### The guard, and one it was missing

`controlHtml` exists **twice** — in the shipped page and in the builder that writes pages — and they
were byte-identical. The harness runs the *page's* copy, so an edit to one alone would pass every
test here while the next generated page kept the old behaviour. Nothing asserted that. It does now.

The harness's old floor said "without the blank, nothing is selected and the browser shows the
first". That was a true description of the defect, used to argue the blank had to stay in the list;
it is replaced by the stronger claim, and the one-way-door test still keeps the blank offered.

```
the running value is no longer carried      -> FAIL
the blank goes back to an empty label       -> FAIL
an unoffered value stops being marked       -> FAIL
every option gets marked, offered or not    -> FAIL
the builder copy drifts from the page       -> FAIL
```

130 tests green across the portal suites; 13 assertions in the harness, run against the shipped page.
