### PR TITLE
Every setting I added claimed a restart it does not need

### DIFF
--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -50,7 +50,7 @@ Anything else is blank, and a blank means go and look.
 | booleans whose default this could read off the source | 49 |
 | numbers whose default this could read off the source | 70 |
 | **defaulting on, and set by nothing** | 5 |
-| offered on the portal | 27 |
+| offered on the portal | 28 |
 | **that nothing in this repository sets** | 156 |
 | documented as keeping an older path alive | 5 |
 | reaching more than two files | 15 |
@@ -312,7 +312,7 @@ The memory pipeline: what gets extracted, embedded, drained and packed. The surf
 | `MATRIXARK_EMBED_BASE_URL` | — | config, script | 1 | — |
 | `MATRIXARK_EMBED_DRAINER` | off | config, launch, test, portal | 1 | — |
 | `MATRIXARK_EMBED_DRAINER_BATCH` | — | config, portal | 1 | — |
-| `MATRIXARK_HOOK_ADDITIONAL_CONTEXT_CHAR_LIMIT` | 40000 | launch | 1 | — |
+| `MATRIXARK_HOOK_ADDITIONAL_CONTEXT_CHAR_LIMIT` | 40000 | launch, portal | 1 | — |
 | `MATRIXARK_REQUIRE_MODEL_EMBEDDINGS` | off | config, test, portal | 1 | — |
 | `MATRIXARK_REQUIRE_MODEL_SUMMARIES` | off | config, portal | 1 | — |
 | `MATRIXARK_RETRIEVAL_TRAVERSAL_TOP_K` | — | nothing | 1 | — |

