### PR TITLE
The proxy benchmarks never checked that they measured a success

### DIFF
--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -2566,6 +2566,13 @@ mod tests {
                 .collect(),
         );
 
+        // Admission has to ADMIT, or this times the refusal path and reports it as the cost of
+        // being served. A drained proxy, a zero quota or a write-disable would each do that
+        // silently -- the loop below discards the result. Checked once, outside the timing.
+        assert!(
+            proxy.admit(None, &commands).is_ok(),
+            "admission refused before the benchmark started, so this would time the refusal"
+        );
         let gate = std::sync::Arc::new(std::sync::Barrier::new(threads + 1));
         let mut handles = Vec::new();
         for _ in 0..threads {
@@ -3017,6 +3024,11 @@ mod tests {
             "the route cache must be warm or this measures the miss path"
         );
 
+        // The route has to RESOLVE, or this times a cache miss and reports it as a hit.
+        assert!(
+            proxy.client().shard_primary_addr(1, false).is_ok(),
+            "no cached route before the benchmark started, so this would time the miss"
+        );
         let gate = std::sync::Arc::new(std::sync::Barrier::new(threads + 1));
         let mut handles = Vec::new();
         for _ in 0..threads {
@@ -3403,6 +3415,14 @@ mod tests {
             .unwrap_or(50_000);
 
         let proxy = std::sync::Arc::new(scoped_proxy(ProxyOptions::default()));
+        // Admission has to ADMIT, or this times the refusal path. A drained proxy or a zero
+        // quota would do that silently -- the loop discards the result.
+        assert!(
+            proxy
+                .admit_context(&context_scope("acct", "tenant"), true)
+                .is_ok(),
+            "context admission refused before the benchmark started"
+        );
         let gate = std::sync::Arc::new(std::sync::Barrier::new(threads + 1));
         let mut handles = Vec::new();
         for _ in 0..threads {


### PR DESCRIPTION
Three measurements in this file turned out to be timing or counting something other than what they were quoted as: the execute row measured a **400** because its body never parsed (#1007), the backend-answering rows counted the **backend's own** allocations (#1066), and the quiet-backend row **never reached the network** (#1089).

The eight `bench_proxy_*` benchmarks have the same shape, and none of them checked either. Each discards the result it measures:

```rust
let admitted = proxy.admit(None, &commands);
std::hint::black_box(&admitted);
```

A drained proxy, a zero quota, a write-disable or an empty route cache would each turn these into a measurement of the **refusal** path — faster than the real one, and reported as the cost of being served.

That is not hypothetical here. `bench_proxy_admission_path` is cited a few lines away to justify leaving the batch walked twice ("measured, interleaved, on two separately built binaries"). That argument rests entirely on the benchmark having measured admissions.

## Where the check goes

**Before the timing, not inside it**, so the measurement itself is unchanged: one admit, one route lookup, one context admit, asserted before the threads start. The conditions do not change during the loop, so one check covers it.

`bench_proxy_shard_id_for_key` needs none — `shard_id_for_key` cannot fail.

## Verified to discriminate

Setting `drop_percent: 100` on the admission benchmark fails it with:

```
admission refused before the benchmark started, so this would time the refusal
```

All 8 benchmarks pass, and the proxy suite passes at 94.
