### PR TITLE
The screen says which controls this build does not read

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -1353,6 +1353,60 @@ def model_catalogue(target: str, provider: Optional[str] = None) -> List[Json]:
 # ================================================================================================
 # Persistence
 # ================================================================================================
+# Knobs the portal offers, the policy resolves, and nothing reads. Setting one writes a value
+# that comes back when you ask for it and changes nothing about how the deployment behaves.
+#
+# This is a static list against a fact about the code, which is exactly the kind of note that goes
+# stale. It cannot here: test_matrixark_a_knob_the_portal_offers_is_read_by_something DERIVES the
+# same set -- accessor reachable from a production caller, variable read directly, or knob asked
+# for by name -- and fails if this disagrees with it in EITHER direction. Wiring one up forces its
+# removal from here; a knob that quietly stops being read forces its addition.
+#
+# Not a reason to hide the control. A deployment may already have one of these set, and a field
+# that vanishes takes its value out of view while leaving it in the file.
+KNOBS_READ_BY_NOTHING = frozenset({
+    "embed_node_path_prefix",
+    "generate_l1_summaries",
+    "max_event_text_chars",
+    "max_summary_text_chars",
+    "recall_reinforcement",
+    "return_all_candidate_threshold",
+    "return_all_candidates",
+    "skill_description_always",
+    "summarize_aggregation_only_nodes",
+    "summary_levels",
+    "write_secondary_index",
+})
+
+
+_UNREAD_ENVS: Optional[frozenset] = None
+
+
+def _unread_envs() -> frozenset:
+    """The environment variables behind the knobs nothing reads.
+
+    Matched by VARIABLE, not by key prefix. Ten of the eleven surface as `behaviour.<knob>` and
+    `skill_description_always` surfaces as `skills.description_always`, so a prefix rule marked
+    ten of them and left the eleventh looking like a working control -- which is the exact defect
+    this badge exists to end, reintroduced by the code drawing it.
+    """
+    global _UNREAD_ENVS
+    if _UNREAD_ENVS is None:
+        try:
+            import matrixark_tenant_policy as _tp
+            _UNREAD_ENVS = frozenset(
+                _tp.KNOBS[name].env for name in KNOBS_READ_BY_NOTHING
+                if name in _tp.KNOBS and _tp.KNOBS[name].env)
+        except Exception:  # pragma: no cover - the policy module is optional at import time
+            _UNREAD_ENVS = frozenset()
+    return _UNREAD_ENVS
+
+
+def setting_is_read(env: str) -> bool:
+    """Whether anything in this build reads the setting whose variable is `env`."""
+    return (env or "") not in _unread_envs()
+
+
 def config_path() -> str:
     """Where the runtime config lives. ``MATRIXARK_RUNTIME_CONFIG_FILE`` wins; else ~/.matrixark/."""
     explicit = os.environ.get("MATRIXARK_RUNTIME_CONFIG_FILE", "").strip()
@@ -1610,6 +1664,9 @@ def snapshot(include_catalog: bool = True) -> Json:
             # running the old value. Distinct from the `applies` badge, which says what KIND of
             # setting this is and says it before anybody touches anything.
             "pending_restart": _is_pending_restart(setting, value),