--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -1084,18 +1084,18 @@ _apply_build_defaults(SETTINGS)
 #: cloned, so a guessed one would reconfigure the clone.
 SETTINGS.extend([
     Setting("embedding.cache_entries", "embedding", "MATRIXARK_EMBEDDING_CACHE_ENTRIES",
-            "Cache entries", "int", "8192", "restart",
+            "Cache entries", "int", "8192", "live",
             "Cache entries. Defaults to 8192. Frozen when the process starts. Read by "
             "matrixark_mcp_embeddings."),
     Setting("embedding.dims", "embedding", "MATRIXARK_EMBEDDING_DIMS",
-            "Dims", "int", "512", "restart",
+            "Dims", "int", "512", "live",
             "Dims. Defaults to 512. Frozen when the process starts. Read by matrixark_mcp_embeddings."),
     Setting("embedding.require_oss_embeddings", "embedding", "MATRIXARK_REQUIRE_OSS_EMBEDDINGS",
-            "Require oss embeddings", "bool", "0", "restart",
+            "Require oss embeddings", "bool", "0", "live",
             "Require oss embeddings. Off by default. Frozen when the process starts. Read by "
             "matrixark_mcp_core."),
     Setting("embedding.rust_proxy_native_c_api_compat", "embedding", "MATRIXARK_RUST_PROXY_NATIVE_MATRIXARK_C_API_COMPAT",
-            "Rust proxy native c api compat", "bool", "0", "restart",
+            "Rust proxy native c api compat", "bool", "0", "live",
             "Rust proxy native c api compat. Off by default. Frozen when the process starts. Read by "
             "matrixark_mcp_rust_proxy_process, matrixark_mcp_temporal_adapters."),
     Setting("embedding.text_prefix_share", "embedding", "MATRIXARK_EMBEDDING_TEXT_PREFIX_SHARE",
@@ -1133,7 +1133,7 @@ SETTINGS.extend([
             "Allow local backend. Off by default. Frozen when the process starts. Read by "
             "matrixark_codex_hook, matrixark_mcp_runtime_config."),
     Setting("ingestion.idle_drain_min_interval_ms", "ingestion", "MATRIXARK_IDLE_DRAIN_MIN_INTERVAL_MS",
-            "Idle drain min interval ms", "int", "1000", "restart",
+            "Idle drain min interval ms", "int", "1000", "live",
             "Idle drain minimum interval milliseconds. Defaults to 1000. Frozen when the process starts. "
             "Read by matrixark_local_adapter_retrieval."),
     Setting("ingestion.local_binary_vectors", "ingestion", "MATRIXARK_LOCAL_BINARY_VECTORS",
@@ -1169,11 +1169,11 @@ SETTINGS.extend([
             "Pre retrieval summary refresh. Off by default. Frozen when the process starts. Read by "
             "matrixark_mcp_local_adapter, matrixark_mcp_retrieve_pre_refresh."),
     Setting("ingestion.rust_proxy_read_lanes", "ingestion", "MATRIXARK_RUST_PROXY_READ_LANES",
-            "Rust proxy read lanes", "int", "4", "restart",
+            "Rust proxy read lanes", "int", "4", "live",
             "Rust proxy read lanes. Defaults to 4. Frozen when the process starts. Read by "
             "matrixark_mcp_temporal_adapters."),
     Setting("ingestion.rust_proxy_write_lanes", "ingestion", "MATRIXARK_RUST_PROXY_WRITE_LANES",
-            "Rust proxy write lanes", "int", "4", "restart",
+            "Rust proxy write lanes", "int", "4", "live",
             "Rust proxy write lanes. Defaults to 4. Frozen when the process starts. Read by "
             "matrixark_mcp_temporal_adapters."),
     Setting("ingestion.stream_materialize_interval_ms", "ingestion", "MATRIXARK_STREAM_MATERIALIZE_INTERVAL_MS",
@@ -1193,7 +1193,7 @@ SETTINGS.extend([
             "Summary refresh maximum duty. Defaults to 0.2. Frozen when the process starts. Read by "
             "matrixark_mcp_core, matrixark_mcp_runtime_config."),
     Setting("limits.admin_timeout_ms", "limits", "MATRIXARK_ADMIN_TIMEOUT_MS",
-            "Admin timeout ms", "int", "10000", "restart",
+            "Admin timeout ms", "int", "10000", "live",
             "Admin timeout milliseconds. Defaults to 10000. Frozen when the process starts. Read by "
             "matrixark_mcp_server."),
     Setting("limits.backend_readiness_connect_timeout_ms", "limits", "MATRIXARK_BACKEND_READINESS_CONNECT_TIMEOUT_MS",
@@ -1201,7 +1201,7 @@ SETTINGS.extend([
             "Backend readiness connect timeout milliseconds. Defaults to 1000. Frozen when the process "
             "starts. Read by matrixark_mcp_core, matrixark_mcp_runtime_config."),
     Setting("limits.backpressure_fallback_record_limit", "limits", "MATRIXARK_BACKPRESSURE_FALLBACK_RECORD_LIMIT",
-            "Backpressure fallback record limit", "int", "0", "restart",
+            "Backpressure fallback record limit", "int", "0", "live",
             "Backpressure fallback record limit. Defaults to 0. Frozen when the process starts. Read by "
             "matrixark_mcp_server_request_policy."),
     Setting("limits.backpressure_timeout_ms", "limits", "MATRIXARK_BACKPRESSURE_TIMEOUT_MS",
@@ -1221,11 +1221,11 @@ SETTINGS.extend([
             "Direct placement candidate table cache maximum entries. Defaults to 1024. Frozen when the "
             "process starts. Read by matrixark_mcp_core."),
     Setting("limits.direct_raw_ingestion", "limits", "MATRIXARK_DIRECT_RAW_INGESTION",
-            "Direct raw ingestion", "bool", "0", "restart",
+            "Direct raw ingestion", "bool", "0", "live",
             "Direct raw ingestion. Off by default. Frozen when the process starts. Read by "
             "matrixark_mcp_temporal_adapters."),
     Setting("limits.direct_raw_ingestion_queue", "limits", "MATRIXARK_DIRECT_RAW_INGESTION_QUEUE",
-            "Direct raw ingestion queue", "bool", "0", "restart",
+            "Direct raw ingestion queue", "bool", "0", "live",
             "Direct raw ingestion queue. Off by default. Frozen when the process starts. Read by "
             "matrixark_mcp_temporal_adapters, matrixark_temporal_direct_backend."),
     Setting("limits.direct_record_log_shard_size", "limits", "MATRIXARK_DIRECT_RECORD_LOG_SHARD_SIZE",
@@ -1241,19 +1241,19 @@ SETTINGS.extend([
             "Direct write backoff milliseconds. Defaults to 25. Frozen when the process starts. Read by "
             "matrixark_mcp_core, matrixark_mcp_runtime_config."),
     Setting("limits.direct_write_queue", "limits", "MATRIXARK_DIRECT_WRITE_QUEUE",
-            "Direct write queue", "bool", "0", "restart",
+            "Direct write queue", "bool", "0", "live",
             "Direct write queue. Off by default. Frozen when the process starts. Read by "
             "matrixark_mcp_temporal_adapters, matrixark_temporal_direct_backend."),
     Setting("limits.direct_write_queue_drain_max_batches", "limits", "MATRIXARK_DIRECT_WRITE_QUEUE_DRAIN_MAX_BATCHES",
-            "Direct write queue drain max batches", "int", "64", "restart",
+            "Direct write queue drain max batches", "int", "64", "live",
             "Direct write queue drain maximum batches. Defaults to 64. Frozen when the process starts. "
             "Read by matrixark_mcp_temporal_adapters, matrixark_temporal_direct_backend."),
     Setting("limits.direct_write_queue_max_records", "limits", "MATRIXARK_DIRECT_WRITE_QUEUE_MAX_RECORDS",
-            "Direct write queue max records", "int", "10000", "restart",
+            "Direct write queue max records", "int", "10000", "live",
             "Direct write queue maximum records. Defaults to 10000. Frozen when the process starts. Read "
             "by matrixark_mcp_temporal_adapters, matrixark_temporal_direct_backend."),
     Setting("limits.direct_write_queue_put_timeout_ms", "limits", "MATRIXARK_DIRECT_WRITE_QUEUE_PUT_TIMEOUT_MS",
-            "Direct write queue put timeout ms", "int", "1000", "restart",
+            "Direct write queue put timeout ms", "int", "1000", "live",
             "Direct write queue put timeout milliseconds. Defaults to 1000. Frozen when the process "
             "starts. Read by matrixark_mcp_temporal_adapters, matrixark_temporal_direct_backend."),
     Setting("limits.direct_write_retries", "limits", "MATRIXARK_DIRECT_WRITE_RETRIES",
@@ -1265,11 +1265,11 @@ SETTINGS.extend([
             "Direct write throttle milliseconds. Defaults to 0. Frozen when the process starts. Read by "
             "matrixark_mcp_core, matrixark_mcp_runtime_config."),
     Setting("limits.feedback_timeout_ms", "limits", "MATRIXARK_FEEDBACK_TIMEOUT_MS",
-            "Feedback timeout ms", "int", "15000", "restart",
+            "Feedback timeout ms", "int", "15000", "live",
             "Feedback timeout milliseconds. Defaults to 15000. Frozen when the process starts. Read by "
             "matrixark_mcp_server."),
     Setting("limits.ingest_timeout_ms", "limits", "MATRIXARK_INGEST_TIMEOUT_MS",
-            "Ingest timeout ms", "int", "30000", "restart",
+            "Ingest timeout ms", "int", "30000", "live",
             "Ingest timeout milliseconds. Defaults to 30000. Frozen when the process starts. Read by "
             "matrixark_mcp_server."),
     Setting("limits.intern_backend_metadata", "limits", "MATRIXARK_INTERN_BACKEND_METADATA",
@@ -1277,11 +1277,11 @@ SETTINGS.extend([
             "Intern backend metadata. Off by default. Frozen when the process starts. Read by "
             "matrixark_mcp_temporal_append."),
     Setting("limits.max_concurrent_ingest", "limits", "MATRIXARK_MAX_CONCURRENT_INGEST",
-            "Max concurrent ingest", "int", "32", "restart",
+            "Max concurrent ingest", "int", "32", "live",
             "Maximum concurrent ingest. Defaults to 32. Frozen when the process starts. Read by "
             "matrixark_mcp_server."),
     Setting("limits.replay_timeout_ms", "limits", "MATRIXARK_REPLAY_TIMEOUT_MS",
-            "Replay timeout ms", "int", "10000", "restart",
+            "Replay timeout ms", "int", "10000", "live",
             "Replay timeout milliseconds. Defaults to 10000. Frozen when the process starts. Read by "
             "matrixark_mcp_server."),
     Setting("limits.resource_ocr_timeout_s", "limits", "MATRIXARK_RESOURCE_OCR_TIMEOUT_S",
@@ -1293,7 +1293,7 @@ SETTINGS.extend([
             "Retrieve shed cooldown milliseconds. Defaults to 0. Frozen when the process starts. Read by "
             "matrixark_mcp_server."),
     Setting("limits.rust_proxy_startup_warmup_timeout_ms", "limits", "MATRIXARK_RUST_PROXY_STARTUP_WARMUP_TIMEOUT_MS",
-            "Rust proxy startup warmup timeout ms", "int", "120000", "restart",
+            "Rust proxy startup warmup timeout ms", "int", "120000", "live",
             "Rust proxy startup warmup timeout milliseconds. Defaults to 120000. Frozen when the process "
             "starts. Read by matrixark_rust_proxy_daemon."),
     Setting("retrieval.allow_python_retrieval_fallback", "retrieval", "MATRIXARK_ALLOW_PYTHON_RETRIEVAL_FALLBACK",
@@ -1320,15 +1320,15 @@ SETTINGS.extend([
             "Context debug records. Off by default. Frozen when the process starts. Read by "
             "matrixark_mcp_runtime_config, matrixark_mcp_serving_records."),
     Setting("retrieval.context_event_time_index_full_payload", "retrieval", "MATRIXARK_CONTEXT_EVENT_TIME_INDEX_FULL_PAYLOAD",
-            "Context event time index full payload", "bool", "0", "restart",
+            "Context event time index full payload", "bool", "0", "live",
             "Context event time index full payload. Off by default. Frozen when the process starts. Read "
             "by matrixark_mcp_event_keys, matrixark_temporal_direct_backend."),
     Setting("retrieval.context_pack_cache_max_entries", "retrieval", "MATRIXARK_CONTEXT_PACK_CACHE_MAX_ENTRIES",
-            "Context pack cache max entries", "int", "256", "restart",
+            "Context pack cache max entries", "int", "256", "live",
             "Context pack cache maximum entries. Defaults to 256. Frozen when the process starts. Read by "
             "matrixark_mcp_local_adapter, matrixark_mcp_temporal_adapters."),
     Setting("retrieval.context_pack_cache_ttl_s", "retrieval", "MATRIXARK_CONTEXT_PACK_CACHE_TTL_S",
-            "Context pack cache ttl s", "float", "30.0", "restart",
+            "Context pack cache ttl s", "float", "30.0", "live",
             "Context pack cache time to live seconds. Defaults to 30.0. Frozen when the process starts. "
             "Read by matrixark_mcp_local_adapter, matrixark_mcp_temporal_adapters."),
     Setting("retrieval.context_pack_debug_refs", "retrieval", "MATRIXARK_CONTEXT_PACK_DEBUG_REFS",
@@ -1364,11 +1364,11 @@ SETTINGS.extend([
             "Cross session raw evidence minimum score. Defaults to 0.45. Frozen when the process starts. "
             "Read by matrixark_mcp_core, matrixark_mcp_runtime_config."),
     Setting("retrieval.direct_write_queue_allow_sync_context", "retrieval", "MATRIXARK_DIRECT_WRITE_QUEUE_ALLOW_SYNC_CONTEXT",
-            "Direct write queue allow sync context", "bool", "0", "restart",
+            "Direct write queue allow sync context", "bool", "0", "live",
             "Direct write queue allow sync context. Off by default. Frozen when the process starts. Read "
             "by matrixark_mcp_temporal_adapters, matrixark_temporal_direct_backend."),
     Setting("retrieval.disable_native_context_pack", "retrieval", "MATRIXARK_DISABLE_NATIVE_CONTEXT_PACK",
-            "Disable native context pack", "bool", "0", "restart",
+            "Disable native context pack", "bool", "0", "live",
             "Disable native context pack. Off by default. Frozen when the process starts. Read by "
             "matrixark_temporal_direct_read."),
     Setting("retrieval.hard_max_children_scored_per_parent", "retrieval", "MATRIXARK_HARD_MAX_CHILDREN_SCORED_PER_PARENT",
@@ -1376,14 +1376,14 @@ SETTINGS.extend([
             "Hard maximum children scored per parent. Defaults to 100000. Frozen when the process starts. "
             "Read by matrixark_mcp_core, matrixark_mcp_runtime_config."),
     Setting("retrieval.hook_additional_context_char_limit", "retrieval", "MATRIXARK_HOOK_ADDITIONAL_CONTEXT_CHAR_LIMIT",
-            "Hook additional context char limit", "int", "40000", "restart",
+            "Hook additional context char limit", "int", "40000", "live",
             "Hook additional context char limit. Defaults to 40000. Frozen when the process starts. Read "
             "by matrixark_codex_hook."),
     Setting("retrieval.hook_fail_open", "retrieval", "MATRIXARK_HOOK_FAIL_OPEN",
-            "Hook fail open", "bool", "1", "restart",
+            "Hook fail open", "bool", "1", "live",
             "Hook fail open. On by default. Frozen when the process starts. Read by matrixark_codex_hook."),
     Setting("retrieval.memory_purge_threshold", "retrieval", "MATRIXARK_MEMORY_PURGE_THRESHOLD",
-            "Memory purge threshold", "int", "0", "restart",
+            "Memory purge threshold", "int", "0", "live",
             "Memory purge threshold. Defaults to 0. Frozen when the process starts. Read by "
             "matrixark_mcp_local_adapter."),
     Setting("retrieval.pack_precision_expand_max_events", "retrieval", "MATRIXARK_PACK_PRECISION_EXPAND_MAX_EVENTS",
@@ -1411,31 +1411,31 @@ SETTINGS.extend([
             "Resource overlap tokens. Defaults to 24. Frozen when the process starts. Read by "
             "matrixark_resource_parser."),
     Setting("retrieval.rust_proxy_dedicated_pack_lanes", "retrieval", "MATRIXARK_RUST_PROXY_DEDICATED_PACK_LANES",
-            "Rust proxy dedicated pack lanes", "bool", "0", "restart",
+            "Rust proxy dedicated pack lanes", "bool", "0", "live",
             "Rust proxy dedicated pack lanes. Off by default. Frozen when the process starts. Read by "
             "matrixark_mcp_temporal_adapters."),
     Setting("retrieval.rust_proxy_pack_lanes", "retrieval", "MATRIXARK_RUST_PROXY_PACK_LANES",
-            "Rust proxy pack lanes", "int", "8", "restart",
+            "Rust proxy pack lanes", "int", "8", "live",
             "Rust proxy pack lanes. Defaults to 8. Frozen when the process starts. Read by "
             "matrixark_mcp_temporal_adapters."),
     Setting("retrieval.segment_max_new_tokens", "retrieval", "MATRIXARK_SEGMENT_MAX_NEW_TOKENS",
-            "Segment max new tokens", "int", "512", "restart",
+            "Segment max new tokens", "int", "512", "live",
             "Segment maximum new tokens. Defaults to 512. Frozen when the process starts. Read by "
             "matrixark_mcp_core."),
     Setting("retrieval.session_commit_threshold", "retrieval", "MATRIXARK_SESSION_COMMIT_THRESHOLD",
-            "Session commit threshold", "int", "20", "restart",
+            "Session commit threshold", "int", "20", "live",
             "Session commit threshold. Defaults to 20. Frozen when the process starts. Read by "
             "matrixark_agent_hook, matrixark_codex_hook."),
     Setting("retrieval.summary_refresh_pass_budget_ms", "retrieval", "MATRIXARK_SUMMARY_REFRESH_PASS_BUDGET_MS",
-            "Summary refresh pass budget ms", "int", "30000", "restart",
+            "Summary refresh pass budget ms", "int", "30000", "live",
             "Summary refresh pass budget milliseconds. Defaults to 30000. Frozen when the process starts. "
             "Read by matrixark_local_adapter_summaries."),
     Setting("retrieval.temporalstore_async_context_warmup", "retrieval", "MATRIXARK_TEMPORALSTORE_ASYNC_CONTEXT_WARMUP",
-            "Temporalstore async context warmup", "bool", "1", "restart",
+            "Temporalstore async context warmup", "bool", "1", "live",
             "Temporalstore async context warmup. On by default. Frozen when the process starts. Read by "
             "matrixark_mcp_temporal_adapters."),
     Setting("retrieval.temporalstore_async_context_warmup_force", "retrieval", "MATRIXARK_TEMPORALSTORE_ASYNC_CONTEXT_WARMUP_FORCE",
-            "Temporalstore async context warmup force", "bool", "0", "restart",
+            "Temporalstore async context warmup force", "bool", "0", "live",
             "Temporalstore async context warmup force. Off by default. Frozen when the process starts. "
             "Read by matrixark_temporal_direct_write."),
     Setting("skills.dedupe_skill_chunk_embedding", "skills", "MATRIXARK_DEDUPE_SKILL_CHUNK_EMBEDDING",
@@ -1479,11 +1479,11 @@ SETTINGS.extend([
             "Resource event text chars. Defaults to 4096. Frozen when the process starts. Read by "
             "matrixark_mcp_core_resource_io."),
     Setting("skills.resource_import_queue_max", "skills", "MATRIXARK_RESOURCE_IMPORT_QUEUE_MAX",
-            "Resource import queue max", "int", "64", "restart",
+            "Resource import queue max", "int", "64", "live",
             "Resource import queue maximum. Defaults to 64. Frozen when the process starts. Read by "
             "matrixark_mcp_local_adapter."),
     Setting("skills.resource_import_workers", "skills", "MATRIXARK_RESOURCE_IMPORT_WORKERS",
-            "Resource import workers", "int", "2", "restart",
+            "Resource import workers", "int", "2", "live",
             "Resource import workers. Defaults to 2. Frozen when the process starts. Read by "
             "matrixark_mcp_local_adapter."),
     Setting("skills.resource_json_records_per_chunk", "skills", "MATRIXARK_RESOURCE_JSON_RECORDS_PER_CHUNK",
@@ -1519,11 +1519,11 @@ SETTINGS.extend([
             "Resource table rows per chunk. Defaults to 20. Frozen when the process starts. Read by "
             "matrixark_resource_parser."),
     Setting("skills.rust_proxy_shared_process", "skills", "MATRIXARK_RUST_PROXY_SHARED_PROCESS",
-            "Rust proxy shared process", "bool", "1", "restart",
+            "Rust proxy shared process", "bool", "1", "live",
             "Rust proxy shared process. On by default. Frozen when the process starts. Read by "
             "matrixark_mcp_temporal_adapters."),
     Setting("skills.rust_proxy_startup_warmup_max_selected_refs", "skills", "MATRIXARK_RUST_PROXY_STARTUP_WARMUP_MAX_SELECTED_REFS",
-            "Rust proxy startup warmup max selected refs", "int", "1", "restart",
+            "Rust proxy startup warmup max selected refs", "int", "1", "live",
             "Rust proxy startup warmup maximum selected refs. Defaults to 1. Frozen when the process "
             "starts. Read by matrixark_rust_proxy_daemon."),
     Setting("skills.skill_discovery_max_skills", "skills", "MATRIXARK_SKILL_DISCOVERY_MAX_SKILLS",
@@ -1563,11 +1563,11 @@ SETTINGS.extend([
             "Maximum secondary index terms per record. Defaults to 10. Frozen when the process starts. "
             "Read by matrixark_mcp_core, matrixark_mcp_indexing."),
     Setting("storage_engine.native_side_index_assume_fresh", "storage_engine", "MATRIXARK_NATIVE_SIDE_INDEX_ASSUME_FRESH",
-            "Native side index assume fresh", "bool", "0", "restart",
+            "Native side index assume fresh", "bool", "0", "live",
             "Native side index assume fresh. Off by default. Frozen when the process starts. Read by "
             "matrixark_mcp_temporal_adapters, matrixark_temporal_direct_backend."),
     Setting("storage_engine.rust_proxy_startup_warmup_full_scan", "storage_engine", "MATRIXARK_RUST_PROXY_STARTUP_WARMUP_FULL_SCAN",
-            "Rust proxy startup warmup full scan", "bool", "1", "restart",
+            "Rust proxy startup warmup full scan", "bool", "1", "live",
             "Rust proxy startup warmup full scan. On by default. Frozen when the process starts. Read by "
             "matrixark_rust_proxy_daemon."),
     Setting("storage_engine.secondary_index_posting_bucket_ms", "storage_engine", "MATRIXARK_SECONDARY_INDEX_POSTING_BUCKET_MS",


### PR DESCRIPTION
Every setting I added claimed a restart it does not need

mx#1130 landed with all 126 new settings labelled `restart`, and main is red on
test_no_setting_claims_a_restart_it_does_not_need. That check named 41 of them:
"labelled restart but every reader is per-call". It is my defect and it merged
while its own ratchet was still running.

The rule was right and the detection was wrong. `applies` should be `restart`
where the value is frozen at import and `live` where it is re-read per call, and
I collected the module-level reads by walking every node in `tree.body` and
taking the Calls beneath them -- which descends INTO every top-level function, so
every per-call read came out as module level.

The label is not cosmetic. It tells an operator whether a change takes effect now
or needs a restart, and claiming a restart that is not needed means a running
deployment is bounced for nothing.

The correction does not reimplement the classification. The guard's own scan is
broader than "module level": it counts a read as import-time when the value is
CAPTURED, including one inside `__init__` that is stored on the instance --
matrixark_mcp_server does exactly that for the backpressure timeout, which my
first correction then mislabelled `live` in the other direction. So the label is
now taken FROM that scan. A second implementation of the same classification
would drift from it, which is the thing this session has spent its time removing.

41 settings move to `live`. One has no read site that scan can see and is left as
written rather than guessed at.

Also regenerated docs/ops/temporalstore-engine-flags.md, which records which
flags the portal offers: adding twelve TS_* settings changed that count from 27
to 28 and left the document stale, failing
test_every_offered_engine_flag_is_marked_portal and
test_regenerating_produces_the_same_document.

WHAT I SHOULD HAVE DONE. I ran a portal guard set before opening mx#1130 and it
passed, but I selected it by grepping test names for "setting|portal|config" and
these three do not match that pattern -- the two that matter live in
test_matrixark_gateway_config_audit and test_matrixark_engine_flag_inventory. A
hand-picked subset of a suite is not the suite.

All three are green now, with the 69 tests across the five portal guards that
touch these settings.
