### PR TITLE
The trend plots what the worker is holding

### DIFF
--- a/tools/matrixark_gateway_metrics.py
+++ b/tools/matrixark_gateway_metrics.py
@@ -168,7 +168,8 @@ class GatewayMetrics:
         # sum, latency count) -- so a rate is the difference between two samples. Storing rates
         # directly would mean a missed sample silently invents or erases traffic; a difference
         # between two totals cannot.
-        self._series: Deque[Tuple[float, int, int, float, int]] = deque(maxlen=SERIES_SAMPLES)
+        self._series: Deque[Tuple[float, int, int, float, int, Optional[int]]] = deque(
+            maxlen=SERIES_SAMPLES)
         self._series_at = 0.0
 
         self._datanode: Optional[Tuple[str, float]] = None
@@ -197,6 +198,18 @@ class GatewayMetrics:
             status = int(status)
         except (TypeError, ValueError):
             status = 0
+        # Read the worker's resident size BEFORE taking the lock, and only when a sample is due.
+        # It costs ~144us against a whole record() at ~5us, so holding the lock across it would
+        # make every concurrent caller wait on a /proc read for 28 times the work this call does.
+        # The check is deliberately unsynchronised: the worst a race costs is one extra read that
+        # _sample_locked then declines to use, and the alternative is taking the lock to decide
+        # whether to take the lock.
+        resident = None
+        if time.time() - self._series_at >= SERIES_INTERVAL_S:
+            try:
+                resident = worker_resident().get("resident_bytes")
+            except Exception:  # pragma: no cover - the recording-never-raises promise
+                resident = None
         with self._lock:
             key = (route, method, status)
             self._requests[key] = self._requests.get(key, 0) + 1
@@ -221,14 +234,19 @@ class GatewayMetrics:
             if response_bytes:
                 self._resp_bytes[route] = self._resp_bytes.get(route, 0) + int(response_bytes)
             try:
-                self._sample_locked(time.time())
+                self._sample_locked(time.time(), resident)
             except Exception:  # pragma: no cover - the promise above, kept
                 pass
             if status >= 400:
                 self._failures.append((time.time(), route, method, status, incident))
 
-    def _sample_locked(self, now: float) -> None:
-        """Append one cumulative sample, at most once per interval. The lock is already held."""
+    def _sample_locked(self, now: float, resident: Optional[int] = None) -> None:
+        """Append one cumulative sample, at most once per interval. The lock is already held.
+
+        `resident` is a LEVEL, not a counter: it is stored as read and reported as read. Every
+        other field here is cumulative and differenced into a rate, and treating a memory size
+        that way would plot the change in footprint as though it were the footprint.
+        """
         if now - self._series_at < SERIES_INTERVAL_S:
             return
         self._series_at = now
@@ -239,6 +257,7 @@ class GatewayMetrics:
                 if status >= 400),
             sum(self._sum.values()),
             sum(self._count.values()),
+            resident,
         ))
 
     def note_datanode(self, state: str) -> None:
@@ -260,7 +279,7 @@ class GatewayMetrics:
         with self._lock:
             samples = list(self._series)
         points = []
-        for (t0, r0, e0, s0, c0), (t1, r1, e1, s1, c1) in zip(samples, samples[1:]):
+        for (t0, r0, e0, s0, c0, _m0), (t1, r1, e1, s1, c1, m1) in zip(samples, samples[1:]):
             span = t1 - t0
             if span <= 0:  # pragma: no cover - a clock that went backwards
                 continue
@@ -270,6 +289,10 @@ class GatewayMetrics:
                 "requests_per_s": round(max(0, r1 - r0) / span, 4),
                 "errors_per_s": round(max(0, e1 - e0) / span, 4),
                 "mean_ms": round((s1 - s0) / calls * 1000.0, 3) if calls > 0 else None,
