### PR TITLE
Pin that a batch is written as one record

### DIFF
--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -362,6 +362,81 @@ fn a_cached_answer_reads_back_as_itself() {
     );
 }
 
+/// A batch is written as ONE record, and that is worth pinning.
+///
+/// The log can take a batch two ways: N records, one per command, or one record carrying every
+/// item. The second amortises the envelope, measured at 16.9% for eight items and 19.0% for
+/// sixty-four with compression off, so the figure is the envelope rather than the compressor.
+///
+/// `batch_execute` already chooses the one-record form when the items can be found again after a
+/// crash, and nothing asserted it. That is how this kind of saving disappears: the condition
+/// (`wal_data_only_enabled() && !staged_outcomes.is_empty() && recoverable`) has three terms, any
+/// of which can quietly become false -- a flag default flips, a path stops staging outcomes -- and
+/// the batch goes back to N records with every test still green.
+///
+/// Counted through the log rather than by reading the file: records are length-framed, so counting
+/// newlines counts nothing -- a first attempt at this reported 7 for both forms -- and
+/// `info().length_bytes` is the preallocated file length rather than what the records occupy.
+#[test]
+fn a_batch_is_written_as_one_record() {
+    let items = 16usize;
+    let commands = |prefix: &str| -> Vec<Command> {
+        (0..items)
+            .map(|index| Command::StringSet {
+                key: format!("{prefix}/{index:06}"),
+                value: vec![118u8; 256],
+            })
+            .collect()
+    };
+    let records_in = |dir: &std::path::Path| -> usize {
+        crate::wal::LocalWriteAheadLogStore::new(dir.join("indexes").join("wals"))
+            .scan(1, 0, u64::MAX, u64::MAX)
+            .map(|rows| rows.len())
+            .unwrap_or(0)
+    };
+    let engine_in = |dir: &std::path::Path| {
+        let engine = TemporalEngine::with_local_dirs(
+            32 * 1024 * 1024,
+            dir.join("cache"),
+            dir.join("pages"),
+            dir.join("indexes"),
+        );
+        engine.load_shard(1);
+        engine
+    };
+
+    let single_dir = tempfile::tempdir().unwrap();
+    let engine = engine_in(single_dir.path());
+    for command in commands("single") {
+        engine.execute(ExecuteRequest { shard_id: 1, command });
+    }
+    let one_at_a_time = records_in(single_dir.path());
+
+    let batch_dir = tempfile::tempdir().unwrap();
+    let engine = engine_in(batch_dir.path());
+    let response = engine.batch_execute(BatchExecuteRequest {
+        shard_id: 1,
+        commands: commands("batch"),
+    });
+    assert!(response.status.ok, "the batch must succeed: {:?}", response.status);
+    let as_a_batch = records_in(batch_dir.path());
+
+    println!(
+        "  BATCHFORM {items} commands | one at a time: {one_at_a_time} record(s) | as a batch: {as_a_batch} record(s)"
+    );
+
+    // The positive control: written separately they must be a record each, or "one record for the
+    // batch" would hold for an uninteresting reason.
+    assert_eq!(
+        one_at_a_time, items,
+        "written one at a time, each command should be its own record"
+    );
+    assert_eq!(
+        as_a_batch, 1,
+        "a batch should be one record carrying every item, not {items} of them"
+    );
+}
+
 #[test]
 fn object_manager_runtime_report_tracks_residency_layout_and_tombstones() {
     let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
A batch can reach the log two ways: N records, one per command, or one record carrying every item.
The second amortises the envelope -- one shard id, one sequence and one frame instead of N -- which
is worth 16.9% at eight items and 19.0% at sixty-four, measured with compression off so the figure
is the envelope and not the compressor finding redundancy that batching exposed.

`batch_execute` already takes the one-record form, and measuring it end to end confirms that:
sixteen commands written one at a time leave sixteen records, and the same sixteen sent as a batch
leave one.

Nothing asserted it. The condition has three terms --
`wal_data_only_enabled() && !staged_outcomes.is_empty() && recoverable` -- and any of them can
quietly become false: a flag default flips, a path stops staging its outcomes, and the batch goes
back to N records with every existing test still green. That is how a saving already taken gets
given back, and the only signal would be a size measurement nobody was running.

So this counts what the log holds, both ways, and asserts both halves. The one-at-a-time count is
the positive control: without it "the batch wrote one record" would pass for an uninteresting
reason, such as the batch having written nothing at all. Disabling the one-record branch fails the
test with "a batch should be one record carrying every item, not 16", which is the point.

Two things about HOW it counts, because both were wrong first. Records are length-framed, so a
payload contains arbitrary bytes and counting newlines counts nothing -- that reported 7 for both
forms. And `info().length_bytes` is the preallocated file length, which is 262,144 whatever the
records occupy. Asking the log to scan its records answers the question; reading the file does not.

Not covered here, deliberately: under bulk ingest the same batch writes sixteen records again,
because `recoverable` is `sync || !staged_blocks.is_empty()` and bulk ingest sets `sync` false. That
fallback is load-bearing -- an outcome-only record names a page whose fsync is deferred, so without
a barrier it can name a value replay cannot rebuild -- and it should not be pinned as if it were
the desired shape.
