### PR TITLE
The compress flag states the default it implements

### DIFF
--- a/crates/temporalstore-rust/src/wal_proto.rs
+++ b/crates/temporalstore-rust/src/wal_proto.rs
@@ -73,12 +73,13 @@ const COMPRESSION_LEVEL: i32 = 3;
 /// payload costs more to compress than it gives back. 256 is the floor that measurement chose.
 const COMPRESSION_MIN_BYTES: usize = 256;
 
-/// Whether new records are written compressed. DEFAULT OFF.
+/// Whether new records are written compressed. **DEFAULT ON.**
 ///
 /// Reading never consults this. A payload says what encoding it is in, so a log written across a
 /// change reads end to end and turning it off again is not a one-way door -- the same contract
 /// `TS_WAL_BINARY_RECORDS` keeps.
-/// **Default ON.** It was built off, which meant every deployment paid to store a log it had the
+///
+/// It was built off, which meant every deployment paid to store a log it had the
 /// code to shrink. Compression is applied only where it pays twice over: a payload under
 /// `COMPRESSION_MIN_BYTES` is left alone, and a payload whose compressed form is not actually
 /// smaller is written raw under its own marker.


### PR DESCRIPTION
The doc comment on `compress_records_enabled` says both things:

    /// Whether new records are written compressed. DEFAULT OFF.
    ...
    /// **Default ON.** It was built off, which meant every deployment paid to store a log it had
    /// the code to shrink.

The second paragraph arrived when the default was flipped; the first line stayed. The code returns
true unless the variable spells a refusal, so the default is ON, and the line an operator reads
first says the opposite.

Only the stale line changes. Everything the comment says about WHY -- that reading never consults
the flag, that a payload declares its own encoding, that turning it off is not a one-way door -- is
still true and still there.

Worth knowing alongside this: the serving store's log is 467 MB across 859 pieces and gzips to
42.8 MB, an 11.8x ratio. A log whose records were already compressed would not have that much left
in it, so the engine serving it is not compressing -- its build predates the flip. This is a
documentation fix; taking the 11.8x is a deployment decision and not made here.