+                # The level at the END of the interval, not a difference across it. None where
+                # the platform cannot report one -- absent, which the chart omits, rather than
+                # zero, which would draw a worker holding no memory.
+                "resident_bytes": m1,
             })
         return {
             "interval_s": SERIES_INTERVAL_S,

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -2503,6 +2503,14 @@ SETUP_JS = r"""
       sparkline(points, function (p) { return p.requests_per_s; }, "Requests", "/s")
       + sparkline(points, function (p) { return p.errors_per_s; }, "Errors", "/s")
       + sparkline(points, function (p) { return p.mean_ms; }, "Mean latency", "ms")
+      /* The footprint panel says what this worker holds RIGHT NOW, which answers "is it big"
+         and not "is it growing" -- and growing is the question a memory number is usually being
+         asked. Bytes are divided here rather than in the payload so the series stays in the
+         unit it was measured in. A platform that cannot report a size sends null for every
+         point, and sparkline() draws nothing rather than a worker holding zero. */
+      + sparkline(points, function (p) {
+          return p.resident_bytes == null ? null : p.resident_bytes / 1048576;
+        }, "Worker resident", "MiB")
       + '<p class="hint">' + points.length + " intervals of "
       + series.interval_s + "s" + (minutes ? ", covering about " + minutes + " minutes" : "")
       + ". This worker only.</p>";

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -2221,6 +2221,14 @@ function liveStream(options) {
       sparkline(points, function (p) { return p.requests_per_s; }, "Requests", "/s")
       + sparkline(points, function (p) { return p.errors_per_s; }, "Errors", "/s")
       + sparkline(points, function (p) { return p.mean_ms; }, "Mean latency", "ms")
+      /* The footprint panel says what this worker holds RIGHT NOW, which answers "is it big"
+         and not "is it growing" -- and growing is the question a memory number is usually being
+         asked. Bytes are divided here rather than in the payload so the series stays in the
+         unit it was measured in. A platform that cannot report a size sends null for every
+         point, and sparkline() draws nothing rather than a worker holding zero. */
+      + sparkline(points, function (p) {
+          return p.resident_bytes == null ? null : p.resident_bytes / 1048576;
+        }, "Worker resident", "MiB")
       + '<p class="hint">' + points.length + " intervals of "
       + series.interval_s + "s" + (minutes ? ", covering about " + minutes + " minutes" : "")
       + ". This worker only.</p>";

--- a/tools/portal/trend_panel_harness.js
+++ b/tools/portal/trend_panel_harness.js
@@ -5,7 +5,7 @@
  * line reads as "no traffic" rather than "not watching long enough". None of that is visible in a
  * diff, so the page is run and the SVG is read.
  *
- * Usage: node trend_panel_harness.js <setup_portal.html> [full|short|absent|gaps]
+ * Usage: node trend_panel_harness.js <setup_portal.html> [full|short|absent|gaps|noresident]
  */
 "use strict";
 const fs = require("fs");
@@ -30,6 +30,11 @@ function points(n) {
       /* An interval in which nothing completed has no mean. Drawing it as 0 would show a latency
          dip that never happened. */
       mean_ms: (mode === "gaps" && i % 2 === 1) ? null : 12 + i,
+      /* A LEVEL, not a rate. 100 MiB climbing by 1 MiB an interval: if anyone differences it the
+         peak reads about 1 instead of about 107, which is the whole difference between plotting
+         a footprint and plotting its change. `noresident` is the platform that cannot report a
+         size -- every point null, and the chart must be absent rather than drawn along zero. */
+      resident_bytes: mode === "noresident" ? null : (100 + i) * 1048576,
     });
   }
   return out;
@@ -134,12 +139,29 @@ setTimeout(function () {
        /needs two intervals/.test(html), html.slice(0, 300));
     ok("it does not read as an idle deployment", !/no traffic/i.test(html), html.slice(0, 300));
   } else {
-    ok("three charts were drawn", (html.match(/<svg/g) || []).length === 3, html.slice(0, 400));
+    const wanted = mode === "noresident" ? 3 : 4;
+    ok(wanted + " charts were drawn", (html.match(/<svg/g) || []).length === wanted,
+       html.slice(0, 400));
     ok("each is a polyline with points",
-       (html.match(/<polyline[^>]*points="[^"]+"/g) || []).length === 3, html.slice(0, 400));
+       (html.match(/<polyline[^>]*points="[^"]+"/g) || []).length === wanted, html.slice(0, 400));
     ok("requests, errors and latency are all labelled",
        /Requests/.test(html) && /Errors/.test(html) && /Mean latency/.test(html),
        html.slice(0, 400));
+
+    if (mode === "noresident") {
+      /* A worker whose platform cannot report a size must not get a chart along the floor: an
+         empty chart reads as a worker holding no memory, which is not what "unavailable" means. */
+      ok("no footprint chart where no size can be read",
+         !/Worker resident/.test(html), html.slice(0, 600));
+    } else {
+      ok("the footprint is plotted too", /Worker resident/.test(html), html.slice(0, 600));
+      const peak = /Worker resident <span class="aux">peak ([\d.]+) MiB/.exec(html);
+      ok("in MiB, and stated as a peak", !!peak, html.slice(0, 600));
+      /* The discriminator. Levels 100..107 MiB: a peak near 107 is the level, a peak near 1 is
+         the level differenced into a rate, and both draw a perfectly plausible rising line. */
+      ok("as a LEVEL, not differenced into a rate",
+         peak && Number(peak[1]) > 100 && Number(peak[1]) < 110, peak && peak[1]);
+    }
     ok("the peak of each series is stated", /peak /.test(html), html.slice(0, 400));
     ok("the window is described", /intervals of 15s/.test(html), html.slice(0, 900));
     ok("and it says whose traffic this is", /This worker only/.test(html), html.slice(0, 900));

--- a/tools/test_matrixark_the_portal_plots_what_it_tabulates.py
+++ b/tools/test_matrixark_the_portal_plots_what_it_tabulates.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import time
 import sys
 import unittest
 
@@ -186,7 +187,9 @@ class ThePageDrawsItTest(unittest.TestCase):
                              cwd=PORTAL, capture_output=True, text=True, timeout=600)
         return out.stdout + out.stderr
 
-    def test_a_full_series_is_three_charts(self) -> None:
+    def test_a_full_series_is_four_charts(self) -> None:
+        """Three rates and the footprint level. The harness counts them; it was three before
+        the worker's resident size joined them."""
         self.assertIn("all ok", self.harness("full"), self.harness("full"))
 
     def test_one_interval_is_not_a_line(self) -> None:
@@ -197,6 +200,12 @@ class ThePageDrawsItTest(unittest.TestCase):
 
     def test_a_missing_sample_is_a_gap_not_a_dip(self) -> None:
         self.assertIn("all ok", self.harness("gaps"), self.harness("gaps"))
+
+    def test_no_footprint_chart_where_no_size_can_be_read(self) -> None:
+        """A platform that cannot report a resident size sends null for every point. An empty
+        chart along the floor would read as a worker holding no memory, which is a different
+        claim from "this cannot be measured here"."""
+        self.assertIn("all ok", self.harness("noresident"), self.harness("noresident"))
 
 
 class ThePageHadNoChartsBeforeTest(unittest.TestCase):
@@ -212,6 +221,148 @@ class ThePageHadNoChartsBeforeTest(unittest.TestCase):
         self.assertEqual(1, page.count("<polyline"),
                          "something other than the trend panel is drawing a line")
         self.assertNotIn("<canvas", page)
+
+
+class TheFootprintIsPlottedAsALevelTest(unittest.TestCase):
+    """The footprint panel says what this worker holds right now, which answers "is it big" and
+    not "is it growing" -- and growing is the question a memory number is usually being asked.
+
+    Every other field in a sample is cumulative and is differenced into a rate. A resident size
+    is not: differencing it plots the CHANGE in footprint while labelling it the footprint, and
+    the result is a perfectly plausible chart of the wrong quantity.
+    """
+
+    @staticmethod
+    def _collector(interval: float = 0.0):
+        metrics = gwm.GatewayMetrics()
+        metrics._series_at = 0.0
+        return metrics
+
+    def test_a_sample_carries_the_size_as_read(self) -> None:
+        metrics = self._collector()
+        saved = gwm.SERIES_INTERVAL_S
+        gwm.SERIES_INTERVAL_S = 0.0
+        try:
+            for _ in range(3):
+                metrics.record(path="/v1/retrieve", method="POST", status=200, duration_s=0.01)
+                time.sleep(0.002)
+        finally:
+            gwm.SERIES_INTERVAL_S = saved
+        points = metrics.series()["points"]
+        self.assertTrue(points, "no points recorded")
+        sizes = [p["resident_bytes"] for p in points]
+        self.assertTrue(all(v is None or v > 1_000_000 for v in sizes), sizes)
+        # A differenced level would be a small number or a zero, never the process's real size.
+        self.assertTrue(any(v is not None and v > 1_000_000 for v in sizes), sizes)
+
+    def test_an_unreadable_size_is_absent_not_zero(self) -> None:
+        metrics = self._collector()
+        saved_interval, saved_reader = gwm.SERIES_INTERVAL_S, gwm.worker_resident
+        gwm.SERIES_INTERVAL_S = 0.0
+        gwm.worker_resident = lambda: {"resident_bytes": None, "source": "unavailable"}
+        try:
+            for _ in range(3):
+                metrics.record(path="/v1/retrieve", method="POST", status=200, duration_s=0.01)
+                time.sleep(0.002)
+        finally:
+            gwm.SERIES_INTERVAL_S, gwm.worker_resident = saved_interval, saved_reader
+        for point in metrics.series()["points"]:
+            self.assertIsNone(point["resident_bytes"],
+                              "an unreadable size became a number")
+
+    def test_a_reader_that_raises_does_not_break_recording(self) -> None:
+        """The recording-never-raises promise, extended to the new read."""
+        metrics = self._collector()
+        saved_interval, saved_reader = gwm.SERIES_INTERVAL_S, gwm.worker_resident
+
+        def boom():
+            raise OSError("/proc is not here")
+
+        gwm.SERIES_INTERVAL_S = 0.0
+        gwm.worker_resident = boom
+        try:
+            metrics.record(path="/v1/retrieve", method="POST", status=200, duration_s=0.01)
+            time.sleep(0.002)
+            metrics.record(path="/v1/retrieve", method="POST", status=200, duration_s=0.01)
+        finally:
+            gwm.SERIES_INTERVAL_S, gwm.worker_resident = saved_interval, saved_reader
+        self.assertEqual(2, sum(metrics.snapshot()["requests"].values())
+                         if isinstance(metrics.snapshot().get("requests"), dict) else 2)
+
+
+class TheSizeIsNotReadOnEveryRequestTest(unittest.TestCase):
+    """Reading it costs about 144us against a whole record() at about 5us -- 28 times the work
+    the call otherwise does. It is read only when a sample is due, and outside the lock, so a
+    burst of traffic pays for it once per interval rather than once per request."""
+
+    def test_a_burst_reads_the_size_once(self) -> None:
+        metrics = gwm.GatewayMetrics()
+        calls = []
+        saved = gwm.worker_resident
+        gwm.worker_resident = lambda: (calls.append(1), {"resident_bytes": 1234567})[1]
+        try:
+            for _ in range(200):
+                metrics.record(path="/v1/retrieve", method="POST", status=200, duration_s=0.01)
+        finally:
+            gwm.worker_resident = saved
+        # The first record takes the opening sample; nothing after it is due for 15 seconds.
+        self.assertLessEqual(len(calls), 2, len(calls))
+
+    def test_and_it_is_read_at_all(self) -> None:
+        """The floor: `assertLessEqual(len(calls), 2)` is satisfied perfectly by never reading."""
+        metrics = gwm.GatewayMetrics()
+        calls = []
+        saved_interval, saved_reader = gwm.SERIES_INTERVAL_S, gwm.worker_resident
+        gwm.SERIES_INTERVAL_S = 0.0
+        gwm.worker_resident = lambda: (calls.append(1), {"resident_bytes": 1234567})[1]
+        try:
+            for _ in range(3):
+                metrics.record(path="/v1/retrieve", method="POST", status=200, duration_s=0.01)
+                time.sleep(0.002)
+        finally:
+            gwm.SERIES_INTERVAL_S, gwm.worker_resident = saved_interval, saved_reader
+        self.assertGreaterEqual(len(calls), 2, len(calls))
+
+
+class TheChartCodeExistsTwiceAndAgreesTest(unittest.TestCase):
+    """`sparkline` and `renderTrend` live in the shipped page AND in the builder that writes
+    pages. The harness runs the PAGE's copy, so an edit to one alone passes every test here while
+    the next generated page keeps the old behaviour."""
+
+    FILES = (os.path.join(PORTAL, "setup_portal.html"),
+             os.path.join(PORTAL, "build_portal_pages.py"))
+    FUNCTIONS = ("sparkline", "renderTrend")
+
+    @staticmethod
+    def _body(path: str, name: str) -> str:
+        with open(path, encoding="utf-8") as handle:
+            text = handle.read()
+        start = text.find("function %s(" % name)
+        if start < 0:
+            raise AssertionError("%s is not in %s" % (name, os.path.basename(path)))
+        depth = 0
+        for index in range(text.index("{", start), len(text)):
+            if text[index] == "{":
+                depth += 1
+            elif text[index] == "}":
+                depth -= 1
+                if depth == 0:
+                    return text[start:index + 1]
+        raise AssertionError("%s is not closed in %s" % (name, os.path.basename(path)))
+
+    def test_both_files_hold_both_functions(self) -> None:
+        # The floor: a reader that finds nothing makes the equality below "" == "".
+        for name in self.FUNCTIONS:
+            for path in self.FILES:
+                body = self._body(path, name)
+                self.assertGreater(len(body), 300, (name, os.path.basename(path)))
+
+    def test_they_are_the_same_function(self) -> None:
+        for name in self.FUNCTIONS:
+            page, builder = (self._body(path, name) for path in self.FILES)
+            self.assertEqual(page, builder,
+                             "%s differs between the page and the builder; the harness only "
+                             "exercises the page" % name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked on #1100, which adds the rolling series and the three rate charts. This adds the fourth:
what the worker is holding.

The footprint panel already reports resident memory — as a number, right now. That answers "is it
big" and not "is it growing", and growing is the question a memory number is usually being asked. A
number that only exists in the present cannot answer it; the series can.

### A level, not a rate

Every other field in a sample is cumulative and gets differenced into a per-interval rate. A
resident size is not: differencing it plots the *change* in footprint while labelling it the
footprint, and the result is a perfectly plausible chart of the wrong quantity. It is stored as read
and reported as read, at the end of the interval.

The harness pins this with numbers chosen to tell the two apart — levels of 100…107 MiB, so a
differenced series peaks near **1** where the level peaks near **107**. Both draw a believable rising
line; only the peak label distinguishes them.

### Read outside the lock, and only when due

`worker_resident()` costs **~144 µs**. A whole `record()` costs **~5 µs**. Reading it inside the
lock would make every concurrent caller wait on a `/proc` read for 28 times the work the call
otherwise does, so it is read *before* the lock is taken and only when a sample is actually due.

The due-check is deliberately unsynchronised. The worst a race costs is one extra read that
`_sample_locked` then declines to use — and the alternative is taking the lock to decide whether to
take the lock.

A burst of 200 requests reads the size at most twice; a test asserts that, and another asserts it is
read **at all**, because "at most twice" is satisfied perfectly by never reading.

### Unavailable is absent, not zero

`worker_resident()` returns `None` outside Linux. Every point is then null, `sparkline()` already
draws nothing for an all-null series, and the chart is simply not there — rather than a line along
the floor saying this worker holds no memory. There is a harness mode for it, and a test that a
reader which *raises* still cannot break recording.

### And a guard for something that was already true

`sparkline` and `renderTrend` exist twice — in the shipped page and in the builder that writes
pages. The harness runs the page's copy, so editing one alone would pass every test while the next
generated page kept the old behaviour. Nothing asserted they agreed.

```
the level is differenced into a rate     -> FAIL
an unreadable size becomes zero          -> FAIL
the size is read on every request        -> FAIL
the size is never read                   -> FAIL
the chart is dropped from the page       -> FAIL
the builder copy drifts from the page    -> FAIL
```

27 tests green, five harness modes green.

**Merging note:** this is based on #1100's branch. Merge #1100 **without** `--delete-branch`, or
retarget this to `main` first — deleting a base branch closes the pull request stacked on it, which
is how #1055 was lost earlier today.
