### PR TITLE
A short batch answer came back as success, on two paths

### DIFF
--- a/crates/temporalstore-rust/src/client.rs
+++ b/crates/temporalstore-rust/src/client.rs
@@ -1610,6 +1610,23 @@ impl TemporalStoreTable {
             sleep_before_retry(&table_options, attempt);
             attempt += 1;
         };
+        // One answer per command, or the caller cannot tell which answer belongs to which command.
+        // `batch_execute_grouped_by_shard` refuses a short answer; this path did not, so a table
+        // with a single shard went unguarded -- and that is the path the proxy's namespaced batch
+        // takes. Same wording as the grouped check, because it is the same fault.
+        if response.status.ok && response.responses.len() != request.commands.len() {
+            return Ok(BatchExecuteResponse {
+                status: Status::error(
+                    "bad_response",
+                    format!(
+                        "batch response length mismatch: {} command(s) sent, {} answer(s) returned",
+                        request.commands.len(),
+                        response.responses.len()
+                    ),
+                ),
+                responses: Vec::new(),
+            });
+        }
         Ok(response)
     }
 

--- a/crates/temporalstore-rust/src/client/tests/part2.rs
+++ b/crates/temporalstore-rust/src/client/tests/part2.rs
@@ -1197,6 +1197,107 @@ fn a_read_only_batch_reaches_the_replica_and_a_write_batch_the_primary() {
     );
 }
 
+/// A single-shard table's batch gets one answer per command, or it is refused.
+///
+/// `batch_execute_grouped_by_shard` has always refused a short answer. This path -- the one a
+/// single-shard table takes, and the one the proxy's namespaced batch goes through -- did not, so
+/// the caller got `ok` with a shorter array than it sent and no way to tell which command each
+/// answer belonged to.
+#[test]
+fn a_single_shard_batch_answer_must_cover_every_command() {
+    fn backend_answering(answers: usize) -> String {
+        let body = serde_json::to_vec(&BatchExecuteResponse {
+            status: Status::ok(),
+            responses: (0..answers)
+                .map(|_| ExecuteResponse {
+                    status: Status::ok(),
+                    response: CommandResponse::Empty,
+                })
+                .collect(),
+        })
+        .expect("canned batch response");
+        let mut canned = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: keep-alive\r\n\r\n",
+            body.len()
+        )
+        .into_bytes();
+        canned.extend_from_slice(&body);
+        let (tx, rx) = std::sync::mpsc::channel::<String>();
+        std::thread::spawn(move || {
+            let listener = match std::net::TcpListener::bind("127.0.0.1:0") {
+                Ok(listener) => listener,
+                Err(_) => return,
+            };
+            let bound = match listener.local_addr() {
+                Ok(addr) => addr.to_string(),
+                Err(_) => return,
+            };
+            if tx.send(bound).is_err() {
+                return;
+            }
+            for stream in listener.incoming().flatten() {
+                let mut stream = stream;
+                let mut scratch = [0u8; 16384];
+                loop {
+                    use std::io::{Read as _, Write as _};
+                    match stream.read(&mut scratch) {
+                        Ok(0) | Err(_) => break,
+                        Ok(_) => {
+                            if stream.write_all(&canned).is_err() {
+                                break;
+                            }
+                            let _ = stream.flush();
+                        }
+                    }
+                }
+            }
+        });
+        rx.recv_timeout(Duration::from_secs(5))
+            .expect("the backend must report its address")
+    }
+
+    let send_five = |addr: &str| -> BatchExecuteResponse {
+        let client = TemporalStoreClient::with_options(ClientOptions {
+            proxy_addr: "127.0.0.1:1".to_string(),
+            // Routed path, with the route already cached, so the dead meta address is never used.
+            meta_addr: Some("127.0.0.1:1".to_string()),
+            route_cache_ttl_ms: 60_000,
+            ..ClientOptions::default()
+        });
+        client.insert_cached_route_for_test(1, addr.to_string());
+        let table = client.open_table(
+            "ns",
+            "tbl",
+            TableOptions {
+                first_shard_id: 1,
+                shard_count: 1,
+                ..TableOptions::default()
+            },
+        );
+        table
+            .batch_execute(
+                (0..5)
+                    .map(|i| Command::StringGet { key: format!("k{i}") })
+                    .collect(),
+            )
+            .expect("the batch answers")
+    };
+
+    // Positive control: a backend answering every command must still succeed, or a check that
+    // refused everything would pass this test just as well.
+    let complete = send_five(&backend_answering(5));
+    assert!(complete.status.ok, "{:?}", complete.status);
+    assert_eq!(complete.responses.len(), 5);
+
+    let short = send_five(&backend_answering(2));
+    assert!(
+        !short.status.ok,
+        "a batch answered 2 of 5 came back ok with {} responses",
+        short.responses.len()
+    );
+    assert_eq!(short.status.code, "bad_response");
+}
+
 #[test]
 fn client_router_matches_crc64_bucket_formula() {
     assert_eq!(crc64_jones(b"123456789"), 0xe9c6d914c4b8d9ca);

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -1124,6 +1124,8 @@ impl ProxyService {
             }
         };
         self.invalidate_cached_routes_if_meta_changed();
