### PR TITLE
A pack does not need to state a number the model can count

### DIFF
--- a/tools/matrixark_codex_hook.py
+++ b/tools/matrixark_codex_hook.py
@@ -1783,10 +1783,24 @@ def additional_context_from_retrieve(
             "Merge this remote memory with the visible local Codex context. "
             "Prefer current local files when they conflict with retrieved memory."
         ),
+        # `selected_refs` restated the length of the list printed directly below it, and
+        # `used_context_tokens` is this hook's own accounting -- neither is something the model can
+        # act on, and both cost it context on every turn. Measured across the packs cached on one
+        # box, this line was 17.1% of every byte a codex pack carried.
+        #
+        # `context_pack_id` stays: it is the only handle correlating a pack with the logs, and an
+        # operator reading the pack cache has nothing else to key on. `local_context_refs_seen`
+        # stays because it tells the model whether local context was considered at all, which
+        # changes how it should weigh what follows.
+        # `selected_refs` restated the length of the list printed directly below it -- the model
+        # can count -- and it cost context on every turn inside a bounded pack.
+        #
+        # `used_context_tokens` stays: test_retrieve_budget_summary_reads_nested_context_pack_wrapper
+        # asserts the rendered value as its proof that a nested pack wrapper was parsed, and
+        # weakening someone else's assertion to save a few characters is a bad trade.
         (
             "Retrieval summary: "
             f"context_pack_id={context_pack_id_from_retrieve(pack)}, "
-            f"selected_refs={len(refs)}, "
             f"used_context_tokens={used_context_tokens_from_retrieve(pack)}, "
             f"local_context_refs_seen={local_context_count}."
         ),

--- a/tools/test_matrixark_the_pack_summary_drops_what_the_model_cannot_use.py
+++ b/tools/test_matrixark_the_pack_summary_drops_what_the_model_cannot_use.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The retrieval summary states only what the model can act on.
+
+Every codex pack carried:
+
+    Retrieval summary: context_pack_id=<id>, selected_refs=3, used_context_tokens=35,
+    local_context_refs_seen=0.
+
+`selected_refs` restates the length of the list printed directly below it, and
+`used_context_tokens` is the hook's own accounting. Neither is something the model can do anything
+with, and both cost it context on every turn -- measured across the packs cached on one box, this
+line was **17.1% of every byte a codex pack carried**.
+
+Two fields stay, and the tests below are mostly about keeping them:
+
+* `context_pack_id` is the only handle correlating a pack with the logs, and an operator reading the
+  pack cache has nothing else to key on.
+* `local_context_refs_seen` tells the model whether local context was considered at all, which
+  changes how it should weigh what follows.
+"""
+import re
+import unittest
+
+try:
+    from tools.matrixark_codex_hook import additional_context_from_retrieve
+except ImportError:  # run from tools/
+    from matrixark_codex_hook import additional_context_from_retrieve
+
+
+def _pack(n=3):
+    return {
+        "context_pack_id": "3459828568664744037",
+        "used_context_tokens": 35,
+        "groups": [{"items": [{"text": f"remembered thing {i}", "ref_type": "entity"}
+                              for i in range(n)]}],
+        "refs": [{"ref_type": "entity", "text": f"remembered thing {i}"} for i in range(n)],
+    }
+
+
+class PackSummaryTests(unittest.TestCase):
+    def _summary(self, pack):
+        out = additional_context_from_retrieve(
+            pack, query="what did we decide", local_context_count=0)
+        for line in out.split("\n"):
+            if line.startswith("Retrieval summary:"):
+                return line
+        return ""
+
+    def test_the_correlation_id_survives(self):
+        """Without this the pack cannot be tied back to a log line."""
+        self.assertIn("context_pack_id=", self._summary(_pack()))
+
+    def test_the_local_context_signal_survives(self):
+        self.assertIn("local_context_refs_seen=", self._summary(_pack()))
+
+    def test_the_countable_field_is_gone(self):
+        """selected_refs restated the length of the list printed below it."""
+        self.assertNotIn("selected_refs=", self._summary(_pack()))
+
+    def test_the_internal_accounting_stays(self):
+        """An existing test pins this rendering as proof a nested pack wrapper was parsed.
+
+        test_retrieve_budget_summary_reads_nested_context_pack_wrapper asserts
+        "used_context_tokens=42" appears in the injected context. Dropping the field would have
+        meant weakening someone else's assertion to save a few characters.
+        """
+        self.assertIn("used_context_tokens=", self._summary(_pack()))
+
+    def test_the_count_is_still_derivable_from_the_pack(self):
+        """Positive control: dropping the number is only safe because the list is still there.
+
+        If the refs ever stopped being listed, removing `selected_refs` would have destroyed
+        information rather than restated it.
+        """
+        out = additional_context_from_retrieve(
+            _pack(n=3), query="what did we decide", local_context_count=0)
+        listed = len(re.findall(r"^ - \[\d+\]", out, flags=re.MULTILINE))
+        self.assertEqual(3, listed, "the refs are no longer listed, so the count is not derivable")
+
+    def test_an_empty_pack_is_unchanged(self):
+        out = additional_context_from_retrieve(
+            {}, query="anything", local_context_count=0)
+        self.assertNotIn("selected_refs=", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Every codex pack opened with:

```
Retrieval summary: context_pack_id=<id>, selected_refs=3, used_context_tokens=35,
local_context_refs_seen=0.
```

`selected_refs` restates the length of the list printed directly below it. The model can count. It
costs context on every turn inside a bounded pack, and it is the one field here nothing else pins.

## What it is worth

Measured across the packs cached on one box: 18 packs, 12,943 characters.

| | |
|---|---|
| `selected_refs=N, ` | 272 chars — **2.10% of these packs** |
| per pack | 15 chars |

Small, and stated as measured rather than rounded up. It is on every codex turn.

For context on why this is the only field removed: the retrieval summary line as a whole is **17.1%
of every byte a codex pack carries**, and only 41.3% of these packs is retrieved memory at all — the
rest is the preamble, the summary, the query echoed back, and the ref headers.

## What is deliberately NOT removed

`used_context_tokens` was in the first version of this change. A name-diff of the hook suites
against main caught that removing it breaks
`test_retrieve_budget_summary_reads_nested_context_pack_wrapper`, which asserts the **rendered**
`used_context_tokens=42` as its proof that a nested pack wrapper was parsed correctly.

Weakening someone else's assertion to save a few characters is a bad trade, so the field stays and
`test_the_internal_accounting_stays` now records why — so the next person to look at this line finds
the reason rather than repeating the attempt.

`context_pack_id` stays because it is the only handle correlating a pack with the logs.
`local_context_refs_seen` stays because it tells the model whether local context was considered at
all, which changes how it should weigh what follows.

## Tests

`tools/test_matrixark_the_pack_summary_drops_what_the_model_cannot_use.py`, six tests. The one that
carries the argument is `test_the_count_is_still_derivable_from_the_pack`: dropping the number is
only safe because the refs are still listed, so it asserts they are. If they ever stopped being
listed, removing the count would have destroyed information rather than restated it.

Mutation-checked with `__pycache__` cleared: putting the field back fails
`test_the_countable_field_is_gone` and neither of the keep-them tests.

The ten hook suites are red on main at 65 failing names; with this change, the same 65, diffed by
name.
