### PR TITLE
A flag that reached one of the two packers, and a penalty that reached neither

### DIFF
--- a/tools/matrixark_mcp_budget_pack.py
+++ b/tools/matrixark_mcp_budget_pack.py
@@ -180,7 +180,22 @@ def is_stale_or_superseded_candidate(candidate: Json) -> bool:
     return version_state in {"stale", "superseded", "historical_superseded"}
 
 
-def is_pending_async_candidate(candidate: Json) -> bool:
+def carries_pending_async_marker(candidate: Json) -> bool:
+    """Does this candidate carry a pending-async marker, whatever shape it is?
+
+    Named apart from `is_pending_async_candidate` on purpose. That one is the RETRIEVAL predicate
+    and returns False unless `ref_type == "event"`, because an event is the only shape it ranks --
+    `matrixark_local_adapter_dashboard._embedding_is_pending` already says so, and explains what
+    counting a backlog with it costs. This module defined a THIRD function under that same name,
+    without the event gate, so the tree had one name meaning two things and a comment elsewhere
+    explaining that it meant one.
+
+    Both call sites keep exactly the function they had. At the memory-layer call the surrounding
+    branch has already established `ref_type == "event"`, so the gate would change nothing there;
+    at `candidate_extraction_phase_name` the unguarded reading is the one wanted, because a
+    resource chunk or a skill section waiting on extraction is in that phase whether or not
+    retrieval would rank it.
+    """
     metadata = candidate.get("metadata", {}) if isinstance(candidate.get("metadata"), dict) else {}
     return (
         str(candidate.get("event_type") or metadata.get("event_type") or "").strip().lower() == "pending_async"
@@ -268,7 +283,7 @@ def candidate_memory_layer_name(candidate: Json) -> str:
             return "cross_session_segment"
         return "session_neutral_segment"
     if ref_type == "event":
-        if is_pending_async_candidate(candidate):
+        if carries_pending_async_marker(candidate):
             if is_memory_feature:
                 return "pending_async_memory_feature_event"
             if memory_scope == "user_profile" and session_continuity == "cross_session":
@@ -650,7 +665,7 @@ def select_token_budgeted_refs(
         phase = str(candidate.get("extraction_phase") or "").strip().lower()
         if not phase and isinstance(candidate.get("metadata"), dict):
             phase = str(candidate.get("metadata", {}).get("extraction_phase") or "").strip().lower()
-        if not phase and is_pending_async_candidate(candidate):
+        if not phase and carries_pending_async_marker(candidate):
             phase = "pending_async"
         return phase or "unknown"
 

--- a/tools/matrixark_mcp_recall_scoring.py
+++ b/tools/matrixark_mcp_recall_scoring.py
@@ -213,57 +213,44 @@ def question_type_ref_boost(candidate: Json, question_type: str) -> float:
     return 0.0
 
 
-def packing_sort_key(candidate: Json, question_type: str) -> tuple[float, float, float, float]:
-    score = float(candidate.get("score", 0.0))
-    ref_type = str(candidate.get("ref_type") or "")
-    memory_scope = str(candidate.get("memory_scope") or "").strip().lower()
-    session_continuity = str(candidate.get("session_continuity") or "").strip().lower()
-    profile_current = bool(candidate.get("profile_entity_current"))
-    try:
-        profile_revision = max(0, int(candidate.get("profile_revision") or 0))
-    except (TypeError, ValueError):
-        profile_revision = 0
-    profile_current_boost = 0.0
-    if ref_type == "entity" and memory_scope == "user_profile" and session_continuity == "cross_session":
-        if profile_current:
-            profile_current_boost = 0.10 if question_type in {"current_state", "latest", "profile_memory"} else 0.04
-        if profile_revision > 0:
-            profile_current_boost += min(0.04, 0.01 * profile_revision)
-    boosted = clamp01(
-        score
-        + question_type_ref_boost(candidate, question_type)
-        + session_continuity_boost(candidate, question_type)
-        + cross_session_rerank_adjustment(candidate, question_type)
-        + profile_current_boost
-    )
-    token_efficiency = boosted / max(1, token_count(str(candidate.get("text", ""))))
-    if candidate.get("ref_type") == "compression" and question_type in {"fact", "current_state", "multi_hop"}:
-        source_count = len(candidate.get("source_event_ids", []) or [])
-        if source_count >= 2:
-            token_efficiency *= 1.5
-    current_state_priority = 0.0
-    if question_type in {"current_state", "latest"} and ref_type == "entity":
-        entity_type = str(candidate.get("entity_type") or candidate.get("event_type") or "").strip().lower()
-        profile_memory_kind = str(candidate.get("profile_memory_kind") or "").strip().lower()
-        if profile_memory_kind == "codex_outcome":
-            current_state_priority = 1.0
-        elif bool(candidate.get("profile_current_state_representative")) or bool(candidate.get("profile_current_state_boost")):
-            current_state_priority = 1.0
-        elif profile_current and memory_scope == "user_profile" and session_continuity == "cross_session":
-            current_state_priority = 0.9
-        elif entity_type in {"assistant_decision", "tool_evidence"}:
-            current_state_priority = 0.75
-        elif memory_scope == "user_profile" and session_continuity == "cross_session":
-            current_state_priority = 0.5
-        if profile_current and memory_scope == "user_profile" and session_continuity == "cross_session":
-            current_state_priority += min(0.08, 0.02 + 0.01 * profile_revision)
-    elif question_type == "profile_memory" and ref_type == "entity":
-        if str(candidate.get("profile_memory_kind") or "").strip().lower() in {"durable_profile", "memory_feature"}:
-            current_state_priority = 0.98 if profile_current else 0.9
-        elif profile_current and memory_scope == "user_profile" and session_continuity == "cross_session":
-            current_state_priority = 0.86
-    return (boosted, current_state_priority, token_efficiency, score)
+_CORE_PACKING_SORT_KEY = None
 
+
+def packing_sort_key(candidate: Json, question_type: str) -> tuple[float, ...]:
+    """Return the packing sort key. The one implementation lives in matrixark_mcp_core_packing.
+
+    Delegates deliberately, in the idiom this tree already uses for the same situation (see
+    `matrixark_mcp_core_compact.latest_context_state_key`): the target imports matrixark_mcp_core,
+    which is far more than this module needs at import time, so it is resolved on first call and
+    cached.
+
+    This module used to carry its own copy, and the two had drifted -- in one direction only, with
+    the other one gaining three things this never did:
+
+      * the `pending_async` penalty of 0.32. Without it a candidate whose extraction has not
+        finished sorted ABOVE settled content: 0.90 against the 0.58 the other packer gave the same
+        candidate. matrixark_mcp_budget_pack sorts with this copy and the retrieve path sorts with
+        the other, so the two put provisional content in opposite places, on every question type,
+        with no flag involved.
+      * `MATRIXARK_PACK_RAW_PRECISION`. The flag shifts events up and summaries down for precision
+        questions, and it existed in one packer only, so turning it on changed the retrieve
+        ordering and left this one alone -- the flag reached half the system.
+      * the feature-profile-memory component, which is why the key is five values there and was
+        four here. Every caller either sorts by the whole tuple or reads [0], so the extra value
+        changes no call site.
+
+    Nothing here says the omissions were meant, and the shape of the difference -- three separate
+    additions, all absent -- reads as a copy that stopped receiving them.
+    """
+    global _CORE_PACKING_SORT_KEY
+    delegate = _CORE_PACKING_SORT_KEY
+    if delegate is None:
+        try:
+            from tools.matrixark_mcp_core_packing import packing_sort_key as delegate
+        except ImportError:  # Direct script execution from tools/.
+            from matrixark_mcp_core_packing import packing_sort_key as delegate
+        _CORE_PACKING_SORT_KEY = delegate
+    return delegate(candidate, question_type)
 
 def is_resource_or_skill_candidate(candidate: Json) -> bool:
     ref_type = str(candidate.get("ref_type") or "")

--- a/tools/test_there_is_one_packing_sort_key.py
+++ b/tools/test_there_is_one_packing_sort_key.py
@@ -31,7 +31,10 @@ comparison cannot quietly start running on cases that agree either way.
 """
 from __future__ import annotations
 
+import ast
 import importlib
+import os
+import subprocess
 import unittest
 from typing import Any, Dict, List
 
@@ -148,6 +151,39 @@ class ThereIsOnePackingSortKeyTest(unittest.TestCase):
             off, on,
             "the flag changed a NON-precision question type, so it is no longer scoped to "
             "PRECISION_QUESTION_TYPES and this file describes the wrong thing")
+
+    def test_only_one_module_defines_the_predicate_the_penalty_depends_on(self) -> None:
+        """The penalty is only consistent if the predicate behind it is.
+
+        `matrixark_mcp_budget_pack` defined a THIRD `is_pending_async_candidate`, without the
+        `ref_type == "event"` gate the canonical one applies -- so the tree had one name meaning
+        two things, while `matrixark_local_adapter_dashboard._embedding_is_pending` carried a
+        comment explaining that it meant one. It is now named for what it is,
+        `carries_pending_async_marker`, and both of its call sites keep exactly the function they
+        had: one is already inside a branch that established `ref_type == "event"`, so the gate
+        would change nothing there, and the other wants the unguarded reading.
+        """
+        repo = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        listed = subprocess.run(["git", "ls-files", "tools/*.py"], cwd=repo,
+                                capture_output=True, text=True).stdout.split()
+        definers = []
+        for rel in listed:
+            if os.path.basename(rel).startswith("test_"):
+                continue
+            try:
+                with open(os.path.join(repo, rel), encoding="utf-8", errors="replace") as handle:
+                    tree = ast.parse(handle.read())
+            except (OSError, SyntaxError):
+                continue
+            for node in tree.body:
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) \
+                        and node.name == "is_pending_async_candidate":
+                    definers.append(os.path.basename(rel)[:-len(".py")])
+        self.assertEqual(
+            ["matrixark_mcp_core_candidate_policy"], sorted(definers),
+            "is_pending_async_candidate is defined in more than one module again. A second copy "
+            "agrees wherever the caller has already established ref_type == 'event', which is "
+            "most call sites, so nothing routine catches the difference")
 
     def test_the_pending_async_penalty_is_applied(self) -> None:
         """The half of the divergence that needed no flag at all."""

--- a/tools/test_there_is_one_packing_sort_key.py
+++ b/tools/test_there_is_one_packing_sort_key.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""One packing sort key, and the flag that shifts it reaches every packer that uses it.
+
+`packing_sort_key` was implemented twice, and both are on live paths.
+`matrixark_local_adapter_retrieve` and `matrixark_mcp_core_ref_selection` sort with
+`matrixark_mcp_core_packing`; `matrixark_mcp_budget_pack`, which the gateway reaches through
+`matrixark_mcp_budget_policies`, sorted with `matrixark_mcp_recall_scoring`.
+
+The copies had drifted in ONE direction. The core_packing one gained three things the other never
+did:
+
+  * the `pending_async` penalty of 0.32. Without it, a candidate whose extraction has not finished
+    scored 0.90 where the other packer gave the same candidate 0.58 -- so provisional content
+    sorted to the TOP on one path and was demoted on the other, on every question type, with no
+    flag involved.
+  * `MATRIXARK_PACK_RAW_PRECISION`, which shifts events up and summaries down for precision
+    questions. It existed in one packer only, so turning it on changed one ordering and left the
+    other alone: the flag reached half the system.
+  * the feature-profile-memory component, which is why the key was five values on one side and
+    four on the other.
+
+This file asserts the property that matters -- the two produce the SAME key -- rather than that
+there is one definition, because the second is now a deliberate delegate and a definition count
+cannot tell a delegate from a divergence.
+
+The corpus below is chosen to discriminate. Ordinary candidates agreed under both copies before
+this change; it takes a pending-async candidate, or the flag turned on with a precision question
+type, to tell them apart. `test_the_corpus_can_tell_the_two_apart` pins exactly that, so the
+comparison cannot quietly start running on cases that agree either way.
+"""
+from __future__ import annotations
+
+import importlib
+import unittest
+from typing import Any, Dict, List
+
+FLAG_ATTRIBUTE = "PACK_RAW_PRECISION"
+
+#: Every question type the flag distinguishes, plus two it does not, as the control.
+QUESTION_TYPES = ("fact", "multi_hop", "evidence", "benchmark_quality", "date",
+                  "current_state", "latest", "profile_memory")
+
+#: Candidates that discriminate. The first four are ordinary and agreed under both copies; the
+#: pending-async ones are what the 0.32 penalty acts on, and the event/summary pair is what the
+#: flag shifts.
+CANDIDATES: List[Dict[str, Any]] = [
+    {"id": "plain_event", "score": 0.70, "ref_type": "event", "text": "the deploy went out"},
+    {"id": "summary", "score": 0.82, "ref_type": "summary", "text": "a summary of the week"},
+    {"id": "compression", "score": 0.80, "ref_type": "compression", "text": "compressed",
+     "source_event_ids": ["a", "b"]},
+    {"id": "profile_entity", "score": 0.75, "ref_type": "entity", "memory_scope": "user_profile",
+     "session_continuity": "cross_session", "profile_entity_current": True,
+     "profile_revision": 3, "text": "prefers metric units"},
+    {"id": "pending_event", "score": 0.72, "ref_type": "event", "event_type": "pending_async",
+     "text": "not yet extracted"},
+    {"id": "pending_class", "score": 0.71, "ref_type": "event",
+     "classification": "PENDING_ASYNC_EXTRACTION", "text": "also not yet"},
+    {"id": "pending_phase", "score": 0.69, "ref_type": "entity",
+     "extraction_phase": "pending_async", "text": "phase pending"},
+    {"id": "feature_profile", "score": 0.66, "ref_type": "entity",
+     "profile_memory_kind": "feature", "memory_scope": "user_profile", "text": "feature"},
+]
+
+
+def _import(name: str):
+    try:
+        return importlib.import_module("tools." + name)
+    except ImportError:
+        return importlib.import_module(name)
+
+
+def _packers():
+    _import("matrixark_mcp_local_adapter")          # settles the circular imports
+    return _import("matrixark_mcp_core_packing"), _import("matrixark_mcp_recall_scoring")
+
+
+class ThereIsOnePackingSortKeyTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.core, self.recall = _packers()
+        self._flag = getattr(self.core, FLAG_ATTRIBUTE)
+
+    def tearDown(self) -> None:
+        setattr(self.core, FLAG_ATTRIBUTE, self._flag)
+
+    def _disagreements(self):
+        found = []
+        for flag in (False, True):
+            setattr(self.core, FLAG_ATTRIBUTE, flag)
+            for question_type in QUESTION_TYPES:
+                for candidate in CANDIDATES:
+                    a = self.core.packing_sort_key(dict(candidate), question_type)
+                    b = self.recall.packing_sort_key(dict(candidate), question_type)
+                    if a != b:
+                        found.append((flag, question_type, candidate["id"], a, b))
+        return found
+
+    def test_both_packers_produce_the_same_key(self) -> None:
+        found = self._disagreements()
+        detail = ["flag=%s %s %s: core_packing=%s recall_scoring=%s" % row for row in found[:5]]
+        self.assertEqual(
+            [], detail,
+            "the two live packers disagree on %d of %d cases, so the gateway and the retrieve path "
+            "order the same candidates differently:\n  %s"
+            % (len(found), 2 * len(QUESTION_TYPES) * len(CANDIDATES), "\n  ".join(detail)))
+
+    def test_the_corpus_can_tell_the_two_apart(self) -> None:
+        """A comparison is worth what its inputs discriminate, so pin what they must contain.
+
+        Before the delegate, ordinary candidates agreed under both copies at every question type;
+        only the pending-async ones and the flag-plus-precision combination disagreed. A corpus
+        that lost those would pass while the copies diverged again.
+        """
+        ids = {candidate["id"] for candidate in CANDIDATES}
+        self.assertTrue(
+            {"pending_event", "pending_class", "pending_phase"} <= ids,
+            "the corpus lost its pending-async candidates, which are what the 0.32 penalty acts "
+            "on -- without them the comparison passes whether or not the penalty is applied")
+        self.assertTrue(
+            {"plain_event", "summary"} <= ids,
+            "the corpus lost the event/summary pair the precision flag shifts in opposite "
+            "directions")
+        precision = {"fact", "multi_hop", "evidence", "benchmark_quality", "date"}
+        self.assertTrue(
+            precision <= set(QUESTION_TYPES),
+            "the question types the flag acts on are not all covered")
+        self.assertTrue(
+            {"current_state", "latest"} & set(QUESTION_TYPES),
+            "no non-precision question type is covered, so nothing shows the flag is SCOPED")
+
+    def test_the_flag_still_changes_the_key_it_is_supposed_to(self) -> None:
+        """If the flag stopped doing anything, the equality above would pass for the wrong reason."""
+        setattr(self.core, FLAG_ATTRIBUTE, False)
+        off = self.core.packing_sort_key(dict(CANDIDATES[0]), "fact")
+        setattr(self.core, FLAG_ATTRIBUTE, True)
+        on = self.core.packing_sort_key(dict(CANDIDATES[0]), "fact")
+        self.assertNotEqual(
+            off, on,
+            "MATRIXARK_PACK_RAW_PRECISION no longer changes the key for a precision question, so "
+            "the agreement asserted above says nothing about the flag reaching both packers")
+
+        setattr(self.core, FLAG_ATTRIBUTE, False)
+        off = self.core.packing_sort_key(dict(CANDIDATES[0]), "current_state")
+        setattr(self.core, FLAG_ATTRIBUTE, True)
+        on = self.core.packing_sort_key(dict(CANDIDATES[0]), "current_state")
+        self.assertEqual(
+            off, on,
+            "the flag changed a NON-precision question type, so it is no longer scoped to "
+            "PRECISION_QUESTION_TYPES and this file describes the wrong thing")
+
+    def test_the_pending_async_penalty_is_applied(self) -> None:
+        """The half of the divergence that needed no flag at all."""
+        setattr(self.core, FLAG_ATTRIBUTE, False)
+        pending = dict(CANDIDATES[4])
+        settled = dict(pending)
+        settled.pop("event_type")
+        self.assertLess(
+            self.core.packing_sort_key(pending, "fact")[0],
+            self.core.packing_sort_key(settled, "fact")[0],
+            "a candidate whose extraction has not finished no longer sorts below the same "
+            "candidate once settled")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`packing_sort_key` was implemented twice, and **both are on live paths**:

| path | reached | sorts with |
|---|---|---|
| retrieve | `matrixark_local_adapter_retrieve`, `matrixark_mcp_core_ref_selection` | `matrixark_mcp_core_packing` |
| gateway | `matrixark_mcp_server` → `matrixark_v1_gateway` → `matrixark_mcp_budget_policies` → `matrixark_mcp_budget_pack` | `matrixark_mcp_recall_scoring` |

The copies had drifted in **one direction**. The `core_packing` one gained three things the other
never did.

## The one that needs no flag at all

A `pending_async` penalty of 0.32. Without it, a candidate whose extraction has not finished scored
**0.90** where the other packer gave the same candidate **0.58** — so provisional content sorted to
the top through the gateway and was demoted through the retrieve path:

```
question_type    core_packing              recall_scoring
fact             plain pend3 ent pend1 pend2   pend1 pend2 plain pend3 ent    DIFFER
evidence         plain pend3 ent pend1 pend2   pend1 pend2 plain pend3 ent    DIFFER
current_state    pend3 ent plain pend1 pend2   pend3 ent pend1 pend2 plain    DIFFER
multi_hop        pend3 ent plain pend1 pend2   pend3 ent pend1 pend2 plain    DIFFER
```

## The one that is a flag

`MATRIXARK_PACK_RAW_PRECISION` shifts events up and summaries down for precision question types. It
existed in **one packer only**, so turning it on changed the retrieve ordering and left the gateway
ordering alone — the flag reached half the system:

```
flag off   the two orders agree on every question type
flag on    they differ on fact, evidence and multi_hop
           and agree on current_state — not a precision type, and the control
           showing the flag is scoped rather than simply broken
```

## And the third

The feature-profile-memory component, which is why the key was five values on one side and four on
the other. Every caller either sorts by the whole tuple or reads `[0]`, so the extra value changes
no call site.

## The change

One implementation. `matrixark_mcp_recall_scoring` delegates to it in the idiom this tree already
uses for the same situation — resolved on first call and cached, because the target imports
`matrixark_mcp_core` and this module does not need that at import time. See
`matrixark_mcp_core_compact.latest_context_state_key`, which carries the same shape and the same
reason.

**This changes gateway ranking, and that is the point rather than a side effect.** Candidates whose
extraction has not finished are now demoted there as they already were on the retrieve path, and the
precision flag now reaches both. All three paths — `core_packing`, `recall_scoring` and
`budget_pack` — were verified to agree on every question type with the flag off **and** on.

Nothing here claims the omissions were meant. Nothing in that copy said so, and the shape of the
difference — three separate additions, all absent — reads as a copy that stopped receiving them.

## And one name meaning three things

`matrixark_mcp_budget_pack` also defined its own `is_pending_async_candidate`, without the
`ref_type == "event"` gate the canonical one applies. So the tree had one name meaning two things
while a comment elsewhere explained that it meant one --
`matrixark_local_adapter_dashboard._embedding_is_pending` says in its own docstring: "Deliberately
not `is_pending_async_candidate`: that is the RETRIEVAL predicate and returns False unless
`ref_type == \"event\"`".

Renamed to `carries_pending_async_marker`, which is what it tests. **Both call sites keep exactly
the function they had**, so nothing changes: one is already inside a branch that established
`ref_type == "event"` (and both copies derive `ref_type` identically, so the gate could not have
changed the answer there), and the other wants the unguarded reading -- a resource chunk waiting on
extraction is in that phase whether or not retrieval would rank it, which is the same argument the
dashboard makes for keeping its own predicate. Nothing imported the old name from this module.

The assertion for it lives with the sort key because the 0.32 penalty is computed FROM this
predicate: the penalty is only consistent if the predicate is.

## The guard

It asserts the **property** rather than the definition count, because the delegate is deliberate and
a count cannot tell a delegate from a divergence.

It also pins what the corpus must *contain*: ordinary candidates agreed under both copies at every
question type, so a corpus that lost its pending-async entries or its event/summary pair would pass
while the copies diverged again. Two further assertions keep the equality honest — the flag must
still change a precision key (otherwise the agreement means nothing) and must still leave a
non-precision one alone.

- **Mutation-tested** — with the four-tuple copy restored, 128 of 128 cases disagree.
- Runs under both import paths, verified both ways.
- The two errors in the pack and budget suites are present on main with this change removed.
