### PR TITLE
A call waits the transport ceiling instead of its own deadline

### DIFF
--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -3368,6 +3368,70 @@ class MatrixArkRustCdylibClient:
     def shutdown(self) -> None:
         self.close()
 
+
+#: The allowance added to a budget for connect and framing rather than for work. Both the transport
+#: budget and the capped one carry it, so capping cannot make a call fail during the handshake.
+SOCKET_OVERHEAD_S = 2.0
+
+#: Floor under the TRANSPORT ceiling, so a misconfigured `--request-timeout-ms` of 0 does not
+#: produce a budget of zero. The capped budget does not need it: that one adds SOCKET_OVERHEAD_S,
+#: so it cannot fall below the allowance however small the caller's deadline is.
+#:
+#: Distinct from `MatrixArkRustProxyClient.SOCKET_CONNECT_TIMEOUT_CEILING_S`, which happens to hold
+#: the same number but bounds the CONNECT rather than the whole call.
+SOCKET_MINIMUM_BUDGET_S = 2.0
+
+
+def _socket_budget_seconds(request_timeout_ms: int, caller_deadline_ms: int = 0) -> float:
+    """How long to wait on the daemon socket for one call.
+
+    The transport timeout is a CEILING on any single call to the store. The caller's deadline is
+    what THIS call was given. Waiting the ceiling when the caller named a smaller number is how a
+    5s hook retrieve came to wait 62s on the live box -- measured, four times in a hundred traced
+    calls, each one twelve times its own budget, and each one reported as
+    `exit1_retriever_raised ... after 62.0s`.
+
+    A caller deadline of 0 means no deadline, which is what the setting documents, so it leaves the
+    ceiling alone. And the cap only ever REDUCES: a caller asking for longer than the transport
+    allows still gets the transport ceiling, because that is the promise the transport makes.
+    """
+    ceiling_s = max(SOCKET_MINIMUM_BUDGET_S, request_timeout_ms / 1000.0 + SOCKET_OVERHEAD_S)
+    if caller_deadline_ms <= 0:
+        return ceiling_s
+    # The allowance is added, not subtracted, so the capped budget cannot fall below it however
+    # small the caller's deadline is. That is what keeps this cap from recreating the constant it
+    # replaced -- not a floor, which would be unreachable here and would only read as one.
+    asked_s = caller_deadline_ms / 1000.0 + SOCKET_OVERHEAD_S
+    return min(ceiling_s, asked_s)
+
+
+def _caller_deadline_ms(kwargs: Json) -> int:
+    """The deadline the CALLER set for this call, in milliseconds, or 0 for none.
+
+    Looked for at the top level, inside `request`, and inside `ranking`, because callers build the
+    call differently: the retrieve path puts it in the request body (matrixark_local_adapter_retrieve
+    builds it there, which is the one that mattered here) while others pass it directly. The first
+    of those that carries a usable value wins.
+
+    0 is the documented "no deadline" value and is returned unchanged, so a call that asked for no
+    deadline keeps the transport budget. Anything unparseable is treated the same way: a deadline
+    nobody can read must not silently shorten a call.
+    """
+    for source in (kwargs, kwargs.get("request"), kwargs.get("ranking")):
+        if not isinstance(source, dict):
+            continue
+        raw = source.get("deadline_ms")
+        if raw is None:
+            continue
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            continue
+        if value > 0:
+            return value
+    return 0
+
+
 class MatrixArkRustProxyClient:
     """Persistent Rust proxy boundary around the Rust TemporalStore SDK.
 
@@ -3692,7 +3756,8 @@ class MatrixArkRustProxyClient:
         started = time.perf_counter()
         if self._proxy_socket:
             try:
-                response = self._call_socket_json(op, payload)
+                response = self._call_socket_json(
+                    op, payload, caller_deadline_ms=_caller_deadline_ms(kwargs))
             except Exception:
                 elapsed_ms = (time.perf_counter() - started) * 1000.0
                 self._record_call_metrics(op, kwargs, None, elapsed_ms, failed=True, lane="daemon", wait_ms=0.0)
@@ -3766,14 +3831,14 @@ class MatrixArkRustProxyClient:
     # whole budget. Reads are a different question -- see `_call_socket_json`.
     SOCKET_CONNECT_TIMEOUT_CEILING_S = 2.0
 
-    def _call_socket_json(self, op: str, payload: str) -> Json:
+    def _call_socket_json(self, op: str, payload: str, *, caller_deadline_ms: int = 0) -> Json:
         # The read timeout tracks what is LEFT of the deadline. It used to be a constant
         # `min(2.0, ...)`, which no `--request-timeout-ms` could raise, so any response
         # slower than two seconds became a timeout -- and since `_call_json` re-raises
         # instead of falling back to the lane path, the call simply failed. A ContextPack
         # over a large store takes longer than that, so hook retrieval failed open with
         # no context and nothing in the logs but "TimeoutError: timed out".
-        budget_s = max(2.0, self.request_timeout_ms / 1000.0 + 2.0)
+        budget_s = _socket_budget_seconds(self.request_timeout_ms, caller_deadline_ms)
         deadline = time.monotonic() + budget_s
         connect_timeout_s = min(
             self.SOCKET_CONNECT_TIMEOUT_CEILING_S,

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -3408,16 +3408,23 @@ def _socket_budget_seconds(request_timeout_ms: int, caller_deadline_ms: int = 0)
 def _caller_deadline_ms(kwargs: Json) -> int:
     """The deadline the CALLER set for this call, in milliseconds, or 0 for none.
 
