### PR TITLE
A failed list is not a scope with nothing in it

### DIFF
--- a/tools/portal/browse_failure_harness.js
+++ b/tools/portal/browse_failure_harness.js
@@ -1,0 +1,116 @@
+/* Run the Explore page's own loadBrowse with one of its two fetches failing, and read both panels.
+ *
+ * The two lists are loaded side by side by one function. When the subject list failed it was
+ * BLANKED -- and an empty scope on this page has words ("No subjects hold memories in this scope
+ * yet"), so a blank panel was a third state saying nothing at all. With the memory list succeeding
+ * the screen contradicted itself: memories listed, and no subject holding any.
+ *
+ * `innerHTML = ""` and `innerHTML = "<div class=empty>...</div>"` are the same shape of statement,
+ * so a diff cannot tell them apart. The shipped function is sliced out and run.
+ *
+ * Usage: node browse_failure_harness.js <explore_portal.html> [users|memories|both|none|empty]
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const failing = process.argv[3] || "users";
+
+const start = page.indexOf("function loadBrowse() {");
+if (start < 0) { console.log("FAIL loadBrowse is not on this page"); process.exit(2); }
+let depth = 0, end = -1;
+for (let i = page.indexOf("{", start); i < page.length; i++) {
+  if (page[i] === "{") depth++;
+  else if (page[i] === "}") { depth--; if (depth === 0) { end = i + 1; break; } }
+}
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+const els = {};
+function el(id) {
+  if (!els[id]) { els[id] = { id: id, innerHTML: "", textContent: "" }; }
+  return els[id];
+}
+const esc = (s) => String(s).replace(/[&<>"]/g, (c) =>
+  ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+
+const said = [];
+function respond(body, good) {
+  return Promise.resolve({
+    ok: good, status: good ? 200 : 500,
+    json: () => Promise.resolve(body)
+  });
+}
+
+const scope = {
+  $: el,
+  esc,
+  say: (element, text) => { element.innerHTML = text ? String(text) : ""; said.push(String(text)); },
+  conn: () => {},
+  auth: () => ({}),
+  scopeQuery: () => "user_id=alice",
+  failure: (status) => "The gateway answered " + status + ".",
+  Date, JSON, String, Number, Promise,
+  fetch: (url) => {
+    const key = String(url);
+    if (key.indexOf("/v1/users") === 0) {
+      /* `empty` is a SUCCESSFUL call with nothing in it -- the state the failure message must not
+         be confused with, and the one every other mode leaves untested because they all return a
+         row. Without it, making the success path say "Not loaded." goes unnoticed. */
+      return respond({ users: failing === "empty" ? [] : [{ user_id: "alice", count: 3 }] },
+                     !(failing === "users" || failing === "both"));
+    }
+    if (key.indexOf("/v1/memories") === 0) {
+      return respond({ memories: [{ id: "m1", memory: "a note", record_type: "note" }] },
+                     !(failing === "memories" || failing === "both"));
+    }
+    return respond({}, true);
+  }
+};
+
+const names = Object.keys(scope);
+const loadBrowse = new Function(...names,
+  page.slice(start, end) + "; return loadBrowse;")(...names.map((k) => scope[k]));
+
+loadBrowse();
+
+setTimeout(() => {
+  const users = el("users").innerHTML;
+  const memories = el("memories").innerHTML;
+  const message = el("browseMsg").innerHTML;
+
+  if (failing === "users" || failing === "both") {
+    ok("a failed subject list is not left blank", users.trim().length > 0,
+       JSON.stringify(users));
+    ok("it says it did not load, not that the scope is empty",
+       /Not loaded/.test(users) && !/No subjects/.test(users), users);
+    ok("and the cause is named rather than left to be guessed",
+       message.trim().length > 0, JSON.stringify(message));
+  }
+  if (failing === "users") {
+    /* The contradiction this fixes: the other list loaded fine. */
+    ok("FLOOR: the memory list still rendered, so the two disagreed",
+       /a note/.test(memories), memories);
+  }
+  if (failing === "none") {
+    ok("a working subject list is rendered", /alice/.test(users), users);
+    ok("with no failure message", message.trim().length === 0, JSON.stringify(message));
+    ok("and no panel claims it failed to load", !/Not loaded/.test(users), users);
+  }
+  if (failing === "empty") {
+    ok("an empty scope says it is empty", /No subjects/.test(users), users);
+    ok("and does not claim the request failed", !/Not loaded/.test(users), users);
+    ok("with no error message", message.trim().length === 0, JSON.stringify(message));
+  }
+  if (failing === "memories") {
+    ok("the sibling still reports its own failure",
+       /Not loaded/.test(memories), memories);
+    ok("and the subject list is unaffected", /alice/.test(users), users);
+  }
+  console.log(failures ? "\n" + failures + " failure(s)" : "\nall ok");
+  process.exit(failures ? 1 : 0);
+}, 30);

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -4337,7 +4337,18 @@ EXPLORE_JS = r"""
             }).join("")
           : '<div class="empty">No subjects hold memories in this scope yet.</div>';
       })
-      .catch(function () { $("users").innerHTML = ""; });
+      .catch(function (e) {
+        /* Blanking the panel made a failed request indistinguishable from an empty scope -- and
+           the empty scope has WORDS ("No subjects hold memories in this scope yet"), so a blank
+           panel was a third state saying nothing at all. With the sibling fetch below succeeding
+           the screen contradicted itself: memories listed, and no subject holding any.
+
+           Same wording and the same message line as that sibling, which already named the cause
+           on failure while this one was silent. */
+        $("users").innerHTML = '<div class="empty">Not loaded.</div>';
+        say($("browseMsg"), typeof e === "number" ? failure(e) : "Could not reach the gateway.",
+            "err");
+      });
 
     $("memories").innerHTML = '<div class="empty">Loading…</div>';
     fetch("/v1/memories?" + scopeQuery() + "&limit=50", { headers: auth() })

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -937,7 +937,18 @@
             }).join("")
           : '<div class="empty">No subjects hold memories in this scope yet.</div>';
       })
-      .catch(function () { $("users").innerHTML = ""; });
+      .catch(function (e) {
+        /* Blanking the panel made a failed request indistinguishable from an empty scope -- and
+           the empty scope has WORDS ("No subjects hold memories in this scope yet"), so a blank
+           panel was a third state saying nothing at all. With the sibling fetch below succeeding
+           the screen contradicted itself: memories listed, and no subject holding any.
+
+           Same wording and the same message line as that sibling, which already named the cause
+           on failure while this one was silent. */
+        $("users").innerHTML = '<div class="empty">Not loaded.</div>';
+        say($("browseMsg"), typeof e === "number" ? failure(e) : "Could not reach the gateway.",
+            "err");
+      });
 
     $("memories").innerHTML = '<div class="empty">Loading…</div>';
     fetch("/v1/memories?" + scopeQuery() + "&limit=50", { headers: auth() })

--- a/tools/test_matrixark_a_failed_list_is_not_an_empty_scope.py
+++ b/tools/test_matrixark_a_failed_list_is_not_an_empty_scope.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A list that failed to load is not a scope with nothing in it.
+
+Explore loads two lists side by side from one function: the subjects holding memories, and the
+memories themselves. When the memory list failed it wrote "Not loaded." and named the cause. When
+the subject list failed it ran ``$("users").innerHTML = ""`` -- it blanked the panel and said
+nothing at all.
+
+That is worse than an unhelpful message. An empty scope on this page has WORDS ("No subjects hold
+memories in this scope yet"), so a blank panel was a third state with nothing in it, and the two
+fetches fail independently: with the memory list succeeding the screen contradicted itself, showing
+memories listed and no subject holding any.
+
+`innerHTML = ""` and `innerHTML = "<div class=empty>…</div>"` are the same shape of statement, so a
+diff cannot tell them apart. The shipped function is run and the DOM is read.
+"""
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+sys.path.insert(0, TOOLS)
+
+HARNESS = os.path.join(PORTAL, "browse_failure_harness.js")
+PAGE = os.path.join(PORTAL, "explore_portal.html")
+
+
+class ThePageSaysWhichHappenedTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    def run_mode(self, mode: str) -> str:
+        out = subprocess.run(["node", HARNESS, PAGE, mode],
+                             capture_output=True, text=True, timeout=600)
+        return out.stdout + out.stderr
+
+    def test_a_failed_subject_list_says_so(self) -> None:
+        self.assertIn("all ok", self.run_mode("users"), self.run_mode("users"))
+
+    def test_a_failed_memory_list_still_does(self) -> None:
+        """The half that was already right; it is the model for the other."""
+        self.assertIn("all ok", self.run_mode("memories"))
+
+    def test_both_failing_is_still_explained(self) -> None:
+        self.assertIn("all ok", self.run_mode("both"))
+
+    def test_nothing_claims_a_failure_when_both_work(self) -> None:
+        """The floor. A panel that always says "Not loaded." would pass every test above."""
+        self.assertIn("all ok", self.run_mode("none"))
+
+    def test_an_empty_scope_still_reads_as_empty(self) -> None:
+        """The other half of that floor, and the one the other modes cannot reach: they all
+        return a row, so a SUCCESSFUL call with nothing in it never gets rendered. Turning the
+        empty-state message into "Not loaded." survived until this mode existed."""
+        self.assertIn("all ok", self.run_mode("empty"), self.run_mode("empty"))
+
+
+class TheTwoPanelsAgreeOnHowToFailTest(unittest.TestCase):
+    """They are loaded by one function and read side by side, so one going quiet while the other
+    explains itself is the inconsistency, not just the silence."""
+
+    @staticmethod
+    def _browse() -> str:
+        with io.open(PAGE, encoding="utf-8") as handle:
+            text = handle.read()
+        start = text.find("function loadBrowse() {")
+        if start < 0:
+            raise AssertionError("loadBrowse is not on the page")
+        depth = 0
+        for index in range(text.index("{", start), len(text)):
+            if text[index] == "{":
+                depth += 1
+            elif text[index] == "}":
+                depth -= 1
+                if depth == 0:
+                    return text[start:index + 1]
+        raise AssertionError("loadBrowse is not closed")
+
+    def test_neither_failure_path_blanks_its_panel(self) -> None:
+        body = self._browse()
+        self.assertNotIn('innerHTML = ""', body,
+                         "a failure path blanks a panel, which reads as an empty result")
+
+    def test_both_failure_paths_name_the_cause(self) -> None:
+        """Counted per .catch, not over the whole function: loadBrowse also CLEARS the message
+        line on entry, so a total of three mentions is one clear and two failures -- and counting
+        mentions would have passed with both of them in the same handler."""
+        import re
+
+        # Comments stripped first: the assertion is about what the handler DOES, and a window
+        # measured over commentary says nothing about the code in it. Mine filled 400 characters.
+        body = re.sub(r"/\*.*?\*/", "", self._browse(), flags=re.S)
+        blocks = body.split(".catch(")[1:]
+        self.assertEqual(2, len(blocks), "expected one failure handler per list")
+        for index, block in enumerate(blocks):
+            self.assertIn("browseMsg", block[:300],
+                          "failure handler %d does not name the cause" % index)
+
+    def test_the_reader_found_the_function(self) -> None:
+        # The floor: the two assertions above are absence checks over this text.
+        body = self._browse()
+        self.assertGreater(len(body), 600)
+        self.assertIn("/v1/users", body)
+        self.assertIn("/v1/memories", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_the_page_and_its_builder_agree.py
+++ b/tools/test_matrixark_the_page_and_its_builder_agree.py
@@ -21,8 +21,33 @@ import re
 import unittest
 
 PORTAL = os.path.join(os.path.dirname(os.path.abspath(__file__)), "portal")
-PAGE = os.path.join(PORTAL, "setup_portal.html")
 BUILDER = os.path.join(PORTAL, "build_portal_pages.py")
+
+
+#: The builder writes some pages whole and only injects a nav into others. `emit(...)` generates;
+#: `inject(...)` edits a page it does not otherwise own.
+_EMITTED = re.compile(r'^emit\(\s*"([a-z_]+_portal\.html)"', re.M)
+
+
+def _pages() -> list:
+    """The pages the builder GENERATES, derived from the builder itself.
+
+    This file checked `setup_portal.html` alone, so a function on any other generated page was
+    unguarded exactly as if the file did not exist -- `loadBrowse` lives on the explore page and a
+    mutation of the builder's copy survived.
+
+    Widening it to every `*_portal.html` was wrong in the other direction. Two pages are only
+    nav-injected, and the builder holds no body for them: comparing them reported four
+    "differences" that were name collisions with the pages it does generate -- `renderSummary`
+    means something different on ingestion than on setup. Neither list is written here; both come
+    from which call the builder makes.
+    """
+    with io.open(BUILDER, encoding="utf-8") as handle:
+        names = _EMITTED.findall(handle.read())
+    return sorted(os.path.join(PORTAL, name) for name in set(names))
+
+
+PAGE = os.path.join(PORTAL, "setup_portal.html")
 
 _DEF = re.compile(r"\bfunction\s+([A-Za-z_$][\w$]*)\s*\(")
 
@@ -64,11 +89,20 @@ def _read(path: str) -> dict:
         return _functions(handle.read())
 
 
-def _shared() -> dict:
-    """name -> (the page's single definition, every definition the builder holds of that name)."""
-    page, builder = _read(PAGE), _read(BUILDER)
+def _shared(page_path: str = PAGE) -> dict:
+    """name -> (the page's definitions, every definition the builder holds of that name)."""
+    page, builder = _read(page_path), _read(BUILDER)
     return {name: (page[name], builder[name])
             for name in sorted(set(page) & set(builder))}
+
+
+def _all_shared() -> dict:
+    """(page, name) -> (page bodies, builder bodies), across every shipped page."""
+    out = {}
+    for path in _pages():
+        for name, bodies in _shared(path).items():
+            out[(os.path.basename(path), name)] = bodies
+    return out
 
 
 class ThePageAndItsBuilderAgreeTest(unittest.TestCase):
@@ -80,6 +114,30 @@ class ThePageAndItsBuilderAgreeTest(unittest.TestCase):
         self.assertGreater(len(shared), 5, sorted(shared))
         for name in ("controlHtml", "fieldHtml", "renderSummary"):
             self.assertIn(name, shared)
+
+    def test_every_generated_page_is_checked_not_only_the_first(self) -> None:
+        """The gap this file had: one page was compared and the rest were not looked at."""
+        pages = _pages()
+        self.assertGreater(len(pages), 3, [os.path.basename(p) for p in pages])
+        covered = {page for page, _name in _all_shared()}
+        self.assertGreater(len(covered), 1,
+                           "only one page shares anything with the builder: %s" % covered)
+
+    def test_a_page_the_builder_only_injects_into_is_left_alone(self) -> None:
+        """The builder holds no body for those, so its same-named functions belong to other
+        pages. Comparing them reported four collisions as drift."""
+        generated = {os.path.basename(p) for p in _pages()}
+        shipped = {n for n in os.listdir(PORTAL) if n.endswith("_portal.html")}
+        injected = shipped - generated
+        self.assertTrue(injected, "every page is generated now; this exclusion is moot")
+        self.assertEqual(set(), injected & {page for page, _name in _all_shared()})
+
+    def test_every_shared_function_on_every_page_is_identical(self) -> None:
+        differing = sorted((page, name) for (page, name), (theirs, ours) in _all_shared().items()
+                           if not set(theirs) & set(ours))
+        self.assertEqual([], differing,
+                         "%d function(s) differ between a shipped page and the builder that "
+                         "writes it" % len(differing))
 
     def test_every_shared_function_is_identical(self) -> None:
         """The page's copy must be one of the builder's copies of that name.


### PR DESCRIPTION
Explore loads two lists side by side from one function. When the memory list failed it wrote
**"Not loaded."** and named the cause. When the subject list failed it ran

```js
.catch(function () { $("users").innerHTML = ""; });
```

— it blanked the panel and said nothing.

That is worse than an unhelpful message. An empty scope on this page has **words** ("No subjects
hold memories in this scope yet"), so a blank panel was a third state with nothing in it. And the
two fetches fail independently: with the memory list succeeding, the screen **contradicted itself** —
memories listed, and no subject holding any.

The fix is the wording and the message line its sibling already used.

### Run, not read

`innerHTML = ""` and `innerHTML = "<div class=empty>…</div>"` are the same shape of statement, so a
diff cannot separate them. The shipped `loadBrowse` is sliced out and run against five fetch
outcomes: subject list failing, memory list failing, both, neither, and — the one that mattered — a
**successful call with nothing in it**.

That last mode exists because a mutation demanded it. Turning the success message into "Not loaded."
**survived** every other mode, because they all return a row and never render the empty branch.

### And a much larger gap in a guard I own

Fixing this in `explore_portal.html` left the builder-drift mutation surviving, and the reason was
not this change: `test_matrixark_the_page_and_its_builder_agree` compared **one page**. Every
function on explore, catalog, overview and the API portal was unguarded exactly as if the file did
not exist.

Widening it to every `*_portal.html` was wrong in the other direction, and the measurement said so
immediately — **4 differences**, all on `ingestion_portal.html`, all false. The builder `emit()`s
five pages and only `inject()`s a nav into two others, so it holds no body for those: its
`renderSummary` belongs to setup, not to ingestion, and comparing them reports a name collision as
drift.

Neither list is written down. Both come from which call the builder makes, and a test asserts the
excluded set is non-empty so the exclusion cannot quietly become "compare nothing".

**Coverage: 88 pairs on one page → 199 across the five generated pages.**

```
the subject list goes back to blanking itself   -> FAIL
it says the scope is empty instead              -> FAIL
the cause stops being named                     -> FAIL
every load claims it did not load               -> FAIL
the builder copy drifts from the page           -> FAIL
```

One test of mine needed correcting on the way: it asserted both failure handlers name the cause by
looking at the first 400 characters of each, and my own comment filled that window. Comments are
stripped before the check now — the assertion is about what the handler does.
