### PR TITLE
The gateway advertised a near-duplicate setting its own packer ignored

### DIFF
--- a/tools/matrixark_mcp_budget_pack.py
+++ b/tools/matrixark_mcp_budget_pack.py
@@ -19,12 +19,17 @@ try:
     from tools.matrixark_mcp_identity import stable_hash
     from tools.matrixark_mcp_runtime_config import (
         DEFAULT_BUDGET_FILL_POLICY,
+        DEFAULT_NEAR_DUPLICATE_OVERLAP_THRESHOLD,
         DEFAULT_MAX_CONTEXT_TOKENS,
         DEFAULT_MAX_GLOBAL_CANDIDATES,
         DEFAULT_MAX_SELECTED_REFS,
         DEFAULT_RETRIEVAL_MIN_SCORE,
     )
-    from tools.matrixark_mcp_scoring import tokens
+    from tools.matrixark_mcp_scoring import (
+        near_duplicate_overlap_ratio,
+        normalized_token_set,
+        tokens,
+    )
     from tools.matrixark_mcp_text import clip_context_text, token_count
 except ModuleNotFoundError:  # Direct script execution from tools/.
     from matrixark_mcp_errors import MatrixArkError
@@ -36,12 +41,17 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
     from matrixark_mcp_identity import stable_hash
     from matrixark_mcp_runtime_config import (
         DEFAULT_BUDGET_FILL_POLICY,
+        DEFAULT_NEAR_DUPLICATE_OVERLAP_THRESHOLD,
         DEFAULT_MAX_CONTEXT_TOKENS,
         DEFAULT_MAX_GLOBAL_CANDIDATES,
         DEFAULT_MAX_SELECTED_REFS,
         DEFAULT_RETRIEVAL_MIN_SCORE,
     )
-    from matrixark_mcp_scoring import tokens
+    from matrixark_mcp_scoring import (
+        near_duplicate_overlap_ratio,
+        normalized_token_set,
+        tokens,
+    )
     from matrixark_mcp_text import clip_context_text, token_count
 
 
