### PR TITLE
Every site that persists a record slims it first

### DIFF
--- a/tools/matrixark_mcp_raw_ingestion.py
+++ b/tools/matrixark_mcp_raw_ingestion.py
@@ -13,9 +13,11 @@ from typing import Any
 try:
     from tools.matrixark_mcp_errors import MatrixArkError
     from tools.matrixark_mcp_identity import stable_hash
+    from tools.matrixark_mcp_temporal_append import slim_persisted_record
 except ModuleNotFoundError:  # Direct script execution from tools/.
     from matrixark_mcp_errors import MatrixArkError
     from matrixark_mcp_identity import stable_hash
+    from matrixark_mcp_temporal_append import slim_persisted_record
 
 
 Json = dict[str, Any]
@@ -213,7 +215,8 @@ def append_raw_ingestion_records(target: Any, records: list[Json], *, allow_queu
         entries: list[Json] = []
         for record in records:
             record_key, record_id = raw_record_location(target._raw_record_hash_key, target._shard_size, sequence)
-            payload = json.dumps(record, sort_keys=True, separators=(",", ":"))
+            payload = json.dumps(slim_persisted_record(record),
+                                 sort_keys=True, separators=(",", ":"))
             route = record.get("storage_route") if isinstance(record.get("storage_route"), dict) else {}
             entries.append({"key": record_key, "field": record_id, "value": payload, "storage_route": route})
             entries.extend(

--- a/tools/matrixark_mcp_temporal_append.py
+++ b/tools/matrixark_mcp_temporal_append.py
@@ -334,6 +334,24 @@ def slim_persisted_record_kind(record: Json) -> Json:
     return slim
 
 
+def slim_persisted_record(record: Json) -> Json:
+    """Everything a record does not need to carry to disk, removed in one place.
+
+    Four sites serialise a record into a persisted entry -- the bundle path and the legacy index
+    path in `matrixark_temporal_direct_write`, the raw path in `matrixark_temporal_direct_backend`,
+    and `matrixark_mcp_raw_ingestion` -- and the slimmers were applied at ONE of them. Measured on
+    the live log after that landed: of 26,944 records written, **871 still carried the derived
+    fields** -- 504 of 1,065 `matrixark_idempotency` rows and 366 of 619 `context_summary` rows,
+    because those went out through a path that never saw a slimmer.
+
+    Composing them here means a fifth call site inherits every one, instead of inheriting none.
+    Each slimmer is a no-op on a record without the fields it looks for, so this is safe to apply
+    to any record on any path.
+    """
+    return slim_persisted_record_kind(
+        slim_persisted_storage_options(slim_persisted_storage_route(record)))
+
+
 def materialize_appended_records_locked(
     target: Any,
     *,

--- a/tools/matrixark_temporal_direct_backend.py
+++ b/tools/matrixark_temporal_direct_backend.py
@@ -11,8 +11,10 @@ except ImportError:  # Direct script execution from tools/.
 
 try:  # package path
     from tools.matrixark_mcp_core import *  # noqa: F401,F403
+    from tools.matrixark_mcp_temporal_append import slim_persisted_record
 except ImportError:
     from matrixark_mcp_core import *  # noqa: F401,F403
+    from matrixark_mcp_temporal_append import slim_persisted_record
 
 try:  # package path
     from tools.matrixark_temporal_location_codec import (
@@ -814,7 +816,8 @@ class _TemporalDirectBackendMixin:
                     except (TypeError, ValueError):
                         pass
                 record["matrixark_write_debug"] = debug
-                payload = json.dumps(record, sort_keys=True, separators=(",", ":"))
+                payload = json.dumps(slim_persisted_record(record),
+                                     sort_keys=True, separators=(",", ":"))
                 route = record.get("storage_route") if isinstance(record.get("storage_route"), dict) else {}
                 entries.append({"key": record_key, "field": record_id, "value": payload, "storage_route": route})
                 sequence += 1

--- a/tools/matrixark_temporal_direct_write.py
+++ b/tools/matrixark_temporal_direct_write.py
@@ -26,17 +26,9 @@ except ImportError:
     )
 
 try:
-    from tools.matrixark_mcp_temporal_append import (
-        slim_persisted_record_kind,
-        slim_persisted_storage_options,
-        slim_persisted_storage_route,
-    )
+    from tools.matrixark_mcp_temporal_append import slim_persisted_record
 except ImportError:
-    from matrixark_mcp_temporal_append import (
-        slim_persisted_record_kind,
-        slim_persisted_storage_options,
-        slim_persisted_storage_route,
-    )
+    from matrixark_mcp_temporal_append import slim_persisted_record
 
 try:  # names owned by the parent module
     from tools.matrixark_mcp_temporal_adapters import (
@@ -317,7 +309,8 @@ class _TemporalDirectWriteMixin:
                     self._index_cache = self._get_index()
                 entries: list[Json] = []
                 for record in records_to_append:
-                    payload = json.dumps(record, sort_keys=True, separators=(",", ":"))
+                    payload = json.dumps(slim_persisted_record(record),
+                                         sort_keys=True, separators=(",", ":"))
                     record_id = (
                         f"{len(self._index_cache):020d}:"
                         f"{record.get('record_type', 'record')}:"
@@ -349,9 +342,7 @@ class _TemporalDirectWriteMixin:
             for bundle in self._record_bundles(records):
                 record_key, record_id = self._record_location(sequence)
                 payload_value: Json
-                slim = [slim_persisted_record_kind(
-                            slim_persisted_storage_options(slim_persisted_storage_route(record)))
-                        for record in bundle]
+                slim = [slim_persisted_record(record) for record in bundle]
                 payload_value = slim[0] if len(slim) == 1 else {"record_bundle": slim}
                 payload = json.dumps(payload_value, sort_keys=True, separators=(",", ":"))
                 entries.append({"key": record_key, "field": record_id, "value": payload, "storage_route": self._storage_route_for_bundle(bundle)})

--- a/tools/test_matrixark_every_persist_site_slims_the_record.py
+++ b/tools/test_matrixark_every_persist_site_slims_the_record.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Every site that serialises a record for storage slims it first.
+
+Four sites turn a record into a persisted entry: the bundle path and the legacy index path in
+matrixark_temporal_direct_write, the raw path in matrixark_temporal_direct_backend, and
+matrixark_mcp_raw_ingestion. The slimmers were applied at ONE of them, on the strength of a comment
+reading "This is the ONLY append call site" -- which is true of the append CLIENT, not of record
+serialisation.
+
+Measured on the live log afterwards: of 26,944 records written, **871 still carried the derived
+fields** -- 504 of 1,065 matrixark_idempotency rows and 366 of 619 context_summary rows.
+
+test_no_persist_site_serialises_an_unslimmed_record is the point of this file. Applying a slimmer to
+one of several equivalent paths is the defect that keeps recurring here, and a structural check is
+the only kind that catches the FIFTH site before it ships.
+"""
+import ast
+import os
+import unittest
+
+try:
+    from tools.matrixark_mcp_temporal_append import slim_persisted_record
+except ImportError:  # run from tools/
+    from matrixark_mcp_temporal_append import slim_persisted_record
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PERSIST_MODULES = (
+    "matrixark_temporal_direct_write.py",
+    "matrixark_temporal_direct_backend.py",
+    "matrixark_mcp_raw_ingestion.py",
+)
+
+
+def _payload_assignments(tree):
+    """Every `payload = json.dumps(...)`, with whether its function slims anything.
+
+    The check is function-scoped rather than line-literal because the bundle path serialises a
+    variable built from an already-slimmed list, which a literal check reads as a bypass when it is
+    not one. Requiring the enclosing function to slim still catches what matters: a NEW persist site
+    in a function that never slims.
+    """
+    for fn in ast.walk(tree):
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        slims = any(
+            isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+            and n.func.id == "slim_persisted_record"
+            for n in ast.walk(fn))
+        for node in ast.walk(fn):
+            if not isinstance(node, ast.Assign):
+                continue
+            if not any(isinstance(t, ast.Name) and t.id == "payload" for t in node.targets):
+                continue
+            call = node.value
+            if isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute) \
+               and call.func.attr == "dumps":
+                yield fn, node, call, slims
+
+
+class EveryPersistSiteSlimsTests(unittest.TestCase):
+    def test_no_persist_site_serialises_an_unslimmed_record(self):
+        checked = 0
+        for name in PERSIST_MODULES:
+            path = os.path.join(HERE, name)
+            if not os.path.exists(path):
+                continue
+            with open(path, encoding="utf-8") as handle:
+                tree = ast.parse(handle.read())
+            for fn, node, call, slims in _payload_assignments(tree):
+                checked += 1
+                self.assertTrue(
+                    slims,
+                    f"{name}:{node.lineno} in {fn.name}() serialises a record for storage and that "
+                    f"function never calls slim_persisted_record:\n    {ast.unparse(call)[:120]}")
+        self.assertGreaterEqual(checked, 3,
+                                "expected to find the persist sites; the idiom may have moved")
+
+    def test_the_helper_composes_all_three(self):
+        record = {
+            "record_type": "context_summary",
+            "storage_record_kind": "summary",
+            "storage_part": "summary",
+            "storage_options": {"route": "default", "write_mode": "async",
+                                "durability_result": "accepted_for_async_durability",
+                                "sync_write": False},
+            "scope_key": "t=1|u=2|s=3|",
+            "node_hash": 7,
+            "summary_text": "kept",
+        }
+        slim = slim_persisted_record(record)
+        self.assertNotIn("storage_record_kind", slim)
+        self.assertNotIn("storage_part", slim)
+        self.assertNotIn("durability_result", slim["storage_options"])
+        self.assertNotIn("sync_write", slim["storage_options"])
+        self.assertEqual("kept", slim["summary_text"])
+
+    def test_the_inputs_are_not_dropped(self):
+        """It must remain the conservative set -- an input is not a derived field."""
+        record = {"storage_options": {"route": "default", "write_mode": "async",
+                                      "background_write": False, "read_preference": "primary"}}
+        kept = slim_persisted_record(record)["storage_options"]
+        for field in ("route", "write_mode", "background_write", "read_preference"):
+            self.assertIn(field, kept, f"{field} is an input and must survive")
+
+    def test_it_is_a_no_op_on_a_record_with_none_of_it(self):
+        record = {"record_type": "context_event", "text": "hello"}
+        self.assertIs(record, slim_persisted_record(record))
+
+    def test_it_does_not_mutate_the_caller(self):
+        options = {"route": "default", "durability_result": "accepted_for_async_durability"}
+        record = {"storage_record_kind": "summary", "record_type": "context_summary",
+                  "storage_options": options}
+        slim_persisted_record(record)
+        self.assertIn("storage_record_kind", record)
+        self.assertIn("durability_result", options)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
mx#1048, #1058 and #1061 applied their slimmers at the bundle path in
`matrixark_temporal_direct_write`, on the strength of a comment there reading *"This is the ONLY
append call site"*. That comment is true of the append **client** — it is about which client the
batch is routed through — and not of record serialisation.

There are **four** sites that turn a record into a persisted entry:

| site | slimmed before this |
|---|---|
| `matrixark_temporal_direct_write.py` bundle path | yes |
| `matrixark_temporal_direct_write.py` legacy index path | **no** |
| `matrixark_temporal_direct_backend.py` raw path | **no** |
| `matrixark_mcp_raw_ingestion.py` | **no** |

## What that cost

Measured on the 139 log pieces written since those changes deployed — so this is a live bypass, not
history:

| | |
|---|---|
| records written | 26,943 |
| **still carrying the derived fields** | **870 (3.2%)** |
| of which `matrixark_idempotency` | 504 |
| of which `context_summary` | 365 |
| those records | 2,340,965 B -> 1,533,153 B |
| recovered | **807,812 B — 1.31% of the log** |
| per affected record | 2,690 -> 1,762 B (**35% smaller**) |

## The change

One function, `slim_persisted_record`, composes the three existing slimmers, and all four sites call
it. Each slimmer is already a no-op on a record without the fields it looks for, so applying it on
the raw paths costs nothing where those fields never appear — and means a change to what gets
slimmed reaches every persist site instead of three of four.

## The test is the point

`test_no_persist_site_serialises_an_unslimmed_record` walks the AST of all three modules and
requires every `payload = json.dumps(...)` to sit in a function that calls `slim_persisted_record`.

It is function-scoped rather than line-literal on purpose: the bundle path serialises a variable
built from an already-slimmed list, which a literal check reads as a bypass when it is not one. The
function-scoped form still catches the case that matters — a **fifth** site added to a function that
never slims.

Mutation-checked with `__pycache__` cleared: putting `matrixark_mcp_raw_ingestion` back the way it
was fails the guard with the exact file, line and function —

```
matrixark_mcp_raw_ingestion.py:218 in append_raw_ingestion_records() serialises a record
for storage and that function never calls slim_persisted_record
```

Applying a slimmer to one of several equivalent paths is the defect that produced four of the last
ten changes here. A structural check is the only kind that catches the next one before it ships.

77 tests pass across the write-path, side-index, placement and record-kind suites.