+        // How many answers this batch is owed. Taken before the request moves into the client.
+        let expected = request.commands.len();
         let response = self
             .client()
             .batch_execute_with_options(request, RequestOptions::default())
@@ -1131,6 +1133,27 @@ impl ProxyService {
                 status: Status::error(proxy_client_error_code(&err), err.to_string()),
                 responses: Vec::new(),
             });
+        // One answer per command, or the caller cannot tell which command each answer belongs to.
+        // A backend that returns fewer used to come back as `ok` with a SHORT array: a caller
+        // indexing its own commands then reads someone else's result, or none, and nothing says
+        // so. The multi-shard path in the client has always refused this
+        // ("batch response length mismatch"); the single-shard forward the proxy uses did not.
+        //
+        // Only checked on an OK response: a failed batch legitimately carries no responses, and
+        // its status already says what went wrong.
+        if response.status.ok && response.responses.len() != expected {
+            return BatchExecuteResponse {
+                status: Status::error(
+                    "bad_response",
+                    format!(
+                        "batch response length mismatch: {} command(s) sent, {} answer(s) returned",
+                        expected,
+                        response.responses.len()
+                    ),
+                ),
+                responses: Vec::new(),
+            };
+        }
         response
     }
 
@@ -5543,6 +5566,107 @@ mod tests {
                 "message".to_string()
             ],
             "the title fallback moved: its own title, then the role, then the constant"
+        );
+    }
+
+    /// A batch gets one answer per command, or it is refused.
+    ///
+    /// A backend that returns fewer used to come back as `ok` with a SHORT array. A caller indexing
+    /// its own commands then reads someone else's answer, or none, and nothing tells it: the
+    /// status says ok and the array is simply shorter than what it sent.
+    ///
+    /// The client's multi-shard path has always refused this ("batch response length mismatch").
+    /// The single-shard forward the proxy uses did not, so the guard existed on one path only.
+    #[test]
+    fn a_batch_answer_must_cover_every_command() {
+        // A backend answering exactly `answers` responses, whatever it is asked.
+        fn backend_answering(answers: usize) -> String {
+            let body = serde_json::to_vec(&BatchExecuteResponse {
+                status: Status::ok(),
+                responses: (0..answers)
+                    .map(|_| ExecuteResponse {
+                        status: Status::ok(),
+                        response: CommandResponse::Empty,
+                    })
+                    .collect(),
+            })
+            .expect("canned batch response");
+            let mut canned = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: keep-alive\r\n\r\n",
+                body.len()
+            )
+            .into_bytes();
+            canned.extend_from_slice(&body);
+            let (tx, rx) = std::sync::mpsc::channel::<String>();
+            std::thread::spawn(move || {
+                let listener = match std::net::TcpListener::bind("127.0.0.1:0") {
+                    Ok(listener) => listener,
+                    Err(_) => return,
+                };
+                let bound = match listener.local_addr() {
+                    Ok(addr) => addr.to_string(),
+                    Err(_) => return,
+                };
+                if tx.send(bound).is_err() {
+                    return;
+                }
+                for stream in listener.incoming().flatten() {
+                    let mut stream = stream;
+                    let mut scratch = [0u8; 16384];
+                    loop {
+                        use std::io::{Read as _, Write as _};
+                        match stream.read(&mut scratch) {
+                            Ok(0) | Err(_) => break,
+                            Ok(_) => {
+                                if stream.write_all(&canned).is_err() {
+                                    break;
+                                }
+                                let _ = stream.flush();
+                            }
+                        }
+                    }
+                }
+            });
+            rx.recv_timeout(Duration::from_secs(5))
+                .expect("the backend must report its address")
+        }
+
+        let send_five = |addr: &str| -> BatchExecuteResponse {
+            let proxy = scoped_proxy(ProxyOptions::default());
+            proxy.client().insert_cached_route_for_test(1, addr.to_string());
+            let body = serde_json::to_vec(&BatchExecuteRequest {
+                shard_id: 1,
+                commands: (0..5)
+                    .map(|i| Command::StringGet { key: format!("k{i}") })
+                    .collect(),
+            })
+            .expect("batch body");
+            let (code, answered) = proxy.handle(crate::proxy::HttpRequest {
+                method: "POST".to_string(),
+                path: "/batch_execute".to_string(),
+                body,
+            });
+            assert_eq!(code, 200, "{}", String::from_utf8_lossy(&answered));
+            parse_json::<BatchExecuteResponse>(&answered).expect("the reply parses")
+        };
+
+        // The positive control, and it is not optional: a backend that answers every command must
+        // still succeed, or the check below would pass by refusing everything.
+        let complete = send_five(&backend_answering(5));
+        assert!(complete.status.ok, "{:?}", complete.status);
+        assert_eq!(complete.responses.len(), 5);
+
+        let short = send_five(&backend_answering(2));
+        assert!(
+            !short.status.ok,
+            "a batch answered 2 of 5 came back ok with {} responses; a caller indexing its own              commands reads the wrong answers and is told nothing",
+            short.responses.len()
+        );
+        assert_eq!(short.status.code, "bad_response");
+        assert!(
+            short.status.message.contains('5') && short.status.message.contains('2'),
+            "the refusal should say how many were sent and how many came back: {}",
+            short.status.message
         );
     }
 


