### PR TITLE
Key the context pack cache on the repository, not the checkout

### DIFF
--- a/tools/matrixark_hook_pack_cache.py
+++ b/tools/matrixark_hook_pack_cache.py
@@ -17,10 +17,45 @@ from __future__ import annotations
 
 import hashlib
 import os
+import subprocess
 import time
 from pathlib import Path
 
 DEFAULT_MAX_AGE_S = 86400.0
+
+
+def workspace_identity(workspace_root: str) -> str:
+    """The repository a workspace belongs to, so sibling worktrees share one pack.
+
+    Keying on the checkout directory fragments the cache the moment an agent works across git
+    worktrees -- every new worktree starts with nothing to fall back to, which is precisely the
+    turn the fallback exists for. The distinction worth keeping is between PROJECTS, and a git
+    common dir draws exactly that line: sibling worktrees share one, a different project has its
+    own.
+
+    Any failure returns the path unchanged, so a workspace that is not a repository, or a box
+    without git, behaves as before rather than losing its cache.
+    """
+    if not workspace_root:
+        return "-"
+    try:
+        finished = subprocess.run(
+            ["git", "-C", workspace_root, "rev-parse", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except Exception:  # noqa: BLE001 - identity is an optimisation; never fail a turn for it.
+        return workspace_root
+    if finished.returncode != 0:
+        return workspace_root
+    common = finished.stdout.strip()
+    if not common:
+        return workspace_root
+    # `--git-common-dir` may answer relatively (".git") depending on git version and cwd.
+    if not os.path.isabs(common):
+        common = os.path.join(workspace_root, common)
+    return os.path.realpath(common)
 
 
 def context_pack_cache_path(agent: str, workspace_root: str) -> Path:
@@ -32,7 +67,8 @@ def context_pack_cache_path(agent: str, workspace_root: str) -> Path:
     root = os.environ.get("MATRIXARK_HOOK_PACK_CACHE_DIR") or str(
         Path.home() / ".matrixark" / "hook-pack-cache"
     )
-    stamp = hashlib.sha256((workspace_root or "-").encode("utf-8")).hexdigest()[:16]
+    # Sibling worktrees of one repository share a pack; different projects never do.
+    stamp = hashlib.sha256(workspace_identity(workspace_root).encode("utf-8")).hexdigest()[:16]
     return Path(root) / f"{agent}-{stamp}.txt"
 
 

--- a/tools/test_sibling_worktrees_share_one_context_pack.py
+++ b/tools/test_sibling_worktrees_share_one_context_pack.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Sibling worktrees share one context pack; different projects never do.
+
+Keying the pack cache on the checkout directory fragments it as soon as an agent works across git
+worktrees, and Codex does: a live box held 18 cache files for 2 agents, spread over wt-l1cache,
+wt-model, wt-flags, wt-snapbin, wt-scratch and more. Every new worktree started with nothing to
+fall back to -- which is exactly the turn the fallback exists for.
+
+The checkout directory was never the thing worth distinguishing. Mixing one PROJECT's context into
+another is the error that matters, and a git common dir draws that line precisely.
+"""
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+import matrixark_hook_pack_cache as pack_cache
+
+GIT = shutil.which("git")
+
+
+def _git(*args, cwd=None):
+    subprocess.run(
+        [GIT, *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+@unittest.skipIf(GIT is None, "git is not available")
+class WorkspaceIdentityTest(unittest.TestCase):
+    def setUp(self):
+        self._dir = tempfile.TemporaryDirectory()
+        self.root = self._dir.name
+        self.repo = os.path.join(self.root, "project")
+        os.makedirs(self.repo)
+        _git("init", "-q", cwd=self.repo)
+        _git("config", "user.email", "t@example.com", cwd=self.repo)
+        _git("config", "user.name", "t", cwd=self.repo)
+        with open(os.path.join(self.repo, "f.txt"), "w", encoding="utf-8") as handle:
+            handle.write("x\n")
+        _git("add", "f.txt", cwd=self.repo)
+        _git("commit", "-qm", "first", cwd=self.repo)
+
+        self.worktree = os.path.join(self.root, "wt-feature")
+        _git("worktree", "add", "-q", "-b", "feature", self.worktree, cwd=self.repo)
+
+    def tearDown(self):
+        self._dir.cleanup()
+
+    def test_a_worktree_shares_its_repository_identity(self):
+        self.assertEqual(
+            pack_cache.workspace_identity(self.repo),
+            pack_cache.workspace_identity(self.worktree),
+            "a worktree and its repository are the same project and must share one pack",
+        )
+
+    def test_a_worktree_shares_the_cache_file(self):
+        self.assertEqual(
+            pack_cache.context_pack_cache_path("codex", self.repo),
+            pack_cache.context_pack_cache_path("codex", self.worktree),
+        )
+
+    def test_a_different_repository_does_not_share(self):
+        """The control: without this, collapsing everything to one key would pass the tests above
+        and let one project's context surface in another."""
+        other = os.path.join(self.root, "other-project")
+        os.makedirs(other)
+        _git("init", "-q", cwd=other)
+        self.assertNotEqual(
+            pack_cache.workspace_identity(self.repo),
+            pack_cache.workspace_identity(other),
+            "two repositories are two projects and must not share a pack",
+        )
+
+    def test_a_path_that_is_not_a_repository_still_keys(self):
+        """Not every workspace is a checkout; the cache must keep working, not disappear."""
+        plain = os.path.join(self.root, "plain-dir")
+        os.makedirs(plain)
+        self.assertEqual(pack_cache.workspace_identity(plain), plain)
+        self.assertTrue(pack_cache.context_pack_cache_path("claude", plain).name.endswith(".txt"))
+
+    def test_a_missing_path_falls_back_rather_than_raising(self):
+        missing = os.path.join(self.root, "does-not-exist")
+        self.assertEqual(pack_cache.workspace_identity(missing), missing)
+
+    def test_an_absent_workspace_is_still_addressable(self):
+        self.assertEqual(pack_cache.workspace_identity(""), "-")
+        self.assertTrue(pack_cache.context_pack_cache_path("codex", "").name.endswith(".txt"))
+
+    def test_agents_still_do_not_share_a_file(self):
+        """Repository identity must not undo the agent split."""
+        self.assertNotEqual(
+            pack_cache.context_pack_cache_path("claude", self.repo),
+            pack_cache.context_pack_cache_path("codex", self.repo),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The last-good-pack cache was keyed on `workspace_root`, the checkout directory. That fragments it
the moment an agent works across git worktrees — and Codex does. A live box held **18 cache files
for 2 agents**, spread across `wt-l1cache`, `wt-model`, `wt-flags`, `wt-snapbin`, `wt-scratch`,
`wt-hermetic`, `wt-livebudget`, `wt-placement-head`, `wt-budgetpath` and more.

Every new worktree therefore starts with **no pack to fall back to** — which is exactly the turn the
fallback exists for. One Claude turn was observed returning empty after 434 s with nothing available
to serve.

### The checkout directory was never the thing worth distinguishing

What must not be mixed is one **project's** context with another's. Git already answers that:
sibling worktrees share a common git dir, a different project has its own.

```
/root/src/github-services/TemporalStore  ->  TemporalStore/.git
/root/wt-l1cache                         ->  TemporalStore/.git      same pack now
/root/wt-flags                           ->  temporalstore-oss/.git  separate
/root/src/github-services/MatrixCache    ->  MatrixCache/.git        separate
```

So the cache keys on repository identity. The agent split is unchanged: Claude and Codex still
never share a file.

### Failure is the old behaviour, not a lost cache

A workspace that is not a repository, a box without git, a git call that errors or exceeds its 5 s
timeout — every one returns the path unchanged and keys exactly as before. The cache must never
cost a turn its answer.

Existing entries become unreachable under the new key and are rebuilt on the next successful turn.
That is a one-off miss, weighed against a fallback that currently misses whenever an agent changes
worktree.

### Tests

`test_sibling_worktrees_share_one_context_pack.py` builds a real repository and a real worktree:

- a worktree and its repository share an identity, and share the cache file
- **two repositories do not** — the control, without which collapsing everything to a single key
  would pass the tests above while letting one project's context surface in another
- a directory that is not a repository still keys, rather than losing its cache
- a missing path falls back instead of raising
- an absent workspace is still addressable
- **agents still do not share a file** — repository identity must not undo the agent split

Skipped cleanly where git is unavailable. All 28 hook-cache tests pass together.
