### PR TITLE
Count the places that touch a field before changing it

### DIFF
--- a/tools/matrixark_field_sites.py
+++ b/tools/matrixark_field_sites.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Count the places that read and write a record field, by AST.
+
+Before changing what a record stores, the question that decides whether the change is tractable is
+"how many places touch this field?" -- and answering it by eye is unreliable. Three changes in a row
+were shipped here on the belief that one routine wrote a field, each time because a comment or a
+call graph said so; the field was written in four places, then five, then six.
+
+A grep does not answer it either: it counts imports, definitions, comments and docstrings alongside
+real accesses, and it cannot tell a READ from a WRITE. That distinction is the one that matters,
+because a write-side change needs every writer and a read-side change needs every reader, and the
+two counts are usually nothing alike.
+
+    $ python3 tools/matrixark_field_sites.py storage_record_kind
+    storage_record_kind
+      reads   9   across 5 module(s)
+      writes 13   across 6 module(s)
+
+    $ python3 tools/matrixark_field_sites.py --detail source_roles
+    ... every site, with the expression it is read from
+
+What counts as what:
+
+* a READ is ``x.get("field")`` or ``x["field"]`` -- and the expression ``x`` is reported, because
+  reading a name off a request is a different thing from reading it off a stored record
+* a WRITE is the field appearing as a key in a dict literal, or ``x["field"] = ...``
+
+Tests live in ``test_matrixark_field_sites.py``.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import collections
+import os
+import sys
+
+TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def _subject(node: ast.AST) -> str:
+    try:
+        return ast.unparse(node)
+    except Exception:  # noqa: BLE001 - a subject we cannot render is still a site.
+        return "?"
+
+
+def field_sites(field: str, *, root: str | None = None, include_tests: bool = False) -> dict:
+    """Every read and write of ``field`` under ``root``, as ast nodes rather than text matches."""
+    root = root or TOOLS_DIR
+    reads: list[tuple[str, int, str]] = []
+    writes: list[tuple[str, int, str]] = []
+
+    for name in sorted(os.listdir(root)):
+        if not name.endswith(".py"):
+            continue
+        if not include_tests and name.startswith("test_"):
+            continue
+        path = os.path.join(root, name)
+        try:
+            with open(path, encoding="utf-8") as handle:
+                tree = ast.parse(handle.read())
+        except (OSError, SyntaxError):
+            continue
+
+        # `ast.walk` yields every node, so an assignment TARGET is reached twice: once through the
+        # Assign that makes it a write, and once on its own, where it looks like a read. Collect the
+        # targets first and skip them by identity.
+        assigned = {
+            id(target)
+            for node in ast.walk(tree) if isinstance(node, ast.Assign)
+            for target in node.targets
+            if isinstance(target, ast.Subscript)
+        }
+
+        for node in ast.walk(tree):
+            if id(node) in assigned:
+                continue
+            # x.get("field") / x.get("field", default)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) \
+               and node.func.attr in {"get", "setdefault", "pop"} and node.args:
+                first = node.args[0]
+                if isinstance(first, ast.Constant) and first.value == field:
+                    where = reads if node.func.attr == "get" else writes
+                    where.append((name, node.lineno, _subject(node.func.value)))
+                continue
+            # x["field"] -- a write when it is an assignment target, a read otherwise
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Subscript) \
+                       and isinstance(target.slice, ast.Constant) \
+                       and target.slice.value == field:
+                        writes.append((name, target.lineno, _subject(target.value)))
+                continue
+            if isinstance(node, ast.Subscript) and isinstance(node.slice, ast.Constant) \
+               and node.slice.value == field:
+                reads.append((name, node.lineno, _subject(node.value)))
+                continue
+            # {"field": ...}
+            if isinstance(node, ast.Dict):
+                for key in node.keys:
+                    if isinstance(key, ast.Constant) and key.value == field:
+                        writes.append((name, node.lineno, "dict literal"))
+
+    return {"field": field, "reads": reads, "writes": writes}
+
+
+def _render(result: dict, *, detail: bool) -> str:
+    reads, writes = result["reads"], result["writes"]
+    read_mods = {r[0] for r in reads}
+    write_mods = {w[0] for w in writes}
+    lines = [result["field"],
+             f"  reads  {len(reads):4}   across {len(read_mods)} module(s)",
+             f"  writes {len(writes):4}   across {len(write_mods)} module(s)"]
+    if detail:
+        for label, sites in (("read", reads), ("write", writes)):
+            for module, lineno, subject in sorted(sites):
+                lines.append(f"    {label:5} {module}:{lineno}   on: {subject[:60]}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("field", nargs="+", help="record field name(s) to count")
+    parser.add_argument("--detail", action="store_true", help="list every site")
+    parser.add_argument("--root", default=None, help="directory to scan (default: tools/)")
+    parser.add_argument("--include-tests", action="store_true")
+    args = parser.parse_args(argv)
+
+    for field in args.field:
+        result = field_sites(field, root=args.root, include_tests=args.include_tests)
+        print(_render(result, detail=args.detail))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_matrixark_field_sites.py
+++ b/tools/test_matrixark_field_sites.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The site counter has to be right about the distinction a grep cannot make.
+
+Three changes in a row were shipped here on the belief that one routine wrote a field, and the field
+was written in four places, then five, then six. What makes this tool worth having is not that it
+counts, but that it counts READS and WRITES separately and ignores text that only looks like an
+access -- a comment, a docstring, a string literal.
+
+The fixtures are written to a temporary directory rather than asserted against the repository, so
+the expected numbers do not drift every time someone adds a call.
+"""
+import os
+import tempfile
+import unittest
+
+try:
+    from tools.matrixark_field_sites import field_sites
+except ImportError:  # run from tools/
+    from matrixark_field_sites import field_sites
+
+MODULE = '''
+"""A docstring mentioning storage_record_kind, which is not an access."""
+
+# a comment mentioning storage_record_kind, also not an access
+LABEL = "storage_record_kind"          # a string literal, still not an access
+
+
+def read_it(record):
+    kind = record.get("storage_record_kind")
+    other = record["storage_record_kind"]
+    return kind, other
+
+
+def write_it(record):
+    record["storage_record_kind"] = "index"
+    return {"storage_record_kind": "index", "unrelated": 1}
+
+
+def pop_it(record):
+    record.pop("storage_record_kind", None)
+    record.setdefault("storage_record_kind", "index")
+'''
+
+
+class FieldSitesTests(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        with open(os.path.join(self.dir, "sample.py"), "w", encoding="utf-8") as fh:
+            fh.write(MODULE)
+
+    def _sites(self, field="storage_record_kind"):
+        return field_sites(field, root=self.dir)
+
+    def test_reads_are_counted(self):
+        """`.get(...)` and a subscript read, and nothing else."""
+        self.assertEqual(2, len(self._sites()["reads"]))
+
+    def test_writes_are_counted(self):
+        """An assignment target, a dict literal, and pop/setdefault which mutate."""
+        self.assertEqual(4, len(self._sites()["writes"]))
+
+    def test_a_subscript_assignment_is_a_write_not_a_read(self):
+        """The distinction a grep cannot make, and the one that decides tractability."""
+        writes = self._sites()["writes"]
+        self.assertTrue(any(subject == "record" for _, _, subject in writes))
+        for _, _, subject in self._sites()["reads"]:
+            self.assertEqual("record", subject)
+
+    def test_prose_and_string_literals_are_not_accesses(self):
+        """A docstring, a comment and a bare string all mention the field; none is a site.
+
+        This is the positive control for the whole tool: a grep would report three extra hits here
+        and the count would be wrong in the direction that makes a change look harder than it is.
+        """
+        total = len(self._sites()["reads"]) + len(self._sites()["writes"])
+        self.assertEqual(6, total, "prose was counted as an access")
+
+    def test_an_absent_field_has_no_sites(self):
+        result = self._sites("a_field_that_is_not_there")
+        self.assertEqual([], result["reads"])
+        self.assertEqual([], result["writes"])
+
+    def test_the_subject_expression_is_reported(self):
+        """Reading a name off a request is a different thing from reading it off a record."""
+        for _, _, subject in self._sites()["reads"]:
+            self.assertTrue(subject, "a site with no subject cannot be judged")
+
+    def test_test_modules_are_skipped_by_default(self):
+        with open(os.path.join(self.dir, "test_sample.py"), "w", encoding="utf-8") as fh:
+            fh.write(MODULE)
+        self.assertEqual(2, len(self._sites()["reads"]))
+        with_tests = field_sites("storage_record_kind", root=self.dir, include_tests=True)
+        self.assertEqual(4, len(with_tests["reads"]))
+
+    def test_a_file_that_does_not_parse_is_skipped(self):
+        with open(os.path.join(self.dir, "broken.py"), "w", encoding="utf-8") as fh:
+            fh.write("def (:\n")
+        self.assertEqual(2, len(self._sites()["reads"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Before changing what a record stores, one question decides whether the change is tractable: **how
many places touch this field?** Answering it by eye is unreliable, and this repository has the scar
tissue to prove it.

Three changes in a row were shipped on the belief that one routine wrote a field:

* mx#1048/#1058/#1061 slimmed the bundle path, on the strength of a comment reading *"This is the
  ONLY append call site"* — true of the append **client**, not of record serialisation
* mx#1126 brought **four** sites under one slimmer, and records were still written fat
* mx#1129 found the latest-state writers — still fat
* mx#1131 found the **second complete copy of the append implementation**, in the module where the
  slimmers are defined

Four rounds, because nothing counted the sites.

## What it does

```
$ python3 tools/matrixark_field_sites.py storage_record_kind source_roles
storage_record_kind
  reads     5   across 3 module(s)
  writes    8   across 3 module(s)
source_roles
  reads   100   across 23 module(s)
  writes  110   across 19 module(s)
```

That contrast is the whole point. `storage_record_kind` was a change worth making and it worked.
`source_roles` has a real 0.97%-of-the-log saving available and **100 read sites across 23 modules**,
where a single missed site serves an empty list where names should be — silently, on the retrieve
path. The number is the decision, and it takes one command instead of a day.

`--detail` lists every site with the expression it is read from, because reading a name off a
request is a different thing from reading it off a stored record.

## Why not grep

A grep counts imports, definitions, comments, docstrings and string literals alongside real
accesses, and it cannot tell a READ from a WRITE. That distinction is the one that matters: a
write-side change needs every writer, a read-side change needs every reader, and the two counts are
usually nothing alike — `raw_hook_payload` is **0 reads and 3 writes**.

## Tests

`tools/test_matrixark_field_sites.py`, eight tests against fixtures in a temporary directory, so the
expected numbers do not drift when someone adds a call.

`test_prose_and_string_literals_are_not_accesses` is the positive control: the fixture mentions the
field in a docstring, a comment and a bare string, and none of the three may be counted. A grep
reports all three, and the count is then wrong in the direction that makes a change look harder than
it is.

The tests also caught a real defect while this was being written. `ast.walk` yields every node, so
`record["field"] = x` was counted as a WRITE from the assignment and again as a READ when the walk
reached the same subscript on its own. Targets are now collected first and skipped by identity —
`test_a_subscript_assignment_is_a_write_not_a_read` holds that.
