### PR TITLE
The plan says which storage you actually get

### DIFF
--- a/tools/matrixark_deployment_plan.py
+++ b/tools/matrixark_deployment_plan.py
@@ -344,6 +344,13 @@ def plan(shape: str, storage: str = "", nodes: int = 0, root: str = "",
         "key_envs": planned_keys,
         "resolved_backend": resolved["backend"],
         "backend_reason": resolved["reason"],
+        # Whether the STORAGE REQUEST was honoured, which `resolve_backend` already decides and
+        # this function used to consume and drop. Without it the caller has to infer a
+        # substitution by comparing `storage` with `resolved_backend`, and those are different
+        # vocabularies: a perfectly ordinary raft/ebs deployment has storage "ebs" and backend
+        # "raft", so that comparison warns about every healthy plan. The fall-through cases are
+        # the only ones that matter and this is the flag that names them.
+        "backend_honoured": bool(resolved.get("honoured", True)),
         "blocking": blocking,
         "warnings": warnings,
         "notes": notes,

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -2608,6 +2608,16 @@ SETUP_JS = r"""
            silently: a shared request with no directory, or MatrixObject on a build without it,
            both fall through to auto-detection and start a deployment nobody chose. */
         var rows = [];
+        /* Only when the request was NOT honoured. `backend_honoured` comes from the resolver
+           that made the decision; comparing the request with the resolved backend here would
+           warn about every healthy plan, because a raft deployment on EBS has storage "ebs" and
+           backend "raft" and nothing is wrong with it. */
+        if (plan.backend_honoured === false) {
+          rows.push("<tr><td>You asked for</td><td><span class='mono'>" + esc(plan.storage) +
+            "</span><div class='hint' style='margin:2px 0 0'>The engine does not refuse this. " +
+            "It falls through to auto-detection, so the deployment starts and serves as " +
+            "something nobody chose.</div></td></tr>");
+        }
         rows.push("<tr><td>Resolves to</td><td><span class='mono'>" +
           esc(plan.resolved_backend) + "</span><div class='hint' style='margin:2px 0 0'>" +
           esc(plan.backend_reason) + "</div></td></tr>");
@@ -2626,10 +2636,17 @@ SETUP_JS = r"""
         $("depCommands").textContent = plan.commands
           ? (plan.commands.launch + "\n\n" + plan.commands.teardown)
           : "";
+        /* Launchable and launchable-as-asked are different answers. A plan that resolves to
+           something else still starts, so "err" would be wrong -- but a bare "launchable" is
+           read as agreement, which is the one thing it is not. */
+        var honoured = plan.backend_honoured !== false;
         say($("depMsg"), plan.ok
-          ? "This plan is launchable."
+          ? (honoured
+             ? "This plan is launchable."
+             : "This plan is launchable, but not as the storage you chose \u2014 see You asked "
+               + "for above.")
           : "This plan cannot produce the deployment described. See Blocked above.",
-          plan.ok ? "ok" : "err");
+          plan.ok ? (honoured ? "ok" : "info") : "err");
       })
       .catch(function (e) {
         say($("depMsg"), typeof e === "number" ? failure(e) : "Could not reach the gateway.",

--- a/tools/portal/deployment_chooser_harness.js
+++ b/tools/portal/deployment_chooser_harness.js
@@ -127,6 +127,9 @@ setTimeout(() => {
       verdictOnLoad,
       live: get("liveShape").textContent,
       verdict: get("depVerdict").innerHTML,
+      /* The sentence under the table. "Launchable" and "launchable, but not as the storage you
+         chose" are different answers and only this element carries the difference. */
+      msg: get("depMsg").innerHTML,
       envFile: get("depEnv").textContent,
       storageAfterShared,
       sharedFieldShownForPath,

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -2326,6 +2326,16 @@ function liveStream(options) {
            silently: a shared request with no directory, or MatrixObject on a build without it,
            both fall through to auto-detection and start a deployment nobody chose. */
         var rows = [];
+        /* Only when the request was NOT honoured. `backend_honoured` comes from the resolver
+           that made the decision; comparing the request with the resolved backend here would
+           warn about every healthy plan, because a raft deployment on EBS has storage "ebs" and
+           backend "raft" and nothing is wrong with it. */
+        if (plan.backend_honoured === false) {
+          rows.push("<tr><td>You asked for</td><td><span class='mono'>" + esc(plan.storage) +
+            "</span><div class='hint' style='margin:2px 0 0'>The engine does not refuse this. " +
+            "It falls through to auto-detection, so the deployment starts and serves as " +
+            "something nobody chose.</div></td></tr>");
+        }
         rows.push("<tr><td>Resolves to</td><td><span class='mono'>" +
           esc(plan.resolved_backend) + "</span><div class='hint' style='margin:2px 0 0'>" +
           esc(plan.backend_reason) + "</div></td></tr>");
@@ -2344,10 +2354,17 @@ function liveStream(options) {
         $("depCommands").textContent = plan.commands
           ? (plan.commands.launch + "\n\n" + plan.commands.teardown)
           : "";
+        /* Launchable and launchable-as-asked are different answers. A plan that resolves to
+           something else still starts, so "err" would be wrong -- but a bare "launchable" is
+           read as agreement, which is the one thing it is not. */
+        var honoured = plan.backend_honoured !== false;
         say($("depMsg"), plan.ok
-          ? "This plan is launchable."
+          ? (honoured
+             ? "This plan is launchable."
+             : "This plan is launchable, but not as the storage you chose \u2014 see You asked "
+               + "for above.")
           : "This plan cannot produce the deployment described. See Blocked above.",
-          plan.ok ? "ok" : "err");
+          plan.ok ? (honoured ? "ok" : "info") : "err");
       })
       .catch(function (e) {
         say($("depMsg"), typeof e === "number" ? failure(e) : "Could not reach the gateway.",

--- a/tools/test_matrixark_deployment_routes.py
+++ b/tools/test_matrixark_deployment_routes.py
@@ -18,6 +18,7 @@ import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
+import matrixark_deployment_plan as _plan  # noqa: E402
 import matrixark_v1_gateway as gw  # noqa: E402
 from test_matrixark_v1_gateway import (  # noqa: E402
     _FakeResponse, _FakeServer, _cfg, _factory_for, drive,
@@ -176,19 +177,26 @@ class _PageHarness:
             self.skipTest("node is not installed")
         self.app = _app()
 
-    def _routes(self, plan_payload) -> dict:
+    def _routes(self, plan_payload, plan_override=None) -> dict:
         _st, _h, config = drive(self.app, method="GET", path="/v1/admin/config", headers=ADMIN)
         _st, _h, deployment = drive(self.app, method="GET", path="/v1/admin/deployment",
                                     headers=ADMIN)
         _st, _h, plan = drive(self.app, method="POST", path="/v1/admin/deployment/plan",
                               body=plan_payload, headers=ADMIN)
+        planned = json.loads(plan)
+        # A build WITH MatrixObject compiled in cannot produce an unhonoured plan through this
+        # route -- the flag comes from the build, not the request. The page's contract is about
+        # what it does with the answer, so that case is handed to it directly rather than
+        # pretending the route produced it.
+        if plan_override:
+            planned.update(plan_override)
         return {
             "config": json.loads(config),
             "deployment": json.loads(deployment),
-            "plan": json.loads(plan),
+            "plan": planned,
         }
 
-    def _run(self, plan_payload) -> dict:
+    def _run(self, plan_payload, plan_override=None) -> dict:
         import subprocess
         import tempfile
         page = os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -196,7 +204,7 @@ class _PageHarness:
         harness = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                "portal", "deployment_chooser_harness.js")
         with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as handle:
-            json.dump(self._routes(plan_payload), handle)
+            json.dump(self._routes(plan_payload, plan_override), handle)
             fixture = handle.name
         try:
             proc = subprocess.run(["node", harness, page, fixture],
@@ -319,6 +327,70 @@ class ThisFileDefinesEachClassOnceTest(unittest.TestCase):
         self.assertEqual([], repeated,
                          "these classes are defined more than once, so the earlier definitions are "
                          "dead code that can never fail: %s" % repeated)
+
+
+class TheStorageYouAskedForTest(unittest.TestCase):
+    """`resolve_backend` decides whether a storage request was honoured, and `plan` used to
+    consume that and drop it, leaving the page to infer a substitution by comparing the request
+    with the resolved backend.
+
+    Those are different vocabularies. An ordinary raft deployment on EBS has storage `ebs` and
+    backend `raft`, and nothing is wrong with it -- so the comparison the page would have had to
+    make warns about every healthy plan, which is the shape of warning nobody reads.
+    """
+
+    def test_an_ordinary_plan_is_honoured(self) -> None:
+        out = _plan.plan(shape="raft", storage="ebs", nodes=3, root="/var/lib/ts")
+        self.assertTrue(out["backend_honoured"])
+        # The floor for the whole flag: the request and the resolved backend DIFFER here, and it
+        # is still honoured. A comparison-based check would have called this a substitution.
+        self.assertNotEqual(out["storage"], out["resolved_backend"])
+
+    def test_a_request_the_build_cannot_serve_is_not(self) -> None:
+        out = _plan.plan(shape="shared", storage="matrixobject", nodes=3,
+                         matrixobject_available=False)
+        self.assertFalse(out["backend_honoured"])
+        self.assertEqual("matrixobject", out["storage"])
+        self.assertNotEqual("matrixobject", out["resolved_backend"])
+        # It still launches. That is why "ok" cannot carry this.
+        self.assertTrue(out["ok"])
+
+    def test_the_same_request_on_a_build_that_has_it_is_honoured(self) -> None:
+        out = _plan.plan(shape="shared", storage="matrixobject", nodes=3,
+                         matrixobject_available=True)
+        self.assertTrue(out["backend_honoured"])
+
+    def test_a_blocked_plan_describes_the_environment_it_emitted(self) -> None:
+        """Shared with no directory is refused rather than emitted, so the flag describes the
+        environment the plan actually produced and `ok` carries the refusal."""
+        out = _plan.plan(shape="shared", storage="path", nodes=3)
+        self.assertFalse(out["ok"])
+        self.assertTrue(out["blocking"])
+
+
+class ThePageSaysWhatYouAskedForTest(_PageHarness, unittest.TestCase):
+
+    PAYLOAD = {"shape": "raft", "storage": "ebs", "nodes": 3, "root": "/var/lib/temporalstore"}
+
+    def test_an_honoured_plan_says_launchable_and_nothing_more(self) -> None:
+        out = self._run(self.PAYLOAD)
+        self.assertIn("launchable", out["msg"])
+        self.assertNotIn("not as the storage you chose", out["msg"])
+        self.assertNotIn("You asked for", out["verdict"])
+
+    def test_an_unhonoured_plan_says_which_storage_it_is_not(self) -> None:
+        out = self._run(self.PAYLOAD, plan_override={"backend_honoured": False,
+                                                     "storage": "matrixobject"})
+        self.assertIn("You asked for", out["verdict"])
+        self.assertIn("matrixobject", out["verdict"])
+        self.assertIn("not as the storage you chose", out["msg"])
+        # Still launchable: it starts and serves, so calling it an error would be wrong.
+        self.assertIn("launchable", out["msg"])
+
+    def test_the_resolved_backend_is_still_shown_either_way(self) -> None:
+        for override in (None, {"backend_honoured": False, "storage": "matrixobject"}):
+            out = self._run(self.PAYLOAD, plan_override=override)
+            self.assertIn("Resolves to", out["verdict"], override)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The deployment chooser's verdict said **"This plan is launchable."** for a plan that launches as
something other than what you asked for.

`resolve_backend` already decides this — it returns `honoured`, and its own docstring says why the
function exists: *"the fall-through is the whole reason this function exists, because from the
outside it is indistinguishable from having been honoured."* `plan()` consumed that flag to raise a
warning and then **dropped it**, so the page never saw it.

### Why the page could not work it out itself

The obvious substitute is comparing the request with the outcome. It does not work: `storage` and
`resolved_backend` are different vocabularies. An ordinary raft deployment on EBS has
`storage: "ebs"` and `resolved_backend: "raft"` and nothing whatever is wrong with it, so that
comparison warns about every healthy plan — the kind of warning people learn to scroll past.

That is not an argument, it is a mutation. Replacing the flag with
`plan.storage === plan.resolved_backend` **fails** `test_an_honoured_plan_says_launchable_and_nothing_more`,
on a plain raft/EBS plan.

| request | resolved | honoured |
|---|---|---|
| `ebs` (raft) | `raft` | **yes** — different names, same intent |
| `path` + a directory | `shared_path` | yes |
| `matrixobject`, build has it | `matrixobject` | yes |
| `matrixobject`, build lacks it | `raft` | **no** |

### On the screen

When the request was not honoured the table gains a **You asked for** row naming the storage and
saying the engine does not refuse it — it falls through to auto-detection, so the deployment starts
and serves as something nobody chose. The verdict becomes *"launchable, but not as the storage you
chose"*, styled as information rather than an error, because it **does** launch. Calling it an error
would be as wrong as calling it fine.

### One case that looks inconsistent and is not

`shared` with no directory reports `backend_honoured: true` while `ok: false`. The plan refuses to
emit that environment at all rather than emitting one that would fall through, so the flag correctly
describes the environment that was produced and `ok` carries the refusal. There is a test for it, so
the next reader does not have to re-derive that.

```
the planner stops reporting the flag           -> FAIL
everything is reported as honoured             -> FAIL
nothing is reported as honoured                -> FAIL
the page drops the asked-for row               -> FAIL
the verdict stops distinguishing the two       -> FAIL
the page compares the request with the backend -> FAIL
the builder copy drifts from the page          -> FAIL
```

The page tests run the shipped page against real route bodies. A build **with** MatrixObject
compiled in cannot produce an unhonoured plan through the route — the flag comes from the build, not
the request — so that one case is handed to the page directly, and the harness now reports the
verdict sentence, which is the only element carrying the difference.

Same shape as #1109: put the comparison where the knowledge already is, rather than making the
consumer infer it.
