### PR TITLE
Regenerate the flag inventory after a flag was offered

### DIFF
--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -50,7 +50,7 @@ Anything else is blank, and a blank means go and look.
 | booleans whose default this could read off the source | 49 |
 | numbers whose default this could read off the source | 70 |
 | **defaulting on, and set by nothing** | 5 |
-| offered on the portal | 27 |
+| offered on the portal | 28 |
 | **that nothing in this repository sets** | 156 |
 | documented as keeping an older path alive | 5 |
 | reaching more than two files | 15 |
@@ -312,7 +312,7 @@ The memory pipeline: what gets extracted, embedded, drained and packed. The surf
 | `MATRIXARK_EMBED_BASE_URL` | — | config, script | 1 | — |
 | `MATRIXARK_EMBED_DRAINER` | off | config, launch, test, portal | 1 | — |
 | `MATRIXARK_EMBED_DRAINER_BATCH` | — | config, portal | 1 | — |
-| `MATRIXARK_HOOK_ADDITIONAL_CONTEXT_CHAR_LIMIT` | 40000 | launch | 1 | — |
+| `MATRIXARK_HOOK_ADDITIONAL_CONTEXT_CHAR_LIMIT` | 40000 | launch, portal | 1 | — |
 | `MATRIXARK_REQUIRE_MODEL_EMBEDDINGS` | off | config, test, portal | 1 | — |
 | `MATRIXARK_REQUIRE_MODEL_SUMMARIES` | off | config, portal | 1 | — |
 | `MATRIXARK_RETRIEVAL_TRAVERSAL_TOP_K` | — | nothing | 1 | — |


### PR DESCRIPTION
`docs/ops/temporalstore-engine-flags.md` is generated from the source by
`tools/build_engine_flag_inventory.py`, and `test_regenerating_produces_the_same_document` checks
that what is committed is what the generator produces. It is not, so that test and
`test_every_offered_engine_flag_is_marked_portal` are failing on main, and every pull request
inherits both -- the ratchet reads them as new failures and will not merge.

The drift is two lines. `MATRIXARK_HOOK_ADDITIONAL_CONTEXT_CHAR_LIMIT` became something the portal
offers, and the count of offered flags went from 27 to 28:

    -| offered on the portal | 27 |
    +| offered on the portal | 28 |
    -| `MATRIXARK_HOOK_ADDITIONAL_CONTEXT_CHAR_LIMIT` | 40000 | launch | 1 | — |
    +| `MATRIXARK_HOOK_ADDITIONAL_CONTEXT_CHAR_LIMIT` | 40000 | launch, portal | 1 | — |

Nothing here was written by hand: the document is the generator's output, run against main and
committed. That is the whole change.

This is what the document being generated is for -- the flag moved and the record of it did not,
which is the failure the test exists to catch rather than a fault in either.