### PR DESCRIPTION
A caller sends 5 commands. The backend answers 2. The proxy returned:

```
code 200, ok=true, responses=2
```

A success carrying a shorter array than what was sent. A caller indexing its own commands then reads someone else's answer, or none — and nothing tells it, because the status says ok.

The client's **multi-shard** path has always refused this:

```rust
if response.responses.len() != indexes.len() {
    return ... Status::error("bad_response", "batch response length mismatch")
}
```

Two paths that needed the same guard did not have it.

## 1. The proxy's shard-addressed batch

`ProxyService::batch_execute` forwards through the client's single-shard call and returned whatever came back. It now takes the command count before the request moves into the client and refuses an `ok` response that does not cover it, naming both numbers. Only on `ok`: a failed batch legitimately carries no responses, and its status already says why.

## 2. The namespaced batch — found by sweeping, in the fix for the first

After the first commit I swept all four proxy request methods for the guards each applies. `execute`, `batch_execute`, `table_execute` and `table_batch_execute` all admit and invalidate topology; only `batch_execute` had gained the new check.

`table_batch_execute` goes through the **table** batch, which refuses a short answer on its grouped multi-shard path and **not** on `batch_execute_single_shard_with_retry`. So a single-shard table — and the proxy's namespaced batch with it — was still unguarded after the first commit. The guard-on-one-path fault, inside the fix for the guard-on-one-path fault.

Fixed at the root rather than in the proxy a second time: the client's single-shard path now refuses a short answer with the same wording its grouped sibling uses, so a direct table caller is covered too, not only the proxy.

## It costs the healthy path nothing

| batch size | allocs/call before | after |
|---|---|---|
| 1 | 15.03 | 15.00 |
| 8 | 42.03 | 42.00 |
| 64 | 223.21 | 223.09 |

Measured on the way in, which is also how this was found: I was pricing the batch path per command (~11.7 fixed plus ~3.3 per command, clean linear) and printed the answer **body**, which showed `"ok":false,"code":"server_error"` — my stub had been answering an `ExecuteResponse` where a `BatchExecuteResponse` was required. Fixing the stub is what exposed the missing check.

## Both tests carry a positive control

A backend answering **all five** must still succeed, or a check that refused everything would pass just as well. Both were verified to discriminate by removing the check they guard.

client 51, proxy 94, http 7 pass.