+            # Offered here, resolved by the policy, and read by nothing in this build. A control
+            # that accepts a value and confirms it is indistinguishable from one that works.
+            "read_by_nothing": not setting_is_read(_env_name(setting, values)),
         }
         if setting.secret:
             entry["configured"] = bool(value)

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -1417,6 +1417,16 @@ SETUP_JS = r"""
         ' setting wins where one exists — set those under Retrieval settings.">' +
         esc((f.overridable_by || []).join("/")) + " can override</span>";
     }
+    /* Offered, stored, resolved -- and read by nothing in this build. Without saying so the
+       field is indistinguishable from one that works: it accepts a value, confirms it, and the
+       deployment behaves identically either way. The control is left in place because a
+       deployment may already have set one, and a field that vanishes takes its value out of
+       view while leaving it in the file. */
+    if (f.read_by_nothing) {
+      badges += '<span class="badge failed" title="This build resolves the value and never reads '
+        + 'it, so setting it changes nothing. It is still shown because a value already stored '
+        + 'here would otherwise be invisible.">not read by this build</span>';
+    }
     if (f.source && f.source !== "default") {
       badges += '<span class="badge ' + esc(f.source) + '">' + esc(f.source) + "</span>";
     }

--- a/tools/portal/setting_badge_harness.js
+++ b/tools/portal/setting_badge_harness.js
@@ -75,5 +75,23 @@ html = fieldHtml(field({ applies: "live", pending_restart: true }));
 ok("the renderer shows what it is given, so the flag is the thing to get right",
    status.test(html), html.slice(0, 200));
 
+/* Offered, stored, resolved -- and read by nothing in this build. Without the badge the field is
+   indistinguishable from one that works: it takes a value, confirms it, and the deployment
+   behaves the same either way. */
+const unread = /not read by this build/;
+
+html = fieldHtml(field({ key: "behaviour.summary_levels", env: "MATRIXARK_SUMMARY_LEVELS",
+                         applies: "live", read_by_nothing: true }));
+ok("a control nothing reads says so", unread.test(html), html.slice(0, 300));
+ok("and it is styled as something to look at", /badge failed/.test(html), html.slice(0, 300));
+ok("and the field is still drawn, so a stored value stays visible",
+   /MATRIXARK_SUMMARY_LEVELS/.test(html), html.slice(0, 300));
+
+/* The floor. Every other field must NOT carry it, or the badge says nothing. */
+ok("FLOOR: an ordinary setting does not carry it", !unread.test(fieldHtml(field({}))));
+ok("FLOOR: nor does a live one", !unread.test(fieldHtml(field({ applies: "live" }))));
+ok("FLOOR: nor one merely pending a restart",
+   !unread.test(fieldHtml(field({ pending_restart: true }))));
+
 console.log(failures === 0 ? "PASS" : "FAILED " + failures);
 process.exit(failures === 0 ? 0 : 1);

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -1135,6 +1135,16 @@ function liveStream(options) {
         ' setting wins where one exists — set those under Retrieval settings.">' +
         esc((f.overridable_by || []).join("/")) + " can override</span>";
     }
+    /* Offered, stored, resolved -- and read by nothing in this build. Without saying so the
+       field is indistinguishable from one that works: it accepts a value, confirms it, and the
+       deployment behaves identically either way. The control is left in place because a
+       deployment may already have set one, and a field that vanishes takes its value out of
+       view while leaving it in the file. */
+    if (f.read_by_nothing) {
+      badges += '<span class="badge failed" title="This build resolves the value and never reads '
+        + 'it, so setting it changes nothing. It is still shown because a value already stored '
+        + 'here would otherwise be invisible.">not read by this build</span>';
+    }
     if (f.source && f.source !== "default") {
       badges += '<span class="badge ' + esc(f.source) + '">' + esc(f.source) + "</span>";
     }

--- a/tools/test_matrixark_a_knob_the_portal_offers_is_read_by_something.py
+++ b/tools/test_matrixark_a_knob_the_portal_offers_is_read_by_something.py
@@ -35,6 +35,7 @@ import unittest
 TOOLS = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, TOOLS)
 
+import matrixark_gateway_config as _cfg  # noqa: E402
 import matrixark_tenant_policy as tp  # noqa: E402
 
 GROWTH_BOUND = "matrixark_index_growth_bound.py"
@@ -42,23 +43,15 @@ GROWTH_BOUND = "matrixark_index_growth_bound.py"
 # Where a knob is DECLARED rather than used. A mention here is not a consumer.
 DECLARING = {GROWTH_BOUND, "matrixark_tenant_policy.py", "matrixark_gateway_config.py"}
 
-# Offered by the portal, resolved by the policy, read by nothing. Measured 2026-09-06.
-OFFERED_AND_UNREAD = frozenset({
-    "embed_node_path_prefix",
-    "generate_l1_summaries",
-    "max_event_text_chars",
-    "max_summary_text_chars",
-    "recall_reinforcement",
-    "return_all_candidate_threshold",
-    "return_all_candidates",
-    "skill_description_always",
-    "summarize_aggregation_only_nodes",
-    "summary_levels",
-    # This one appears EXACTLY ONCE in the repository -- the line that declares it. It defaults
-    # to on, so an operator turning secondary index writes off to hold down index growth gets a
-    # stored value, a confirmation, and the same number of records as before.
-    "write_secondary_index",
-})
+# The registry's own list, not a second copy of it. The portal badges a field with this set, so
+# a list here that drifted from it would fail the deployment's screen while passing its tests --
+# and a test holding its own copy of the answer is not checking the answer.
+#
+# Measured 2026-09-06. `write_secondary_index` is the one worth reading twice: it appears EXACTLY
+# ONCE in the repository, the line that declares it, and defaults to on, so an operator turning
+# secondary index writes off to hold down index growth gets a stored value, a confirmation, and
+# the same number of records as before.
+OFFERED_AND_UNREAD = _cfg.KNOBS_READ_BY_NOTHING
 
 
 _SOURCES_CACHE = {}
@@ -223,6 +216,51 @@ class TheDetectorWorks(unittest.TestCase):
         self.assertGreater(len(reachable), 5, sorted(reachable))
         self.assertNotIn("summary_levels", reachable)
         self.assertNotIn("node_summary_plan", reachable)
+
+
+class TheScreenSaysSoTest(unittest.TestCase):
+    """A test that only reports the number in CI leaves the operator looking at eleven controls
+    that accept a value, confirm it, and do nothing. The field carries the answer now."""
+
+    @staticmethod
+    def _fields() -> list:
+        snapshot = _cfg.snapshot()
+        groups = snapshot["groups"]
+        if isinstance(groups, list):
+            return [field for group in groups for field in group["fields"]]
+        return [field for fields in groups.values() for field in fields]
+
+    def test_every_unread_knob_is_marked(self) -> None:
+        marked = {f["key"] for f in self._fields() if f.get("read_by_nothing")}
+        self.assertEqual(len(_cfg.KNOBS_READ_BY_NOTHING), len(marked),
+                         "%d knobs, %d marked: %s" % (len(_cfg.KNOBS_READ_BY_NOTHING),
+                                                      len(marked), sorted(marked)))
+
+    def test_the_match_is_by_variable_not_by_key_prefix(self) -> None:
+        """The discriminator. Ten of the eleven surface as `behaviour.<knob>`; this one does not,
+        and a prefix rule marked ten and left it looking like a working control."""
+        marked = {f["key"] for f in self._fields() if f.get("read_by_nothing")}
+        self.assertIn("skills.description_always", marked)
+        self.assertNotIn("behaviour.skill_description_always",
+                         {f["key"] for f in self._fields()})
+
+    def test_nothing_else_is_marked(self) -> None:
+        """A badge on every field is a badge on none."""
+        fields = self._fields()
+        marked = [f["key"] for f in fields if f.get("read_by_nothing")]
+        self.assertGreater(len(fields), len(marked) * 5, len(fields))
+        for field in fields:
+            self.assertIn("read_by_nothing", field, field["key"])
+
+    def test_the_control_is_still_offered(self) -> None:
+        """Not hidden. A deployment may already have one set, and a field that vanishes takes its
+        value out of view while leaving it in the file."""
+        keys = {f["key"] for f in self._fields()}
+        for name in _cfg.KNOBS_READ_BY_NOTHING:
+            self.assertTrue(
+                any(f.get("env") and f["env"].endswith(name.upper()) for f in self._fields())
+                or ("behaviour." + name) in keys,
+                "%s is no longer offered at all" % name)
 
 
 if __name__ == "__main__":

--- a/tools/test_matrixark_the_page_and_its_builder_agree.py
+++ b/tools/test_matrixark_the_page_and_its_builder_agree.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Every function the page and its builder both define is the same function.
+
+`tools/portal/build_portal_pages.py` carries page templates; `tools/portal/setup_portal.html` is
+the page a browser runs. A number of JavaScript functions exist in both, byte for byte.
+
+Every harness in this repository runs the PAGE's copy, because that is the one that ships. So an
+edit made to only one of the two passes every test there is, and the next generated page quietly
+carries the old behaviour. Nothing checked that, and three separate changes have now had to add a
+bespoke guard for the one function each of them touched -- `controlHtml`, then `sparkline` and
+`renderTrend`, then `fieldHtml`. A written list of function names would need a fourth.
+
+So the pairs are DERIVED: whatever the two files both define, they must define identically.
+"""
+from __future__ import annotations
+
+import io
+import os
+import re
+import unittest
+
+PORTAL = os.path.join(os.path.dirname(os.path.abspath(__file__)), "portal")
+PAGE = os.path.join(PORTAL, "setup_portal.html")
+BUILDER = os.path.join(PORTAL, "build_portal_pages.py")
+
+_DEF = re.compile(r"\bfunction\s+([A-Za-z_$][\w$]*)\s*\(")
+
+
+def _functions(text: str) -> dict:
+    """Every `function name(...) { ... }` in `text`, by name, brace-matched.
+
+    A name defined more than once is dropped rather than guessed at: this file is about whether
+    two definitions agree, and picking one of several would be inventing the question.
+    """
+    found: dict = {}
+    duplicates = set()
+    for match in _DEF.finditer(text):
+        name = match.group(1)
+        try:
+            start = text.index("{", match.end() - 1)
+        except ValueError:  # pragma: no cover - a function with no body
+            continue
+        depth = 0
+        for index in range(start, len(text)):
+            if text[index] == "{":
+                depth += 1
+            elif text[index] == "}":
+                depth -= 1
+                if depth == 0:
+                    body = text[match.start():index + 1]
+                    if name in found and found[name] != body:
+                        duplicates.add(name)
+                    found[name] = body
+                    break
+    for name in duplicates:
+        found.pop(name, None)
+    return found
+
+
+def _read(path: str) -> dict:
+    with io.open(path, encoding="utf-8") as handle:
+        return _functions(handle.read())
+
+
+def _shared() -> dict:
+    page, builder = _read(PAGE), _read(BUILDER)
+    return {name: (page[name], builder[name]) for name in sorted(set(page) & set(builder))}
+
+
+class ThePageAndItsBuilderAgreeTest(unittest.TestCase):
+
+    def test_they_share_a_meaningful_number_of_functions(self) -> None:
+        # The floor. Every assertion below is over this set, and a reader that finds nothing
+        # passes them all: an empty intersection has no disagreement in it.
+        shared = _shared()
+        self.assertGreater(len(shared), 5, sorted(shared))
+        for name in ("controlHtml", "fieldHtml"):
+            self.assertIn(name, shared)
+
+    def test_every_shared_function_is_identical(self) -> None:
+        differing = sorted(name for name, (page, builder) in _shared().items()
+                           if page != builder)
+        self.assertEqual([], differing,
+                         "%d function(s) differ between the shipped page and the builder that "
+                         "writes pages; the harnesses only exercise the page" % len(differing))
+
+
+class TheReaderWorksTest(unittest.TestCase):
+    """The assertion above is an equality against an empty list, which is also what a reader that
+    parses nothing produces."""
+
+    def test_it_finds_a_function_and_its_whole_body(self) -> None:
+        found = _functions("function a(x) { if (x) { return 1; } return 2; }\n")
+        self.assertEqual(["a"], sorted(found))
+        self.assertTrue(found["a"].endswith("return 2; }"), found["a"])
+
+    def test_it_reports_a_difference_when_there_is_one(self) -> None:
+        left = _functions("function a() { return 1; }")
+        right = _functions("function a() { return 2; }")
+        self.assertNotEqual(left["a"], right["a"])
+
+    def test_a_name_defined_twice_is_left_out_rather_than_guessed(self) -> None:
+        found = _functions("function a() { return 1; }\nfunction a() { return 2; }")
+        self.assertNotIn("a", found)
+
+    def test_the_real_files_parse_into_something(self) -> None:
+        for path in (PAGE, BUILDER):
+            self.assertGreater(len(_read(path)), 5, os.path.basename(path))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked on #1104, which found eleven knobs the portal offers, the policy resolves, and nothing
reads. That change reports the number in CI. This one tells the operator looking at the screen.

