### PR TITLE
A variable the portal does not offer was winning over a field it does

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -1446,6 +1446,51 @@ def config_path() -> str:
     return os.path.join(home, DEFAULT_CONFIG_FILENAME)
 
 
+#: Variables that WIN over a setting's own, and are offered nowhere themselves.
+#:
+#: `matrixark_mcp_core` reads MATRIXARK_ANTHROPIC_TIMEOUT_SEC first and falls back to
+#: MATRIXARK_EXTRACTION_TIMEOUT_SEC, so on an Anthropic deployment the field the portal shows is
+#: not what decides. With the override set the page displayed the fallback -- 30 where the
+#: extraction path was using 5 -- with no badge, and editing the field changed nothing.
+#:
+#: Written here because the portal needs it per request and deriving it means parsing the tree.
+#: `test_matrixark_a_variable_the_portal_does_not_offer` derives the same set from the source and
+#: fails in either direction, so this cannot drift from what the code does.
+#:
+#: key -> (overriding variable, the setting whose value decides, values that make it apply)
+_UNOFFERED_OVERRIDES: Dict[str, Tuple[str, str, Tuple[str, ...]]] = {
+    "extraction.timeout_sec": ("MATRIXARK_ANTHROPIC_TIMEOUT_SEC", "extraction.provider",
+                               ("anthropic",)),
+    "extraction.max_tokens": ("MATRIXARK_ANTHROPIC_MAX_TOKENS", "extraction.provider",
+                              ("anthropic",)),
+}
+
+
+def unoffered_override(key: str, values: Dict[str, str]) -> Optional[Json]:
+    """The variable currently overriding `key`, or None.
+
+    None unless BOTH hold: the variable is set, and the setting it depends on has a value that
+    makes the override apply. A variable that is set on a deployment the override does not reach
+    is not overriding anything, and saying it is would be the same false alarm as reporting every
+    healthy plan as a substitution.
+    """
+    entry = _UNOFFERED_OVERRIDES.get(key)
+    if entry is None:
+        return None
+    variable, depends_on, applies_when = entry
+    raw = os.environ.get(variable)
+    if raw is None or not str(raw).strip():
+        return None
+    setting = SETTINGS_BY_KEY.get(depends_on)
+    if setting is None:
+        return None
+    current, _source = _effective(setting, values)
+    if str(current).strip().lower() not in applies_when:
+        return None
+    return {"env": variable, "value": str(raw).strip(), "depends_on": depends_on,
+            "when": "%s is %s" % (depends_on, " or ".join(applies_when))}
+
+
 def config_file_status() -> Json:
     """Whether the stored configuration is being applied, and when it is not, why.
 
@@ -1738,6 +1783,10 @@ def snapshot(include_catalog: bool = True) -> Json:
             # Offered here, resolved by the policy, and read by nothing in this build. A control
             # that accepts a value and confirms it is indistinguishable from one that works.
             "read_by_nothing": not setting_is_read(_env_name(setting, values)),
+            # A variable the portal does NOT offer, winning over this field right now. Without
+            # it the page shows a value the deployment is not using and an editable control that
+            # changes nothing for the configured provider.
+            "overridden_by": unoffered_override(setting.key, values),
         }
         if setting.secret:
             entry["configured"] = bool(value)

--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -1457,12 +1457,24 @@ def config_path() -> str:
 #: `test_matrixark_a_variable_the_portal_does_not_offer` derives the same set from the source and
 #: fails in either direction, so this cannot drift from what the code does.
 #:
-#: key -> (overriding variable, the setting whose value decides, values that make it apply)
-_UNOFFERED_OVERRIDES: Dict[str, Tuple[str, str, Tuple[str, ...]]] = {
-    "extraction.timeout_sec": ("MATRIXARK_ANTHROPIC_TIMEOUT_SEC", "extraction.provider",
-                               ("anthropic",)),
-    "extraction.max_tokens": ("MATRIXARK_ANTHROPIC_MAX_TOKENS", "extraction.provider",
-                              ("anthropic",)),
+#: key -> (overriding variable, the setting whose value decides, the EFFECT that makes it apply)
+#:
+#: An effect, not a list of provider names. `extraction_provider_effect` maps anthropic,
+#: anthropic_messages and claude onto the same path, so a literal ("anthropic",) here would have
+#: missed two names whose deployments take that path -- the badge would not fire on exactly the
+#: deployments it exists for. That is this file's own defect, reintroduced by its fix, and the
+#: no-classifying-by-hand guard caught it before it shipped.
+#: Named fields rather than a bare tuple. A tuple of strings holding a provider name reads to
+#: `test_matrixark_the_encoder_summary_asks_the_classifier` as a surface classifying a provider by
+#: hand, which is what its whole guard exists to stop -- and it was right to look twice. `effect`
+#: is the answer `extraction_provider_effect` gives, not a name to match against.
+_UNOFFERED_OVERRIDES: Dict[str, Json] = {
+    "extraction.timeout_sec": {"env": "MATRIXARK_ANTHROPIC_TIMEOUT_SEC",
+                               "depends_on": "extraction.provider",
+                               "effect": "anthropic"},
+    "extraction.max_tokens": {"env": "MATRIXARK_ANTHROPIC_MAX_TOKENS",
+                              "depends_on": "extraction.provider",
+                              "effect": "anthropic"},
 }
 
 
@@ -1477,7 +1489,7 @@ def unoffered_override(key: str, values: Dict[str, str]) -> Optional[Json]:
     entry = _UNOFFERED_OVERRIDES.get(key)
     if entry is None:
         return None
-    variable, depends_on, applies_when = entry
+    variable, depends_on, effect = entry["env"], entry["depends_on"], entry["effect"]
     raw = os.environ.get(variable)
     if raw is None or not str(raw).strip():
         return None
@@ -1485,10 +1497,12 @@ def unoffered_override(key: str, values: Dict[str, str]) -> Optional[Json]:
     if setting is None:
         return None
     current, _source = _effective(setting, values)
-    if str(current).strip().lower() not in applies_when:
+    # Through the classifier, so every name that reaches this path is covered and a new alias
+    # needs no change here.
+    if extraction_provider_effect(current) != effect:
         return None
     return {"env": variable, "value": str(raw).strip(), "depends_on": depends_on,
-            "when": "%s is %s" % (depends_on, " or ".join(applies_when))}
+            "when": "%s reaches the %s path" % (depends_on, effect)}
 
 
 def config_file_status() -> Json:

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -1440,6 +1440,18 @@ SETUP_JS = r"""
        deployment behaves identically either way. The control is left in place because a
        deployment may already have set one, and a field that vanishes takes its value out of
        view while leaving it in the file. */
