### PR TITLE
The second append implementation slims a record too

### DIFF
--- a/tools/matrixark_mcp_temporal_append.py
+++ b/tools/matrixark_mcp_temporal_append.py
@@ -416,7 +416,8 @@ def append_many_materialized(target: Any, records: list[Json], *, allow_queue: b
                 target._index_cache = target._get_index()
             entries: list[Json] = []
             for record in records_to_append:
-                payload = json.dumps(record, sort_keys=True, separators=(",", ":"))
+                payload = json.dumps(slim_persisted_record(record),
+                                     sort_keys=True, separators=(",", ":"))
                 record_id = (
                     f"{len(target._index_cache):020d}:"
                     f"{record.get('record_type', 'record')}:"
@@ -450,7 +451,7 @@ def append_many_materialized(target: Any, records: list[Json], *, allow_queue: b
         for bundle in target._record_bundles(records):
             record_key, record_id = target._record_location(sequence)
             payload_value: Json
-            slim = [slim_persisted_storage_route(record) for record in bundle]
+            slim = [slim_persisted_record(record) for record in bundle]
             payload_value = slim[0] if len(slim) == 1 else {"record_bundle": slim}
             payload = json.dumps(payload_value, sort_keys=True, separators=(",", ":"))
             entries.append(

--- a/tools/test_matrixark_every_persist_site_slims_the_record.py
+++ b/tools/test_matrixark_every_persist_site_slims_the_record.py
@@ -26,10 +26,15 @@ except ImportError:  # run from tools/
     from matrixark_mcp_temporal_append import slim_persisted_record
 
 HERE = os.path.dirname(os.path.abspath(__file__))
+# matrixark_mcp_temporal_append.py carries a SECOND copy of the append implementation -- the same
+# legacy-index and bundle branches as matrixark_temporal_direct_write. Leaving it off this list is
+# why five successive changes to what gets slimmed never reached it, and why context_summary was
+# still written fat after four of them.
 PERSIST_MODULES = (
     "matrixark_temporal_direct_write.py",
     "matrixark_temporal_direct_backend.py",
     "matrixark_mcp_raw_ingestion.py",
+    "matrixark_mcp_temporal_append.py",
 )
 
 


### PR DESCRIPTION
`matrixark_mcp_temporal_append.py` carries a **second, complete copy of the append implementation** —
the same legacy-index and bundle branches as `matrixark_temporal_direct_write`. It is the copy that
actually runs for these records, and it never received any of the last five changes to what gets
slimmed. Its bundle branch still read:

```python
slim = [slim_persisted_storage_route(record) for record in bundle]
```

Only the route slimmer: the state before mx#1048. Its legacy-index branch slimmed nothing at all.

This is why `context_summary` was **still written fat after four successive fixes**, including
mx#1126 which existed specifically to bring every persist site under one slimmer, and mx#1129 which
fixed the latest-state writers the records were keyed under.

## How it was found

Not by reading call graphs — those sent me down four wrong paths (the proxy client is transport; the
direct write queue flushes back through a slimmed path; the records are new, not rewrites of old
ones; the latest-state writers were already fixed and the records stayed fat).

The frame header answered it. It carries `p[]` (pages: an object id and a `"~N"` blob pointer) and
`t[]` (index entries: object key `o`, object id `i`), so a blob maps back to the key it was stored
under. That gave `matrixark:claude-hook:context_latest_state`, and from there the writer that still
served it unslimmed.

## The guard did not cover it

mx#1126's guard lists the modules it checks, and this one was not on the list — the module where the
slimmers are **defined**. That omission is exactly why five changes in a row missed a live path.

`PERSIST_MODULES` now includes it, with a comment saying why.

## Its remaining limit, stated plainly

The check is function-scoped: a function that slims in one branch and not another still passes.
Reverting a single branch here is therefore not caught; reverting the function is. That is a real
hole, and narrowing it further would need dataflow rather than a name check — so it is written down
rather than left for the next reader to discover the way I did.

Mutation-checked with `__pycache__` cleared: reverting this implementation fails the guard with

```
matrixark_mcp_temporal_append.py:455 in append_many_materialized() serialises a record
for storage and that function never calls slim_persisted_record
```

82 tests pass across the write-path, side-index, placement, record-kind and interning suites.
