### PR TITLE
A bare ref header does not earn a line of its own

### DIFF
--- a/tools/matrixark_codex_hook.py
+++ b/tools/matrixark_codex_hook.py
@@ -1834,8 +1834,16 @@ def additional_context_from_retrieve(
                 header_bits.append(f"score={score}")
             if token_cost != "":
                 header_bits.append(f"tokens={token_cost}")
-            lines.append(" - " + " | ".join(header_bits))
             text = _ref_text(ref)
+            # A header carrying only "[n] type" says nothing the content line does not, so it does
+            # not earn a line of its own. 48 of 49 headers on one box were bare. Anything richer --
+            # a citation, a score, a token count -- still gets its own line, because then the header
+            # is information and running it together with the text would bury it.
+            if text and len(header_bits) == 1:
+                lines.append(" - " + header_bits[0] + "  "
+                             + _compact_one_line(text, max_chars=700))
+                continue
+            lines.append(" - " + " | ".join(header_bits))
             if text:
                 lines.append("   " + _compact_one_line(text, max_chars=700))
     else:

--- a/tools/test_matrixark_a_bare_ref_header_does_not_earn_a_line.py
+++ b/tools/test_matrixark_a_bare_ref_header_does_not_earn_a_line.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A ref header carrying only an index and a type does not earn a line of its own.
+
+A retrieved ref was rendered as two lines:
+
+     - [1] ref
+       tool_evidence: tool_evidence = tool: Exit code: 0; Ran 159 tests
+
+When the header has no citation, no score and no token count, the newline and the following indent
+are spent on nothing. Measured on the packs cached on one box, **48 of 49 headers were bare**.
+
+A header that DOES carry something keeps its own line: running a citation or a score together with
+the text would bury it, and the point of the header is that those are visible at a glance.
+"""
+import re
+import unittest
+
+try:
+    from tools.matrixark_codex_hook import additional_context_from_retrieve
+except ImportError:  # run from tools/
+    from matrixark_codex_hook import additional_context_from_retrieve
+
+
+def _render(refs):
+    pack = {"context_pack_id": "pack-1", "refs": refs,
+            "groups": [{"items": refs}]}
+    return additional_context_from_retrieve(pack, query="q", local_context_count=0)
+
+
+def _ref_lines(out):
+    return [l for l in out.split("\n") if l.startswith(" - [")]
+
+
+class BareRefHeaderTests(unittest.TestCase):
+    def test_a_bare_header_shares_its_line_with_the_text(self):
+        out = _render([{"ref_type": "entity", "text": "a remembered thing"}])
+        lines = _ref_lines(out)
+        self.assertEqual(1, len(lines))
+        self.assertIn("[1] entity", lines[0])
+        self.assertIn("a remembered thing", lines[0])
+
+    def test_the_text_is_not_lost(self):
+        out = _render([{"ref_type": "entity", "text": "a remembered thing"}])
+        self.assertIn("a remembered thing", out)
+
+    def test_a_header_with_a_score_keeps_its_own_line(self):
+        """The control: a header that carries something must not be run together with the text."""
+        out = _render([{"ref_type": "entity", "text": "a remembered thing", "score": 0.91}])
+        lines = _ref_lines(out)
+        self.assertEqual(1, len(lines))
+        self.assertIn("score=0.91", lines[0])
+        self.assertNotIn("a remembered thing", lines[0],
+                         "a header carrying a score should keep the text on its own line")
+        self.assertIn("a remembered thing", out)
+
+    def test_a_ref_with_no_text_still_renders_its_header(self):
+        out = _render([{"ref_type": "entity"}])
+        self.assertIn("[1] entity", out)
+
+    def test_every_ref_is_still_numbered_in_order(self):
+        out = _render([{"ref_type": "entity", "text": f"thing {i}"} for i in range(4)])
+        numbers = [int(n) for n in re.findall(r"^ - \[(\d+)\]", out, flags=re.MULTILINE)]
+        self.assertEqual([1, 2, 3, 4], numbers)
+
+    def test_the_pack_gets_shorter(self):
+        """The reason this exists, asserted rather than assumed."""
+        refs = [{"ref_type": "entity", "text": f"a remembered thing number {i}"}
+                for i in range(6)]
+        out = _render(refs)
+        # two lines per ref would cost at least an extra newline and three spaces each
+        self.assertEqual(6, len(_ref_lines(out)))
+        self.assertNotIn("\n   a remembered thing", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A retrieved ref was rendered as two lines:

```
 - [1] ref
   tool_evidence: tool_evidence = tool: Exit code: 0; Ran 159 tests
```

When the header carries nothing but an index and a type — no citation, no score, no token count —
the newline and the following indent are spent on nothing, on every ref, inside a bounded pack.

Measured on the packs cached on one box: **48 of 49 headers were bare**, and folding them saves 336
characters, **2.7% of those packs**.

Small, and stated as measured. It is on every codex turn, and it is a rendering change only: the
same index, the same type, the same text.

## What still gets its own line

A header carrying a citation, a score or a token count keeps its line. Running those together with
the text would bury them, and being visible at a glance is the only reason the header exists.
`test_a_header_with_a_score_keeps_its_own_line` is the control for that, and it asserts both halves
— that the score is on the header line and the text is not.

## Tests

`tools/test_matrixark_a_bare_ref_header_does_not_earn_a_line.py`, six tests: the fold happens, the
text is not lost, a rich header is untouched, a ref with no text still renders, the numbering stays
in order, and the pack actually gets shorter.

Mutation-checked with `__pycache__` cleared: disabling the fold fails
`test_a_bare_header_shares_its_line_with_the_text` and `test_the_pack_gets_shorter`, and **not** the
control.

The hook suites are red on main at 77 failing names; with this change, the same 77, diffed by name
rather than by count.
