### PR TITLE
The portal says what writes the summaries

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -2653,6 +2653,40 @@ _OSS_EMBEDDING_PROVIDERS = {"oss", "open_source", "sentence_transformers", "sent
 _DELIBERATE_FALLBACK_PROVIDERS = {"", "deterministic", "rules", "local", "hash"}
 
 
+#: The names `summary_provider()` maps onto the openai-compatible path, and the names it treats as
+#: that path directly. Sets rather than a condition written inline, so the mirror test can compare
+#: them with the writer's own literals instead of restating them.
+_SUMMARY_OSS_ALIASES = {"oss", "open_source", "local_llm", "oss_llm"}
+_SUMMARY_MODEL_PROVIDERS = {"openai", "openai_compatible", "openai_compatible_llm"}
+
+
+def summary_provider_effect(provider: Optional[str], extraction_provider: str = "") -> str:
+    """What the SUMMARY path does with this name: "model" or "rules".
+
+    Mirrors `summary_provider()` in matrixark_mcp_summaries and must keep mirroring it -- the two
+    answer the same question about the same setting, and a screen that disagrees with the writer is
+    worse than one that says nothing.
+
+    ABSENT and EMPTY are different, and the difference is not cosmetic. The writer reads
+    `os.environ.get(NAME, <the extraction chain>)`, so a variable that is not set falls through to
+    the extraction provider, and one that is set to an empty string returns that empty string and
+    lands on the rule-written path. `None` here means not set; `""` means set to nothing. Treating
+    both as "follow extraction" reported a model on a deployment writing its summaries with rules,
+    which is this file's own defect in miniature -- the mirror test caught it.
+
+    Only the openai-compatible family calls a model: `anthropic` returns rule-written summaries and
+    no error, so a deployment doing Anthropic extraction gets deterministic summaries unless it
+    names a provider here. That is in the setting's own help and was reported on no screen.
+    """
+    if provider is None:
+        name = (extraction_provider or "").strip().lower().replace("-", "_")
+    else:
+        name = provider.strip().lower().replace("-", "_")
+    if name in _SUMMARY_OSS_ALIASES:
+        return "model"
+    return "model" if name in _SUMMARY_MODEL_PROVIDERS else "rules"
+
+
 def embedding_provider_effect(provider: str) -> str:
     """What the ENCODER does with this name: "api", "local_model" or "hash".
 

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1982,10 +1982,44 @@ def _model_config_snapshot() -> Json:
             "Extraction key variable or Embedding key variable, then set that key again."
         )
 
+    # ---- summaries -----------------------------------------------------------------------
+    # Blank follows the extraction provider, so both are needed to say what actually writes them.
+    # os.environ.get, not _env: `None` (not set) follows the extraction provider and `""` (set to
+    # nothing) does not, exactly as the writer reads it. _env flattens the two into "".
+    _summary_raw = os.environ.get("MATRIXARK_SUMMARY_PROVIDER")
+    _summary_choice = (_summary_raw or "").strip()
+    _extraction_choice = (_env("MATRIXARK_UNDERSTANDING_PROVIDER")
+                          or _env("MATRIXARK_EXTRACTION_PROVIDER"))
+    _summary_writes = _gwconfig.summary_provider_effect(_summary_raw, _extraction_choice)
+    summary = {
+        "provider": _summary_choice,
+        # Only when the variable is absent. Set-to-empty is a choice of rules, not a deferral.
+        "follows_extraction": _summary_raw is None,
+        "writes": _summary_writes,
+        # The summary call uses the EXTRACTION endpoint and its model: a separate summary model
+        # was removed because it was a second name for the same call.
+        "model": extraction.get("model", "") if _summary_writes == "model" else "",
+    }
+    # Rules where extraction reaches a model is the surprising half. Rules everywhere is already
+    # said by the extraction warning above, and repeating it here would be noise.
+    if _summary_writes == "rules" and _gwconfig.extraction_provider_effect(
+            _extraction_choice) != "rules":
+        warnings.append(
+            "Summaries are written by rules, not by a model, while extraction calls one. Every "
+            "context node gets a summary and retrieval walks them, so this is the model called "
+            "most. Only the openai-compatible family writes them with a model -- an Anthropic "
+            "extraction provider returns rule-written summaries and no error. Set Summary "
+            "provider to openai_compatible to use a model for them."
+        )
+
     return {
         "status": "ok",
         "extraction": extraction,
         "embedding": embedding,
+        # The third model role, and the one called most: extraction runs once per ingest, and every
+        # context node gets a summary. It had no block here at all, so a deployment writing its
+        # summaries with rules looked exactly like one writing them with a model.
+        "summary": summary,
         "skills": skills,
         "warnings": warnings,
         "encoders": encoder_catalog(),

--- a/tools/test_matrixark_the_portal_says_what_writes_the_summaries.py
+++ b/tools/test_matrixark_the_portal_says_what_writes_the_summaries.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The third model role is reported: the one that writes the summaries retrieval walks.
+
+A deployment runs three model roles. The model status surface carried two. Extraction runs once per
+ingest; **every context node gets a summary**, so the summary path is the model called most, and it
+had no block at all -- a deployment writing its summaries with rules looked exactly like one
+writing them with a model.
+
+It is not a hypothetical configuration. ``summary.provider``'s own help says it:
+
+    openai_compatible is the only value that calls a model: anthropic returns rule-written
+    summaries and no error, so a deployment on anthropic extraction gets deterministic summaries
+    unless it names openai_compatible here.
+
+Documented, and reported on no screen. The snapshot's own docstring says ``warnings`` exists for
+exactly this: *the silent-degradation cases … indistinguishable from a healthy system at the API
+surface.*
+
+**The classifier mirrors the writer.** ``summary_provider_effect`` answers the same question as
+``summary_provider()`` in matrixark_mcp_summaries, and a screen that disagrees with the writer is
+worse than one that says nothing -- so the mirror is asserted here against the writer's own
+literals rather than against a copy of them.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+import matrixark_gateway_config as cfg  # noqa: E402
+import matrixark_v1_gateway as gw  # noqa: E402
+
+
+def snapshot(extraction: str, summary) -> dict:
+    """The snapshot a deployment with these two providers would show.
+
+    `summary=None` means the variable is NOT SET, which follows the extraction provider;
+    `summary=""` means it is set to nothing, which does not. The writer reads
+    `os.environ.get(NAME, <chain>)`, so the two differ, and a helper that flattened them would
+    test something no deployment has.
+
+    A subprocess because the summariser binds its provider chain into module constants at import,
+    and this must be read the way a gateway reads it rather than after mutating a live process.
+    """
+    script = (
+        "import json, matrixark_v1_gateway as gw;"
+        "print(json.dumps(gw._model_config_snapshot()))"
+    )
+    environ = dict(os.environ)
+    environ["MATRIXARK_UNDERSTANDING_PROVIDER"] = extraction
+    if summary is None:
+        environ.pop("MATRIXARK_SUMMARY_PROVIDER", None)
+    else:
+        environ["MATRIXARK_SUMMARY_PROVIDER"] = summary
+    environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = "/nonexistent/matrixark-summary-test.json"
+    out = subprocess.run([sys.executable, "-c", script], cwd=TOOLS, env=environ,
+                         capture_output=True, text=True, timeout=300)
+    if out.returncode != 0:
+        raise AssertionError(out.stderr[-600:])
+    import json
+    return json.loads(out.stdout)
+
+
+def warned(snap: dict) -> bool:
+    return any("Summaries are written by rules" in w for w in snap.get("warnings", []))
+
+
+class TheClassifierMirrorsTheWriterTest(unittest.TestCase):
+    """`summary_provider_effect` and `summary_provider()` decide the same question."""
+
+    NAMES = ("", "deterministic", "openai_compatible", "anthropic", "oss", "open_source",
+             "local_llm", "oss_llm", "local", "rules", "openai", "nonsense")
+
+    @staticmethod
+    def _writer(provider: str, extraction: str) -> str:
+        script = (
+            "import matrixark_mcp_summaries as sm;"
+            "p = sm.summary_provider();"
+            "print('model' if p in {'openai', 'openai_compatible', 'openai_compatible_llm'} "
+            "else 'rules')"
+        )
+        environ = dict(os.environ)
+        environ["MATRIXARK_SUMMARY_PROVIDER"] = provider
+        environ["MATRIXARK_UNDERSTANDING_PROVIDER"] = extraction
+        environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = "/nonexistent/matrixark-summary-test.json"
+        out = subprocess.run([sys.executable, "-c", script], cwd=TOOLS, env=environ,
+                             capture_output=True, text=True, timeout=300)
+        if out.returncode != 0:
+            raise AssertionError(out.stderr[-600:])
+        return out.stdout.strip()
+
+    def test_every_name_gets_the_same_answer_from_both(self) -> None:
+        for extraction in ("openai_compatible", "anthropic", "deterministic"):
+            for name in self.NAMES:
+                with self.subTest(summary=name, extraction=extraction):
+                    self.assertEqual(self._writer(name, extraction),
+                                     cfg.summary_provider_effect(name, extraction),
+                                     "the screen would disagree with the writer")
+
+    def test_the_comparison_sees_both_answers(self) -> None:
+        """The floor: if every name gave "rules" the loop above would pass on a constant."""
+        answers = {cfg.summary_provider_effect(n, "deterministic") for n in self.NAMES}
+        self.assertEqual({"model", "rules"}, answers, answers)
+
+
+class TheSummaryBlockIsReportedTest(unittest.TestCase):
+
+    def test_it_is_there_at_all(self) -> None:
+        block = snapshot("openai_compatible", None)["summary"]
+        self.assertEqual({"provider", "follows_extraction", "writes", "model"}, set(block))
+
+    def test_an_unset_provider_follows_extraction(self) -> None:
+        block = snapshot("openai_compatible", None)["summary"]
+        self.assertTrue(block["follows_extraction"])
+        self.assertEqual("model", block["writes"])
+
+    def test_but_set_to_nothing_does_not_follow_it(self) -> None:
+        """The distinction the writer makes and this file first missed. `os.environ.get(NAME,
+        chain)` falls through only when the name is absent; set to an empty string it returns
+        that, and the summary path lands on rules."""
+        block = snapshot("openai_compatible", "")["summary"]
+        self.assertFalse(block["follows_extraction"])
+        self.assertEqual("rules", block["writes"])
+
+    def test_anthropic_extraction_writes_summaries_with_rules(self) -> None:
+        """The case the help documents and nothing reported."""
+        snap = snapshot("anthropic", None)
+        self.assertEqual("rules", snap["summary"]["writes"])
+        self.assertTrue(warned(snap), "the surprising case is still unreported")
+
+    def test_naming_a_provider_fixes_it(self) -> None:
+        """The remedy the warning offers has to work, or it is worse than silence."""
+        snap = snapshot("anthropic", "openai_compatible")
+        self.assertEqual("model", snap["summary"]["writes"])
+        self.assertFalse(warned(snap))
+
+    def test_the_model_is_named_only_when_one_is_called(self) -> None:
+        self.assertEqual("", snapshot("anthropic", None)["summary"]["model"])
+        self.assertTrue(snapshot("openai_compatible", "oss")["summary"]["writes"] == "model")
+
+
+class TheWarningIsNotNoiseTest(unittest.TestCase):
+    """A warning on every deployment is a warning nobody reads."""
+
+    def test_rules_everywhere_is_not_warned_about_twice(self) -> None:
+        snap = snapshot("deterministic", None)
+        self.assertEqual("rules", snap["summary"]["writes"])
+        self.assertFalse(warned(snap),
+                         "extraction already says this deployment calls no model; saying it "
+                         "again about summaries is noise")
+
+    def test_but_the_extraction_warning_is_still_there(self) -> None:
+        """The floor for the test above: it must be silent because the other warning covers it,
+        not because nothing warns at all."""
+        snap = snapshot("deterministic", None)
+        self.assertTrue(any("deterministic" in w.lower() for w in snap["warnings"]),
+                        snap["warnings"])
+
+    def test_a_deliberate_opt_out_is_still_reported(self) -> None:
+        """Choosing rules while extraction calls a model is a choice, and still worth stating:
+        the summary is what retrieval walks."""
+        snap = snapshot("openai_compatible", "deterministic")
+        self.assertTrue(warned(snap))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A deployment runs **three** model roles. The model status surface carried two.

Extraction runs once per ingest. **Every context node gets a summary**, and retrieval walks those
summaries — so the summary path is the model called most, and it had no block at all. A deployment
writing its summaries with rules looked exactly like one writing them with a model.

It is not a hypothetical configuration. `summary.provider`'s own help says it:

> openai_compatible is the only value that calls a model: **anthropic returns rule-written summaries
> and no error**, so a deployment on anthropic extraction gets deterministic summaries unless it
> names openai_compatible here.

Documented, and reported on no screen. The snapshot's own docstring says `warnings` exists for
exactly this — *the silent-degradation cases … indistinguishable from a healthy system at the API
surface.*

### What it says now

```
extraction=openai_compatible  summary=(unset)            writes=model  warned=no
extraction=anthropic          summary=(unset)            writes=rules  warned=YES
extraction=anthropic          summary=openai_compatible  writes=model  warned=no
extraction=deterministic      summary=(unset)            writes=rules  warned=no
extraction=openai_compatible  summary=deterministic      writes=rules  warned=YES
```

Rules **everywhere** is not warned about twice — the extraction warning already says that
deployment calls no model, and repeating it would be noise. A test asserts the silence is for that
reason and not because nothing warns at all.

### The classifier mirrors the writer, and the mirror earned its keep

`summary_provider_effect` answers the same question as `summary_provider()` in
`matrixark_mcp_summaries`. A screen that disagrees with the writer is worse than one that says
nothing, so the mirror is asserted against the writer's own answers across twelve provider names and
three extraction providers.

**It caught a bug in my first version.** The writer reads
`os.environ.get(NAME, <the extraction chain>)`, so a variable that is **not set** falls through to
extraction, while one **set to an empty string** returns that and lands on rules. I treated both as
"follow extraction" — which would have reported *model* on a deployment writing its summaries with
rules. That is this PR's own defect in miniature.

`None` now means not set and `""` means set to nothing, in the classifier, in the gateway (which
passes `os.environ.get` through rather than flattening it with `_env`), and in the test helper —
which had the same flaw and hid the case until it was fixed too.

```
the summary block is dropped                -> FAIL
the warning is never raised                 -> FAIL
it warns whatever extraction does           -> FAIL
absent and empty are flattened again        -> FAIL
the classifier stops following extraction   -> FAIL
the oss aliases stop reaching a model       -> FAIL
anthropic is treated as calling a model     -> FAIL
```
