### PR TITLE
Three copies of the index normaliser, and none of the callers agreed

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -2244,25 +2244,27 @@ def registry_access_scope(scope: Json, *, sharing_scope: str = "private_user") -
 # quota, the discarded bigrams still consumed their slots: measured on a CN/EN corpus, only
 # 42.9-51.1% of emitted keywords survived to become terms, so a cap of 12 bought 6 usable terms
 # and a cap of 200 bought 86.
-_INDEX_VALUE_CJK = (
-    "㐀-䶿"  # CJK extension A
-    "一-鿿"  # CJK unified ideographs
-    "豈-﫿"  # compatibility ideographs
-    "぀-ヿ"  # hiragana + katakana
-    "가-힯"  # hangul syllables
-)
-_INDEX_VALUE_STRIP_RE = re.compile(r"[^a-z0-9_.:/-" + _INDEX_VALUE_CJK + r"]+")
-
-
-def normalized_index_value(value: Any) -> str:
-    text = str(value or "").strip().lower()
-    text = _INDEX_VALUE_STRIP_RE.sub("_", text)
-    return text.strip("_")
-
-
-def context_index_name(kind: str, value: Any) -> str:
-    normalized = normalized_index_value(value)
-    return f"{kind}:{normalized}" if normalized else ""
+# `normalized_index_value` and `context_index_name` are not defined here. They were, and this copy
+# was the one that kept CJK and other non-ASCII characters; matrixark_mcp_indexing had a plainer
+# copy that replaced everything outside [a-z0-9_.:/-] with "_". Because the result is then stripped
+# of "_", and `context_index_name` returns "" for an empty value, a term written only in Chinese,
+# Japanese or Korean normalised to the EMPTY STRING through that copy:
+#
+#     written here                keyword:内存
+#     normalised there            ''
+#
+# Both are live and they sit on opposite sides of the same lookup: matrixark_mcp_core_query_analysis
+# and matrixark_mcp_core_codex_outcome reach this module, while matrixark_mcp_query reaches
+# matrixark_mcp_indexing. A term indexed under one could not be found by a query normalised through
+# the other -- not ranked lower, not found at all. `café` lost its accent the same way.
+#
+# The character class moved to matrixark_mcp_indexing, which owns index naming and imports nothing
+# from here, and this module re-exports it, so there is one normaliser and a change to it cannot
+# reach the writer and miss the reader again.
+try:
+    from tools.matrixark_mcp_indexing import context_index_name, normalized_index_value
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_indexing import context_index_name, normalized_index_value
 
 
 def profile_memory_class_for_entity_type(entity_type: Any) -> str:

--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -2049,16 +2049,15 @@ def dedupe_entities(entities: list[Json]) -> list[Json]:
     return [entity for index, entity in enumerate(out) if index in kept_indexes]
 
 
-def ordered_unique(values: list[str]) -> list[str]:
-    seen = set()
-    out = []
-    for value in values:
-        value = value.strip()
-        if not value or value in seen:
-            continue
-        seen.add(value)
-        out.append(value)
-    return out
+# `ordered_unique` is not defined here either. matrixark_mcp_indexing had its own copy, spelled
+# `_ordered_unique`, and that copy neither trimmed nor dropped the empty string -- so the index
+# term builders there returned [""] for metadata with none of the fields they read. This copy is
+# the one that drops it, and it is now the only one. Twelve modules import the name from here and
+# are unaffected: the behaviour they get is exactly what this definition did.
+try:
+    from tools.matrixark_mcp_indexing import ordered_unique
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_indexing import ordered_unique
 
 
 RAW_BYTE_METADATA_FIELDS = {"raw_bytes", "file_bytes", "bytes", "binary", "payload_bytes", "data_url", "base64"}

--- a/tools/matrixark_mcp_extraction_normalization.py
+++ b/tools/matrixark_mcp_extraction_normalization.py
@@ -284,8 +284,18 @@ def feature_scope_excludes_outcome_evidence(text: str) -> bool:
     return bool(FEATURE_SCOPE_EXCLUSION_RE.search(str(text or "").lower())) and profile_entity_type_for_memory_text(text) == "memory_feature_profile"
 
 
