### PR TITLE
A write that changes nothing records nothing

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -1903,6 +1903,11 @@ def update(patch: Json, actor: Optional[str] = None) -> Json:
 
     document = load()
     values: Dict[str, str] = {k: str(v) for k, v in (document.get("values") or {}).items()}
+    # What the FILE held before this write. Not the same as the effective values below: storing a
+    # value identical to the build default changes the file and not the effective value, and that
+    # is a real change -- it pins the setting against a later build. So "did anything change" is
+    # asked of this, and "changed from what" is answered by `previous`.
+    stored_before: Dict[str, str] = dict(values)
     # The effective values BEFORE this write, so the log can say what each setting changed from --
     # including a value that came from the launcher environment rather than a previous write.
     previous: Dict[str, str] = {}
@@ -1967,6 +1972,22 @@ def update(patch: Json, actor: Optional[str] = None) -> Json:
     changes: List[Json] = []
     for key in sorted(coerced):
         setting = SETTINGS_BY_KEY[key]
+        # Nothing moved in the file, so nothing is recorded. A caller re-POSTing the values it
+        # already holds is common -- a periodic reconciler, a page saving a form nobody edited --
+        # and each such write used to append a full entry with `from` equal to `to`. On the
+        # deployment this was found on, 45 of the 50 retained entries recorded no change at all,
+        # 254 of 269 individual changes had from == to, and the window they had pushed out was
+        # down to eleven hours. The log exists to answer "who changed the embedding model, and
+        # when"; it had evicted the answer with writes that changed nothing.
+        #
+        # A SECRET is exempt: its value is never compared, so re-setting one is indistinguishable
+        # from rotating it, and the fact of the write is the useful half.
+        if not setting.secret:
+            if key in reset:
+                if key not in stored_before:
+                    continue
+            elif stored_before.get(key) == coerced[key]:
+                continue
         entry: Json = {"key": key, "env": _env_name(setting, values)}
         if key in reset:
             entry["action"] = "reset"
@@ -1981,12 +2002,14 @@ def update(patch: Json, actor: Optional[str] = None) -> Json:
 
     history = document.get("history")
     history = history if isinstance(history, list) else []
-    history.append({
-        "at": time.time(),
-        "by": actor or "portal",
-        "changes": changes,
-        "restart_required": sorted({e["key"] for e in applied if not e["in_effect"]}),
-    })
+    # An entry with no changes in it is the same noise one level up.
+    if changes:
+        history.append({
+            "at": time.time(),
+            "by": actor or "portal",
+            "changes": changes,
+            "restart_required": sorted({e["key"] for e in applied if not e["in_effect"]}),
+        })
     document["history"] = history[-HISTORY_LIMIT:]
 
     document["values"] = values

--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -2002,20 +2002,30 @@ def update(patch: Json, actor: Optional[str] = None) -> Json:
 
     history = document.get("history")
     history = history if isinstance(history, list) else []
-    # An entry with no changes in it is the same noise one level up.
-    if changes:
-        history.append({
-            "at": time.time(),
-            "by": actor or "portal",
-            "changes": changes,
-            "restart_required": sorted({e["key"] for e in applied if not e["in_effect"]}),
-        })
+    # No guard on this append, deliberately. A write with nothing in `changes` does not reach
+    # `_store` below, so the entry is built and dropped with the document -- and a second check
+    # here would be one no test could make fail.
+    history.append({
+        "at": time.time(),
+        "by": actor or "portal",
+        "changes": changes,
+        "restart_required": sorted({e["key"] for e in applied if not e["in_effect"]}),
+    })
     document["history"] = history[-HISTORY_LIMIT:]
 
     document["values"] = values
