### PR TITLE
Keep the dump manifests reclaim still needs, not just the newest

### DIFF
--- a/crates/temporalstore-rust/src/engine/bucket_dump_io.rs
+++ b/crates/temporalstore-rust/src/engine/bucket_dump_io.rs
@@ -200,12 +200,36 @@ pub(super) fn bucket_dump_manifest_chain_issues(
 /// Anything older is now prunable unless a follower cursor or raft snapshot ref pins it, which
 /// is exactly what those cursors are for.
 pub(super) fn retained_bucket_dump_manifest_ids(manifests: &[BucketDumpManifest]) -> BTreeSet<String> {
-    manifests
-        .iter()
-        .max_by_key(|manifest| (manifest.index_log_sequence, manifest.created_unix_ms))
-        .map(|manifest| manifest.manifest_id.clone())
-        .into_iter()
-        .collect()
+    // The newest manifest, PLUS any older one that is still the only dump covering some bucket.
+    //
+    // Reclaim advances its frontier only for buckets that have a manifest matching their current
+    // generation. Keeping just the newest meant an ordinary cycle -- which dumps only the few
+    // DIRTY buckets -- deleted the manifest covering everything else, and coverage collapsed to
+    // those few. Seen on a live store: a round covering all 3,190 buckets let reclaim apply and the
+    // log fall 806 -> 478 MB, then an ordinary cycle within the hour left `covered_slot_count: 0`
+    // and a durable frontier of 0, so the log grew back and every cold start paid for it.
+    //
+    // Self-limiting: walking newest first, once a manifest covers everything, older ones add no
+    // coverage and are pruned exactly as before.
+    let mut ordered = manifests.iter().collect::<Vec<_>>();
+    ordered.sort_by_key(|manifest| {
+        std::cmp::Reverse((manifest.index_log_sequence, manifest.created_unix_ms))
+    });
+    let mut retained = BTreeSet::new();
+    let mut covered = BTreeSet::<u32>::new();
+    for manifest in ordered {
+        let adds_coverage = manifest
+            .bucket_ids
+            .iter()
+            .any(|bucket| !covered.contains(bucket));
+        // `retained.is_empty()` keeps the newest even when it covers nothing new, so the previous
+        // guarantee -- there is always a most recent dump to anchor on -- is unchanged.
+        if retained.is_empty() || adds_coverage {
+            retained.insert(manifest.manifest_id.clone());
+            covered.extend(manifest.bucket_ids.iter().copied());
+        }
+    }
+    retained
 }
 
 /// A cursor older than every manifest we kept: nothing retained can serve it. Named because the

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -17123,3 +17123,65 @@ fn which_children_a_limited_query_returns() {
     // The unlimited answer is untouched, and still oldest-first.
     assert_eq!(vec![100, 101, 102, 103, 104], all, "an unlimited query is unchanged");
 }
+
+/// Pruning keeps the manifests reclaim still needs, not just the newest.
+///
+/// Reclaim can only advance its durable frontier for a bucket whose CURRENT generation has a dump
+/// manifest. Keeping only the newest meant an ordinary cycle -- which dumps just the few DIRTY
+/// buckets -- deleted the manifest covering everything else. Seen on a live store: a round covering
+/// all 3,190 buckets let reclaim apply and the log fall 806 -> 478 MB, and within the hour an
+/// ordinary cycle left `covered_slot_count: 0` with a durable frontier of 0, so the log grew back
+/// and every cold start paid for it.
+#[test]
+fn pruning_keeps_the_manifests_reclaim_still_needs() {
+    use crate::engine::reports::BucketDumpManifest;
+
+    fn manifest(id: &str, index_log_sequence: u64, buckets: &[u32]) -> BucketDumpManifest {
+        BucketDumpManifest {
+            manifest_id: id.to_string(),
+            index_log_sequence,
+            created_unix_ms: index_log_sequence,
+            bucket_ids: buckets.to_vec(),
+            ..BucketDumpManifest::default()
+        }
+    }
+
+    // The live shape: a wide dump, then a small one covering only what was dirty.
+    let wide = manifest("wide", 1, &[1, 2, 3, 4]);
+    let narrow = manifest("narrow", 2, &[4]);
+    let retained = crate::engine::bucket_dump_io::retained_bucket_dump_manifest_ids(&[
+        wide.clone(),
+        narrow.clone(),
+    ]);
+    assert!(
+        retained.contains("narrow"),
+        "the newest manifest must always be kept"
+    );
+    assert!(
+        retained.contains("wide"),
+        "the wide dump is the only cover for buckets 1-3; pruning it blocks reclaim on them"
+    );
+
+    // The control: a manifest whose buckets are all covered by newer ones is still pruned, so
+    // "retain everything" does not pass this test.
+    let superseded = manifest("superseded", 1, &[4]);
+    let covers_all = manifest("covers_all", 2, &[1, 2, 3, 4]);
+    let retained = crate::engine::bucket_dump_io::retained_bucket_dump_manifest_ids(&[
+        superseded,
+        covers_all,
+    ]);
+    assert!(retained.contains("covers_all"));
+    assert!(
+        !retained.contains("superseded"),
+        "an older manifest adding no coverage must still be pruned"
+    );
+
+    // The other control: the newest is kept even when it adds nothing, so the guarantee that there
+    // is always a most recent dump to anchor on is unchanged.
+    let only = manifest("only", 7, &[]);
+    let retained = crate::engine::bucket_dump_io::retained_bucket_dump_manifest_ids(&[only]);
+    assert!(
+        retained.contains("only"),
+        "the newest manifest is kept even when it covers no buckets"
+    );
+}


### PR DESCRIPTION
Reclaim can only advance its durable frontier for a bucket whose **current generation** has a dump
manifest. Pruning kept exactly one manifest — the newest — so the moment an ordinary cycle dumped a
handful of dirty buckets, the manifest covering everything else was deleted and coverage collapsed.

On a continuously written store that makes the log **impossible to reclaim**, no matter how often
maintenance runs.

### Measured on a live store

A round that dumped all 3,190 buckets let reclaim apply for the first time and the log fell
**806 MB → 478 MB**. Within the hour, an ordinary cycle had replaced that manifest with a small one:

```
current_wal_sequence: 75346     durable frontier: 0
covered_slot_count: 0           uncovered_slot_count: 3190
blocker_reasons: ["slot_generation_without_durable_dump"]
```

Frontier zero, nothing reclaimable, the log growing again — and cold start grows with it at roughly
0.13 s per MB (709 MB → 66.6 s against 417 MB → 28.0 s, measured on copies of the same store).

So the log's growth was never really about the dump cadence. Each maintenance round did its work
and the next ordinary cycle threw it away.

### The change

`retained_bucket_dump_manifest_ids` keeps the newest manifest **plus any older one that is still
the only dump covering some bucket**.

Self-limiting: manifests are walked newest first, so once one covers everything, every older
manifest adds no coverage and is pruned exactly as before. The newest is always kept whether or not
it adds coverage, so the existing guarantee — there is always a most recent dump to anchor on — is
unchanged.

### Tests

`pruning_keeps_the_manifests_reclaim_still_needs`, built around the live shape (a wide dump followed
by a narrow one):

- the newest manifest is kept
- the wide dump is kept, because it is the only cover for the buckets the narrow one omits
- **an older manifest whose buckets are all covered by newer ones is still pruned** — the control,
  without which "retain everything" would pass
- **the newest is kept even when it covers no buckets** — the previous guarantee

Verified to fail with newest-only retention restored. 15 related manifest and cycle tests pass
together.