Without it the field is indistinguishable from one that works: it takes a value, confirms it, saves
it, and the deployment behaves identically either way. This deployment has three of the eleven set.

The control is **left in place**, not hidden. A deployment may already have one set, and a field
that vanishes takes its value out of view while leaving it in the file.

### One list, not two

The set moves into the registry as `KNOBS_READ_BY_NOTHING`, and #1104's guard now reads *that*
instead of holding its own copy. A test carrying its own copy of the answer is not checking the
answer — and a second list would let the screen and the tests disagree, which is precisely the
failure mode here.

The guard still derives the truth independently and fails in **either** direction: wiring one up
forces its removal from the registry, and a knob that quietly stops being read forces its addition.

### The badge nearly reproduced the bug it describes

My first version matched by key prefix — `behaviour.<knob>` — and marked **ten of eleven**.
`skill_description_always` surfaces as `skills.description_always`, so the eleventh kept looking
like a working control on exactly the screen this exists to correct.

It matches by **variable** now, and the test that would have caught it asserts specifically that
`skills.description_always` is marked while `behaviour.skill_description_always` does not exist.

### Replacing three bespoke guards with one derived check

`controlHtml`, `sparkline`/`renderTrend` and now `fieldHtml` each exist twice — in the shipped page
and in the builder that writes pages — and every harness runs the **page's** copy, so an edit to one
alone passes every test while the next generated page keeps the old behaviour. Three changes have
now added a bespoke guard for the one function each touched; a written list of names would need a
fourth.

`test_matrixark_the_page_and_its_builder_agree.py` derives the pairs instead: whatever the two files
both define, they must define identically. It finds **74** shared functions, and none of them
differ today.

```
the match goes back to a key prefix        -> FAIL
nothing is ever marked                     -> FAIL
everything is marked                       -> FAIL
a dead knob leaves the registry list       -> FAIL
a wired knob joins the registry list       -> FAIL
the badge is dropped from the page         -> FAIL
the builder copy drifts from the page      -> FAIL
```

The last one **survived** until the derived check existed — the bespoke guards covered the other
functions, not this one, which is the argument for deriving them.

82 tests and the badge harness green. Floors throughout: an ordinary setting, a live one, and one
merely pending a restart must each carry no badge, or a badge on everything is a badge on nothing.

**Merging note:** based on #1104's branch. Merge #1104 **without** `--delete-branch`, or retarget
this to `main` first — deleting a base branch closes the pull request stacked on it, which is how
#1055 was lost earlier today.