-    Looked for at the top level, inside `request`, and inside `ranking`, because callers build the
-    call differently: the retrieve path puts it in the request body (matrixark_local_adapter_retrieve
-    builds it there, which is the one that mattered here) while others pass it directly. The first
-    of those that carries a usable value wins.
+    Callers build the call differently, so this looks at the top level and inside each dict that
+    carries a request body. `record` is the one that matters in production:
+    `matrixark_retrieve_context_pack` passes the retrieve request as `record=request`, and that is
+    the call the 62s timeouts came from. `request` and `ranking` are the other two spellings in
+    this module; `ranking` is a real carrier because `retrieval_deadline_ms` reads the request's
+    deadline from there when the arguments do not name one.
 
-    0 is the documented "no deadline" value and is returned unchanged, so a call that asked for no
-    deadline keeps the transport budget. Anything unparseable is treated the same way: a deadline
-    nobody can read must not silently shorten a call.
+    The first of those carrying a usable value wins. 0 is the documented "no deadline" value and is
+    returned unchanged, so a call that asked for no deadline keeps the transport budget. Anything
+    unparseable is treated the same way: a deadline nobody can read must not silently shorten a
+    call.
+
+    This list is a hazard -- a fourth spelling would be missed silently, and one already was. The
+    guard that protects it drives the real `matrixark_retrieve_context_pack` entry point against a
+    socket rather than asserting on these names, so renaming the carrier fails the test.
     """
-    for source in (kwargs, kwargs.get("request"), kwargs.get("ranking")):
+    for source in (kwargs, kwargs.get("record"), kwargs.get("request"), kwargs.get("ranking")):
         if not isinstance(source, dict):
             continue
         raw = source.get("deadline_ms")

--- a/tools/test_the_callers_deadline_reaches_the_socket.py
+++ b/tools/test_the_callers_deadline_reaches_the_socket.py
@@ -29,6 +29,11 @@ stop early, not permission to wait longer.
 from __future__ import annotations
 
 import importlib
+import os
+import socket
+import tempfile
+import threading
+import time
 import unittest
 
 
@@ -90,11 +95,17 @@ class TheCallersDeadlineReachesTheSocketTest(unittest.TestCase):
                 "a %dms transport timeout produced a budget below the minimum" % request_timeout_ms)
 
     def test_the_deadline_is_found_where_callers_put_it(self) -> None:
-        """Three shapes, because three callers build the call differently."""
+        """Four spellings, because callers build the call differently.
+
+        `record` is the production one: `matrixark_retrieve_context_pack` passes the retrieve
+        request as `record=request`. These assertions are documentation -- the test that actually
+        protects the behaviour is the end-to-end one below, which does not name any of them.
+        """
         self.assertEqual(5000, self.deadline_of({"deadline_ms": 5000}))
         self.assertEqual(
-            5000, self.deadline_of({"request": {"deadline_ms": 5000}}),
-            "the retrieve path puts it in the request body, which is the one that mattered")
+            5000, self.deadline_of({"record": {"deadline_ms": 5000}}),
+            "the live retrieve carries its request under `record`")
+        self.assertEqual(5000, self.deadline_of({"request": {"deadline_ms": 5000}}))
         self.assertEqual(250, self.deadline_of({"ranking": {"deadline_ms": 250}}))
 
     def test_no_deadline_reads_as_no_deadline(self) -> None:
@@ -131,6 +142,110 @@ class TheCallersDeadlineReachesTheSocketTest(unittest.TestCase):
                 "0", ast.unparse(keywords["caller_deadline_ms"]),
                 "the deadline is passed as a literal 0, which is the pre-fix behaviour spelled "
                 "with an extra argument")
+
+
+class TheLiveRetrieveDeadlineReachesTheSocketTest(unittest.TestCase):
+    """Drive the real entry point, not a dict I invented.
+
+    This is the test that was missing. The first version of this fix read the deadline from
+    `kwargs`, `kwargs["request"]` and `kwargs["ranking"]` -- all three plausible, none of them the
+    one `matrixark_retrieve_context_pack` actually uses, which is `record=request`. Every
+    shape-based assertion passed and the fix was a no-op on the only path it was written for.
+
+    So this test never names a carrier. It calls the retrieve entry point the hook calls, against a
+    socket that never answers, and times how long it waits. If the deadline stops reaching the
+    socket -- renamed key, changed call site, reverted arithmetic -- this fails.
+    """
+
+    def _hang(self, socket_path: str) -> None:
+        """A daemon that accepts and then never answers."""
+        ready = threading.Event()
+        stop = threading.Event()
+        self.addCleanup(stop.set)
+
+        def run() -> None:
+            server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            server.bind(socket_path)
+            server.listen(1)
+            server.settimeout(1.0)
+            ready.set()
+            conn = None
+            try:
+                while not stop.is_set():
+                    try:
+                        conn, _ = server.accept()
+                        break
+                    except socket.timeout:
+                        continue
+                if conn is not None:
+                    with conn:
+                        conn.recv(65536)
+                        stop.wait(120.0)
+            except OSError:
+                pass
+            finally:
+                server.close()
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+        self.assertTrue(ready.wait(10.0), "socket server did not come up")
+        self.addCleanup(thread.join, 5.0)
+
+    def _client(self, socket_path: str, request_timeout_ms: int):
+        module = _adapters()
+        previous = os.environ.get("MATRIXARK_RUST_PROXY_SOCKET")
+        os.environ["MATRIXARK_RUST_PROXY_SOCKET"] = socket_path
+
+        def restore() -> None:
+            if previous is None:
+                os.environ.pop("MATRIXARK_RUST_PROXY_SOCKET", None)
+            else:
+                os.environ["MATRIXARK_RUST_PROXY_SOCKET"] = previous
+
+        self.addCleanup(restore)
+        client = module.MatrixArkRustProxyClient(
+            proxy_path="matrixark_rust_proxy",
+            metaserver="local",
+            namespace="ns",
+            table="table",
+            request_timeout_ms=request_timeout_ms,
+            io_timeout_ms=request_timeout_ms,
+        )
+        self.assertEqual(client._proxy_socket, socket_path)
+        return client
+
+    def test_a_retrieve_gives_up_at_its_own_deadline_not_the_transport_ceiling(self) -> None:
+        """The measured failure, end to end.
+
+        The live box runs `--request-timeout-ms 300000`, so the transport ceiling there is 302s.
+        A retrieve carrying a 3s deadline must not wait anywhere near it.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            socket_path = os.path.join(tmp, "hung.sock")
+            self._hang(socket_path)
+            client = self._client(socket_path, request_timeout_ms=300000)
+
+            started = time.monotonic()
+            with self.assertRaises(Exception):
+                client.matrixark_retrieve_context_pack(
+                    count_key="c",
+                    record_hash_key="h",
+                    shard_size=1,
+                    request={"deadline_ms": 3000, "scope": {}, "secondary_index_groups": []},
+                )
+            elapsed_s = time.monotonic() - started
+
+        # Below: the 3s deadline plus the connect-and-framing allowance, with room for a slow
+        # machine. Above: it really did wait for the deadline rather than failing to connect,
+        # so this cannot pass because the socket was broken.
+        self.assertGreaterEqual(
+            elapsed_s, 2.5,
+            "gave up before the deadline -- this passed for the wrong reason")
+        self.assertLess(
+            elapsed_s, 30.0,
+            "a retrieve with a 3s deadline waited %.1fs; the caller's deadline is not reaching "
+            "the socket, and on the live box that means 302s" % elapsed_s)
+
 
 
 if __name__ == "__main__":

