### PR TITLE
The context row counted the backend too

### DIFF
--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -3969,6 +3969,49 @@ mod tests {
             counts.alloc_bytes / ITERS as u64,
         ));
 
+        // The context forward against the same non-allocating backend. The stub-backed context row
+        // above has the problem #1066 found on the execute path: it counts the backend's own
+        // allocations, because the probe reads global atomics while that thread parses and
+        // serialises. This is the proxy's own cost for a context ingest.
+        let ctx_quiet = scoped_proxy(ProxyOptions::default());
+        ctx_quiet
+            .client()
+            .insert_cached_route_for_test(ctx_quiet.context_shard_id(0), quiet.clone());
+        let before = crate::http::EXCHANGES.load(std::sync::atomic::Ordering::Relaxed);
+        let (code, answered) = ctx_quiet.handle(crate::proxy::HttpRequest {
+            method: "POST".to_string(),
+            path: "/context/ingest".to_string(),
+            body: ingest_body.clone(),
+        });
+        let first: String = String::from_utf8_lossy(&answered).chars().take(60).collect();
+        assert_eq!(code, 200, "{first}");
+        assert!(
+            first.contains("\"ok\":true"),
+            "the context forward must succeed or this row measures the failure path: {first}"
+        );
+        let probe = crate::alloc_probe::Probe::start();
+        for _ in 0..ITERS {
+            let out = ctx_quiet.handle(crate::proxy::HttpRequest {
+                method: "POST".to_string(),
+                path: "/context/ingest".to_string(),
+                body: ingest_body.clone(),
+            });
+            std::hint::black_box(&out);
+        }
+        let counts = probe.stop();
+        let exchanges = crate::http::EXCHANGES.load(std::sync::atomic::Ordering::Relaxed) - before;
+        assert_eq!(
+            exchanges,
+            ITERS as u64 + 1,
+            "only {exchanges} of {} calls reached the socket, so this row is not measuring a              forward",
+            ITERS + 1
+        );
+        rows.push((
+            "POST /context/ingest, backend allocates NOTHING",
+            counts.allocs / ITERS as u64,
+            counts.alloc_bytes / ITERS as u64,
+        ));
+
 
         // SCRATCH: the layers, against the quiet backend so the numbers are this process only.
         let typed_req = ExecuteRequest {


### PR DESCRIPTION
#1066 found that the backend-answering rows include the **backend's own** allocations: the probe reads global atomics, and that thread parses the request and serialises a reply while the client blocks in `read()`. #1089 fixed the row that measures it honestly — but only for the execute path.

The context row still reports the inflated figure. Same fix, same shape:

| POST /context/ingest | allocs/call | bytes |
|---|---|---|
| backend ANSWERS (stub) | 32 | 3625 |
| **backend allocates NOTHING** | **23** | **2170** |

So the proxy's own cost for a context ingest is 23 and 2170; the backend was contributing 9 allocations and about 1455 bytes.

Both paths now report a trustworthy absolute beside the stub-backed one, which is the figure an optimisation budget gets set from:

| forward, backend allocates nothing | allocs/call | bytes |
|---|---|---|
| POST /execute | 11 | 947 |
| POST /context/ingest | 23 | 2170 |

That gap is the real one to reason about: a context ingest costs roughly twice a command, and it is payload construction — the per-message field key and the serialized record — not proxy overhead.

## The row checks it measured a forward

It asserts it performed `ITERS` socket exchanges and that the answer body says `"ok":true`. The proxy answers HTTP 200 with failures in the body, so a status code cannot tell a forward from the client's failure skip — that check is what caught the quiet backend never binding in #1089.

proxy suite passes at 94.