@@ -417,6 +427,7 @@ def select_token_budgeted_refs(
     min_score: float = DEFAULT_RETRIEVAL_MIN_SCORE,
     max_global_candidates: int | None = None,
     budget_fill_policy: str = DEFAULT_BUDGET_FILL_POLICY,
+    near_duplicate_overlap_threshold: float = DEFAULT_NEAR_DUPLICATE_OVERLAP_THRESHOLD,
     duplicate_text_hashes: set[int] | None = None,
     deadline_exceeded: Callable[[], bool] | None = None,
     deadline_reason: str = "deadline_during_pack",
@@ -436,6 +447,14 @@ def select_token_budgeted_refs(
     )
     min_score = max(0.0, min(1.0, float(min_score)))
     budget_fill_policy = (budget_fill_policy or DEFAULT_BUDGET_FILL_POLICY).strip().lower()
+    try:
+        near_duplicate_overlap_threshold = float(near_duplicate_overlap_threshold)
+    except (TypeError, ValueError):
+        near_duplicate_overlap_threshold = DEFAULT_NEAR_DUPLICATE_OVERLAP_THRESHOLD
+    near_duplicate_overlap_threshold = max(0.0, min(1.0, near_duplicate_overlap_threshold))
+    #: A threshold of 0 turns the suppression off, which is how the setting is disabled.
+    near_duplicate_enabled = near_duplicate_overlap_threshold > 0.0
+    selected_token_sets: list[frozenset[str]] = []
     candidates = merge_ranked_paths(
         primary,
         auxiliary,
@@ -667,6 +686,7 @@ def select_token_budgeted_refs(
     dropped: Json = {
         "over_budget": 0,
         "duplicate": 0,
+        "near_duplicate": 0,
         "low_score": 0,
         "stale": 0,
         "summary": 0,
@@ -687,6 +707,7 @@ def select_token_budgeted_refs(
         "estimated_tokens": {
             "over_budget": 0,
             "duplicate": 0,
+            "near_duplicate": 0,
             "low_score": 0,
             "stale": 0,
             "summary": 0,
@@ -708,6 +729,7 @@ def select_token_budgeted_refs(
         "reason_descriptions": {
             "over_budget": "candidate was relevant but exceeded the remaining remote context token budget",
             "duplicate": "candidate duplicated local context or an already selected ref",
+            "near_duplicate": "candidate text near-duplicated a higher-ranked already selected ref (token overlap above the configured threshold)",
             "low_score": "candidate score was below the minimum packing threshold",
             "stale": "candidate was stale or superseded for the query policy",
             "summary": "summary text was dropped in favor of denser raw/evidence refs",
@@ -795,6 +817,22 @@ def select_token_budgeted_refs(
             dropped["estimated_tokens"]["stale"] += ref_tokens
             record_dropped_candidate(dropped, candidate, reason="stale", token_estimate=ref_tokens)
             continue
+        # Near-duplicate suppression: drop a candidate whose normalized token set overlaps an
+        # already-selected (strictly higher-ranked, since selection is in ranked order) ref
+        # above the configured threshold, so repetitive refs do not dilute precision or spend
+        # budget on redundant content. The highest-ranked instance is the one already in
+        # `selected`, so it is kept. Same placement as matrixark_mcp_core_ref_selection: before
+        # the budget check, so a near-duplicate is not counted as over_budget instead.
+        if near_duplicate_enabled and selected_token_sets:
+            candidate_token_set = normalized_token_set(candidate.get("text", ""))
+            if candidate_token_set and any(
+                near_duplicate_overlap_ratio(candidate_token_set, selected_tokens) >= near_duplicate_overlap_threshold
+                for selected_tokens in selected_token_sets
+            ):
+                dropped["near_duplicate"] += 1
+                dropped["estimated_tokens"]["near_duplicate"] += ref_tokens
+                record_dropped_candidate(dropped, candidate, reason="near_duplicate", token_estimate=ref_tokens)
+                continue
         if remote_budget <= 0 or (selected and used_tokens + ref_tokens > remote_budget):
             dropped["over_budget"] += 1
             dropped["estimated_tokens"]["over_budget"] += ref_tokens
@@ -975,6 +1013,8 @@ def select_token_budgeted_refs(
             )
             continue
         seen_text_hashes.add(text_hash)
+        if near_duplicate_enabled:
+            selected_token_sets.append(normalized_token_set(candidate.get("text", "")))
         selected.append(
             {
                 **candidate,

--- a/tools/matrixark_mcp_core_ref_selection.py
+++ b/tools/matrixark_mcp_core_ref_selection.py
@@ -60,29 +60,21 @@ except ImportError:  # top-level path (matrixark_mcp_core)
 __all__ = ['dropped_candidate_audit_ref', 'record_dropped_candidate', 'diversify_for_question_type', 'entity_current_state_key', 'prefer_profile_entities_for_current_state', 'is_stale_or_superseded_candidate', 'suppress_profile_shadowed_session_entity_refs', 'normalized_token_set', 'near_duplicate_overlap_ratio', 'clamp_refs_to_token_budget', 'select_token_budgeted_refs']
 
 
-def normalized_token_set(text: str) -> frozenset[str]:
-    """Lower-cased, de-duplicated token set used for near-duplicate detection."""
-    return frozenset(token.lower() for token in tokens(str(text or "")) if token)
-
-
-def near_duplicate_overlap_ratio(candidate_tokens: frozenset[str], selected_tokens: frozenset[str]) -> float:
-    """Jaccard token-set similarity between two refs (|A ∩ B| / |A ∪ B|).
-
-    Jaccard is the near-duplicate metric here (rather than containment) so a
-    short ref whose few tokens merely happen to be a subset of a longer but
-    genuinely different ref is NOT collapsed: near-duplicate requires the two
-    texts to be substantially the same, in both content and size. Ranges 0.0
-    (disjoint) .. 1.0 (identical token sets).
-    """
-    if not candidate_tokens or not selected_tokens:
-        return 0.0
-    intersection = len(candidate_tokens & selected_tokens)
-    if intersection == 0:
-        return 0.0
-    union = len(candidate_tokens | selected_tokens)
-    if union <= 0:
-        return 0.0
-    return intersection / union
+# `normalized_token_set` and `near_duplicate_overlap_ratio` are not defined here any more. They
+# moved to matrixark_mcp_scoring so matrixark_mcp_budget_pack can use them too: the gateway reaches
+# that packer, and it had no near-duplicate suppression at all while the setting that governs it,
+# MATRIXARK_NEAR_DUPLICATE_OVERLAP_THRESHOLD, is offered by matrixark_gateway_config and defaults
+# to 0.85 -- on. This module could not be the shared home because it imports matrixark_mcp_core.
+try:
+    from tools.matrixark_mcp_scoring import (
+        near_duplicate_overlap_ratio,
+        normalized_token_set,
+    )
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_scoring import (
+        near_duplicate_overlap_ratio,
+        normalized_token_set,
+    )
 
 
 def clamp_refs_to_token_budget(

--- a/tools/matrixark_mcp_scoring.py
+++ b/tools/matrixark_mcp_scoring.py
@@ -22,6 +22,35 @@ def tokens(text: str) -> list[str]:
     return re.findall(r"[a-z0-9_]+", text.lower())
 
 
+# Near-duplicate detection lives here rather than beside one of the two packers that need it.
+# It was defined in matrixark_mcp_core_ref_selection, which imports matrixark_mcp_core, so the
+# other packer -- matrixark_mcp_budget_pack, which the gateway reaches -- could not use it without
+# taking that whole dependency at import time. It is built on `tokens`, which this module owns.
+def normalized_token_set(text: str) -> frozenset[str]:
+    """Lower-cased, de-duplicated token set used for near-duplicate detection."""
+    return frozenset(token.lower() for token in tokens(str(text or "")) if token)
+
+
+def near_duplicate_overlap_ratio(candidate_tokens: frozenset[str], selected_tokens: frozenset[str]) -> float:
+    """Jaccard token-set similarity between two refs (|A ∩ B| / |A ∪ B|).
+
+    Jaccard is the near-duplicate metric here (rather than containment) so a
+    short ref whose few tokens merely happen to be a subset of a longer but
+    genuinely different ref is NOT collapsed: near-duplicate requires the two
+    texts to be substantially the same, in both content and size. Ranges 0.0
+    (disjoint) .. 1.0 (identical token sets).
+    """
+    if not candidate_tokens or not selected_tokens:
+        return 0.0
+    intersection = len(candidate_tokens & selected_tokens)
+    if intersection == 0:
+        return 0.0
+    union = len(candidate_tokens | selected_tokens)
+    if union <= 0:
+        return 0.0
+    return intersection / union
+
+
 def cosine(left: list[float], right: list[float]) -> float:
     """Cosine similarity, normalised on both sides.
 

--- a/tools/test_the_near_duplicate_setting_reaches_both_packers.py
+++ b/tools/test_the_near_duplicate_setting_reaches_both_packers.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The near-duplicate setting reaches both packers, including the one the gateway uses.
+
+`matrixark_gateway_config` offers `retrieval.near_duplicate_overlap_threshold`, describes it as
+"A candidate this similar to an already-selected, higher-ranked one is dropped. Stops a pack paying
+twice for one fact.", and defaults it to 0.85 -- on. `matrixark_load_config` maps it to
+`MATRIXARK_NEAR_DUPLICATE_OVERLAP_THRESHOLD` and applies it to the environment.
+
+`matrixark_mcp_budget_pack`, which the gateway reaches through `matrixark_mcp_budget_policies` from
+`matrixark_mcp_server`, had no near-duplicate logic at all -- the word did not appear in the file.
+Measured on four candidates, three of them near-duplicates of one another:
+
+    matrixark_mcp_core_ref_selection   selected ['d', 'a']              near_duplicate dropped 2
+    matrixark_mcp_budget_pack          selected ['d', 'a', 'c', 'b']    no such reason
+
+So a deployment that read its own settings page believed near-duplicate suppression was on, and on
+the gateway path it was not. This is the shape of mx#959 -- a surface advertising a knob nothing
+reads -- and the check below is written to catch it the same way: not "does the packer have a
+threshold parameter" but "does the SETTING the gateway offers change what the packer selects".
+"""
+from __future__ import annotations
+
+import importlib
+import unittest
+
+SETTING = "retrieval.near_duplicate_overlap_threshold"
+ENV = "MATRIXARK_NEAR_DUPLICATE_OVERLAP_THRESHOLD"
+
+SHARED = "the deploy went out on tuesday and p99 latency improved to 41 milliseconds"
+
+#: Three of these are near-duplicates of one another; "distinct" is not, and is what shows the
+#: suppression is selective rather than simply dropping candidates.
+CANDIDATES = [
+    {"ref_id": "first", "text": SHARED, "score": 0.90},
+    {"ref_id": "reworded", "text": SHARED + " roughly", "score": 0.85},
+    {"ref_id": "abbreviated",
+     "text": "the deploy went out on tuesday and p99 latency improved to 41 ms", "score": 0.80},
+    {"ref_id": "distinct", "text": "shard rebalance completed with no errors", "score": 0.75},
+]
+
+
+def _import(name: str):
+    try:
+        return importlib.import_module("tools." + name)
+    except ImportError:
+        return importlib.import_module(name)
+
+
+def _candidates():
+    return [dict(c, ref_hash="h_" + c["ref_id"], ref_type="event", context_class="event",
+                 memory_scope="session", session_continuity="same_session",
+                 metadata={"ref_type": "event"})
+            for c in CANDIDATES]
+
+
+def _select(fn, **kwargs):
+    selected, _tokens, audit = fn(_candidates(), [], max_context_tokens=4000,
+                                  auxiliary_quota=0, question_type="fact", **kwargs)
+    return [ref["ref_id"] for ref in selected], audit
+
+
+class TheNearDuplicateSettingReachesBothPackersTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        _import("matrixark_mcp_local_adapter")            # settles the circular imports
+        self.gateway_packer = _import("matrixark_mcp_budget_pack").select_token_budgeted_refs
+        self.retrieve_packer = _import(
+            "matrixark_mcp_core_ref_selection").select_token_budgeted_refs
+
+    def test_the_gateway_packer_drops_near_duplicates(self) -> None:
+        selected, audit = _select(self.gateway_packer)
+        self.assertEqual(
+            ["distinct", "first"], selected,
+            "the packer the gateway reaches selected %s. It kept refs that near-duplicate a "
+            "higher-ranked one, which is exactly what the setting it advertises says it does not "
+            "do" % selected)
+        self.assertEqual(2, audit.get("near_duplicate"),
+                         "the drop was not attributed to near_duplicate, so an operator reading "
+                         "the audit cannot see why the pack is smaller")
+
+    def test_both_packers_select_the_same_refs(self) -> None:
+        gateway, _ = _select(self.gateway_packer)
+        retrieve, _ = _select(self.retrieve_packer)
+        self.assertEqual(
+            retrieve, gateway,
+            "the two live packers select different refs for the same candidates, so a request "
+            "served through the gateway gets a different pack from one served through retrieve")
+
+    def test_the_threshold_is_what_decides_it(self) -> None:
+        """Control. Without this, the assertions above pass for a packer that always drops."""
+        off, off_audit = _select(self.gateway_packer, near_duplicate_overlap_threshold=0.0)
+        self.assertEqual(
+            ["distinct", "first", "abbreviated", "reworded"], off,
+            "a threshold of 0 must turn the suppression OFF -- that is how an operator disables "
+            "it, and if it drops anyway the setting is decorative in the other direction")
+        self.assertEqual(0, off_audit.get("near_duplicate"))
+
+        exact, _ = _select(self.gateway_packer, near_duplicate_overlap_threshold=1.0)
+        self.assertEqual(
+            len(CANDIDATES), len(exact),
+            "a threshold of 1 requires identical token sets, and none of these are identical, so "
+            "nothing should be dropped -- if something is, the comparison is not the ratio it "
+            "claims to be")
+
+    def test_the_default_the_packer_uses_is_the_one_the_gateway_advertises(self) -> None:
+        """The mx#959 shape: a settings page and the code that consumes it must not disagree."""
+        import inspect
+
+        config = _import("matrixark_gateway_config")
+        declared = None
+        for setting in getattr(config, "SETTINGS", []):
+            if getattr(setting, "key", None) == SETTING:
+                declared = setting
+                break
+        self.assertIsNotNone(
+            declared, "%s is no longer offered by matrixark_gateway_config. If the setting was "
+                      "withdrawn, this file should go with it; if it was renamed, the packers "
+                      "need to follow it" % SETTING)
+        self.assertEqual(
+            ENV, getattr(declared, "env", None),
+            "the setting no longer maps to %s, which is the variable the default is read from" % ENV)
+
+        runtime = _import("matrixark_mcp_runtime_config")
+        self.assertAlmostEqual(
+            float(declared.default), runtime.DEFAULT_NEAR_DUPLICATE_OVERLAP_THRESHOLD, places=6,
+            msg="the gateway advertises a default of %s and the code applies %s"
+                % (declared.default, runtime.DEFAULT_NEAR_DUPLICATE_OVERLAP_THRESHOLD))
+
+        for name, fn in (("gateway", self.gateway_packer), ("retrieve", self.retrieve_packer)):
+            default = inspect.signature(fn).parameters["near_duplicate_overlap_threshold"].default
+            self.assertAlmostEqual(
+                runtime.DEFAULT_NEAR_DUPLICATE_OVERLAP_THRESHOLD, float(default), places=6,
+                msg="the %s packer defaults its threshold to %s rather than to the value the "
+                    "setting resolves to" % (name, default))
+
+    def test_one_module_owns_the_comparison(self) -> None:
+        scoring = _import("matrixark_mcp_scoring")
+        selection = _import("matrixark_mcp_core_ref_selection")
+        budget = _import("matrixark_mcp_budget_pack")
+        for module, label in ((selection, "core_ref_selection"), (budget, "budget_pack")):
+            self.assertIs(
+                scoring.normalized_token_set, module.normalized_token_set,
+                "%s uses its own normalized_token_set, so the two packers can tokenise the same "
+                "text differently and disagree about what a duplicate is" % label)
+            self.assertIs(
+                scoring.near_duplicate_overlap_ratio, module.near_duplicate_overlap_ratio,
+                "%s uses its own near_duplicate_overlap_ratio" % label)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`matrixark_gateway_config` offers `retrieval.near_duplicate_overlap_threshold` and describes it:

> "A candidate this similar to an already-selected, higher-ranked one is dropped. **Stops a pack
> paying twice for one fact.**"

Default `0.85` — on. `matrixark_load_config` maps it to `MATRIXARK_NEAR_DUPLICATE_OVERLAP_THRESHOLD`
and applies it to the environment.

**`matrixark_mcp_budget_pack` had no near-duplicate logic at all.** The word did not appear in the
file. That is the packer the gateway reaches, through `matrixark_mcp_budget_policies` from
`matrixark_mcp_server`.

Measured on four candidates, three of them near-duplicates of one another:

```
core_ref_selection   selected ['distinct', 'first']                          dropped 2
budget_pack          selected ['distinct', 'first', 'abbreviated', 'reworded']
```

So a deployment that read its own settings page believed suppression was on, and on the gateway
path it was not — the pack paid twice for one fact, and the budget it spent doing so was budget the
operator had asked it not to spend. Same shape as mx#959, where the portal advertised a retrieval
budget nothing read.

## The change

The two helpers the comparison is built on — `normalized_token_set` and
`near_duplicate_overlap_ratio` — moved to `matrixark_mcp_scoring`, which already owns `tokens` and
which both packers already import. They could not stay in `matrixark_mcp_core_ref_selection`,
because it imports `matrixark_mcp_core` — more than the gateway packer takes at import time. The old
home re-exports them, so there is **one** comparison rather than two.

The suppression itself is placed exactly where the other packer places it — before the budget check
— so a near-duplicate is attributed to `near_duplicate` rather than counted as `over_budget`.

## What this does not do

**The two implementations of `select_token_budgeted_refs` are still two.** After this change they
select the same refs and report the same token total for the same candidates. What still differs is
the *audit*:

| | |
|---|---|
| `entity_bridge_slot_reserved` | in `budget_pack`, absent from `core_ref_selection` |
| `memory_layer_floor` description | worded differently |
| `refs` | one records dropped refs, the other returns `[]` |

Worth consolidating, and not this change.

## Verified

- Both packers now select the same refs, and the same token total.
- The threshold is what decides it: `0.0` turns suppression off and every candidate is kept; `1.0`
  requires identical token sets, and none of these are identical, so nothing is dropped.
- The default the packers use is the value the setting resolves to — asserted against the `Setting`
  the gateway declares, not against a literal.
- Both packers reach the same helper *objects*.

**Mutation-tested both ways.** Removing the check fails the gateway assertion and the agreement
assertion. Making it drop regardless of the threshold fails the control — because "near-duplicates
are dropped" passes trivially for a packer that drops everything.

The two errors in the pack and budget suites are present on main with this change removed;
ref_selection, scoring, retrieve, gateway (260 tests) and config are green.