--- a/tools/test_the_callers_deadline_reaches_the_socket.py
+++ b/tools/test_the_callers_deadline_reaches_the_socket.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The caller's deadline reaches the socket, and cannot lengthen the wait.
+
+Measured on the live one-box: 4 of 101 traced retrievals ended
+
+    native_live exit1_retriever_raised=Rust TemporalStore matrixark_retrieve_context_pack daemon
+    timed out waiting for response from /tmp/matrixark-rust-proxy-shared-live.sock after 62.0s
+
+62.0 is `max(2.0, request_timeout_ms / 1000 + 2.0)` with the 60s transport default. It is the
+TRANSPORT ceiling -- how long any single call to the store may take -- and it was being used as the
+budget for a call whose caller had named a much smaller number. The Claude hook budgets 5s for a
+retrieve, so a call with 5s waited 62: twelve times its own budget, and the turn showed it.
+
+The retrieve request already carried `deadline_ms`; `matrixark_local_adapter_retrieve` puts it
+there. It simply was not read at this layer.
+
+WHAT THE FIX MUST NOT DO, and why the floor exists. The read timeout was once a constant
+`min(2.0, ...)` that no `--request-timeout-ms` could raise, so any response slower than two seconds
+became a timeout and hook retrieval came back empty with nothing in the logs but
+"TimeoutError: timed out". A cap that can drive the budget to zero would be that bug again, so the
+budget never goes below `SOCKET_MINIMUM_BUDGET_S` and always carries `SOCKET_OVERHEAD_S` for
+connect and framing.
+
+And the cap only ever REDUCES. A caller asking for longer than the transport allows still gets the
+transport ceiling, because that is the promise the transport makes; a deadline is permission to
+stop early, not permission to wait longer.
+"""
+from __future__ import annotations
+
+import importlib
+import unittest
+
+
+def _adapters():
+    try:
+        return importlib.import_module("tools.matrixark_mcp_temporal_adapters")
+    except ImportError:
+        return importlib.import_module("matrixark_mcp_temporal_adapters")
+
+
+class TheCallersDeadlineReachesTheSocketTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.module = _adapters()
+        self.budget = self.module._socket_budget_seconds
+        self.deadline_of = self.module._caller_deadline_ms
+
+    def test_the_transport_ceiling_is_unchanged_when_no_deadline_is_given(self) -> None:
+        """Control. A caller that names no deadline must keep exactly what it had."""
+        self.assertAlmostEqual(62.0, self.budget(60000, 0), places=6)
+        self.assertAlmostEqual(
+            62.0, self.budget(60000, -1), places=6,
+            msg="a negative deadline is not a deadline and must not shorten the wait")
+
+    def test_a_caller_deadline_shortens_the_wait(self) -> None:
+        """The measured case: a 5s hook retrieve waited 62s."""
+        self.assertAlmostEqual(
+            7.0, self.budget(60000, 5000), places=6,
+            msg="a 5s retrieve still waits the transport ceiling")
+        self.assertLess(
+            self.budget(60000, 5000), 62.0,
+            "the caller's deadline does not reach the socket")
+
+    def test_the_cap_only_reduces(self) -> None:
+        """A deadline is permission to stop early, not permission to wait longer."""
+        self.assertAlmostEqual(
+            4.0, self.budget(2000, 60000), places=6,
+            msg="a caller asking for 60s got more than the 2s transport ceiling allows")
+
+    def test_no_deadline_however_small_can_starve_the_call(self) -> None:
+        """The failure this must not recreate.
+
+        The read timeout was once a constant `min(2.0, ...)` that no `--request-timeout-ms` could
+        raise, so any response slower than two seconds became a timeout and hook retrieval came
+        back empty. A cap that subtracted rather than added -- `min(ceiling, deadline/1000)` --
+        would be that bug again, reached by any caller with a deadline under two seconds.
+        """
+        for deadline_ms in (1, 10, 100, 250, 999, 1000, 1999):
+            self.assertGreaterEqual(
+                self.budget(60000, deadline_ms), self.module.SOCKET_OVERHEAD_S,
+                "a %dms deadline left less than the connect-and-framing allowance, so the call "
+                "cannot complete a handshake and every such caller times out" % deadline_ms)
+
+    def test_the_ceiling_itself_never_goes_below_the_minimum(self) -> None:
+        """The transport side of the same property, which a 0 timeout would otherwise break."""
+        for request_timeout_ms in (0, 1, 500):
+            self.assertGreaterEqual(
+                self.budget(request_timeout_ms, 0), self.module.SOCKET_MINIMUM_BUDGET_S,
+                "a %dms transport timeout produced a budget below the minimum" % request_timeout_ms)
+
+    def test_the_deadline_is_found_where_callers_put_it(self) -> None:
+        """Three shapes, because three callers build the call differently."""
+        self.assertEqual(5000, self.deadline_of({"deadline_ms": 5000}))
+        self.assertEqual(
+            5000, self.deadline_of({"request": {"deadline_ms": 5000}}),
+            "the retrieve path puts it in the request body, which is the one that mattered")
+        self.assertEqual(250, self.deadline_of({"ranking": {"deadline_ms": 250}}))
+
+    def test_no_deadline_reads_as_no_deadline(self) -> None:
+        """0 is the documented "no deadline" value and must not read as "expire immediately"."""
+        for shape in ({"deadline_ms": 0}, {"request": {}}, {}, {"deadline_ms": None},
+                      {"deadline_ms": "soon"}, {"request": None}):
+            self.assertEqual(
+                0, self.deadline_of(shape),
+                "%r should read as no deadline; anything else caps the socket by accident" % shape)
+
+    def test_the_socket_call_site_passes_the_deadline(self) -> None:
+        """The wiring, not just the arithmetic.
+
+        A parameter nothing passes changes nothing, and a signature check cannot tell the
+        difference -- so assert the CALL SITE, which is what the live path actually executes.
+        """
+        import ast
+        import inspect
+
+        calls = [
+            node for node in ast.walk(ast.parse(inspect.getsource(self.module)))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "_call_socket_json"
+        ]
+        self.assertTrue(calls, "no call to the socket reader; this guard is testing nothing")
+        for call in calls:
+            keywords = {kw.arg: kw.value for kw in call.keywords}
+            self.assertIn(
+                "caller_deadline_ms", keywords,
+                "the call to _call_socket_json at line %d does not pass the caller's deadline, "
+                "so that call still waits the full transport ceiling" % call.lineno)
+            self.assertNotEqual(
+                "0", ast.unparse(keywords["caller_deadline_ms"]),
+                "the deadline is passed as a literal 0, which is the pre-fix behaviour spelled "
+                "with an extra argument")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The socket read was armed with `max(2s, request_timeout_ms/1000 + 2s)` — the **transport**
timeout, which is a ceiling on any single call to the store, not the budget *this* call was given.

## What the live box showed

Of 101 traced retrievals on the one-box, 95 returned a pack and 6 raised. Four of those six were:

```
daemon timed out waiting for response from /tmp/matrixark-rust-proxy-shared-live.sock after 62.0s
```

62.0 is not a coincidence — it is that expression with a 60s transport timeout. The Claude hook
budgets 5s for a retrieve, so each of those waited **twelve times its own budget** before failing,
and the turn ran without context for the whole 62 seconds.

It is worse than the log suggests. The hooks on that box run `--request-timeout-ms 300000`, so the
ceiling there is **302s**.

The request already carried `deadline_ms`. It was never read at this layer.

## The change

`_socket_budget_seconds(request_timeout_ms, caller_deadline_ms)` — the arithmetic now has a name and
a docstring instead of sitting inline.

| transport | caller deadline | budget | |
|---|---|---|---|
| 60000 | none | 62.0s | unchanged |
| 60000 | 5000 | **7.0s** | the measured case |
| 300000 | 5000 | **7.0s** | the same call on this box, was 302s |
| 2000 | 60000 | 4.0s | the cap only ever reduces |

Two properties the code has to keep, both of which cost an incident before:

- **The cap only reduces.** A caller asking for longer than the transport allows still gets the
  transport ceiling — a deadline is permission to stop early, not permission to wait longer.
- **The allowance is added, not subtracted.** The budget is `deadline/1000 + 2s`, so no deadline
  however small can starve connect and framing. This budget was once a constant `min(2.0, ...)` that
  no `--request-timeout-ms` could raise, so every response slower than two seconds became a timeout
  and hook retrieval came back empty with nothing in the logs but `TimeoutError: timed out`. A cap
  that could drive the budget toward zero would be that bug again.

## I shipped this wrong first, and the second commit is the fix

The first commit read the deadline from `kwargs`, `kwargs["request"]` and `kwargs["ranking"]`. All
three are plausible spellings. None is the one the live path uses —
`matrixark_retrieve_context_pack` passes the retrieve request as **`record=request`**. Measured
against the kwargs that entry point actually builds:

```
deadline found: 0
socket budget with the box's 300s transport timeout: 302.0s
```

A no-op on the one call it was written for. Every shape assertion passed, because I had written the
shapes.

So the guard no longer depends on that list being right. `TheLiveRetrieveDeadlineReachesTheSocketTest`
calls `matrixark_retrieve_context_pack` — the entry point the hook calls — against a Unix socket
that accepts and never answers, and times how long it waits. It names no carrier key. Renaming the
carrier, changing the call site, or reverting the arithmetic all fail it.

## Guard

9 tests. Mutation-tested; all nine mutations are caught:

| mutation | |
|---|---|
| **`record` is not a carrier** (the bug above) | caught |
| the carrier is renamed to a spelling not in the list | caught |
| the cap is gone (pre-fix behaviour) | caught |
| the cap subtracts instead of adds | caught |
| the cap can raise the budget past the ceiling | caught |
| zero reads as a deadline | caught |
| the transport ceiling loses its own minimum | caught |
| the call site stops passing the deadline | caught |
| garbage in `deadline_ms` is no longer rejected | caught |

Mutation testing also deleted something: a `max(SOCKET_MINIMUM_BUDGET_S, ...)` I had written on the
capped branch was unreachable, because the overhead is added and equals the minimum. Removing it
changed no result, so it is gone rather than left to read as protection that never runs.

## Verification

- The existing `test_matrixark_rust_proxy_socket_deadline` suite — which documents the earlier fix
  cited above and drives real Unix sockets — passes unchanged. Its cases use no caller deadline and
  fall on the untouched path.
- Name-diff against `main` over the 23 suites that import this module: **10 failures on main, the
  same 10 on this branch, no difference.**
- Rebased onto `243442d8`.
