### PR TITLE
The gateway audit counted drops it never explained

### DIFF
--- a/tools/matrixark_mcp_core_ref_selection.py
+++ b/tools/matrixark_mcp_core_ref_selection.py
@@ -120,90 +120,26 @@ def clamp_refs_to_token_budget(
     return kept, trimmed, used_tokens
 
 
-def dropped_candidate_audit_ref(candidate: Json, *, reason: str, token_estimate: int) -> Json:
-    metadata = candidate.get("metadata", {}) if isinstance(candidate.get("metadata"), dict) else {}
-    audit_ref = {
-        "ref_type": candidate.get("ref_type", ""),
-        "ref_hash": candidate.get("ref_hash"),
-        "context_class": candidate.get("context_class") or candidate.get("ref_type", ""),
-        "drop_reason": reason,
-        "reason": reason,
-        "score": candidate.get("score", 0.0),
-        "origin_score": candidate.get("origin_score", 0.0),
-        "packing_score": round(packing_sort_key(candidate, str(candidate.get("packing_policy") or "fact"))[0], 6),
-        "token_estimate": token_estimate,
-        "token_cost": token_estimate,
-        "raw_uri": candidate.get("raw_uri", ""),
-        "source_ref": candidate.get("source_ref", ""),
-        "citation": candidate.get("citation") or candidate.get("source_ref", ""),
-        "resource_type": candidate.get("resource_type", ""),
-        "resource_version": candidate.get("resource_version") or metadata.get("resource_version", ""),
-        "version_state": candidate.get("version_state", "current"),
-        "stale_or_superseded": bool(candidate.get("stale_or_superseded", False)),
-        "access_decision": candidate.get("access_decision", "allowed_by_scope"),
-        "selection_reason": candidate.get("selection_reason", ""),
-        "matched_index_terms": candidate.get("matched_index_terms", []),
-        "node_hash": candidate.get("node_hash"),
-        "node_path": candidate.get("node_path", []),
-    }
-    for field in [
-        "memory_scope",
-        "session_continuity",
-        "extraction_phase",
-        "entity_type",
-        "entity_name",
-        "event_type",
-        "source_role",
-        "classification",
-        "extraction_status",
-        "extraction_mode",
-        "source_roles",
-        "source_role_counts",
-        "budget_source_roles",
-        "budget_source_role_counts",
-        "budget_memory_layer",
-        "budget_memory_selection_policies",
-        "memory_selection_policy_budget_capped_policies",
-        "memory_layer_budget_capped_layer",
-        "memory_layer_floor_reserved_layer",
-        "source_hook_types",
-        "source_hook_type_counts",
-        "source_codex_events",
-        "source_codex_event_counts",
-        "source_role_budget_capped_roles",
-        "profile_shadowed_by_ref_hash",
-        "profile_shadowed_reason",
-    ]:
-        value = candidate.get(field)
-        if value not in (None, "", [], {}):
-            audit_ref[field] = value
-    return audit_ref
-
-
-def record_dropped_candidate(dropped: Json, candidate: Json, *, reason: str, token_estimate: int) -> None:
-    ref_type = str(candidate.get("ref_type") or "")
-    context_class = str(candidate.get("context_class") or "")
-    is_memory_candidate = ref_type in {
-        "event",
-        "entity",
-        "segment",
-        "summary",
-        "compression",
-        "resource_chunk",
-        "skill_section",
-    } or context_class in {
-        "raw_event",
-        "entity_state",
-        "assistant_decision",
-        "tool_evidence",
-        "summary",
-        "compression",
-        "resource_fact",
-        "resource_entity_fact",
-    }
-    if not is_memory_candidate and not is_resource_or_skill_candidate(candidate):
-        return
-    dropped.setdefault("refs", []).append(dropped_candidate_audit_ref(candidate, reason=reason, token_estimate=token_estimate))
+# `record_dropped_candidate` is not defined here. It was, with a WIDER rule than the copy in
+# matrixark_mcp_recall_scoring -- that one recorded only a resource/skill candidate or a stale
+# entity, so an audit built there counted drops it never explained. The two had also drifted the
+# other way: its `dropped_candidate_audit_ref` emits six fields this module's did not
+# (entity_name, entity_type, memory_scope, session_continuity, and the two profile_shadowed_*).
+# Neither was the complete one, so the surviving pair takes the wider rule and the richer record.
+#
+# It lives there rather than here because that module does not import matrixark_mcp_core and this
+# one does; matrixark_mcp_budget_pack, which the gateway reaches, already resolved both names
+# there.
+try:
+    from tools.matrixark_mcp_recall_scoring import (
+        dropped_candidate_audit_ref,
+        record_dropped_candidate,
+    )
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_recall_scoring import (
+        dropped_candidate_audit_ref,
+        record_dropped_candidate,
+    )
 
 
 def diversify_for_question_type(candidates: list[Json], question_type: str, *, total_limit: int) -> list[Json]:

--- a/tools/matrixark_mcp_recall_scoring.py
+++ b/tools/matrixark_mcp_recall_scoring.py
@@ -292,9 +292,48 @@ def dropped_candidate_audit_ref(candidate: Json, *, reason: str, token_estimate:
     }
 
 
+#: A candidate whose drop is worth explaining. Taken from
+#: matrixark_mcp_core_ref_selection, which recorded these while this module recorded only a
+#: resource/skill candidate or a stale entity -- so an audit produced here counted drops it never
+#: explained, `cross_session_budget: 2` beside `refs: []`.
+MEMORY_CANDIDATE_REF_TYPES = {
+    "event",
+    "entity",
+    "segment",
+    "summary",
+    "compression",
+    "resource_chunk",
+    "skill_section",
+}
+MEMORY_CANDIDATE_CONTEXT_CLASSES = {
+    "raw_event",
+    "entity_state",
+    "assistant_decision",
+    "tool_evidence",
+    "summary",
+    "compression",
+    "resource_fact",
+    "resource_entity_fact",
+}
+
+
 def record_dropped_candidate(dropped: Json, candidate: Json, *, reason: str, token_estimate: int) -> None:
-    if not is_resource_or_skill_candidate(candidate) and not (
-        reason == "stale" and str(candidate.get("ref_type") or "") == "entity"
+    """Record WHICH ref was dropped, not only that one was.
+
+    The rule is the wider of the two this replaces and the record is the richer, because the two
+    had drifted in opposite directions and neither was complete: that one recorded more candidate
+    kinds, this one recorded more fields per candidate.
+
+    `reason == "stale"` on an entity is kept as its own clause even though an entity is now a
+    memory candidate anyway -- it was the one case the narrow rule went out of its way to include,
+    and dropping the clause would rely on the set above continuing to contain "entity".
+    """
+    ref_type = str(candidate.get("ref_type") or "")
+    context_class = str(candidate.get("context_class") or "")
+    is_memory_candidate = (ref_type in MEMORY_CANDIDATE_REF_TYPES
+                           or context_class in MEMORY_CANDIDATE_CONTEXT_CLASSES)
+    if not is_memory_candidate and not is_resource_or_skill_candidate(candidate) and not (
+        reason == "stale" and ref_type == "entity"
     ):
         return
     dropped.setdefault("refs", []).append(dropped_candidate_audit_ref(candidate, reason=reason, token_estimate=token_estimate))

--- a/tools/test_an_audit_that_counts_a_drop_says_which.py
+++ b/tools/test_an_audit_that_counts_a_drop_says_which.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""An audit that counts a drop says which ref was dropped.
+
+`record_dropped_candidate` and `dropped_candidate_audit_ref` were each implemented twice, and the
+two copies had drifted in OPPOSITE directions, so neither was the complete one:
+
+  * `matrixark_mcp_core_ref_selection.record_dropped_candidate` recorded every memory candidate --
+    events, entities, segments, summaries, compressions, resource chunks, skill sections, and the
+    matching context classes. `matrixark_mcp_recall_scoring`'s recorded only a resource/skill
+    candidate or a stale entity.
+  * `matrixark_mcp_recall_scoring.dropped_candidate_audit_ref` emitted six fields the other did not
+    -- entity_name, entity_type, memory_scope, session_continuity, profile_shadowed_by_ref_hash,
+    profile_shadowed_reason -- and missed none of the other's.
+
+`matrixark_mcp_budget_pack`, which the gateway reaches through `matrixark_mcp_budget_policies`,
+resolved both names to `matrixark_mcp_recall_scoring`. So a gateway pack's audit reported
+`cross_session_budget: 2` beside `refs: []`: the count said two refs were dropped and the list said
+which of them for none. Measured, on three cross-session entities.
+
+The surviving pair takes the wider rule and the richer record, and lives in
+`matrixark_mcp_recall_scoring` because that module does not import `matrixark_mcp_core`.
+
+The check is behavioural rather than a definition count, because a definition count cannot tell a
+delegate from a divergence -- and the corpus is pinned, because a corpus of only resource and skill
+candidates agreed under BOTH copies and would have passed all along.
+"""
+from __future__ import annotations
+
+import ast
+import importlib
+import os
+import subprocess
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+HOME = "matrixark_mcp_recall_scoring"
+NAMES = ("record_dropped_candidate", "dropped_candidate_audit_ref")
+
+#: The six fields the richer record carries. They are what an operator reads to tell one dropped
+#: entity from another.
+RICH_FIELDS = ("entity_name", "entity_type", "memory_scope", "session_continuity")
+
+
+def _import(name: str):
+    try:
+        return importlib.import_module("tools." + name)
+    except ImportError:
+        return importlib.import_module(name)
+
+
+def _candidates():
+    """Cross-session entities: memory candidates, and NOT resource or skill ones.
+
+    That is the discriminating shape. The narrow rule recorded a resource or skill candidate and
+    a stale entity; a corpus made of those agrees under either copy.
+    """
+    out = []
+    for index, score in enumerate((0.7, 0.6, 0.5)):
+        out.append({
+            "ref_id": "e%d" % index, "ref_hash": "h_e%d" % index, "ref_type": "entity",
+            "context_class": "entity_state", "score": score, "text": "entity %d" % index,
+            "entity_name": "name%d" % index, "entity_type": "preference",
+            "memory_scope": "user_profile", "session_continuity": "cross_session",
+            "metadata": {"ref_type": "entity"},
+        })
+    return out
+
+
+def _select(fn):
+    _selected, _tokens, audit = fn(_candidates(), [], max_context_tokens=40,
+                                   auxiliary_quota=0, question_type="fact")
+    return audit
+
+
+def _modules_defining(name: str) -> list:
+    listed = subprocess.run(["git", "ls-files", "tools/*.py"], cwd=REPO,
+                            capture_output=True, text=True).stdout.split()
+    found = []
+    for rel in listed:
+        if os.path.basename(rel).startswith("test_"):
+            continue
+        try:
+            tree = ast.parse((REPO / rel).read_text(encoding="utf-8", errors="replace"))
+        except (SyntaxError, OSError):
+            continue
+        for node in tree.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+                found.append(os.path.basename(rel)[:-3])
+    return sorted(found)
+
+
+class AnAuditThatCountsADropSaysWhichTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        _import("matrixark_mcp_local_adapter")
+        self.gateway = _import("matrixark_mcp_budget_pack").select_token_budgeted_refs
+        self.retrieve = _import(
+            "matrixark_mcp_core_ref_selection").select_token_budgeted_refs
+
+    def test_only_one_module_defines_each(self) -> None:
+        for name in NAMES:
+            self.assertEqual(
+                [HOME], _modules_defining(name),
+                "%s is defined in more than one module again. The copies drifted in opposite "
+                "directions last time -- one recorded more candidates, the other more fields -- "
+                "so neither was the one to keep" % name)
+
+    def test_the_corpus_is_one_the_narrow_rule_would_have_skipped(self) -> None:
+        """Control. A resource or skill candidate agreed under both copies."""
+        recall = _import(HOME)
+        for candidate in _candidates():
+            self.assertFalse(
+                recall.is_resource_or_skill_candidate(candidate),
+                "the corpus became resource/skill candidates, which the narrow rule recorded "
+                "anyway -- the comparison below would pass whichever rule were in force")
+
+    def test_a_counted_drop_is_a_recorded_drop(self) -> None:
+        for label, fn in (("gateway", self.gateway), ("retrieve", self.retrieve)):
+            audit = _select(fn)
+            counted = sum(value for key, value in audit.items()
+                          if isinstance(value, int) and key != "refs" and value)
+            recorded = len(audit.get("refs") or [])
+            self.assertTrue(counted, "%s dropped nothing, so this asserts nothing" % label)
+            self.assertEqual(
+                counted, recorded,
+                "the %s audit counts %d drops and names %d. An operator reading it sees that "
+                "something was dropped and cannot see what" % (label, counted, recorded))
+
+    def test_both_paths_produce_the_same_audit(self) -> None:
+        gateway, retrieve = _select(self.gateway), _select(self.retrieve)
+        self.assertEqual(
+            [r.get("ref_hash") for r in (retrieve.get("refs") or [])],
+            [r.get("ref_hash") for r in (gateway.get("refs") or [])],
+            "the two live packers record different refs for the same drops")
+
+    def test_the_record_carries_the_fields_that_tell_two_entities_apart(self) -> None:
+        refs = _select(self.gateway).get("refs") or []
+        self.assertTrue(refs, "nothing recorded, so the fields below are not being checked")
+        for field in RICH_FIELDS:
+            self.assertIn(
+                field, refs[0],
+                "the audit record lost %s. Without it two dropped entities read alike, which is "
+                "the half of this the other copy had and this one did not" % field)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The gateway audit counted drops it never explained

matrixark_mcp_budget_pack, which the gateway reaches through
matrixark_mcp_budget_policies, produced pack audits like this:

    counters = {"cross_session_budget": 2}      refs = []

Two refs dropped, and which of them named for none. Measured on three
cross-session entities.

`record_dropped_candidate` and `dropped_candidate_audit_ref` are each implemented
twice, and the copies had drifted in OPPOSITE directions, so neither was the
complete one:

  * matrixark_mcp_core_ref_selection.record_dropped_candidate records every memory
    candidate -- events, entities, segments, summaries, compressions, resource
    chunks, skill sections, and the matching context classes.
    matrixark_mcp_recall_scoring's recorded only a resource/skill candidate or a
    stale entity, which is why the gateway explained almost nothing it dropped.
  * matrixark_mcp_recall_scoring.dropped_candidate_audit_ref emits six fields the
    other does not -- entity_name, entity_type, memory_scope, session_continuity
    and the two profile_shadowed_* -- and misses none of the other's. Without
    them two dropped entities read alike in the audit.

The surviving pair takes the wider rule and the richer record. It lives in
matrixark_mcp_recall_scoring because that module does not import
matrixark_mcp_core and the other does, and because matrixark_mcp_budget_pack
already resolved both names there.

The `reason == "stale"` clause on an entity is kept even though an entity is now
a memory candidate anyway: it was the one case the narrow rule went out of its
way to include, and dropping it would rely on the memory set continuing to
contain "entity".

ONE THING I BROKE AND FIXED IN THE SAME CHANGE. Re-exporting
dropped_candidate_audit_ref into matrixark_mcp_core_ref_selection left that
module's own definition of the name 120 lines above the import -- shadowed, and
therefore exactly the defect I have been removing all session. It is deleted.

The check is behavioural rather than a definition count, because a count cannot
tell a delegate from a divergence, and its corpus is pinned: cross-session
ENTITIES, which are memory candidates and not resource or skill ones. A corpus of
resource and skill candidates agreed under both copies and would have passed all
along.

Mutation-tested both ways: restoring the narrow rule fails with "counts 3 drops
and names 0"; renaming entity_name out of the record fails the field assertion.

The two errors in the budget and pack suites are on main with this change
removed; ref_selection, recall and audit suites are green.