-    document["updated_at"] = time.time()
-    document["updated_by"] = actor or "portal"
-    _store(document)
+    if changes:
+        document["updated_at"] = time.time()
+        document["updated_by"] = actor or "portal"
+        _store(document)
+    # Nothing moved, so the file is left exactly as it was -- including `updated_at`.
+    #
+    # That timestamp is not decoration: the live frame carries it, and the Setup page reads a
+    # change in it as "somebody else changed this configuration", which it tells anyone with
+    # unsaved edits rather than discarding their work. A caller re-sending the values it already
+    # holds raised that notice on every open page, every few minutes, about nothing. The
+    # environment is still applied below, because that is what `update()` promises whatever the
+    # file already said.
 
     # Only now. _store is the half that can fail; assignment into the environment is the half that
     # cannot be undone, and it has been checked for the one input that would make it raise.

--- a/tools/test_matrixark_a_write_that_changes_nothing_records_nothing.py
+++ b/tools/test_matrixark_a_write_that_changes_nothing_records_nothing.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import os
 import sys
 import tempfile
+import time
 import unittest
 
 TOOLS = os.path.dirname(os.path.abspath(__file__))
@@ -157,6 +158,47 @@ class ASecretIsAlwaysRecordedTest(Case):
         key = self._secret()
         cfg.update({key: "sk-do-not-log-me"}, actor="test")
         self.assertNotIn("sk-do-not-log-me", json.dumps(self.entries()))
+
+
+class ItDoesNotAnnounceAChangeEitherTest(Case):
+    """`updated_at` is not decoration.
+
+    The live frame carries it, and the Setup page reads a change in it as "somebody else changed
+    this configuration" -- which it tells anyone holding unsaved edits rather than discarding
+    their work. A caller re-sending what it already stored raised that notice on every open page,
+    every few minutes, about nothing.
+    """
+
+    def test_a_no_op_does_not_move_the_timestamp(self) -> None:
+        cfg.update({KEY: "0.44"}, actor="test")
+        before = cfg.load()["updated_at"]
+        cfg.update({KEY: "0.44"}, actor="test")
+        self.assertEqual(before, cfg.load()["updated_at"])
+
+    def test_nor_rewrite_the_file(self) -> None:
+        cfg.update({KEY: "0.44"}, actor="test")
+        before = os.path.getmtime(cfg.config_path())
+        time.sleep(0.02)
+        cfg.update({KEY: "0.44"}, actor="test")
+        self.assertEqual(before, os.path.getmtime(cfg.config_path()))
+
+    def test_a_real_change_still_moves_it(self) -> None:
+        """The floor. Never moving the timestamp would pass both tests above and break the
+        notice this is protecting."""
+        cfg.update({KEY: "0.44"}, actor="test")
+        before = cfg.load()["updated_at"]
+        time.sleep(0.02)
+        cfg.update({KEY: "0.55"}, actor="test")
+        self.assertNotEqual(before, cfg.load()["updated_at"])
+
+    def test_the_environment_is_applied_even_by_a_no_op(self) -> None:
+        """`update()` promises to apply to the live process environment whatever the file already
+        said, and skipping the file write must not quietly drop that half."""
+        cfg.update({KEY: "0.44"}, actor="test")
+        variable = cfg.SETTINGS_BY_KEY[KEY].env
+        os.environ.pop(variable, None)
+        cfg.update({KEY: "0.44"}, actor="test")
+        self.assertEqual("0.44", os.environ.get(variable))
 
 
 if __name__ == "__main__":