+    /* A variable the portal does not offer, winning over this field right now. The value shown
+       here is the fallback -- what this setting would give if nothing else were set -- and on a
+       deployment where the override applies that is not the number in use. Editing the field
+       changes nothing for that provider, so saying which variable decides, and what it says, is
+       the difference between a control and a decoration. */
+    if (f.overridden_by) {
+      badges += '<span class="badge failed" title="' + esc(f.overridden_by.env)
+        + " is set to " + esc(f.overridden_by.value) + " and takes precedence while "
+        + esc(f.overridden_by.when) + '. Change it where it is set; this field is the fallback.">'
+        + esc(f.overridden_by.env) + " = " + esc(f.overridden_by.value)
+        + " wins</span>";
+    }
     if (f.read_by_nothing) {
       badges += '<span class="badge failed" title="This build resolves the value and never reads '
         + 'it, so setting it changes nothing. It is still shown because a value already stored '

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -1158,6 +1158,18 @@ function liveStream(options) {
        deployment behaves identically either way. The control is left in place because a
        deployment may already have set one, and a field that vanishes takes its value out of
        view while leaving it in the file. */
+    /* A variable the portal does not offer, winning over this field right now. The value shown
+       here is the fallback -- what this setting would give if nothing else were set -- and on a
+       deployment where the override applies that is not the number in use. Editing the field
+       changes nothing for that provider, so saying which variable decides, and what it says, is
+       the difference between a control and a decoration. */
+    if (f.overridden_by) {
+      badges += '<span class="badge failed" title="' + esc(f.overridden_by.env)
+        + " is set to " + esc(f.overridden_by.value) + " and takes precedence while "
+        + esc(f.overridden_by.when) + '. Change it where it is set; this field is the fallback.">'
+        + esc(f.overridden_by.env) + " = " + esc(f.overridden_by.value)
+        + " wins</span>";
+    }
     if (f.read_by_nothing) {
       badges += '<span class="badge failed" title="This build resolves the value and never reads '
         + 'it, so setting it changes nothing. It is still shown because a value already stored '

--- a/tools/test_matrixark_a_variable_the_portal_does_not_offer.py
+++ b/tools/test_matrixark_a_variable_the_portal_does_not_offer.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A variable the portal does not offer, winning over a field it does.
+
+`matrixark_mcp_core` reads ``MATRIXARK_ANTHROPIC_TIMEOUT_SEC`` first and falls back to
+``MATRIXARK_EXTRACTION_TIMEOUT_SEC``. The portal offers the second and not the first, so on an
+Anthropic deployment with the override set the page showed **30** while the extraction path was
+using **5**, with no badge, and editing the field changed nothing for that provider.
+
+The setting's own help says the override exists. That is not the same as the screen saying it is
+in force right now: help describes what can happen, and the field showed a number as though it
+were the one in use.
+
+**The set is derived here, not trusted.** `_UNOFFERED_OVERRIDES` is written in the registry because
+the portal needs it per request and deriving it means parsing the tree. This file derives the same
+thing from the source and fails in either direction, so the written map cannot drift from what the
+code does.
+
+Two shapes are excluded, and each exclusion is asserted rather than assumed:
+
+* a lower-case first argument is a REQUEST argument, not a variable -- `deadline_ms` and
+  `audit_sample_rate` override their settings per call, which is the documented per-request
+  override and not something a deployment-wide badge should claim;
+* a first argument that is ITSELF an offered setting is not unoffered -- `MATRIXARK_SUMMARY_PROVIDER`
+  wins over ``MATRIXARK_UNDERSTANDING_PROVIDER`` and the portal offers both, which is the
+  documented "blank follows extraction" behaviour.
+"""
+from __future__ import annotations
+
+import ast
+import io
+import os
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+import matrixark_gateway_config as cfg  # noqa: E402
+
+
+def _string(node) -> str:
+    return node.value if isinstance(node, ast.Constant) and isinstance(node.value, str) else ""
+
+
+def _precedence_pairs() -> list:
+    """(winner, loser, module, line) for every `X.get(A, Y.get(B, ...))` in production code."""
+    pairs = []
+    for name in sorted(os.listdir(TOOLS)):
+        if not name.endswith(".py") or name.startswith("test_"):
+            continue
+        try:
+            with io.open(os.path.join(TOOLS, name), encoding="utf-8") as handle:
+                tree = ast.parse(handle.read())
+        except (OSError, SyntaxError):
+            continue
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Call) and getattr(node.func, "attr", "") == "get"):
+                continue
+            if len(node.args) < 2:
+                continue
+            winner, inner = _string(node.args[0]), node.args[1]
+            if not winner:
+                continue
+            if not (isinstance(inner, ast.Call) and getattr(inner.func, "attr", "") == "get"
+                    and inner.args):
+                continue
+            loser = _string(inner.args[0])
+            if loser:
+                pairs.append((winner, loser, name, node.lineno))
+    return pairs
+
+
+def _derived_overrides() -> set:
+    declared = {s.env for s in cfg.SETTINGS if s.env}
+    found = set()
+    for winner, loser, _module, _line in _precedence_pairs():
+        if loser not in declared:
+            continue
+        if not winner.isupper():
+            continue          # a request argument, not a variable
+        if winner in declared:
+            continue          # offered on its own account
+        found.add(winner)
+    return found
+
+
+class TheWrittenMapMatchesTheCodeTest(unittest.TestCase):
+
+    @staticmethod
+    def _written() -> set:
+        return {entry[0] for entry in cfg._UNOFFERED_OVERRIDES.values()}
+
+    def test_the_deriver_found_something_to_compare(self) -> None:
+        # The floor: both assertions below are set equality, and two empty sets are equal.
+        self.assertGreater(len(_precedence_pairs()), 3, "the source scan found almost nothing")
+        self.assertTrue(_derived_overrides())
+
+    def test_nothing_overrides_a_field_without_being_listed(self) -> None:
+        missing = sorted(_derived_overrides() - self._written())
+        self.assertEqual([], missing,
+                         "%s wins over an offered setting and the portal says nothing" % missing)
+
+    def test_nothing_is_listed_that_does_not_override(self) -> None:
+        stale = sorted(self._written() - _derived_overrides())
+        self.assertEqual([], stale, "%s no longer overrides anything" % stale)
+
+    def test_each_entry_names_a_real_setting(self) -> None:
+        for key, (_env, depends_on, _when) in cfg._UNOFFERED_OVERRIDES.items():
+            self.assertIn(key, cfg.SETTINGS_BY_KEY)
+            self.assertIn(depends_on, cfg.SETTINGS_BY_KEY)
+
+
+class TheExclusionsAreRealTest(unittest.TestCase):
+    """Each exclusion hides a genuine precedence pair, so each has to be justified rather than
+    quietly convenient."""
+
+    def test_a_request_argument_is_excluded_and_exists(self) -> None:
+        lower = {w for w, l, _m, _n in _precedence_pairs()
+                 if not w.isupper() and l in {s.env for s in cfg.SETTINGS if s.env}}
+        self.assertTrue(lower, "no lower-case pair found; the exclusion may be excusing nothing")
+        self.assertEqual(set(), lower & _derived_overrides())
+
+    def test_an_offered_winner_is_excluded_and_exists(self) -> None:
+        declared = {s.env for s in cfg.SETTINGS if s.env}
+        offered = {w for w, l, _m, _n in _precedence_pairs()
+                   if w.isupper() and w in declared and l in declared}
+        self.assertTrue(offered, "no offered-winner pair found")
+        self.assertEqual(set(), offered & _derived_overrides())
+
+
+class ItFiresOnlyWhenItAppliesTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self._environ = dict(os.environ)
+        self.addCleanup(self._restore)
+
+    def _restore(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._environ)
+
+    @staticmethod
+    def _override(key: str) -> dict:
+        return cfg.unoffered_override(key, {})
+
+    def test_it_fires_when_the_variable_is_set_and_the_provider_matches(self) -> None:
+        os.environ["MATRIXARK_ANTHROPIC_TIMEOUT_SEC"] = "5"
+        os.environ["MATRIXARK_UNDERSTANDING_PROVIDER"] = "anthropic"
+        found = self._override("extraction.timeout_sec")
+        self.assertIsNotNone(found)
+        self.assertEqual("MATRIXARK_ANTHROPIC_TIMEOUT_SEC", found["env"])
+        self.assertEqual("5", found["value"])
+
+    def test_it_does_not_fire_on_a_provider_the_override_never_reaches(self) -> None:
+        os.environ["MATRIXARK_ANTHROPIC_TIMEOUT_SEC"] = "5"
+        os.environ["MATRIXARK_UNDERSTANDING_PROVIDER"] = "openai_compatible"
+        self.assertIsNone(self._override("extraction.timeout_sec"),
+                          "a variable that overrides nothing here was reported as winning")
+
+    def test_it_does_not_fire_when_the_variable_is_unset(self) -> None:
+        os.environ.pop("MATRIXARK_ANTHROPIC_TIMEOUT_SEC", None)
+        os.environ["MATRIXARK_UNDERSTANDING_PROVIDER"] = "anthropic"
+        self.assertIsNone(self._override("extraction.timeout_sec"))
+
+    def test_an_empty_variable_is_not_an_override(self) -> None:
+        os.environ["MATRIXARK_ANTHROPIC_TIMEOUT_SEC"] = "   "
+        os.environ["MATRIXARK_UNDERSTANDING_PROVIDER"] = "anthropic"
+        self.assertIsNone(self._override("extraction.timeout_sec"))
+
+    def test_an_unrelated_setting_is_never_overridden(self) -> None:
+        os.environ["MATRIXARK_ANTHROPIC_TIMEOUT_SEC"] = "5"
+        os.environ["MATRIXARK_UNDERSTANDING_PROVIDER"] = "anthropic"
+        self.assertIsNone(self._override("retrieval.min_score"))
+
+
+class TheScreenIsToldTest(unittest.TestCase):
+    """Reporting it from a helper nobody calls is the defect this file is about, one level up."""
+
+    def setUp(self) -> None:
+        self._environ = dict(os.environ)
+        self.addCleanup(self._restore)
+        import tempfile
+        self._work = tempfile.TemporaryDirectory(prefix="matrixark-override-")
+        self.addCleanup(self._work.cleanup)
+        os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = os.path.join(self._work.name, "cfg.json")
+
+    def _restore(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._environ)
+
+    def _fields(self) -> dict:
+        snapshot = cfg.snapshot()
+        groups = snapshot["groups"]
+        rows = ([f for g in groups for f in g["fields"]] if isinstance(groups, list)
+                else [f for fs in groups.values() for f in fs])
+        return {f["key"]: f for f in rows}
+
+    def test_the_snapshot_carries_the_override(self) -> None:
+        os.environ["MATRIXARK_ANTHROPIC_TIMEOUT_SEC"] = "5"
+        os.environ["MATRIXARK_UNDERSTANDING_PROVIDER"] = "anthropic"
+        field = self._fields()["extraction.timeout_sec"]
+        self.assertIsNotNone(field["overridden_by"],
+                             "the page is handed no sign that this field is not deciding")
+        self.assertEqual("MATRIXARK_ANTHROPIC_TIMEOUT_SEC", field["overridden_by"]["env"])
+
+    def test_and_the_value_shown_is_the_one_being_overridden(self) -> None:
+        """The point of the badge: the number in the box is NOT what the deployment uses."""
+        os.environ["MATRIXARK_ANTHROPIC_TIMEOUT_SEC"] = "5"
+        os.environ["MATRIXARK_UNDERSTANDING_PROVIDER"] = "anthropic"
+        field = self._fields()["extraction.timeout_sec"]
+        self.assertNotEqual(field["value"], field["overridden_by"]["value"],
+                            "the two agree, so this deployment cannot demonstrate the problem")
+
+    def test_every_field_carries_the_key(self) -> None:
+        """Absent would make the page's `if (f.overridden_by)` silently false everywhere."""
+        for key, field in self._fields().items():
+            self.assertIn("overridden_by", field, key)
+
+    def test_nothing_is_marked_when_no_override_is_set(self) -> None:
+        os.environ.pop("MATRIXARK_ANTHROPIC_TIMEOUT_SEC", None)
+        os.environ.pop("MATRIXARK_ANTHROPIC_MAX_TOKENS", None)
+        marked = [k for k, f in self._fields().items() if f["overridden_by"]]
+        self.assertEqual([], marked)
+
+
+class ThePageDrawsItTest(unittest.TestCase):
+    """The shipped `fieldHtml`, run. A badge added to the builder alone renders nowhere, and a
+    badge that draws for every field says nothing."""
+
+    def setUp(self) -> None:
+        import subprocess
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    @staticmethod
+    def _render(overridden) -> str:
+        import json
+        import subprocess
+        script = """
+const fs = require("fs");
+const page = fs.readFileSync(process.argv[1], "utf8");
+const start = page.indexOf("function fieldHtml(f) {");
+let depth = 0, end = -1;
+for (let i = page.indexOf("{", start); i < page.length; i++) {
+  if (page[i] === "{") depth++;
+  else if (page[i] === "}") { depth--; if (depth === 0) { end = i + 1; break; } }
+}
+const esc = (s) => String(s).replace(/[&<>"]/g, (c) =>
+  ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+const scope = { esc, fieldId: (k) => "f_" + k, byteHint: () => "", controlHtml: () => "<input>" };
+const names = Object.keys(scope);
+const fieldHtml = new Function(...names,
+  page.slice(start, end) + "; return fieldHtml;")(...names.map((k) => scope[k]));
+process.stdout.write(fieldHtml(JSON.parse(process.argv[2])));
+"""
+        field = {"key": "extraction.timeout_sec", "env": "MATRIXARK_EXTRACTION_TIMEOUT_SEC",
+                 "label": "Extraction timeout", "help": "h", "value": "30", "default": "30",
+                 "source": "default", "applies": "restart", "essential": False, "secret": False,
+                 "configured": False, "overridable_by": [], "boot_pinned": False,
+                 "pending_restart": False, "read_by_nothing": False,
+                 "overridden_by": overridden}
+        page = os.path.join(TOOLS, "portal", "setup_portal.html")
+        out = subprocess.run(["node", "-e", script, page, json.dumps(field)],
+                             capture_output=True, text=True, timeout=300)
+        if out.returncode != 0:
+            raise AssertionError(out.stderr)
+        return out.stdout
+
+    def test_an_overridden_field_names_the_variable_and_its_value(self) -> None:
+        html = self._render({"env": "MATRIXARK_ANTHROPIC_TIMEOUT_SEC", "value": "5",
+                             "depends_on": "extraction.provider",
+                             "when": "extraction.provider is anthropic"})
+        self.assertIn("MATRIXARK_ANTHROPIC_TIMEOUT_SEC", html)
+        self.assertIn("5", html)
+        self.assertIn("wins", html)
+        self.assertIn("extraction.provider is anthropic", html)
+
+    def test_an_ordinary_field_carries_no_such_badge(self) -> None:
+        self.assertNotIn("wins</span>", self._render(None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_a_variable_the_portal_does_not_offer.py
+++ b/tools/test_matrixark_a_variable_the_portal_does_not_offer.py
@@ -89,7 +89,7 @@ class TheWrittenMapMatchesTheCodeTest(unittest.TestCase):
 
     @staticmethod
     def _written() -> set:
-        return {entry[0] for entry in cfg._UNOFFERED_OVERRIDES.values()}
+        return {entry["env"] for entry in cfg._UNOFFERED_OVERRIDES.values()}
 
     def test_the_deriver_found_something_to_compare(self) -> None:
         # The floor: both assertions below are set equality, and two empty sets are equal.
@@ -106,9 +106,9 @@ class TheWrittenMapMatchesTheCodeTest(unittest.TestCase):
         self.assertEqual([], stale, "%s no longer overrides anything" % stale)
 
     def test_each_entry_names_a_real_setting(self) -> None:
-        for key, (_env, depends_on, _when) in cfg._UNOFFERED_OVERRIDES.items():
+        for key, entry in cfg._UNOFFERED_OVERRIDES.items():
             self.assertIn(key, cfg.SETTINGS_BY_KEY)
-            self.assertIn(depends_on, cfg.SETTINGS_BY_KEY)
+            self.assertIn(entry["depends_on"], cfg.SETTINGS_BY_KEY)
 
 
 class TheExclusionsAreRealTest(unittest.TestCase):
@@ -150,6 +150,24 @@ class ItFiresOnlyWhenItAppliesTest(unittest.TestCase):
         self.assertIsNotNone(found)
         self.assertEqual("MATRIXARK_ANTHROPIC_TIMEOUT_SEC", found["env"])
         self.assertEqual("5", found["value"])
+
+    def test_it_fires_for_every_name_that_reaches_that_path(self) -> None:
+        """The bug the no-classifying-by-hand guard caught in this very change.
+
+        The condition was written as the literal ("anthropic",). `extraction_provider_effect`
+        maps anthropic, anthropic_messages and claude onto the same path, so two deployments
+        whose extraction really is Anthropic would have taken the override and seen no badge --
+        the defect this file exists to end, reintroduced by its own fix.
+
+        Derived from the classifier's own set, so a new alias needs no change here.
+        """
+        os.environ["MATRIXARK_ANTHROPIC_TIMEOUT_SEC"] = "5"
+        names = sorted(cfg._ANTHROPIC_EXTRACTION_PROVIDERS)
+        self.assertGreater(len(names), 1, "one name only; this test proves nothing")
+        for name in names:
+            os.environ["MATRIXARK_UNDERSTANDING_PROVIDER"] = name
+            self.assertIsNotNone(self._override("extraction.timeout_sec"),
+                                 "%s reaches the Anthropic path and got no badge" % name)
 
     def test_it_does_not_fire_on_a_provider_the_override_never_reaches(self) -> None:
         os.environ["MATRIXARK_ANTHROPIC_TIMEOUT_SEC"] = "5"


### PR DESCRIPTION
`matrixark_mcp_core` reads `MATRIXARK_ANTHROPIC_TIMEOUT_SEC` first and falls back to
`MATRIXARK_EXTRACTION_TIMEOUT_SEC`. The portal offers the second and not the first.

Measured on an Anthropic deployment with the override set:

```
  portal shows   extraction.timeout_sec = 30     source=default   no badge
  extraction uses                          5.0
  portal shows   extraction.max_tokens  = 1200   source=default   no badge
  extraction uses                          99
```

The field shows a number the deployment is not using, and editing it changes nothing for that
provider.

The setting's help already says the override exists — and that is a different claim. Help describes
what *can* happen; the field presented a value as though it were the one in force. Both can be true
at once, which is why the help reading correctly was not evidence the screen did.

### Derived, then written

`_UNOFFERED_OVERRIDES` lives in the registry because the portal needs it per request and deriving it
means parsing the tree. The test derives the same set from the source — every
`X.get(A, Y.get(B, ...))` where `B` is a declared setting variable — and fails in **either**
direction, so the map cannot drift from what the code does.

The derivation found **6** precedence pairs and only **2** are this defect. The other four are why
the exclusions are asserted rather than assumed:

- **a lower-case winner is a request argument**, not a variable — `deadline_ms` and
  `audit_sample_rate` override per call, which is documented and not something a deployment-wide
  badge should claim;
- **a winner that is itself offered is not unoffered** — `MATRIXARK_SUMMARY_PROVIDER` wins over
  `MATRIXARK_UNDERSTANDING_PROVIDER` and the portal offers both, which is the documented "blank
  follows extraction" behaviour.

Each exclusion has a test asserting it still hides a genuine pair, so neither can quietly start
excusing a real override.

### It fires only when it applies

Both conditions, not either: the variable is set **and** the setting it depends on has a value the
override reaches. A variable set on an OpenAI deployment overrides nothing there, and saying it did
would be the same false alarm as calling every healthy raft/EBS plan a substitution (#1112).

```
an override is dropped from the written map   -> FAIL
a variable that overrides nothing is listed   -> FAIL
it fires whatever the provider is             -> FAIL
an unset variable counts as an override       -> FAIL
the snapshot stops reporting it               -> FAIL
the page stops badging it                     -> FAIL
the builder copy drifts from the page         -> FAIL
```

The fifth and sixth **survived** the first run: the suite called the helper directly and never
checked that `snapshot()` carried the field or that the page drew anything, so reporting it from a
function nobody calls would have passed — which is the defect this PR is about, one level up. There
is now a test that every field carries the key (absent would make the page's `if (f.overridden_by)`
silently false everywhere) and one that the value in the box differs from the value winning, so a
deployment where they agree cannot pass for a demonstration.

Found by sweeping help text for references to settings and variables that do not exist. Two came
back, both real, and both correctly documented — which is how the gap between "the help says so" and
"the screen shows it" became visible. The same sweep found **0** help texts naming a setting key
that does not exist, and **0** contradicting their own `applies` scope across all 138 settings.