-def normalized_index_value(value: Any) -> str:
-    return re.sub(r"[^a-z0-9]+", "_", str(value or "").strip().lower()).strip("_")
+#: Not an index value -- the one use is the dedup key in `codex_outcome_fact_entities` below. It
+#: had its own definition, and that definition was the strictest of the three copies of this name:
+#: `[^a-z0-9]+` drops `_ . : / -` along with every non-ASCII character. Two distinct facts written
+#: in Chinese therefore normalised to "" alike, shared a key, and the second was dropped as a
+#: duplicate -- the extraction lost it. The shared normaliser keeps CJK, hiragana, katakana, hangul
+#: and accented Latin, so those facts now key apart. It also keeps `_ . : / -`, which makes the key
+#: slightly less folding for ASCII punctuation: "a.b" and "a-b" used to share a key and no longer
+#: do. That is the same direction -- two things that are not the same are no longer called the same.
+try:
+    from tools.matrixark_mcp_indexing import normalized_index_value
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_indexing import normalized_index_value
 
 
 CODEX_OUTCOME_CHANGE_RE = re.compile(

--- a/tools/matrixark_mcp_indexing.py
+++ b/tools/matrixark_mcp_indexing.py
@@ -66,9 +66,23 @@ def _ordered_unique(values: list[str]) -> list[str]:
     return output
 
 
+#: Characters an index value may keep beyond ASCII. Without these the normaliser replaced every
+#: non-ASCII character with "_", and since the result is then stripped of "_" a term written only
+#: in one of these scripts normalised to the EMPTY string -- `context_index_name` returns "" for an
+#: empty value, so the term did not merely change, it disappeared.
+_INDEX_VALUE_CJK = (
+    "\u3400-\u4dbf"  # CJK extension A
+    "\u4e00-\u9fff"  # CJK unified ideographs
+    "\uf900-\ufaff"  # compatibility ideographs
+    "\u3040-\u30ff"  # hiragana + katakana
+    "\uac00-\ud7af"  # hangul syllables
+)
+_INDEX_VALUE_STRIP_RE = re.compile(r"[^a-z0-9_.:/-" + _INDEX_VALUE_CJK + r"]+")
+
+
 def normalized_index_value(value: Any) -> str:
     text = str(value or "").strip().lower()
-    text = re.sub(r"[^a-z0-9_.:/-]+", "_", text)
+    text = _INDEX_VALUE_STRIP_RE.sub("_", text)
     return text.strip("_")
 
 

--- a/tools/matrixark_mcp_indexing.py
+++ b/tools/matrixark_mcp_indexing.py
@@ -55,15 +55,32 @@ SECONDARY_INDEX_PRIORITY_PREFIXES = (
 )
 
 
-def _ordered_unique(values: list[str]) -> list[str]:
-    output: list[str] = []
+def ordered_unique(values: list[str]) -> list[str]:
+    """Unique, order-preserving, trimmed, and WITHOUT the empty string.
+
+    Dropping the empty value is the part that matters here. `context_index_name` returns "" for
+    anything that normalises to nothing, and the term builders below append its result
+    unconditionally, so a copy that kept "" emitted an empty index term: `metadata_index_terms({})`
+    returned `[""]`. An index name of "" is not a name -- every record that produced one would post
+    under the same key.
+
+    Two of the five callers below already worked around this with `if term`, which is the shape of
+    a helper that does not do what its callers need.
+    """
     seen: set[str] = set()
+    output: list[str] = []
     for value in values:
-        if value in seen:
+        value = value.strip()
+        if not value or value in seen:
             continue
         seen.add(value)
         output.append(value)
     return output
+
+
+#: The private spelling this module used before the two copies were reconciled. Kept so the call
+#: sites below read unchanged; it is the same object, not a second implementation.
+_ordered_unique = ordered_unique
 
 
 #: Characters an index value may keep beyond ASCII. Without these the normaliser replaced every

--- a/tools/test_there_is_one_index_normaliser.py
+++ b/tools/test_there_is_one_index_normaliser.py
@@ -35,6 +35,32 @@ SELF = Path(__file__).name
 
 HOME = "matrixark_mcp_indexing"
 
+
+def _import(name: str):
+    """Import a tools module whichever way the suite is being run.
+
+    The suite runs both from tools/ (bare names) and from the repository root (as
+    `tools.<module>`), and every module in the tree carries the same try/except for this reason.
+    A guard that picks one path fails on the OTHER path, which reads as a defect in the code it
+    is guarding rather than in how it was invoked.
+    """
+    try:
+        return importlib.import_module("tools." + name)
+    except ImportError:
+        return importlib.import_module(name)
+
+
+def _module_name(obj) -> str:
+    """The defining module's name without its package prefix.
+
+    The suite runs both from tools/ and as `tools.<module>`, so the same function reports
+    `matrixark_mcp_scoring` in one and `tools.matrixark_mcp_scoring` in the other. Comparing whole
+    dotted names makes this file fail on the import path rather than on what it is checking.
+    """
+    module = inspect.getmodule(obj)
+    return getattr(module, "__name__", "").rsplit(".", 1)[-1]
+
+
 #: Everything that normalises an index value, on either side of the lookup.
 CALLERS = (
     "matrixark_mcp_core",
@@ -79,19 +105,19 @@ class ThereIsOneIndexNormaliserTest(unittest.TestCase):
 
     def test_every_caller_reaches_that_one(self) -> None:
         for module_name in CALLERS:
-            module = importlib.import_module(module_name)
+            module = _import(module_name)
             for name in ("normalized_index_value", "context_index_name"):
                 fn = getattr(module, name, None)
                 if fn is None:
                     continue
                 self.assertEqual(
-                    HOME, inspect.getmodule(fn).__name__,
+                    HOME, _module_name(fn),
                     "%s reaches a %s from %s rather than %s, so the writer and the reader can "
                     "normalise differently"
-                    % (module_name, name, inspect.getmodule(fn).__name__, HOME))
+                    % (module_name, name, _module_name(fn), HOME))
 
     def test_a_non_ascii_term_survives(self) -> None:
-        indexing = importlib.import_module(HOME)
+        indexing = _import(HOME)
         for term in NON_ASCII_TERMS:
             self.assertNotEqual(
                 "", indexing.normalized_index_value(term),
@@ -104,8 +130,8 @@ class ThereIsOneIndexNormaliserTest(unittest.TestCase):
 
     def test_the_writer_and_the_reader_agree_on_the_same_term(self) -> None:
         """The property that actually matters: one term, two paths, one index name."""
-        core = importlib.import_module("matrixark_mcp_core")
-        query = importlib.import_module("matrixark_mcp_query")
+        core = _import("matrixark_mcp_core")
+        query = _import("matrixark_mcp_query")
         for term in NON_ASCII_TERMS + ("plain ascii term",):
             written = core.context_index_name("keyword", term)
             read = query.context_index_name("keyword", term)
@@ -120,7 +146,7 @@ class ThereIsOneIndexNormaliserTest(unittest.TestCase):
         drops every non-ASCII character, two unrelated Chinese facts both normalise to "" and the
         second is discarded as a duplicate.
         """
-        norm = importlib.import_module("matrixark_mcp_extraction_normalization")
+        norm = _import("matrixark_mcp_extraction_normalization")
         first = norm.normalized_index_value("内存不足")
         second = norm.normalized_index_value("延迟过高")
         self.assertNotEqual("", first)
@@ -134,7 +160,7 @@ class ThereIsOneIndexNormaliserTest(unittest.TestCase):
         On its own it is not evidence of anything -- it is the assertion that made the original
         divergence invisible.
         """
-        indexing = importlib.import_module(HOME)
+        indexing = _import(HOME)
         self.assertEqual("hello_world", indexing.normalized_index_value("Hello World"))
         self.assertEqual("matrixark-2026", indexing.normalized_index_value("MatrixArk-2026"))
         self.assertEqual("", indexing.normalized_index_value(""))

--- a/tools/test_there_is_one_index_normaliser.py
+++ b/tools/test_there_is_one_index_normaliser.py
@@ -8,13 +8,25 @@ outside `[a-z0-9_.:/-]` with `_`. Because the result is then stripped of `_`, an
 Korean normalised to the EMPTY STRING through the plainer copy. The term did not rank lower. It
 disappeared.
 
-The two copies sat on opposite sides of the same lookup: `matrixark_mcp_core_query_analysis` and
-`matrixark_mcp_core_codex_outcome` reached `matrixark_mcp_core`, while `matrixark_mcp_query`
-reached `matrixark_mcp_indexing`. A term indexed under one could not be found by a query normalised
-through the other.
-
 `café` lost its accent the same way, so this is not only a CJK question -- any non-ASCII letter was
 dropped.
+
+WHAT THIS DOES NOT CLAIM, having checked: no live path could hit the divergence. Both copies are
+reached -- `matrixark_mcp_core_query_analysis` and `matrixark_mcp_core_codex_outcome` reach core's,
+and `matrixark_mcp_indexing`'s own term builders reach its own -- but every LIVE entry into this
+module passes values that are ASCII by construction. The only live text-taking entry is
+`benchmark_quality_index_terms`, reached from `matrixark_mcp_core` and
+`matrixark_mcp_local_adapter`, and its terms are fixed benchmark and metric names plus a workload
+capture whose character class is `[a-z0-9_.:/ -]`. Measured: `benchmark_quality_index_terms`
+("workload: 内存测试 p99") yields `['metric:p99_latency']` and no workload term at all.
+
+`matrixark_mcp_query`, which does call the term builders with arbitrary text, is reached by nothing
+outside `tools/test_*`.
+
+So the divergence was latent, and the reason it was latent is an accident of which builders exist
+today -- it stops being true the moment a term builder takes user text. A copy that is both wrong
+and unreachable-in-practice is the combination worth removing, which is why this is a change rather
+than a note.
 
 The rule is the strong form -- not "the two must agree" but "there must not be two". Every ASCII
 input agrees under either copy, so a same-answer check written against ordinary test data would
@@ -61,16 +73,26 @@ def _module_name(obj) -> str:
     return getattr(module, "__name__", "").rsplit(".", 1)[-1]
 
 
-#: Everything that normalises an index value, on either side of the lookup.
-CALLERS = (
+#: Reached from a production entry point.
+LIVE_CALLERS = (
     "matrixark_mcp_core",
     "matrixark_mcp_core_query_analysis",
     "matrixark_mcp_core_codex_outcome",
+)
+
+#: Reached by nothing outside `tools/test_*`. Checked all the same, so a second implementation
+#: cannot appear here and be adopted later -- but a pass on THESE is not evidence about a live
+#: lookup, which is the distinction this list exists to keep visible.
+#:
+#: `matrixark_mcp_extraction_normalization` is not an index path at all: its use is the dedup key in
+#: `codex_outcome_fact_entities`, where two distinct facts written in Chinese shared a key and the
+#: second was dropped. It sits in a seven-module island that imports only itself.
+TEST_ONLY_CALLERS = (
     "matrixark_mcp_query",
-    # Not an index path: its use is a dedup key. It had the strictest copy of the three, so two
-    # distinct facts written in Chinese shared a key and the second was dropped as a duplicate.
     "matrixark_mcp_extraction_normalization",
 )
+
+CALLERS = LIVE_CALLERS + TEST_ONLY_CALLERS
 
 #: Scripts written in these must survive normalisation, because a term made only of them would
 #: otherwise normalise to nothing at all.
@@ -129,7 +151,11 @@ class ThereIsOneIndexNormaliserTest(unittest.TestCase):
                 "merely changing" % term)
 
     def test_the_writer_and_the_reader_agree_on_the_same_term(self) -> None:
-        """The property that actually matters: one term, two paths, one index name."""
+        """One term, two modules, one index name.
+
+        `matrixark_mcp_query` is reached only by tests, so this is not asserting a lookup that
+        happens today -- it is asserting that the two modules cannot drift apart again.
+        """
         core = _import("matrixark_mcp_core")
         query = _import("matrixark_mcp_query")
         for term in NON_ASCII_TERMS + ("plain ascii term",):

--- a/tools/test_there_is_one_index_normaliser.py
+++ b/tools/test_there_is_one_index_normaliser.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+"""There is one index normaliser, and a non-ASCII term survives it.
+
+`normalized_index_value` was implemented twice. `matrixark_mcp_core`'s kept CJK and other non-ASCII
+characters through an explicit character class; `matrixark_mcp_indexing`'s replaced everything
+outside `[a-z0-9_.:/-]` with `_`. Because the result is then stripped of `_`, and
+`context_index_name` returns `""` for an empty value, a term written only in Chinese, Japanese or
+Korean normalised to the EMPTY STRING through the plainer copy. The term did not rank lower. It
+disappeared.
+
+The two copies sat on opposite sides of the same lookup: `matrixark_mcp_core_query_analysis` and
+`matrixark_mcp_core_codex_outcome` reached `matrixark_mcp_core`, while `matrixark_mcp_query`
+reached `matrixark_mcp_indexing`. A term indexed under one could not be found by a query normalised
+through the other.
+
+`café` lost its accent the same way, so this is not only a CJK question -- any non-ASCII letter was
+dropped.
+
+The rule is the strong form -- not "the two must agree" but "there must not be two". Every ASCII
+input agrees under either copy, so a same-answer check written against ordinary test data would
+have passed indefinitely; the first probe of this pair used seven ASCII strings and reported no
+difference at all.
+"""
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+import subprocess
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+SELF = Path(__file__).name
+
+HOME = "matrixark_mcp_indexing"
+
+#: Everything that normalises an index value, on either side of the lookup.
+CALLERS = (
+    "matrixark_mcp_core",
+    "matrixark_mcp_core_query_analysis",
+    "matrixark_mcp_core_codex_outcome",
+    "matrixark_mcp_query",
+    # Not an index path: its use is a dedup key. It had the strictest copy of the three, so two
+    # distinct facts written in Chinese shared a key and the second was dropped as a duplicate.
+    "matrixark_mcp_extraction_normalization",
+)
+
+#: Scripts written in these must survive normalisation, because a term made only of them would
+#: otherwise normalise to nothing at all.
+NON_ASCII_TERMS = ("内存", "检索延迟 p99", "メモリ", "메모리", "café")
+
+
+def _modules_defining(name: str) -> list[str]:
+    listed = subprocess.run(
+        ["git", "ls-files", "tools/*.py"], cwd=REPO, capture_output=True, text=True).stdout.split()
+    found = []
+    for rel in listed:
+        if Path(rel).name == SELF:
+            continue
+        try:
+            tree = ast.parse((REPO / rel).read_text(encoding="utf-8", errors="replace"))
+        except (SyntaxError, OSError):
+            continue
+        for node in tree.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+                found.append(Path(rel).stem)
+    return sorted(found)
+
+
+class ThereIsOneIndexNormaliserTest(unittest.TestCase):
+
+    def test_only_one_module_defines_each(self) -> None:
+        for name in ("normalized_index_value", "context_index_name"):
+            self.assertEqual(
+                [HOME], _modules_defining(name),
+                "%s is defined in more than one module again. A second copy will agree on every "
+                "ASCII input, so nothing routine will catch it -- re-export instead" % name)
+
+    def test_every_caller_reaches_that_one(self) -> None:
+        for module_name in CALLERS:
+            module = importlib.import_module(module_name)
+            for name in ("normalized_index_value", "context_index_name"):
+                fn = getattr(module, name, None)
+                if fn is None:
+                    continue
+                self.assertEqual(
+                    HOME, inspect.getmodule(fn).__name__,
+                    "%s reaches a %s from %s rather than %s, so the writer and the reader can "
+                    "normalise differently"
+                    % (module_name, name, inspect.getmodule(fn).__name__, HOME))
+
+    def test_a_non_ascii_term_survives(self) -> None:
+        indexing = importlib.import_module(HOME)
+        for term in NON_ASCII_TERMS:
+            self.assertNotEqual(
+                "", indexing.normalized_index_value(term),
+                "%r normalises to the empty string, so a term written in it cannot be indexed or "
+                "looked up at all" % term)
+            self.assertNotEqual(
+                "", indexing.context_index_name("keyword", term),
+                "context_index_name is empty for %r, which is how the term disappears rather than "
+                "merely changing" % term)
+
+    def test_the_writer_and_the_reader_agree_on_the_same_term(self) -> None:
+        """The property that actually matters: one term, two paths, one index name."""
+        core = importlib.import_module("matrixark_mcp_core")
+        query = importlib.import_module("matrixark_mcp_query")
+        for term in NON_ASCII_TERMS + ("plain ascii term",):
+            written = core.context_index_name("keyword", term)
+            read = query.context_index_name("keyword", term)
+            self.assertEqual(
+                written, read,
+                "%r is indexed as %r and looked up as %r" % (term, written, read))
+
+    def test_two_distinct_non_ascii_facts_do_not_share_a_dedup_key(self) -> None:
+        """The third copy was not an index normaliser at all, and lost data rather than lookups.
+
+        `codex_outcome_fact_entities` keys `seen` on the normalised fact. Under a normaliser that
+        drops every non-ASCII character, two unrelated Chinese facts both normalise to "" and the
+        second is discarded as a duplicate.
+        """
+        norm = importlib.import_module("matrixark_mcp_extraction_normalization")
+        first = norm.normalized_index_value("内存不足")
+        second = norm.normalized_index_value("延迟过高")
+        self.assertNotEqual("", first)
+        self.assertNotEqual(
+            first, second,
+            "two distinct facts share a dedup key, so one of them is dropped by the extraction")
+
+    def test_ascii_is_unchanged(self) -> None:
+        """Control. This passes under either copy, and is here to say so.
+
+        On its own it is not evidence of anything -- it is the assertion that made the original
+        divergence invisible.
+        """
+        indexing = importlib.import_module(HOME)
+        self.assertEqual("hello_world", indexing.normalized_index_value("Hello World"))
+        self.assertEqual("matrixark-2026", indexing.normalized_index_value("MatrixArk-2026"))
+        self.assertEqual("", indexing.normalized_index_value(""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_there_is_one_index_normaliser.py
+++ b/tools/test_there_is_one_index_normaliser.py
@@ -154,6 +154,28 @@ class ThereIsOneIndexNormaliserTest(unittest.TestCase):
             first, second,
             "two distinct facts share a dedup key, so one of them is dropped by the extraction")
 
+    def test_an_index_term_list_never_contains_the_empty_string(self) -> None:
+        """The other way an index term stops being a name.
+
+        `context_index_name` returns "" for anything that normalises to nothing, and the term
+        builders append its result unconditionally. matrixark_mcp_indexing had its own
+        `_ordered_unique` that neither trimmed nor dropped the empty string, so
+        `metadata_index_terms({})` returned [""]. An index name of "" is not a name -- every
+        record producing one posts under the same key.
+        """
+        indexing = _import(HOME)
+        core = _import("matrixark_mcp_core")
+        self.assertIs(
+            core.ordered_unique, indexing.ordered_unique,
+            "ordered_unique is two objects again, and the copies disagreed about the empty string")
+        for metadata in ({}, {"keywords": []}, {"keywords": ["", " ", "k"]}):
+            for terms in (indexing.metadata_index_terms(metadata),
+                          core.metadata_index_terms(metadata)):
+                self.assertNotIn(
+                    "", terms,
+                    "metadata_index_terms(%r) returned an empty index term: %r"
+                    % (metadata, terms))
+
     def test_ascii_is_unchanged(self) -> None:
         """Control. This passes under either copy, and is here to say so.
 


### PR DESCRIPTION
`normalized_index_value` was implemented **three** times, and the copies disagreed about every
character outside `[a-z0-9_.:/-]`.

| input | `matrixark_mcp_core` | `matrixark_mcp_indexing` | `..._extraction_normalization` |
|---|---|---|---|
| `内存` | `'内存'` | `''` | `''` |
| `检索延迟 p99` | `'检索延迟_p99'` | `'p99'` | `'p99'` |
| `メモリ` | `'メモリ'` | `''` | `''` |
| `메모리` | `'메모리'` | `''` | `''` |
| `café` | `'café'` | `'caf'` | `'caf'` |
| `hello world` | `'hello_world'` | `'hello_world'` | `'hello_world'` |

The result is stripped of `_`, and `context_index_name` returns `""` for an empty value, so a term
written only in one of those scripts normalised to the **empty string** — it would not rank lower,
it would be absent.

A second copy of the same shape one level down: `matrixark_mcp_indexing`'s own `_ordered_unique`
neither trimmed nor dropped the empty string, unlike `matrixark_mcp_core.ordered_unique`, so
`metadata_index_terms({})` returned `['']`. An index name of `""` is not a name.

## What this is not

**No live path could hit either.** I checked after writing the first version of this description,
which claimed a term indexed through one copy could not be found by a query normalised through the
other. That is not true today, and the correction is the more useful half of this PR.

Both copies are reached. `matrixark_mcp_core_query_analysis` and `matrixark_mcp_core_codex_outcome`
reach core's; `matrixark_mcp_indexing`'s own term builders reach its own. But **every live entry
into `matrixark_mcp_indexing` passes values that are ASCII by construction.** The only live
text-taking entry is `benchmark_quality_index_terms`, reached from `matrixark_mcp_core` and
`matrixark_mcp_local_adapter`, and its terms are fixed benchmark and metric names plus a workload
capture whose character class is `[a-z0-9_.:/ -]`:

```
benchmark_quality_index_terms("workload: 内存测试 p99")
    -> ['metric:p99_latency']       and no workload term at all
```

`matrixark_mcp_query` — which does call the term builders with arbitrary text, and which I first
named as the reader — is reached by nothing outside `tools/test_*`. The same applies to the
empty-term case: `metadata_index_terms` has no caller outside its own module except
`matrixark_mcp_query`.

`matrixark_mcp_extraction_normalization`, holding the third copy, sits in a seven-module island that
imports only itself.

## Why land it anyway

Three implementations of one name, measurably different, and the only reason the difference was
latent is an accident of which term builders exist today — it stops being true the moment one takes
user text. A copy that is both wrong and unreachable-in-practice is the combination worth removing:
it cannot fail today and it is what somebody reaches for tomorrow.

The character class and the unique helper both live in `matrixark_mcp_indexing`, which owns index
naming and imports nothing from the other two; `matrixark_mcp_core` re-exports them. ASCII is
unchanged everywhere, and the twelve modules importing `ordered_unique` from core get exactly what
core's definition did.

## The guard is the strong form

Not "the copies must agree" but **"there must not be copies"**. Every ASCII input agrees under all
three, so a same-answer check written against ordinary test data would have passed indefinitely —
the first probe of this pair used seven ASCII strings and reported no difference at all.

Its caller list is split into live and test-only, each labelled in the code, so a pass on the second
group is not read as evidence about a live lookup.

- **Mutation-tested three ways.** Restoring the ASCII-only class fails the survival and dedup
  assertions; giving core its own copy again fails the definition count, the caller resolution and
  the writer/reader agreement; a helper that keeps the empty string fails the term-list assertion.
- Runs under both import paths (`tools.<module>` and bare), verified both ways.
- The 69 failures across the index and codex suites are present on main with this change removed —
  identical sets, name-diffed both ways.
