### PR TITLE
The policy screen says which overrides this build never reads

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -3095,6 +3095,11 @@ def _policy_view(policy_mod: Any, tenant_id: str, user_id: str) -> Json:
             "default": knob.default,
             "choices": sorted(knob.choices) if knob.choices else [],
             "description": knob.description,
+            # Travels with the knob for the same reason its description does: the policy screen
+            # offers an override for every knob in the registry, and eleven of them are read by
+            # nothing in this build. The settings field says so (a value written there is at
+            # least stored); an override written here is stored, resolved, and equally inert.
+            "read_by_nothing": name in _gwconfig.KNOBS_READ_BY_NOTHING,
         }
     return {
         "status": "ok",

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -2001,25 +2001,39 @@ SETUP_JS = r"""
 
   function policyControl(name, knob) {
     var id = "pol_" + name;
+    /* Marked, not withdrawn. An override here is stored and resolved exactly like any other and
+       changes nothing, which is indistinguishable from one that works -- so it is said. But the
+       control stays: a tenant may already HAVE an override on one of these, and taking the
+       control away would leave that value set, invisible and impossible to clear from here. That
+       is the mistake the settings field made with its reset button, hidden for exactly the fields
+       that had something to clear. */
+    var inert = knob.read_by_nothing
+      ? '<span class="hint" style="margin:0 0 0 6px" title="This build resolves the value and '
+        + 'never reads it, so setting it changes nothing today. It is still shown because an '
+        + 'override already stored here would otherwise be invisible.">not read by this build'
+        + "</span>"
+      : "";
     if (!settableHere(name)) {
       /* Shown, not hidden: a customer looking for a setting needs to find it and learn where it
          lives, rather than conclude it does not exist. */
-      return '<span class="hint" style="margin:0">set it for the whole tenant</span>';
+      return '<span class="hint" style="margin:0">set it for the whole tenant</span>'
+        + inert;
     }
     if (knob.kind === "bool") {
       return "<select id='" + id + "' data-knob='" + esc(name) + "'>" +
         "<option value='0'" + (knob.value ? "" : " selected") + ">off</option>" +
-        "<option value='1'" + (knob.value ? " selected" : "") + ">on</option></select>";
+        "<option value='1'" + (knob.value ? " selected" : "") + ">on</option></select>"
+        + inert;
     }
     if (knob.kind === "choice") {
       return "<select id='" + id + "' data-knob='" + esc(name) + "'>" +
         (knob.choices || []).map(function (c) {
           return "<option value='" + esc(c) + "'" + (c === knob.value ? " selected" : "") + ">" +
             esc(c) + "</option>";
-        }).join("") + "</select>";
+        }).join("") + "</select>" + inert;
     }
     return "<input type='text' id='" + id + "' data-knob='" + esc(name) + "' value='" +
-      esc(knob.value) + "' spellcheck='false'>";
+      esc(knob.value) + "' spellcheck='false'>" + inert;
   }
 
   function renderPolicy() {

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -1719,25 +1719,39 @@ function liveStream(options) {
 
   function policyControl(name, knob) {
     var id = "pol_" + name;
+    /* Marked, not withdrawn. An override here is stored and resolved exactly like any other and
+       changes nothing, which is indistinguishable from one that works -- so it is said. But the
+       control stays: a tenant may already HAVE an override on one of these, and taking the
+       control away would leave that value set, invisible and impossible to clear from here. That
+       is the mistake the settings field made with its reset button, hidden for exactly the fields
+       that had something to clear. */
+    var inert = knob.read_by_nothing
+      ? '<span class="hint" style="margin:0 0 0 6px" title="This build resolves the value and '
+        + 'never reads it, so setting it changes nothing today. It is still shown because an '
+        + 'override already stored here would otherwise be invisible.">not read by this build'
+        + "</span>"
+      : "";
     if (!settableHere(name)) {
       /* Shown, not hidden: a customer looking for a setting needs to find it and learn where it
          lives, rather than conclude it does not exist. */
-      return '<span class="hint" style="margin:0">set it for the whole tenant</span>';
+      return '<span class="hint" style="margin:0">set it for the whole tenant</span>'
+        + inert;
     }
     if (knob.kind === "bool") {
       return "<select id='" + id + "' data-knob='" + esc(name) + "'>" +
         "<option value='0'" + (knob.value ? "" : " selected") + ">off</option>" +
-        "<option value='1'" + (knob.value ? " selected" : "") + ">on</option></select>";
+        "<option value='1'" + (knob.value ? " selected" : "") + ">on</option></select>"
+        + inert;
     }
     if (knob.kind === "choice") {
       return "<select id='" + id + "' data-knob='" + esc(name) + "'>" +
         (knob.choices || []).map(function (c) {
           return "<option value='" + esc(c) + "'" + (c === knob.value ? " selected" : "") + ">" +
             esc(c) + "</option>";
-        }).join("") + "</select>";
+        }).join("") + "</select>" + inert;
     }
     return "<input type='text' id='" + id + "' data-knob='" + esc(name) + "' value='" +
-      esc(knob.value) + "' spellcheck='false'>";
+      esc(knob.value) + "' spellcheck='false'>" + inert;
   }
 
   function renderPolicy() {

--- a/tools/test_matrixark_a_policy_override_says_when_nothing_reads_it.py
+++ b/tools/test_matrixark_a_policy_override_says_when_nothing_reads_it.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""An override for a knob nothing reads says so, as the settings field already does.
+
+The policy screen offers a per-user or per-tenant override for every knob in the registry.
+**Eleven of the thirty-two are read by nothing in this build** -- the set mx#1104 derived and
+mx#1110 marked on the settings field. An override written here is stored, resolved, returned when
+asked for, and inert, which is indistinguishable from one that works.
+
+The flag travels with the knob for the same reason its description does, which the endpoint's own
+docstring gives: *the explanation for a setting lives next to the setting rather than in a copy that
+drifts.*
+
+**Marked, not withdrawn.** The first version of this replaced the control. That repeats the mistake
+mx#1123 fixed on the settings field, where the reset button was hidden for exactly the fields that
+had something to clear: a tenant may already hold an override on one of these, and taking the
+control away would leave that value set, invisible, and impossible to clear from this page.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+sys.path.insert(0, TOOLS)
+
+import matrixark_gateway_config as cfg  # noqa: E402
+import matrixark_tenant_policy as tp  # noqa: E402
+
+
+class TheKnobsTheScreenOffersTest(unittest.TestCase):
+
+    def test_the_policy_layer_offers_knobs_nothing_reads(self) -> None:
+        """The premise. If it offered none of them there would be nothing to mark."""
+        dead = sorted(set(tp.KNOBS) & set(cfg.KNOBS_READ_BY_NOTHING))
+        self.assertGreater(len(dead), 5, dead)
+        self.assertLess(len(dead), len(tp.KNOBS),
+                        "every knob is dead, which would make the marking meaningless")
+
+    def test_the_dead_set_is_the_registry_s_own(self) -> None:
+        """Not a second list. mx#1104's guard derives it and fails in either direction."""
+        for name in cfg.KNOBS_READ_BY_NOTHING:
+            self.assertIn(name, tp.KNOBS, "%s is not a knob at all" % name)
+
+
+class ThePayloadCarriesItTest(unittest.TestCase):
+
+    @staticmethod
+    def _knobs() -> dict:
+        with io.open(os.path.join(TOOLS, "matrixark_v1_gateway.py"),
+                     encoding="utf-8") as handle:
+            return handle.read()
+
+    def test_the_endpoint_marks_each_knob(self) -> None:
+        self.assertIn('"read_by_nothing": name in _gwconfig.KNOBS_READ_BY_NOTHING',
+                      self._knobs(),
+                      "the policy payload does not say which knobs are inert")
+
+    def test_it_is_keyed_on_the_knob_name(self) -> None:
+        """The settings field needed the VARIABLE because its keys differ from knob names; here
+        the loop variable IS the knob name, so a name match is right and a variable lookup would
+        be the wrong indirection."""
+        self.assertIn("for name, state in (described.get(\"knobs\") or {}).items():",
+                      self._knobs())
+
+
+class TheControlIsMarkedNotWithdrawnTest(unittest.TestCase):
+
+    SCRIPT = """
+const fs = require("fs");
+const page = fs.readFileSync(process.argv[1], "utf8");
+const start = page.indexOf("function policyControl(name, knob) {");
+let depth = 0, end = -1;
+for (let i = page.indexOf("{", start); i < page.length; i++) {
+  if (page[i] === "{") depth++;
+  else if (page[i] === "}") { depth--; if (depth === 0) { end = i + 1; break; } }
+}
+const esc = (s) => String(s).replace(/[&<>"]/g, (c) =>
+  ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+const arg = JSON.parse(process.argv[2]);
+const scope = { esc, settableHere: () => arg.settable };
+const names = Object.keys(scope);
+const policyControl = new Function(...names,
+  page.slice(start, end) + "; return policyControl;")(...names.map((k) => scope[k]));
+process.stdout.write(policyControl(arg.name, arg.knob));
+"""
+
+    def setUp(self) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    def render(self, knob: dict, settable: bool = True, name: str = "a_knob") -> str:
+        payload = json.dumps({"name": name, "knob": knob, "settable": settable})
+        out = subprocess.run(["node", "-e", self.SCRIPT,
+                              os.path.join(PORTAL, "setup_portal.html"), payload],
+                             capture_output=True, text=True, timeout=300)
+        if out.returncode != 0:
+            raise AssertionError(out.stderr)
+        return out.stdout
+
+    def test_a_live_knob_is_not_marked(self) -> None:
+        """The floor. Marking everything would pass every test below."""
+        html = self.render({"kind": "int", "value": "8", "read_by_nothing": False})
+        self.assertIn("data-knob=", html)
+        self.assertNotIn("not read by this build", html)
+
+    def test_a_dead_knob_keeps_its_control(self) -> None:
+        """The mx#1123 lesson: an override already stored must stay visible and clearable."""
+        for kind, knob in (("int", {"kind": "int", "value": "0"}),
+                           ("bool", {"kind": "bool", "value": True}),
+                           ("choice", {"kind": "choice", "value": "auto",
+                                       "choices": ["auto", "none"]})):
+            with self.subTest(kind=kind):
+                html = self.render(dict(knob, read_by_nothing=True))
+                self.assertIn("data-knob=", html, "the control was withdrawn")
+                self.assertIn("not read by this build", html)
+
+    def test_a_tenant_only_knob_is_marked_too(self) -> None:
+        """That branch returns early, so it needed the marker adding separately -- and a reader
+        looking at a knob they cannot set here still deserves to know it does nothing anywhere."""
+        html = self.render({"kind": "choice", "value": "auto", "choices": [],
+                            "read_by_nothing": True}, settable=False)
+        self.assertIn("not read by this build", html)
+        self.assertIn("whole tenant", html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Eleven of the thirty-two knobs the policy layer can set are resolved and read by nothing in this build. The settings field already says so; the per-user and per-tenant override screen did not, so an override written there was stored, resolved, returned when asked for, and inert — indistinguishable from one that works.

The policy payload now carries the flag next to the knob, for the same reason its description travels there: the explanation lives beside the thing it explains rather than in a copy that drifts. The set is the registry-derived one, not a second list, so it moves when the build does.

**Marked, not withdrawn.** The first version replaced the control. That repeats the mistake fixed for the settings field in #1123, where the reset button was hidden for exactly the fields that had something to clear: a tenant may already hold an override on one of these, and removing the control would leave that value set, invisible, and impossible to clear from this page.

Seven tests. Each of these mutations reddens at least one of them:

| mutation | reddens |
|---|---|
| the payload drops the flag | `test_the_endpoint_marks_each_knob` |
| the payload marks every knob | `test_the_endpoint_marks_each_knob` |
| the page stops drawing the marker | `test_a_dead_knob_keeps_its_control`, `test_a_tenant_only_knob_is_marked_too` |
| a marked knob loses its control | `test_a_dead_knob_keeps_its_control`, `test_a_tenant_only_knob_is_marked_too` |
| the tenant-only branch omits it | `test_a_tenant_only_knob_is_marked_too`, `test_every_shared_function_is_identical` |
| the builder copy drifts from the page | `test_every_shared_function_is_identical` |

The page tests run the shipped `policyControl` in a DOM stub rather than reading it, so a marker that renders but never reaches the control would fail.
