### PR TITLE
The block CRC fields say they are not computed

### DIFF
--- a/crates/temporalstore-rust/src/storage_descriptor.rs
+++ b/crates/temporalstore-rust/src/storage_descriptor.rs
@@ -129,6 +129,16 @@ pub struct SlabHeader {
     pub data_slabs: Vec<SlabInfo>,
     #[prost(uint64, tag = "9")]
     pub start_offset: u64,
+    /// Present in the layout, never computed here. Nothing writes it and nothing reads it.
+    ///
+    /// It exists to chain one block to the one before it, so a block that went missing or arrived
+    /// out of order is caught by the chain rather than by each record separately. This store does
+    /// not do that: a record carries its own CRC32C, which is written and verified on every read,
+    /// and a missing record shows up as a break in the sequence the loader already refuses.
+    ///
+    /// Left in place so the layout stays the shape it is read against. Do not add a check against
+    /// it without computing it first -- it is always zero, so such a check would either pass
+    /// always or fail always, and both look like a working validator.
     #[prost(uint32, tag = "10")]
     pub prev_block_crc32c: u32,
     #[prost(uint64, tag = "11")]
@@ -152,6 +162,10 @@ pub struct BlockFooter {
     pub version: u32,
     #[prost(uint64, tag = "3")]
     pub timestamp_ms: u64,
+    /// Present in the layout, never computed here: the writer passes a literal zero and nothing
+    /// reads it back. Integrity comes from the per-record CRC32C instead, which is verified on
+    /// every read -- see `prev_block_crc32c` for the same note and the same warning about adding
+    /// a check against a field that is always zero.
     #[prost(fixed32, tag = "4")]
     pub block_crc: u32,
     #[prost(uint64, tag = "5")]


### PR DESCRIPTION
`BlockFooter.block_crc` and `SlabHeader.prev_block_crc32c` are part of the layout and neither is
computed here. The footer writer passes a literal zero for the first, and the second is written by
nothing. Read back at zero sites between them.

They belong to a different integrity design: chain each block to the one before it, so a block that
went missing or arrived out of order is caught by the chain rather than by each record on its own.
This store answers that question twice, differently. A record carries its own CRC32C, written into
its frame and verified on every read, and a missing record breaks the sequence, which the loader
already refuses. Six tests cover the record half, including a bit flip that still parses as valid
JSON and one that leaves the value readable but different.

So the fields stay -- the layout is read against a shape, and dropping them changes it -- but they
now say what they are. The warning is the point: they are always zero, so a check added against
either one would pass always or fail always, and both of those look exactly like a validator that
works. Anyone wanting that check has to compute the value first.

No behaviour changes. Two doc comments.
