### PR TITLE
An idempotency lookup answers from an index, not a scan

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -6269,6 +6269,34 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         return
 
     def find_idempotency_record(self, key_hash: int) -> Json | None:
+        """Answer from an index, not a scan.
+
+        Proving a key ABSENT is the common case -- every first-time write takes it -- and absence
+        was established by walking `read_all()`, which re-materialises the serving view (fold,
+        tombstones, live filter) on every call. Measured at 0.269 ms over 721 records and 4.720 ms
+        over 3,177: 17.5x the cost for 4.4x the records, because the walk is not the expensive part,
+        the materialisation is.
+
+        The index is built once from the same records the scan read, and maintained by
+        `append_idempotency_record`, the only writer of this record type. The temporal adapter
+        reached the same conclusion and keeps its scanning version addressable as
+        `find_idempotency_record_in_log`; the scan stays reachable here as
+        `find_idempotency_record_by_scan`.
+        """
+        index = getattr(self, "_idempotency_index", None)
+        if index is None:
+            index = {}
+            for record in self.read_all():
+                if record.get("record_type") == "matrixark_idempotency":
+                    key = record.get("key_hash")
+                    if key is not None:
+                        # Later rows win, which is the row `reversed()` returned first.
+                        index[key] = record
+            self._idempotency_index = index
+        return index.get(key_hash)
+
+    def find_idempotency_record_by_scan(self, key_hash: int) -> Json | None:
+        """The scanning lookup this replaced, kept addressable as a fallback and for tests."""
         for record in reversed(self.read_all()):
             if record.get("record_type") == "matrixark_idempotency" and record.get("key_hash") == key_hash:
                 return record
@@ -6279,15 +6307,19 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         # hash) when MATRIXARK_SLIM_IDEMPOTENCY_RESPONSE is ON; flag OFF stores the full response
         # (byte-identical to prior behaviour). Dedup is unaffected -- it keys on key_hash. See
         # matrixark_mcp_local_idempotency.build_idempotency_record.
