### PR TITLE
The connection test compares the answer with the question

### DIFF
--- a/tools/context_minilm_embed_server.py
+++ b/tools/context_minilm_embed_server.py
@@ -97,7 +97,10 @@ class Handler(BaseHTTPRequestHandler):
         except Exception as exc:  # noqa: BLE001
             self._send(400, {"error": str(exc)})
             return
-        model = payload.get("model", MODEL_NAME)
+        # What the caller asked for. It does NOT choose the encoder: this server loads one model
+        # at startup and encodes everything with it, so honouring the request would be a lie in
+        # the other direction. It is kept only to be compared against below.
+        asked = payload.get("model", MODEL_NAME)
         inp = payload.get("input", [])
         if isinstance(inp, str):
             inp = [inp]
@@ -116,7 +119,15 @@ class Handler(BaseHTTPRequestHandler):
             {
                 "object": "list",
                 "data": data,
-                "model": model,
+                # The model that ENCODED this text, not the one that was requested. Echoing the
+                # request back made a mismatch invisible: ask a server running all-MiniLM-L6-v2
+                # for text-embedding-3-small and it returned MiniLM vectors labelled
+                # text-embedding-3-small. Both are 384 wide, so nothing downstream could notice
+                # by length, and the portal's connection test read the echo as confirmation that
+                # the endpoint served the model. It is also what the OpenAI response contract
+                # says this field is.
+                "model": MODEL_NAME,
+                "requested_model": asked,
                 "usage": {"prompt_tokens": 0, "total_tokens": 0},
             },
         )

