### PR TITLE
The portal says when the stored configuration is not in force

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -1417,6 +1417,45 @@ def config_path() -> str:
     return os.path.join(home, DEFAULT_CONFIG_FILENAME)
 
 
+def config_file_status() -> Json:
+    """Whether the stored configuration is being applied, and when it is not, why.
+
+    ``load()`` returns the same empty document for a file that is absent, unreadable, unparsable
+    or the wrong shape, and it is right to: a deployment must start whatever state that file is
+    in. But those are four situations and only one of them is normal. In the other three every
+    stored setting is being ignored and the deployment is running built-in defaults -- which on
+    the screen is indistinguishable from having configured nothing at all.
+
+    Read separately rather than reported by ``load()``, so the hot path keeps its one job and its
+    promise never to raise. This is asked for once, by the page that draws it.
+    """
+    path = config_path()
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            raw = handle.read()
+    except FileNotFoundError:
+        # Nothing stored, so nothing is being ignored. This is the ordinary state of a fresh
+        # deployment and must NOT be reported as a problem.
+        return {"state": "absent", "path": path, "applied": True}
+    except OSError as exc:
+        return {"state": "unreadable", "path": path, "applied": False,
+                "detail": exc.strerror or exc.__class__.__name__}
+    try:
+        document = json.loads(raw)
+    except ValueError as exc:
+        return {"state": "unparsable", "path": path, "applied": False,
+                "detail": str(exc)[:200]}
+    if not isinstance(document, dict):
+        return {"state": "wrong_shape", "path": path, "applied": False,
+                "detail": "the file holds a %s, not an object" % type(document).__name__}
+    values = document.get("values")
+    if values is not None and not isinstance(values, dict):
+        return {"state": "wrong_shape", "path": path, "applied": False,
+                "detail": "\"values\" holds a %s, not an object" % type(values).__name__}
+    return {"state": "ok", "path": path, "applied": True,
+            "settings": len(values or {})}
+
+
 def load() -> Json:
     """The stored document, or an empty one. A corrupt file is treated as empty, never fatal: a
     deployment must still start when someone hand-edits this file and breaks it."""
@@ -1626,6 +1665,9 @@ def snapshot(include_catalog: bool = True) -> Json:
     document = load()
     values: Dict[str, str] = {k: str(v) for k, v in (document.get("values") or {}).items()}
     override_layers = _override_layers_by_env()
+    # Whether what is on disk is actually in force. Without this a corrupt file renders exactly
+    # like a deployment nobody has configured yet, and every value in it is being ignored.
+    file_status = config_file_status()
     groups: Dict[str, List[Json]] = {}
     for setting in SETTINGS:
         value, source = _effective(setting, values)
@@ -1697,6 +1739,10 @@ def snapshot(include_catalog: bool = True) -> Json:
             for name, meta in GROUPS.items() if name in groups
         },
         "inventory": inventory(),