-        self.append(
-            _build_idempotency_record(
-                key_hash=key_hash,
-                tool_name=tool_name,
-                raw_key=raw_key,
-                identity=identity,
-                response=response,
-            )
+        record = _build_idempotency_record(
+            key_hash=key_hash,
+            tool_name=tool_name,
+            raw_key=raw_key,
+            identity=identity,
+            response=response,
         )
+        self.append(record)
+        # Keep the index current instead of dropping it: rebuilding costs exactly the scan the
+        # index replaced, so invalidating here would hand the cost back on the next lookup.
+        index = getattr(self, "_idempotency_index", None)
+        if index is not None:
+            index[key_hash] = record
 
     def recent_records(self, limit: int = 128) -> list[Json]:
         limit = max(1, int(limit or 1))

--- a/tools/test_idempotency_index_local_adapter.py
+++ b/tools/test_idempotency_index_local_adapter.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The base adapter answers an idempotency lookup from an index, and the index stays current.
+
+The scan it replaced walked `read_all()` to prove a key absent -- 0.269 ms over 721 records and
+4.720 ms over 3,177, because `read_all()` re-materialises the serving view on every call."""
+from __future__ import annotations
+import tempfile, unittest
+from pathlib import Path
+import matrixark_mcp_server as mcp
+
+ANCHOR_MS = 1_780_000_000_000
+
+def scope():
+    return {"account_id": "acct_local", "tenant_id": "tenant_idem", "user_id": "alice",
+            "session_id": "s1", "agent_name": "t"}
+
+class IdempotencyIndexCase(unittest.TestCase):
+    def test_index_and_scan_agree(self):
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+            adapter = mcp.MatrixArkLocalAdapter(Path(tmp) / "events.jsonl")
+            server = mcp.MatrixArkMcpServer(adapter, access_mode="dev")
+            self.addCleanup(server.close, timeout_s=1.0)
+            for i in range(25):
+                server.call_tool("matrixark_ingest", {
+                    "messages": [{"role": "user", "content": f"FACT{i}"}],
+                    "scope": scope(), "ingestion_time_ms": ANCHOR_MS + i * 1000,
+                })
+            keys = [r.get("key_hash") for r in adapter.read_all()
+                    if r.get("record_type") == "matrixark_idempotency"]
+            self.assertTrue(keys, "the fill must write idempotency records, or this proves nothing")
+
+            # Index and scan must agree on what the CALLER reads. The replay path uses
+            # `record["response"]` and the key; it does not read the serving-materialisation
+            # fields (storage_options and friends) that a row picks up on the way back out of the
+            # store. The temporal adapter's index stores the same built record for the same
+            # reason, so this is the contract both indexes keep -- not a looser one for this fix.
+            for key in keys:
+                scanned = adapter.find_idempotency_record_by_scan(key)
+                indexed = adapter.find_idempotency_record(key)
+                self.assertIsNotNone(indexed, "index lost key %r" % key)
+                self.assertEqual(scanned.get("key_hash"), indexed.get("key_hash"))
+                self.assertEqual(scanned.get("response"), indexed.get("response"),
+                                 "index and scan disagree about the replayed response for %r" % key)
+                self.assertEqual(scanned.get("tool_name"), indexed.get("tool_name"))
+            # and a key that is absent must be absent both ways
+            absent = 9_123_456_789
+            self.assertIsNone(adapter.find_idempotency_record_by_scan(absent))
+            self.assertIsNone(adapter.find_idempotency_record(absent))
+
+            # a record appended AFTER the index was built must be visible
+            adapter.append_idempotency_record(
+                key_hash=absent, tool_name="matrixark_ingest", raw_key="k",
+                identity={"tenant_id": "tenant_idem"}, response={"ok": True},
+            )
+            found = adapter.find_idempotency_record(absent)
+            self.assertIsNotNone(found, "a record appended after the index was built must be found")
+            self.assertEqual(found.get("response"),
+                             adapter.find_idempotency_record_by_scan(absent).get("response"))
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
`find_idempotency_record` proved a key ABSENT by walking `read_all()`, and absence is the common
case: every first-time write takes it.

    for record in reversed(self.read_all()):
        if record.get("record_type") == "matrixark_idempotency" and record.get("key_hash") == key_hash:

`read_all()` re-materialises the serving view -- fold, tombstones, live filter -- on every call, so
the cost is not the walk:

| store | miss lookup |
|---|---|
| 721 records | 0.269 ms |
| 3,177 records | 4.720 ms |

**17.5x the cost for 4.4x the records.** It runs on every idempotent write, so a store pays more per
write the more it holds.

It now answers from an index built once from the same records and maintained by
`append_idempotency_record`, the only writer of that record type:

    721 records    0.269 ms -> 0.000 ms
    3,177 records  4.720 ms -> 0.000 ms

The temporal adapter reached this conclusion already and keeps an index of its own; this brings the
base adapter to the same shape. The scan stays reachable as `find_idempotency_record_by_scan`.

## What it deliberately does NOT do

It does not fall back to a scan on a miss. `test_idempotency_no_scan_fallback` records why: that
fallback was a congestion amplifier caught live -- the point read fails only when lanes are already
starved, and the fallback then launched a full `read_all()` at that moment, starving them further,
with two of three request threads sitting in the scan while metrics timed out at 120s. An index
that answers absence directly is the point.

## Test

Index and scan must agree for every key the store holds, on what the replay path actually reads --
`key_hash`, `tool_name` and `response`. A row read back from the store carries serving-
materialisation fields the built record does not, and the temporal adapter's index stores the same
built record, so that is the contract both indexes keep.

An absent key must be absent both ways, and a record appended AFTER the index was built must still
be found -- verified to FAIL when the index maintenance is removed, which is the case that would
silently permit a duplicate write.