--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -1961,7 +1961,8 @@ def _probe(kind: str, url: str, payload: Json, headers: Dict[str, str], timeout:
         status, parsed = _post_json(url, payload, headers, timeout)
         result["status"] = status
         result["ok"] = 200 <= status < 300
-        result["response"] = parsed if isinstance(parsed, str) else _summarize(kind, parsed)
+        result["response"] = (parsed if isinstance(parsed, str)
+                              else _summarize(kind, parsed, payload.get("model")))
     except urllib.error.HTTPError as exc:
         detail = ""
         try:
@@ -1978,31 +1979,64 @@ def _probe(kind: str, url: str, payload: Json, headers: Dict[str, str], timeout:
     return result
 
 
-def _summarize(kind: str, parsed: Any) -> Json:
+def _with_match(summary: Json, requested: Any) -> Json:
+    """Add what was asked for, and whether the answer matches it.
+
+    Absent rather than False when either side is unknown: a provider that returns no model name
+    has not disagreed with anything, and saying it did would put a warning on every endpoint that
+    is merely terse.
+    """
+    served = summary.get("model")
+    summary["requested_model"] = requested or None
+    if requested and served:
+        summary["model_matches_request"] = _same_model(requested, served)
+    return summary
+
+
+def _same_model(asked: Any, served: Any) -> bool:
+    """Whether two model names denote the same model.
+
+    An organisation prefix is not a difference: `sentence-transformers/paraphrase-multilingual-
+    MiniLM-L12-v2` and `paraphrase-multilingual-MiniLM-L12-v2` are one model under two spellings,
+    and the shipped local_minilm preset uses the short one while the encoder catalogue lists the
+    long one. Reporting that pair as a mismatch would be a false alarm on a supported setup, and
+    a warning that cries wolf on the shipped configuration is one nobody reads.
+    """
+    left = str(asked or "").strip().lower().rsplit("/", 1)[-1]
+    right = str(served or "").strip().lower().rsplit("/", 1)[-1]
+    return left == right
+
+
+def _summarize(kind: str, parsed: Any, requested: Any = None) -> Json:
     """Keep only what an operator needs from a provider response -- never the whole body, which for
-    an embedding probe is a full vector."""
+    an embedding probe is a full vector.
+
+    `requested` is carried in so the answer can be compared with the question. Reporting only the
+    model that came back reads as confirmation that the endpoint serves it, and against a server
+    that echoes the request that confirmation is of the operator's own input.
+    """
     if not isinstance(parsed, dict):
         return {"raw": str(parsed)[:200]}
     if kind == "embedding":
         data = parsed.get("data")
         vector = data[0].get("embedding") if isinstance(data, list) and data and isinstance(data[0], dict) else None
-        return {
+        return _with_match({
             "model": parsed.get("model"),
             "dimensions": len(vector) if isinstance(vector, list) else None,
-        }
+        }, requested)
     if kind == "extraction_anthropic":
         # Messages API: the reply is a list of content blocks, not a choices list.
         blocks = parsed.get("content")
         text = "".join(str(b.get("text", "")) for b in blocks
                        if isinstance(b, dict) and b.get("type", "text") == "text") \
             if isinstance(blocks, list) else ""
-        return {"model": parsed.get("model"), "sample": text[:120]}
+        return _with_match({"model": parsed.get("model"), "sample": text[:120]}, requested)
     choices = parsed.get("choices")
     text = ""
     if isinstance(choices, list) and choices and isinstance(choices[0], dict):
         message = choices[0].get("message") or {}
         text = str(message.get("content", ""))[:120]
-    return {"model": parsed.get("model"), "sample": text}
+    return _with_match({"model": parsed.get("model"), "sample": text}, requested)
 
 
 def probe(targets: Optional[List[str]] = None, timeout: float = 10.0) -> Json:

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -2248,21 +2248,36 @@ SETUP_JS = r"""
 
   /* ---------- probe ---------- */
   function probeHtml(r) {
-    var cls = r.ok ? "ok" : (r.skipped ? "" : "bad");
+    /* A call that succeeded with the WRONG model is the failure this panel is least able to
+       show: it answered, it was fast, and the vectors are unusable. Candidate encoders are
+       routinely the same width -- all-MiniLM-L6-v2 and BGE-M3 truncated to 384 both emit 384
+       values -- so nothing downstream can notice by length, and retrieval degrades to noise
+       with nothing in the logs. It is reported here because this is the one moment the
+       question was actually asked of the endpoint. */
+    var response = r.response || {};
+    var mismatch = r.ok && response.model_matches_request === false;
+    var cls = mismatch ? "bad" : (r.ok ? "ok" : (r.skipped ? "" : "bad"));
     var title = r.target === "extraction" ? "Extraction" : "Embedding";
     var detail;
     if (r.ok) {
-      var extra = r.response && r.response.dimensions ? " · " + r.response.dimensions + " dimensions" : "";
-      var model = r.response && r.response.model ? " · " + r.response.model : "";
+      var extra = response.dimensions ? " · " + response.dimensions + " dimensions" : "";
+      var model = response.model ? " · " + response.model : "";
       detail = "answered in " + r.latency_ms + " ms" + model + extra;
+      if (mismatch) {
+        detail = "asked for " + response.requested_model + ", answered as " + response.model
+          + extra + ". Vectors from a different model cannot be compared with the ones already "
+          + "stored, and both may be the same width, so nothing else will notice.";
+      }
     } else if (r.skipped) {
       detail = r.detail || r.error;
     } else {
       detail = (r.error || "failed") + (r.detail ? " — " + r.detail : "");
     }
+    var pill = mismatch ? "failed" : (r.ok ? "completed" : (r.skipped ? "queued" : "failed"));
+    var word = mismatch ? "different model"
+      : (r.ok ? "ok" : (r.skipped ? "not configured" : "failed"));
     return '<div class="probe ' + cls + '"><h3>' + esc(title) +
-      '<span class="pill ' + (r.ok ? "completed" : (r.skipped ? "queued" : "failed")) + '">' +
-      (r.ok ? "ok" : (r.skipped ? "not configured" : "failed")) + "</span></h3>" +
+      '<span class="pill ' + pill + '">' + word + "</span></h3>" +
       "<p>" + esc(detail) + (r.url ? ' <span class="mono">' + esc(r.url) + "</span>" : "") + "</p></div>";
   }
 

--- a/tools/portal/probe_model_harness.js
+++ b/tools/portal/probe_model_harness.js
@@ -1,0 +1,71 @@
+/* Run the shipped probeHtml and read what it says about the model that answered.
+ *
+ * A call that succeeded with the WRONG model is the failure this panel is least able to show: it
+ * answered, it was fast, and the vectors are unusable. So the function is run rather than read.
+ *
+ * Usage: node probe_model_harness.js <setup_portal.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const start = page.indexOf("function probeHtml(r)");
+if (start < 0) { console.log("probeHtml is not on this page"); process.exit(2); }
+let depth = 0, end = -1;
+for (let i = page.indexOf("{", start); i < page.length; i++) {
+  if (page[i] === "{") depth++;
+  else if (page[i] === "}") { depth--; if (depth === 0) { end = i + 1; break; } }
+}
+const esc = (s) => String(s).replace(/[&<>"]/g, (c) =>
+  ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+const probeHtml = new Function("esc", page.slice(start, end) + "; return probeHtml;")(esc);
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+const base = { target: "embedding", ok: true, latency_ms: 12, url: "http://127.0.0.1:8400/v1" };
+
+const agreed = probeHtml(Object.assign({}, base, {
+  response: { model: "all-MiniLM-L6-v2", dimensions: 384,
+              requested_model: "all-MiniLM-L6-v2", model_matches_request: true },
+}));
+ok("a model that matches reads as ok", />ok</.test(agreed), agreed);
+ok("and is not styled as a problem", !/class="probe bad"/.test(agreed), agreed);
+
+const differs = probeHtml(Object.assign({}, base, {
+  response: { model: "all-MiniLM-L6-v2", dimensions: 384,
+              requested_model: "text-embedding-3-small", model_matches_request: false },
+}));
+ok("a different model is not reported as ok", !/>ok</.test(differs), differs);
+ok("it is named as a different model", />different model</.test(differs), differs);
+ok("and styled as something to look at", /class="probe bad"/.test(differs), differs);
+ok("both names are shown, so it can be acted on",
+   differs.indexOf("text-embedding-3-small") >= 0 && differs.indexOf("all-MiniLM-L6-v2") >= 0,
+   differs);
+ok("and it says why a same-width answer is still wrong",
+   /same width/.test(differs), differs);
+
+/* The false-alarm floor. A provider that returns no model name has not disagreed with anything,
+   and a warning on every terse endpoint is one nobody reads. */
+const terse = probeHtml(Object.assign({}, base, { target: "extraction",
+  response: { model: "gpt-4o-mini", sample: "hi" } }));
+ok("FLOOR: no comparison available is not a mismatch",
+   />ok</.test(terse) && !/different model/.test(terse), terse);
+
+const noModel = probeHtml(Object.assign({}, base, { response: { dimensions: 384 } }));
+ok("FLOOR: a response naming no model is not a mismatch either",
+   />ok</.test(noModel) && !/different model/.test(noModel), noModel);
+
+/* A failure is still a failure, and must not be relabelled by any of the above. */
+const broken = probeHtml({ target: "embedding", ok: false, error: "ConnectionRefused",
+                           detail: "no listener", url: "http://127.0.0.1:8400/v1" });
+ok("a real failure still reads as failed", />failed</.test(broken), broken);
+ok("and a not-configured target still says so",
+   />not configured</.test(probeHtml({ target: "embedding", skipped: true, detail: "no key" })),
+   "skipped");
+
+console.log(failures ? "\n" + failures + " failure(s)" : "\nall ok");
+process.exit(failures ? 1 : 0);

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -1966,21 +1966,36 @@ function liveStream(options) {
 
   /* ---------- probe ---------- */
   function probeHtml(r) {
-    var cls = r.ok ? "ok" : (r.skipped ? "" : "bad");
+    /* A call that succeeded with the WRONG model is the failure this panel is least able to
+       show: it answered, it was fast, and the vectors are unusable. Candidate encoders are
+       routinely the same width -- all-MiniLM-L6-v2 and BGE-M3 truncated to 384 both emit 384
+       values -- so nothing downstream can notice by length, and retrieval degrades to noise
+       with nothing in the logs. It is reported here because this is the one moment the
+       question was actually asked of the endpoint. */
+    var response = r.response || {};
+    var mismatch = r.ok && response.model_matches_request === false;
+    var cls = mismatch ? "bad" : (r.ok ? "ok" : (r.skipped ? "" : "bad"));
     var title = r.target === "extraction" ? "Extraction" : "Embedding";
     var detail;
     if (r.ok) {
-      var extra = r.response && r.response.dimensions ? " · " + r.response.dimensions + " dimensions" : "";
-      var model = r.response && r.response.model ? " · " + r.response.model : "";
+      var extra = response.dimensions ? " · " + response.dimensions + " dimensions" : "";
+      var model = response.model ? " · " + response.model : "";
       detail = "answered in " + r.latency_ms + " ms" + model + extra;
+      if (mismatch) {
+        detail = "asked for " + response.requested_model + ", answered as " + response.model
+          + extra + ". Vectors from a different model cannot be compared with the ones already "
+          + "stored, and both may be the same width, so nothing else will notice.";
+      }
     } else if (r.skipped) {
       detail = r.detail || r.error;
     } else {
       detail = (r.error || "failed") + (r.detail ? " — " + r.detail : "");
     }
+    var pill = mismatch ? "failed" : (r.ok ? "completed" : (r.skipped ? "queued" : "failed"));
+    var word = mismatch ? "different model"
+      : (r.ok ? "ok" : (r.skipped ? "not configured" : "failed"));
     return '<div class="probe ' + cls + '"><h3>' + esc(title) +
-      '<span class="pill ' + (r.ok ? "completed" : (r.skipped ? "queued" : "failed")) + '">' +
-      (r.ok ? "ok" : (r.skipped ? "not configured" : "failed")) + "</span></h3>" +
+      '<span class="pill ' + pill + '">' + word + "</span></h3>" +
       "<p>" + esc(detail) + (r.url ? ' <span class="mono">' + esc(r.url) + "</span>" : "") + "</p></div>";
   }
 

--- a/tools/test_matrixark_the_connection_test_compares_the_answer.py
+++ b/tools/test_matrixark_the_connection_test_compares_the_answer.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The connection test says whether the model that answered is the one that was asked for.
+
+"Test connection" reported the model name from the response and stopped there. An operator reads
+that as confirmation the endpoint serves that model. It is not: the co-located encoder server
+returned ``payload.get("model", MODEL_NAME)`` -- the caller's own request, echoed -- while
+encoding every text with the one model it loaded at startup. Ask a server running
+``all-MiniLM-L6-v2`` for ``text-embedding-3-small`` and it answered, quickly, with 384 MiniLM
+values labelled ``text-embedding-3-small``.
+
+Nothing downstream could notice. Candidate encoders are routinely the same width --
+``all-MiniLM-L6-v2`` and BGE-M3 truncated to 384 both emit 384 values -- so there is no length
+mismatch to raise, retrieval degrades to noise against everything already stored, and the logs say
+nothing. The one moment the question is actually put to the endpoint is this probe, so this is
+where the answer has to be checked.
+
+Two halves, and both are needed: the server now reports the model it loaded (which is also what
+the OpenAI response contract says that field is), and the probe compares it with what it asked.
+Fixing only the server would leave the portal not looking; fixing only the probe would leave it
+comparing a value against itself.
+"""
+from __future__ import annotations
+
+import ast
+import io
+import os
+import subprocess
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+sys.path.insert(0, TOOLS)
+
+import matrixark_gateway_config as cfg  # noqa: E402
+
+SERVER = os.path.join(TOOLS, "context_minilm_embed_server.py")
+
+
+class TheServerReportsWhatItLoadedTest(unittest.TestCase):
+    """Read structurally, not by import: the module builds a SentenceTransformer at import time,
+    so importing it here would download a model to run an assertion about a dict key."""
+
+    @staticmethod
+    def _embeddings_response() -> dict:
+        """The dict literal sent back from the embeddings handler, as {key: source-of-value}."""
+        with io.open(SERVER, encoding="utf-8") as handle:
+            tree = ast.parse(handle.read())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Dict):
+                continue
+            keys = [k.value for k in node.keys if isinstance(k, ast.Constant)]
+            if "data" in keys and "model" in keys:
+                out = {}
+                for key, value in zip(node.keys, node.values):
+                    if isinstance(key, ast.Constant):
+                        out[key.value] = value
+                return out
+        raise AssertionError("the embeddings response literal is not in %s"
+                             % os.path.basename(SERVER))
+
+    def test_the_response_literal_was_found(self) -> None:
+        # The floor: every assertion below is about this dict, and a reader that finds nothing
+        # would make them all vacuous.
+        found = self._embeddings_response()
+        self.assertIn("model", found)
+        self.assertIn("data", found)
+
+    def test_the_model_reported_is_the_one_it_loaded(self) -> None:
+        value = self._embeddings_response()["model"]
+        self.assertIsInstance(value, ast.Name,
+                              "the model field is no longer a plain name")
+        self.assertEqual("MODEL_NAME", value.id,
+                         "the response reports something other than the loaded model; echoing "
+                         "the request back is what made a mismatch invisible")
+
+    def test_the_request_is_still_reported_separately(self) -> None:
+        """Dropping it would lose the evidence of what was asked, which is half the comparison."""
+        found = self._embeddings_response()
+        self.assertIn("requested_model", found)
+        self.assertIsInstance(found["requested_model"], ast.Name)
+
+    def test_the_health_endpoint_still_names_the_loaded_model(self) -> None:
+        with io.open(SERVER, encoding="utf-8") as handle:
+            source = handle.read()
+        self.assertIn('{"status": "ok", "model": MODEL_NAME}', source)
+
+
+class TheComparisonIsNotFooledBySpellingTest(unittest.TestCase):
+    """A false alarm on the shipped configuration is a warning nobody reads."""
+
+    def test_an_organisation_prefix_is_not_a_difference(self) -> None:
+        # The shipped local_minilm preset writes the short name; the encoder catalogue lists the
+        # long one. One model, two spellings.
+        self.assertTrue(cfg._same_model(
+            "paraphrase-multilingual-MiniLM-L12-v2",
+            "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"))
+
+    def test_nor_is_case(self) -> None:
+        self.assertTrue(cfg._same_model("deepseek-chat", "DeepSeek-Chat"))
+
+    def test_but_a_different_model_is(self) -> None:
+        self.assertFalse(cfg._same_model("text-embedding-3-small", "all-MiniLM-L6-v2"))
+
+    def test_and_a_different_model_under_the_same_org_is(self) -> None:
+        self.assertFalse(cfg._same_model(
+            "sentence-transformers/all-MiniLM-L6-v2",
+            "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"))
+
+    def test_the_shipped_preset_would_not_raise_a_false_alarm(self) -> None:
+        """Derived from the preset rather than written down, so a change to it is caught here."""
+        import matrixark_v1_gateway as gw
+
+        preset = cfg.PRESETS["local_minilm"]["values"]["embedding.model"]
+        # The embedding catalogue is the gateway's MEASURED encoder table, not the config
+        # module's -- asking cfg for it raises, on purpose.
+        catalogue = [row["model"] for row in gw.embedding_picker_catalogue()]
+        self.assertGreater(len(catalogue), 1, catalogue)
+        exact = [name for name in catalogue if name == preset]
+        same = [name for name in catalogue if cfg._same_model(preset, name)]
+        # The point of the whole comparison: this pair is NOT equal as strings and IS the same
+        # model. Comparing by equality would warn about the configuration this repo ships.
+        self.assertEqual([], exact, "the spellings agree now; this test no longer proves anything")
+        self.assertTrue(same, "the preset's model matches nothing in the catalogue: %r" % preset)
+
+
+class TheSummaryCarriesBothSidesTest(unittest.TestCase):
+
+    @staticmethod
+    def _embedding(model, requested):
+        return cfg._summarize("embedding",
+                              {"model": model, "data": [{"embedding": [0.0] * 384}]}, requested)
+
+    def test_a_mismatch_is_reported(self) -> None:
+        out = self._embedding("all-MiniLM-L6-v2", "text-embedding-3-small")
+        self.assertEqual("text-embedding-3-small", out["requested_model"])
+        self.assertIs(False, out["model_matches_request"])
+
+    def test_a_match_is_reported_too(self) -> None:
+        self.assertIs(True, self._embedding("gpt", "gpt")["model_matches_request"])
+
+    def test_nothing_asked_means_no_verdict(self) -> None:
+        """Absent, not False. A probe that named no model has not been contradicted."""
+        self.assertNotIn("model_matches_request", self._embedding("all-MiniLM-L6-v2", None))
+
+    def test_nothing_answered_means_no_verdict(self) -> None:
+        self.assertNotIn("model_matches_request", self._embedding(None, "anything"))
+
+    def test_the_extraction_branches_compare_too(self) -> None:
+        """Three branches build a summary and each had to be given the comparison; one left out
+        would be a whole provider family silently unchecked."""
+        chat = cfg._summarize("extraction",
+                              {"model": "b", "choices": [{"message": {"content": "hi"}}]}, "a")
+        anthropic = cfg._summarize("extraction_anthropic",
+                                   {"model": "b", "content": [{"type": "text", "text": "hi"}]}, "a")
+        for name, out in (("openai-shaped", chat), ("anthropic-shaped", anthropic)):
+            self.assertIs(False, out.get("model_matches_request"), name)
+
+
+class ThePageSaysSoTest(unittest.TestCase):
+
+    HARNESS = os.path.join(PORTAL, "probe_model_harness.js")
+    PAGE = os.path.join(PORTAL, "setup_portal.html")
+
+    def setUp(self) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    def test_the_shipped_panel_says_it(self) -> None:
+        out = subprocess.run(["node", self.HARNESS, self.PAGE],
+                             capture_output=True, text=True, timeout=600)
+        self.assertIn("all ok", out.stdout + out.stderr)
+
+    def test_both_copies_of_the_panel_agree(self) -> None:
+        """probeHtml lives in the page AND in the builder that writes pages; the harness runs the
+        page's copy, so an edit to one alone passes while the next generated page keeps the old
+        behaviour."""
+        bodies = []
+        for name in ("setup_portal.html", "build_portal_pages.py"):
+            text = io.open(os.path.join(PORTAL, name), encoding="utf-8").read()
+            start = text.find("function probeHtml(r)")
+            self.assertGreater(start, 0, name)
+            depth = 0
+            for index in range(text.index("{", start), len(text)):
+                if text[index] == "{":
+                    depth += 1
+                elif text[index] == "}":
+                    depth -= 1
+                    if depth == 0:
+                        bodies.append(text[start:index + 1])
+                        break
+        self.assertEqual(2, len(bodies))
+        self.assertGreater(len(bodies[0]), 400)
+        self.assertEqual(bodies[0], bodies[1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_the_connection_test_compares_the_answer.py
+++ b/tools/test_matrixark_the_connection_test_compares_the_answer.py
@@ -178,7 +178,8 @@ class ThePageSaysSoTest(unittest.TestCase):
         behaviour."""
         bodies = []
         for name in ("setup_portal.html", "build_portal_pages.py"):
-            text = io.open(os.path.join(PORTAL, name), encoding="utf-8").read()
+            with io.open(os.path.join(PORTAL, name), encoding="utf-8") as handle:
+                text = handle.read()
             start = text.find("function probeHtml(r)")
             self.assertGreater(start, 0, name)
             depth = 0

--- a/tools/test_matrixark_the_connection_test_covers_every_provider_it_offers.py
+++ b/tools/test_matrixark_the_connection_test_covers_every_provider_it_offers.py
@@ -207,8 +207,25 @@ class TheAnthropicProviderIsActuallyTestedTest(ProbeCase):
                                reply={"model": "claude-sonnet-5",
                                       "content": [{"type": "text", "text": "pong"}]},
                                MATRIXARK_UNDERSTANDING_PROVIDER="anthropic", key="k")
-        self.assertEqual({"model": "claude-sonnet-5", "sample": "pong"},
+        self.assertEqual({"model": "claude-sonnet-5", "sample": "pong",
+                          # The summary carries what was ASKED beside what answered, so a call
+                          # that succeeded against a different model is not read as confirmation
+                          # that the endpoint serves the configured one.
+                          "requested_model": "claude-sonnet-5",
+                          "model_matches_request": True},
                          result["results"][0]["response"])
+
+    def test_a_reply_from_another_model_is_not_read_as_agreement(self) -> None:
+        """The Anthropic branch specifically: three branches build a summary, and one left
+        without the comparison would be a whole provider family silently unchecked."""
+        result, _ = self.probe(["extraction"],
+                               reply={"model": "claude-haiku-4-5",
+                                      "content": [{"type": "text", "text": "pong"}]},
+                               MATRIXARK_UNDERSTANDING_PROVIDER="anthropic", key="k")
+        response = result["results"][0]["response"]
+        self.assertEqual("claude-haiku-4-5", response["model"])
+        self.assertEqual("claude-sonnet-5", response["requested_model"])
+        self.assertIs(False, response["model_matches_request"])
 
 
 class TheTestDoesNotPassOnAConfigurationThatMakesNoCallTest(ProbeCase):


### PR DESCRIPTION
"Test connection" reported the model name from the response and stopped there. An operator reads
that as confirmation the endpoint serves that model.

It was not. The co-located encoder server returned `payload.get("model", MODEL_NAME)` — **the
caller's own request, echoed** — while encoding every text with the one model it loaded at startup.
Ask a server running `all-MiniLM-L6-v2` for `text-embedding-3-small` and it answers, quickly, with
384 MiniLM values labelled `text-embedding-3-small`.

Nothing downstream can notice. Candidate encoders are routinely the same width — `all-MiniLM-L6-v2`
and BGE-M3 truncated to 384 both emit 384 values — so there is **no length mismatch to raise**,
retrieval degrades to noise against everything already stored, and the logs say nothing. The probe
is the one moment the question is actually put to the endpoint.

### Both halves, because either alone is useless

**The server reports the model it loaded**, and keeps the requested name beside it. Echoing the
request back is also a violation of the response contract, where that field means the model that
produced the output.

**The probe compares.** `_summarize` now carries the requested model in and reports
`model_matches_request`.

Fixing only the server would leave the portal not looking. Fixing only the probe would leave it
comparing a value against itself and reporting agreement every time.

### Two ways this could have become a warning nobody reads

**An organisation prefix is not a difference.** The shipped `local_minilm` preset writes
`paraphrase-multilingual-MiniLM-L12-v2`; the encoder catalogue lists
`sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`. One model, two spellings — and a
warning that fires on the configuration this repository ships is one nobody reads. A test derives
that pair from the preset and the catalogue and asserts both that they are *not* string-equal and
that the comparison calls them the same, so it cannot quietly stop proving anything.

**A verdict is absent, not false, when either side is unknown.** A provider that returns no model
name has not disagreed with anything.

### In the panel

A call that succeeded with the wrong model is the failure this panel is least able to show: it
answered, it was fast, and the vectors are unusable. It now reads **`different model`**, carries the
attention styling, names both models, and says why a same-width answer is still wrong.

```
the server echoes the request back again        -> FAIL
the server stops reporting what was asked       -> FAIL
the comparison ignores a real difference        -> FAIL
an organisation prefix counts as a difference   -> FAIL
a verdict is given even with nothing to compare -> FAIL
the openai-shaped branch stops comparing        -> FAIL
the page stops flagging a different model       -> FAIL
the builder copy drifts from the page           -> FAIL
```

The sixth matters: `_summarize` has three branches — embedding, Anthropic-shaped and OpenAI-shaped —
and one left without the comparison would be a whole provider family silently unchecked.

The server is read by AST rather than imported, because importing it builds a `SentenceTransformer`
and would download a model to assert something about a dict key.

Found while checking whether presets leave a working configuration. They do — all six set a model
the provider can serve, which is how the spelling pair surfaced.