+        # Whether the file on disk is in force. `absent` is the ordinary state of a deployment
+        # nobody has configured and reports applied; the other states mean every value stored
+        # there is being ignored while the deployment runs built-in defaults.
+        "config_file_status": file_status,
     }
     if include_catalog:
         result["presets"] = {

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -1297,7 +1297,25 @@ SETUP_JS = r"""
        remove them -- a write of an unknown key is refused, correctly -- so it says where they
        are instead. */
     var forgotten = ((d.settings || {}).unknown_stored) || [];
-    $("warnings").innerHTML = (d.warnings || []).map(function (w) {
+    /* A stored configuration that is NOT in force. `load()` returns the same empty document for
+       a file that is absent, unreadable, unparsable or the wrong shape -- correctly, because the
+       deployment has to start regardless -- so without this the screen below is identical to a
+       deployment nobody has configured, while every value in that file is being ignored and the
+       build-in defaults are what is running.
+
+       First, and its own kind of note, because it invalidates everything under it: the fields
+       are showing what this process resolved, and none of the stored half reached it. */
+    var fileState = (d.settings || {}).config_file_status || d.config_file_status || {};
+    var notApplied = fileState.applied === false
+      ? '<div class="note err">The configuration file at <span class="mono">'
+        + esc(fileState.path || "") + "</span> is not being used"
+        + (fileState.detail ? " (" + esc(fileState.detail) + ")" : "")
+        + ". Every value stored in it is ignored and this deployment is running built-in "
+        + "defaults, so the settings below are not what that file says. Repair or remove the "
+        + "file; nothing here can rewrite it while it cannot be read."
+        + "</div>"
+      : "";
+    $("warnings").innerHTML = notApplied + (d.warnings || []).map(function (w) {
       return '<div class="note">' + esc(w) + "</div>";
     }).join("") + (forgotten.length
       ? '<div class="note">' + esc(forgotten.length) +

--- a/tools/portal/config_not_applied_harness.js
+++ b/tools/portal/config_not_applied_harness.js
@@ -1,0 +1,91 @@
+/* Run the shipped renderSummary and read what it says about a configuration that is not in force.
+ *
+ * The distinction cannot be read off the source. A deployment with a corrupt config file and one
+ * that has never been configured produce the SAME settings document -- `load()` returns an empty
+ * one for both, on purpose, because the deployment has to start either way. So the only thing that
+ * separates them on the screen is this banner, and the only way to know it is drawn is to draw it.
+ *
+ * Usage: node config_not_applied_harness.js <setup_portal.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const start = page.indexOf("function renderSummary(d) {");
+if (start < 0) { console.log("renderSummary is not on this page"); process.exit(2); }
+let depth = 0, end = -1;
+for (let i = page.indexOf("{", start); i < page.length; i++) {
+  if (page[i] === "{") depth++;
+  else if (page[i] === "}") { depth--; if (depth === 0) { end = i + 1; break; } }
+}
+
+const els = {};
+function el(id) {
+  if (!els[id]) { els[id] = { innerHTML: "", textContent: "" }; }
+  return els[id];
+}
+const esc = (s) => String(s).replace(/[&<>"]/g, (c) =>
+  ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+
+const scope = { $: el, esc, fields: {} };
+const names = Object.keys(scope);
+const renderSummary = new Function(...names,
+  page.slice(start, end) + "; return renderSummary;")(...names.map((k) => scope[k]));
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+function warningsFor(status) {
+  els.warnings = { innerHTML: "", textContent: "" };
+  renderSummary({ settings: { config_file_status: status }, warnings: [], extraction: {},
+                  embedding: {} });
+  return els.warnings.innerHTML;
+}
+
+/* Absent is the ordinary state of a deployment nobody has configured. A banner here would fire on
+   every fresh install, which is the shape of warning people stop reading. */
+const absent = warningsFor({ state: "absent", path: "/root/.matrixark/runtime_config.json",
+                             applied: true });
+ok("FLOOR: no file at all is not a problem", absent.indexOf("not being used") < 0, absent);
+
+const good = warningsFor({ state: "ok", path: "/root/.matrixark/runtime_config.json",
+                           applied: true, settings: 12 });
+ok("FLOOR: a file that IS applied says nothing", good.indexOf("not being used") < 0, good);
+
+const broken = warningsFor({ state: "unparsable", path: "/etc/matrixark/runtime_config.json",
+                             applied: false, detail: "Expecting ',' delimiter: line 1 column 42" });
+ok("a file that is not in force says so", broken.indexOf("not being used") >= 0, broken);
+ok("it names the file, so it can be found",
+   broken.indexOf("/etc/matrixark/runtime_config.json") >= 0, broken);
+ok("and says what was wrong with it",
+   broken.indexOf("Expecting") >= 0, broken);
+ok("it says the deployment is on defaults, not that it is unconfigured",
+   /built-in\s+defaults/.test(broken), broken);
+ok("and is styled as an error rather than a note",
+   /class="note err"/.test(broken), broken);
+
+const unreadable = warningsFor({ state: "unreadable", path: "/x/cfg.json", applied: false,
+                                 detail: "Is a directory" });
+ok("an unreadable file says so too", unreadable.indexOf("not being used") >= 0, unreadable);
+
+/* Ordinary warnings must survive: the banner is added to them, not in place of them. */
+els.warnings = { innerHTML: "", textContent: "" };
+renderSummary({ settings: { config_file_status: { state: "unparsable", applied: false,
+                                                  path: "/x", detail: "bad" } },
+                warnings: ["an ordinary warning"], extraction: {}, embedding: {} });
+const both = els.warnings.innerHTML;
+ok("the existing warnings are still there", both.indexOf("an ordinary warning") >= 0, both);
+ok("and the banner comes first, because it invalidates them",
+   both.indexOf("not being used") < both.indexOf("an ordinary warning"), both);
+
+/* A build that does not send the field at all must not be reported as broken. */
+els.warnings = { innerHTML: "", textContent: "" };
+renderSummary({ settings: {}, warnings: [], extraction: {}, embedding: {} });
+ok("FLOOR: an older gateway that sends no status is not accused",
+   els.warnings.innerHTML.indexOf("not being used") < 0, els.warnings.innerHTML);
+
+console.log(failures ? "\n" + failures + " failure(s)" : "\nall ok");
+process.exit(failures ? 1 : 0);

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -1015,7 +1015,25 @@ function liveStream(options) {
        remove them -- a write of an unknown key is refused, correctly -- so it says where they
        are instead. */
     var forgotten = ((d.settings || {}).unknown_stored) || [];
-    $("warnings").innerHTML = (d.warnings || []).map(function (w) {
+    /* A stored configuration that is NOT in force. `load()` returns the same empty document for
+       a file that is absent, unreadable, unparsable or the wrong shape -- correctly, because the
+       deployment has to start regardless -- so without this the screen below is identical to a
+       deployment nobody has configured, while every value in that file is being ignored and the
+       build-in defaults are what is running.
+
+       First, and its own kind of note, because it invalidates everything under it: the fields
+       are showing what this process resolved, and none of the stored half reached it. */
+    var fileState = (d.settings || {}).config_file_status || d.config_file_status || {};
+    var notApplied = fileState.applied === false
+      ? '<div class="note err">The configuration file at <span class="mono">'
+        + esc(fileState.path || "") + "</span> is not being used"
+        + (fileState.detail ? " (" + esc(fileState.detail) + ")" : "")
+        + ". Every value stored in it is ignored and this deployment is running built-in "
+        + "defaults, so the settings below are not what that file says. Repair or remove the "
+        + "file; nothing here can rewrite it while it cannot be read."
+        + "</div>"
+      : "";
+    $("warnings").innerHTML = notApplied + (d.warnings || []).map(function (w) {
       return '<div class="note">' + esc(w) + "</div>";
     }).join("") + (forgotten.length
       ? '<div class="note">' + esc(forgotten.length) +

--- a/tools/test_matrixark_a_stored_config_that_is_not_in_force.py
+++ b/tools/test_matrixark_a_stored_config_that_is_not_in_force.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A stored configuration that is not being applied says so.
+
+``load()`` returns the same empty document for four different situations: no file, a file it
+cannot read, a file that is not JSON, and JSON that is not the right shape. That is deliberate and
+right -- the docstring says so -- because a deployment must start whatever state that file is in.
+
+But only one of the four is normal. In the other three every value in the file is being ignored and
+the deployment is running built-in defaults, and on the screen that is indistinguishable from a
+deployment nobody has configured yet. The settings page shows the resolved values either way, so an
+operator whose file was truncated mid-write reads a page full of defaults as their configuration.
+
+``config_file_status()`` separates them. It is read on its own rather than reported by ``load()``,
+so the hot path keeps its one job and its promise never to raise.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+sys.path.insert(0, TOOLS)
+
+import matrixark_gateway_config as cfg  # noqa: E402
+
+
+class Case(unittest.TestCase):
+    """Each test gets its own directory and the real config file is never in reach."""
+
+    def setUp(self) -> None:
+        self._environ = dict(os.environ)
+        self.addCleanup(self._restore)
+        self._work = tempfile.TemporaryDirectory(prefix="matrixark-status-")
+        self.addCleanup(self._work.cleanup)
+        self.path = os.path.join(self._work.name, "runtime_config.json")
+        os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = self.path
+
+    def _restore(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._environ)
+
+    def write(self, text: str) -> None:
+        with io.open(self.path, "w", encoding="utf-8") as handle:
+            handle.write(text)
+
+
+class TheFourStatesAreToldApartTest(Case):
+
+    def test_no_file_is_normal_and_nothing_is_being_ignored(self) -> None:
+        status = cfg.config_file_status()
+        self.assertEqual("absent", status["state"])
+        self.assertTrue(status["applied"],
+                        "a fresh deployment must not be reported as having a problem")
+
+    def test_a_good_file_is_applied(self) -> None:
+        cfg.update({"retrieval.min_score": "0.35"}, actor="test")
+        status = cfg.config_file_status()
+        self.assertEqual("ok", status["state"])
+        self.assertTrue(status["applied"])
+        self.assertEqual(1, status["settings"])
+
+    def test_a_truncated_file_is_not(self) -> None:
+        self.write('{"values": {"retrieval.min_score": "0.35"')
+        status = cfg.config_file_status()
+        self.assertEqual("unparsable", status["state"])
+        self.assertFalse(status["applied"])
+        self.assertTrue(status["detail"], "an operator cannot repair what is not described")
+
+    def test_json_of_the_wrong_shape_is_not(self) -> None:
+        self.write('["not", "an", "object"]')
+        status = cfg.config_file_status()
+        self.assertEqual("wrong_shape", status["state"])
+        self.assertFalse(status["applied"])
+
+    def test_nor_is_a_values_key_that_is_not_an_object(self) -> None:
+        """The shape `load()` silently repairs: it replaces a non-dict `values` with {}, so every
+        stored setting disappears while the document still parses."""
+        self.write('{"values": ["a", "b"]}')
+        status = cfg.config_file_status()
+        self.assertEqual("wrong_shape", status["state"])
+        self.assertFalse(status["applied"])
+
+    def test_a_file_that_cannot_be_read_is_not(self) -> None:
+        """A directory where the file should be. Deliberately NOT chmod 000: these tests run as
+        root often enough that a permission bit proves nothing -- root reads a 0000 file, and the
+        case would pass while testing the branch above it instead."""
+        os.mkdir(self.path)
+        status = cfg.config_file_status()
+        self.assertEqual("unreadable", status["state"])
+        self.assertFalse(status["applied"])
+        self.assertIn("directory", (status.get("detail") or "").lower())
+
+    def test_every_state_names_the_file(self) -> None:
+        """Whatever went wrong, the operator has to be told where."""
+        self.write("{}")
+        for setup in (lambda: None, lambda: self.write("nonsense")):
+            setup()
+            self.assertEqual(self.path, cfg.config_file_status()["path"])
+
+
+class TheDistinctionIsReachableFromTheScreenTest(Case):
+
+    def test_the_snapshot_carries_it(self) -> None:
+        self.write("nonsense")
+        status = cfg.snapshot()["config_file_status"]
+        self.assertEqual("unparsable", status["state"])
+        self.assertFalse(status["applied"])
+
+    def test_and_a_healthy_deployment_reports_applied(self) -> None:
+        cfg.update({"retrieval.min_score": "0.35"}, actor="test")
+        self.assertTrue(cfg.snapshot()["config_file_status"]["applied"])
+
+    def test_the_settings_look_identical_either_way(self) -> None:
+        """The premise. If a corrupt file produced a visibly different settings document there
+        would be nothing to report, and this whole file would be decoration."""
+        self.write("nonsense")
+        broken = cfg.snapshot()
+        os.unlink(self.path)
+        absent = cfg.snapshot()
+        self.assertEqual(json.dumps(broken["groups"], sort_keys=True),
+                         json.dumps(absent["groups"], sort_keys=True),
+                         "a corrupt file already renders differently; check what changed")
+
+
+class ThePageSaysSoTest(unittest.TestCase):
+
+    HARNESS = os.path.join(PORTAL, "config_not_applied_harness.js")
+    PAGE = os.path.join(PORTAL, "setup_portal.html")
+
+    def setUp(self) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    def test_the_shipped_page_draws_the_banner(self) -> None:
+        out = subprocess.run(["node", self.HARNESS, self.PAGE],
+                             capture_output=True, text=True, timeout=600)
+        self.assertIn("all ok", out.stdout + out.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_the_page_and_its_builder_agree.py
+++ b/tools/test_matrixark_the_page_and_its_builder_agree.py
@@ -28,13 +28,19 @@ _DEF = re.compile(r"\bfunction\s+([A-Za-z_$][\w$]*)\s*\(")
 
 
 def _functions(text: str) -> dict:
-    """Every `function name(...) { ... }` in `text`, by name, brace-matched.
+    """Every `function name(...) { ... }` in `text`, by name, as a LIST of bodies.
 
-    A name defined more than once is dropped rather than guessed at: this file is about whether
-    two definitions agree, and picking one of several would be inventing the question.
+    A list rather than one body, because the builder holds templates for several pages and the
+    same function name legitimately appears once per template. The first version of this file
+    DROPPED any name defined more than once -- "picking one of several would be inventing the
+    question" -- which silently excused exactly those names from the check. `renderSummary` is
+    defined twice in the builder, so it was skipped, and a mutation that changed only the
+    builder's copy of it survived this guard.
+
+    Dropping them was also invisible: nothing said which names had been skipped, so the guard
+    read as covering everything it had parsed.
     """
     found: dict = {}
-    duplicates = set()
     for match in _DEF.finditer(text):
         name = match.group(1)
         try:
@@ -48,13 +54,8 @@ def _functions(text: str) -> dict:
             elif text[index] == "}":
                 depth -= 1
                 if depth == 0:
-                    body = text[match.start():index + 1]
-                    if name in found and found[name] != body:
-                        duplicates.add(name)
-                    found[name] = body
+                    found.setdefault(name, []).append(text[match.start():index + 1])
                     break
-    for name in duplicates:
-        found.pop(name, None)
     return found
 
 
@@ -64,8 +65,10 @@ def _read(path: str) -> dict:
 
 
 def _shared() -> dict:
+    """name -> (the page's single definition, every definition the builder holds of that name)."""
     page, builder = _read(PAGE), _read(BUILDER)
-    return {name: (page[name], builder[name]) for name in sorted(set(page) & set(builder))}
+    return {name: (page[name], builder[name])
+            for name in sorted(set(page) & set(builder))}
 
 
 class ThePageAndItsBuilderAgreeTest(unittest.TestCase):
@@ -75,15 +78,31 @@ class ThePageAndItsBuilderAgreeTest(unittest.TestCase):
         # passes them all: an empty intersection has no disagreement in it.
         shared = _shared()
         self.assertGreater(len(shared), 5, sorted(shared))
-        for name in ("controlHtml", "fieldHtml"):
+        for name in ("controlHtml", "fieldHtml", "renderSummary"):
             self.assertIn(name, shared)
 
     def test_every_shared_function_is_identical(self) -> None:
-        differing = sorted(name for name, (page, builder) in _shared().items()
-                           if page != builder)
+        """The page's copy must be one of the builder's copies of that name.
+
+        Not "the builder's copy", because the builder holds a template per page and the same
+        name appears once per template. What must hold is that the page a browser runs is one
+        the builder can still produce.
+        """
+        differing = sorted(name for name, (page_bodies, builder_bodies) in _shared().items()
+                           if not set(page_bodies) & set(builder_bodies))
         self.assertEqual([], differing,
                          "%d function(s) differ between the shipped page and the builder that "
                          "writes pages; the harnesses only exercise the page" % len(differing))
+
+    def test_a_name_the_builder_defines_twice_is_still_checked(self) -> None:
+        """The gap this file used to have. Names defined more than once were dropped, silently,
+        so the guard read as covering everything it had parsed while excusing exactly those."""
+        builder = _read(BUILDER)
+        repeated = sorted(name for name, bodies in builder.items() if len(bodies) > 1)
+        self.assertTrue(repeated, "the builder no longer repeats any name; this test is moot")
+        covered = [name for name in repeated if name in _shared()]
+        self.assertTrue(covered,
+                        "every repeated name is being skipped again: %s" % repeated[:5])
 
 
 class TheReaderWorksTest(unittest.TestCase):
@@ -93,16 +112,24 @@ class TheReaderWorksTest(unittest.TestCase):
     def test_it_finds_a_function_and_its_whole_body(self) -> None:
         found = _functions("function a(x) { if (x) { return 1; } return 2; }\n")
         self.assertEqual(["a"], sorted(found))
-        self.assertTrue(found["a"].endswith("return 2; }"), found["a"])
+        self.assertEqual(1, len(found["a"]))
+        self.assertTrue(found["a"][0].endswith("return 2; }"), found["a"])
 
     def test_it_reports_a_difference_when_there_is_one(self) -> None:
         left = _functions("function a() { return 1; }")
         right = _functions("function a() { return 2; }")
-        self.assertNotEqual(left["a"], right["a"])
+        self.assertFalse(set(left["a"]) & set(right["a"]))
 
-    def test_a_name_defined_twice_is_left_out_rather_than_guessed(self) -> None:
+    def test_a_name_defined_twice_keeps_both(self) -> None:
         found = _functions("function a() { return 1; }\nfunction a() { return 2; }")
-        self.assertNotIn("a", found)
+        self.assertIn("a", found)
+        self.assertEqual(2, len(found["a"]))
+
+    def test_matching_one_of_several_is_enough(self) -> None:
+        """A page whose copy equals the SECOND of the builder's definitions agrees with it."""
+        page = _functions("function a() { return 2; }")
+        builder = _functions("function a() { return 1; }\nfunction a() { return 2; }")
+        self.assertTrue(set(page["a"]) & set(builder["a"]))
 
     def test_the_real_files_parse_into_something(self) -> None:
         for path in (PAGE, BUILDER):


### PR DESCRIPTION
`load()` returns the same empty document for four different situations: no file, a file it cannot
read, a file that is not JSON, and JSON of the wrong shape. That is deliberate and correct — its
docstring says so, and a deployment must start whatever state that file is in.

**Only one of the four is normal.** In the other three every value in the file is being ignored and
the deployment is running built-in defaults — and on the settings page that is indistinguishable
from a deployment nobody has configured yet. An operator whose file was truncated mid-write opens
the portal, sees a page full of resolved values, and reads it as their configuration.

Measured before writing anything, across all four states:

```
  no file at all                load->values=0    snapshot: nothing distinguishes it
  a good file with one value    load->values=1
  truncated mid-write           load->values=0    nothing distinguishes it
  valid JSON, wrong shape       load->values=0    nothing distinguishes it
  present but unreadable        load->values=0    nothing distinguishes it
```

### What it says now

`config_file_status()` reports `absent` / `ok` / `unreadable` / `unparsable` / `wrong_shape`, with
`applied` and the reason. It reads the file on its own rather than having `load()` report it, so the
hot path keeps its one job and its promise never to raise.

The page draws a banner naming the file and what was wrong with it, saying the deployment is running
**built-in defaults** — not that it is unconfigured — and it comes *first*, because it invalidates
everything under it.

`absent` reports `applied: true`. A fresh install has nothing stored, so nothing is being ignored,
and a banner there would fire on every new deployment.

`wrong_shape` also covers the case `load()` silently repairs: a `values` key that is not an object
is replaced with `{}`, so every stored setting vanishes while the document still parses.

### One test that would have lied

The unreadable case is a **directory** where the file should be, not `chmod 000`. These tests run as
root often enough that a permission bit proves nothing — root reads a `0000` file, and my first
version of that check passed while silently testing the branch above it. The measurement caught it
before the test did.

There is also a test asserting the two settings documents are *identical* between a corrupt file and
an absent one. If that ever stops being true there is nothing to report and this whole file is
decoration.

```
everything is reported as applied         -> FAIL
an absent file is reported as a problem   -> FAIL
a wrong-shaped values key passes          -> FAIL
an unreadable file is called absent       -> FAIL
the snapshot stops carrying it            -> FAIL
the file is no longer named               -> FAIL
the page stops drawing the banner         -> FAIL
the banner replaces the other warnings    -> FAIL
the builder copy drifts from the page     -> SURVIVED
```

**The last one survives, and I am not adding a fourth bespoke guard for it.** `renderSummary` exists
in both the shipped page and the builder, and this change edits both identically — but nothing on
`main` yet asserts they agree. #1110 adds exactly that, derived rather than listed (it finds 74
shared functions), which is why three earlier changes each wrote their own one-function guard and
this one should not write a fourth. That mutation reddens once #1110 lands.

11 tests and 11 harness assertions green. The harness runs the shipped `renderSummary`, including
the floor that a gateway sending no status at all is not accused of anything.