--- a/tools/test_matrixark_a_write_that_changes_nothing_records_nothing.py
+++ b/tools/test_matrixark_a_write_that_changes_nothing_records_nothing.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The configuration log records what changed, and only what changed.
+
+Its own comment says why it exists: *"Who changed the embedding model, and when" is a real support
+question, and until now the file recorded only the latest state -- which answers neither.*
+
+Every write appended a full entry regardless of whether anything moved. A caller re-POSTing the
+values it already holds -- a periodic reconciler, a form saved without an edit -- produced an entry
+whose ``from`` equalled its ``to``, and the log is capped, so those entries evicted the ones that
+answered the question.
+
+Measured on the deployment this was found on:
+
+===========================================  =====
+history entries retained                        50
+entries where nothing changed at all            45
+individual changes recorded                    269
+...with ``from`` equal to ``to``               254
+...that changed something                       15
+window still covered                     10.9 hours
+===========================================  =====
+
+**"Changed" means the FILE changed, not the effective value.** Storing a value identical to the
+build default moves nothing an operator can observe today and is still a real change: it pins the
+setting, so a later build that improves that default will not reach this deployment. That write is
+recorded. Comparing effective values instead would have dropped exactly the entry explaining how a
+deployment came to be pinned.
+
+**A secret is exempt.** Its value is never compared, so re-setting one cannot be told from rotating
+it, and the fact of the write is the useful half.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+import matrixark_gateway_config as cfg  # noqa: E402
+
+KEY = "retrieval.min_score"
+
+
+class Case(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self._environ = dict(os.environ)
+        self.addCleanup(self._restore)
+        self._work = tempfile.TemporaryDirectory(prefix="matrixark-log-")
+        self.addCleanup(self._work.cleanup)
+        os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = os.path.join(self._work.name, "cfg.json")
+
+    def _restore(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._environ)
+
+    def entries(self) -> list:
+        return cfg.history(limit=50)
+
+
+class ARepeatedWriteIsNotAChangeTest(Case):
+
+    def test_the_first_write_is_recorded(self) -> None:
+        cfg.update({KEY: "0.44"}, actor="test")
+        self.assertEqual(1, len(self.entries()))
+
+    def test_writing_the_same_value_again_is_not(self) -> None:
+        cfg.update({KEY: "0.44"}, actor="test")
+        for _ in range(5):
+            cfg.update({KEY: "0.44"}, actor="test")
+        self.assertEqual(1, len(self.entries()),
+                         "a caller re-sending what it already stored fills the log")
+
+    def test_a_different_value_is_recorded_again(self) -> None:
+        """The floor. A log that recorded nothing would pass the test above."""
+        cfg.update({KEY: "0.44"}, actor="test")
+        cfg.update({KEY: "0.55"}, actor="test")
+        self.assertEqual(2, len(self.entries()))
+
+    def test_one_no_op_among_real_changes_is_dropped_alone(self) -> None:
+        """The entry survives; the change that changed nothing does not appear in it."""
+        # Taken from the registry rather than written here: a name invented for a test is a name
+        # that can stop existing, and update() refuses an unknown key outright.
+        other = next(s.key for s in cfg.SETTINGS
+                     if s.kind == "int" and not s.secret and s.key != KEY)
+        cfg.update({KEY: "0.44", other: "1000"}, actor="test")
+        cfg.update({KEY: "0.44", other: "2000"}, actor="test")
+        latest = self.entries()[0]
+        self.assertEqual([other], [c["key"] for c in latest["changes"]],
+                         "the unchanged setting was recorded beside the changed one")
+
+    def test_nothing_at_all_appends_no_entry(self) -> None:
+        cfg.update({KEY: "0.44"}, actor="test")
+        before = len(self.entries())
+        cfg.update({KEY: "0.44"}, actor="test")
+        self.assertEqual(before, len(self.entries()))
+
+
+class TheFileIsWhatCountsAsChangedTest(Case):
+    """Not the effective value: those differ exactly where it matters."""
+
+    def test_storing_the_build_default_is_recorded(self) -> None:
+        default = cfg.SETTINGS_BY_KEY[KEY].default
+        cfg.update({KEY: default}, actor="test")
+        self.assertEqual(1, len(self.entries()),
+                         "pinning a setting to the default left no trace, and a pin is what "
+                         "stops a later build reaching this deployment")
+
+    def test_and_the_effective_value_did_not_move(self) -> None:
+        """The premise of the test above. If the effective value changed too, it would not be
+        showing that the file is the thing being compared."""
+        default = cfg.SETTINGS_BY_KEY[KEY].default
+        before, _source = cfg._effective(cfg.SETTINGS_BY_KEY[KEY], {})
+        cfg.update({KEY: default}, actor="test")
+        after, _source = cfg._effective(cfg.SETTINGS_BY_KEY[KEY], {KEY: default})
+        self.assertEqual(before, after)
+
+    def test_storing_it_twice_records_once(self) -> None:
+        default = cfg.SETTINGS_BY_KEY[KEY].default
+        cfg.update({KEY: default}, actor="test")
+        cfg.update({KEY: default}, actor="test")
+        self.assertEqual(1, len(self.entries()))
+
+    def test_a_reset_that_removes_something_is_recorded(self) -> None:
+        cfg.update({KEY: "0.44"}, actor="test")
+        cfg.update({KEY: None}, actor="test")
+        self.assertEqual(2, len(self.entries()))
+
+    def test_a_reset_of_something_unstored_is_not(self) -> None:
+        cfg.update({KEY: None}, actor="test")
+        self.assertEqual([], self.entries())
+
+
+class ASecretIsAlwaysRecordedTest(Case):
+
+    def _secret(self) -> str:
+        secrets = [s.key for s in cfg.SETTINGS if s.secret]
+        if not secrets:
+            self.skipTest("no secret settings in this build")
+        return secrets[0]
+
+    def test_setting_the_same_secret_twice_records_twice(self) -> None:
+        key = self._secret()
+        cfg.update({key: "sk-same"}, actor="test")
+        cfg.update({key: "sk-same"}, actor="test")
+        self.assertEqual(2, len(self.entries()),
+                         "a secret's value is never compared, so a rotation cannot be told from "
+                         "a repeat and the write itself is the record")
+
+    def test_and_the_value_is_still_never_written_down(self) -> None:
+        import json
+
+        key = self._secret()
+        cfg.update({key: "sk-do-not-log-me"}, actor="test")
+        self.assertNotIn("sk-do-not-log-me", json.dumps(self.entries()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The configuration log's own comment says why it exists:

> *"Who changed the embedding model, and when" is a real support question, and until now the file
> recorded only the latest state — which answers neither.*

Every write appended a full entry regardless of whether anything moved. A caller re-sending the
values it already holds — a periodic reconciler, a form saved without an edit — produced an entry
whose `from` equalled its `to`. The log is capped, so those entries **evicted the ones that answered
the question**.

Measured on this deployment:

| | |
|---|---|
| history entries retained | 50 (the cap) |
| entries where **nothing changed at all** | **45** |
| individual changes recorded | 269 |
| ...with `from` equal to `to` | **254** |
| ...that changed something | **15** |
| window still covered | **10.9 hours** |

Six settings, rewritten every few minutes all day, had pushed the log's useful history out of reach.

### "Changed" means the file changed, not the effective value

This is the part worth getting right. Storing a value **identical to the build default** moves
nothing an operator can observe today — and it is a real change: it pins the setting, so a later
build that improves that default will not reach this deployment. That write is recorded.

Comparing effective values instead would have dropped exactly the entry that explains how a
deployment came to be pinned — and that is not hypothetical either, since 109 of this deployment's
115 stored settings are pins (#1123). A mutation swapping the comparison to `previous` (the
effective value) reddens `test_storing_the_build_default_is_recorded`.

### A secret stays exempt

Its value is never compared, so re-setting one cannot be told from rotating it, and the fact of the
write is the useful half. A separate test keeps the value itself out of the log.

```
every write is recorded again                       -> FAIL
it compares the EFFECTIVE value instead of the file -> FAIL
a secret stops being exempt                         -> FAIL
an entry with no changes is appended anyway         -> FAIL
a reset of something unstored is recorded           -> FAIL
```

Floors on the other side: a *different* value is still recorded (a log that recorded nothing would
pass the headline test), and one no-op among real changes drops only itself while the entry
survives.

Found by asking the live config's own history how 109 pins got there — and discovering the history
could no longer say.
