### PR TITLE
The latest-state copy of a record is slimmed too

### DIFF
--- a/tools/matrixark_temporal_direct_backend.py
+++ b/tools/matrixark_temporal_direct_backend.py
@@ -1615,7 +1615,7 @@ class _TemporalDirectBackendMixin:
             field = self._latest_context_state_field(record)
             if not field:
                 continue
-            payload_record = dict(record)
+            payload_record = dict(slim_persisted_record(record))
             payload_record.pop("summary_version_hash", None)
             entries.append(
                 {
@@ -1640,7 +1640,7 @@ class _TemporalDirectBackendMixin:
             if not field:
                 append_records_for_log.append(record)
                 continue
-            payload_record = dict(record)
+            payload_record = dict(slim_persisted_record(record))
             payload_record.pop("summary_version_hash", None)
             latest_state_entries.append(
                 {

--- a/tools/test_matrixark_every_persist_site_slims_the_record.py
+++ b/tools/test_matrixark_every_persist_site_slims_the_record.py
@@ -49,14 +49,36 @@ def _payload_assignments(tree):
             and n.func.id == "slim_persisted_record"
             for n in ast.walk(fn))
         for node in ast.walk(fn):
-            if not isinstance(node, ast.Assign):
+            if isinstance(node, ast.Assign) \
+               and any(isinstance(t, ast.Name) and t.id == "payload" for t in node.targets):
+                call = node.value
+                if isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute) \
+                   and call.func.attr == "dumps":
+                    yield fn, node, call, slims
                 continue
-            if not any(isinstance(t, ast.Name) and t.id == "payload" for t in node.targets):
-                continue
-            call = node.value
-            if isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute) \
-               and call.func.attr == "dumps":
-                yield fn, node, call, slims
+            # An entry can spell its value inline, with no intermediate variable at all:
+            #     {"key": ..., "field": ..., "value": json.dumps(record_copy, ...)}
+            # The latest-context-state writers do exactly that, and went unseen by the first
+            # version of this guard for that reason alone. A guard that knows one spelling of the
+            # idiom is not a guard.
+            if isinstance(node, ast.Dict):
+                names = {k.value for k in node.keys
+                         if isinstance(k, ast.Constant) and isinstance(k.value, str)}
+                if "value" not in names or not ({"key", "field"} & names):
+                    continue
+                for key, value in zip(node.keys, node.values):
+                    if not (isinstance(key, ast.Constant) and key.value == "value"):
+                        continue
+                    if not (isinstance(value, ast.Call)
+                            and isinstance(value.func, ast.Attribute)
+                            and value.func.attr == "dumps"):
+                        continue
+                    # Only a RECORD needs slimming. The same entry shape also carries index
+                    # postings -- {"ref_hashes": ...}, {"locations": ...} -- which have none of
+                    # the fields a slimmer looks for, so flagging those would be noise that
+                    # trains the next reader to wave this test through.
+                    if value.args and "record" in ast.unparse(value.args[0]):
+                        yield fn, node, value, slims
 
 
 class EveryPersistSiteSlimsTests(unittest.TestCase):


### PR DESCRIPTION
mx#1126 brought four persist sites under one slimmer and added a guard. After deploying it,
`context_summary` was **still 6 of 12 records written fat**. There was a fifth writer, and the guard
could not see it.

## Finding it

Reading call graphs sent me down three wrong paths — the proxy client (transport, it forwards a
value serialised upstream), the direct write queue (it flushes back through the slimmed path), and
"these are old records being rewritten" (their timestamps are after the deploy, so they are new).

The data answered it. The frame header carries `p[]` (pages: an object id and a `"~N"` blob
pointer) and `t[]` (index entries: object key `o`, object id `i`), so a blob maps back to the key
it was written under:

```
13 fat context_summary records -> matrixark:claude-hook:context_latest_state
```

That names `_latest_context_state_entries` and `_split_compacted_latest_context_state`, which write
a copy of the record under a separate key for current-value lookups.

## Why the guard missed it

Both spell the entry with no intermediate variable:

```python
payload_record = dict(record)
payload_record.pop("summary_version_hash", None)
entries.append({"key": ..., "field": field,
                "value": json.dumps(payload_record, sort_keys=True, separators=(",", ":"))})
```

mx#1126's guard looked for `payload = json.dumps(...)`. **A guard that knows one spelling of the
idiom is not a guard.** It now also inspects an entry dict's inline `"value"`.

It is narrowed at the same time: the same entry shape carries index postings — `{"ref_hashes": ...}`,
`{"locations": ...}` — which have none of the fields a slimmer looks for. Flagging those would be
noise that trains the next reader to wave the test through, so the guard requires the serialised
expression to name a record.

## What it recovers

Measured on the pieces written since mx#1126 deployed:

| | |
|---|---|
| records still carrying the derived fields | 17, all `context_summary` |
| those records | 66,120 B -> 48,950 B |
| recovered | **17,170 B — 0.47% of the log** |
| per affected record | 3,889 -> 2,879 B (**26% smaller**) |

## Tests

Mutation-checked with `__pycache__` cleared: reverting both latest-state sites fails the guard with
the exact file, line and function —

```
matrixark_temporal_direct_backend.py:1621 in _latest_context_state_entries() serialises a
record for storage and that function never calls slim_persisted_record
```

— which is precisely what the previous version of the guard could not report.

77 tests pass across the write-path, side-index, placement and record-kind suites.
