### PR TITLE
A sentence naming a module does not reach it

### DIFF
--- a/tools/matrixark_mcp_core_ref_selection.py
+++ b/tools/matrixark_mcp_core_ref_selection.py
@@ -61,8 +61,8 @@ __all__ = ['dropped_candidate_audit_ref', 'record_dropped_candidate', 'diversify
 
 
 # `normalized_token_set` and `near_duplicate_overlap_ratio` are not defined here any more. They
-# moved to matrixark_mcp_scoring so matrixark_mcp_budget_pack can use them too: the gateway reaches
-# that packer, and it had no near-duplicate suppression at all while the setting that governs it,
+# moved to matrixark_mcp_scoring so matrixark_mcp_budget_pack can use them too: no production
+# path reaches that packer, and it had no near-duplicate suppression at all while the setting that governs it,
 # MATRIXARK_NEAR_DUPLICATE_OVERLAP_THRESHOLD, is offered by matrixark_gateway_config and defaults
 # to 0.85 -- on. This module could not be the shared home because it imports matrixark_mcp_core.
 try:
@@ -128,7 +128,7 @@ def clamp_refs_to_token_budget(
 # Neither was the complete one, so the surviving pair takes the wider rule and the richer record.
 #
 # It lives there rather than here because that module does not import matrixark_mcp_core and this
-# one does; matrixark_mcp_budget_pack, which the gateway reaches, already resolved both names
+# one does; matrixark_mcp_budget_pack, which no production path reaches, already resolved both names
 # there.
 try:
     from tools.matrixark_mcp_recall_scoring import (

--- a/tools/matrixark_mcp_scoring.py
+++ b/tools/matrixark_mcp_scoring.py
@@ -24,7 +24,8 @@ def tokens(text: str) -> list[str]:
 
 # Near-duplicate detection lives here rather than beside one of the two packers that need it.
 # It was defined in matrixark_mcp_core_ref_selection, which imports matrixark_mcp_core, so the
-# other packer -- matrixark_mcp_budget_pack, which the gateway reaches -- could not use it without
+# other packer -- matrixark_mcp_budget_pack, which no production path reaches -- could not use
+# it without
 # taking that whole dependency at import time. It is built on `tokens`, which this module owns.
 def normalized_token_set(text: str) -> frozenset[str]:
     """Lower-cased, de-duplicated token set used for near-duplicate detection."""

--- a/tools/test_a_module_only_tests_reach_is_not_live.py
+++ b/tools/test_a_module_only_tests_reach_is_not_live.py
@@ -139,6 +139,16 @@ UNREACHABLE = {
         "matrixark_mcp_direct_cache",
         "matrixark_mcp_direct_cache_state",
     ),
+    # Two packers, ~1,639 lines, and the reason the docstring rule exists: both were held OUT of
+    # this list by a sentence. `matrixark_mcp_budget_pack` defines `select_token_budgeted_refs`,
+    # which production does import -- from `matrixark_mcp_core_ref_selection`, by way of
+    # `matrixark_mcp_core`. `matrixark_mcp_dashboard` defines `latest_async_pipeline_rows`, which
+    # production imports from `matrixark_mcp_async_readiness`. Each is a second copy of a name the
+    # live tree serves elsewhere, which is what makes them worth listing rather than ignoring.
+    "packers": (
+        "matrixark_mcp_budget_pack",
+        "matrixark_mcp_dashboard",
+    ),
     # Singles, ~4,062 lines between them.
     "singles": (
         "matrixark_mcp_deadline_pack",
@@ -174,9 +184,32 @@ def _parse() -> Dict[str, Tuple[str, ast.Module]]:
     return found
 
 
+def _docstrings(tree: ast.Module) -> Set[int]:
+    """The string Constants that are DOCSTRINGS -- module, class, function, method.
+
+    A docstring is prose. It is never the argument to `import_module`, so it can never be the
+    only thing reaching a module -- but the word scan below cannot tell "mirrors
+    `summary_provider()` in matrixark_mcp_summaries" from an import site, and one sentence of
+    explanation in a reachable module marked THREE unreachable ones live. That is this check's
+    own failure mode running backwards: a module nothing calls, hidden by a mention of its name.
+    """
+    found: Set[int] = set()
+    for node in ast.walk(tree):
+        body = getattr(node, "body", None)
+        if not isinstance(node, (ast.Module, ast.ClassDef,
+                                 ast.FunctionDef, ast.AsyncFunctionDef)) or not body:
+            continue
+        first = body[0]
+        if isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant) \
+                and isinstance(first.value.value, str):
+            found.add(id(first.value))
+    return found
+
+
 def _edges(modules) -> Dict[str, Set[str]]:
     graph: Dict[str, Set[str]] = collections.defaultdict(set)
     for stem, (_path, tree) in modules.items():
+        prose = _docstrings(tree)
         for node in ast.walk(tree):
             if isinstance(node, ast.ImportFrom) and node.module:
                 target = node.module.rsplit(".", 1)[-1]
@@ -187,7 +220,8 @@ def _edges(modules) -> Dict[str, Set[str]]:
                     target = alias.name.rsplit(".", 1)[-1]
                     if target in modules:
                         graph[stem].add(target)
-            elif isinstance(node, ast.Constant) and isinstance(node.value, str):
+            elif isinstance(node, ast.Constant) and isinstance(node.value, str) \
+                    and id(node) not in prose:
                 # importlib.import_module("tools.x") is an edge. Reading only import statements
                 # reports its target unreachable when a test or a launcher does reach it.
                 for word in _WORD.findall(node.value):

--- a/tools/test_matrixark_a_docstring_is_not_an_import.py
+++ b/tools/test_matrixark_a_docstring_is_not_an_import.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A sentence naming a module does not reach it.
+
+`test_a_module_only_tests_reach_is_not_live` builds its import graph from statements AND from words
+inside string literals, because ``importlib.import_module("tools.x")`` is a real edge that reading
+`import` statements alone would miss. A docstring is a string literal too, so this line, added to a
+reachable module while documenting a mirror:
+
+    Mirrors `summary_provider()` in matrixark_mcp_summaries and must keep mirroring it
+
+marked three recorded modules live. Nothing changed about what runs. One sentence did it.
+
+That is the check's own purpose running backwards. It exists because "a copy that is wrong and
+unreachable cannot fail today, and is exactly what somebody reaches for tomorrow" -- and a module
+that stays hidden because somebody once explained it is the same defect, protected by prose.
+
+**Excluding docstrings cannot lose a real edge**, which is why this is the rule rather than a
+looser one: a docstring is never the argument to `import_module`, so no module is reached only by
+one. The alternative tried first -- count a string only if the whole string is a dotted path --
+stranded thirty-three modules that real string edges reach, and is refused by
+`test_a_dynamic_import_string_still_reaches`.
+
+Applying it revealed two modules held live by exactly that sentence, each a second copy of a name
+the live tree serves from somewhere else. `TheTwoPackersAreRealTest` checks that from the source
+rather than restating it.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+import test_a_module_only_tests_reach_is_not_live as guard  # noqa: E402
+
+
+def graph_for(source: str, targets=("matrixark_mcp_core",)) -> set:
+    """The edges `_edges` finds out of a one-module tree naming `targets`."""
+    modules = {"caller": ("tools/caller.py", ast.parse(source))}
+    for name in targets:
+        modules[name] = ("tools/%s.py" % name, ast.parse(""))
+    return guard._edges(modules).get("caller", set())
+
+
+class ADocstringIsNotAnEdgeTest(unittest.TestCase):
+
+    def test_a_module_docstring_naming_a_module_is_not_an_edge(self) -> None:
+        self.assertEqual(set(), graph_for('"""Mirrors matrixark_mcp_core, and must."""\n'))
+
+    def test_a_function_docstring_is_not_either(self) -> None:
+        self.assertEqual(set(), graph_for(
+            'def f():\n    """Unlike matrixark_mcp_core, this one is cheap."""\n    return 1\n'))
+
+    def test_a_method_docstring_is_not_either(self) -> None:
+        """The walk has to reach nested definitions, not just the top level."""
+        self.assertEqual(set(), graph_for(
+            'class C:\n    def m(self):\n        """See matrixark_mcp_core."""\n        return 1\n'))
+
+    def test_a_dynamic_import_string_still_reaches(self) -> None:
+        """The control. Without this the rule could be "drop every string edge", which is the
+        change that would break the check rather than fix it."""
+        self.assertEqual({"matrixark_mcp_core"}, graph_for(
+            'import importlib\nm = importlib.import_module("tools.matrixark_mcp_core")\n'))
+
+    def test_an_ordinary_string_still_reaches(self) -> None:
+        """A name in a table, a registry entry, a subprocess argument -- all still edges."""
+        self.assertEqual({"matrixark_mcp_core"}, graph_for('BACKENDS = ["matrixark_mcp_core"]\n'))
+
+    def test_a_string_that_is_not_the_first_statement_is_not_a_docstring(self) -> None:
+        """A bare string after real code is not documentation and is not treated as such."""
+        self.assertEqual({"matrixark_mcp_core"}, graph_for(
+            'def f():\n    x = 1\n    "matrixark_mcp_core"\n    return x\n'))
+
+    def test_an_import_statement_is_still_an_edge(self) -> None:
+        self.assertEqual({"matrixark_mcp_core"}, graph_for(
+            'from tools.matrixark_mcp_core import thing\n'))
+
+
+class TheTwoPackersAreRealTest(unittest.TestCase):
+    """Both were revealed by the rule. Checked here from the source, not asserted from the list."""
+
+    PACKERS = {
+        "matrixark_mcp_budget_pack": ("select_token_budgeted_refs",
+                                      "matrixark_mcp_core_ref_selection"),
+        "matrixark_mcp_dashboard": ("latest_async_pipeline_rows",
+                                    "matrixark_mcp_async_readiness"),
+    }
+
+    @staticmethod
+    def _defines(module: str, function: str) -> bool:
+        path = os.path.join(TOOLS, module + ".py")
+        with open(path, encoding="utf-8") as handle:
+            tree = ast.parse(handle.read())
+        return any(isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and n.name == function
+                   for n in tree.body)
+
+    def test_each_is_recorded_as_unreachable(self) -> None:
+        recorded = {name for group in guard.UNREACHABLE.values() for name in group}
+        for module in self.PACKERS:
+            self.assertIn(module, recorded)
+
+    def test_each_holds_a_copy_of_a_name_a_live_module_also_defines(self) -> None:
+        """Not merely unused: a second definition of a name the tree serves elsewhere, which is
+        what makes reading one of them as current a real mistake rather than a tidiness point."""
+        for module, (function, live) in self.PACKERS.items():
+            with self.subTest(module=module):
+                self.assertTrue(self._defines(module, function),
+                                "%s no longer defines %s" % (module, function))
+                self.assertTrue(self._defines(live, function),
+                                "%s no longer defines %s, so the pair is gone" % (live, function))
+
+    def test_the_live_copy_is_the_one_production_reaches(self) -> None:
+        """The floor for the test above: a duplicate only matters if the OTHER one is live."""
+        _library, reachable = guard.reachable_from_production()
+        for module, (_function, live) in self.PACKERS.items():
+            with self.subTest(module=module):
+                self.assertIn(live, reachable)
+                self.assertNotIn(module, reachable)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The reachability check builds its import graph from statements **and** from words inside string literals, because `importlib.import_module("tools.x")` is a real edge that reading `import` statements alone would miss.

A docstring is a string literal too. So this line, added to a reachable module while documenting a mirror —

> Mirrors `summary_provider()` in the summariser module and must keep mirroring it

— marked three recorded modules live. Nothing changed about what runs. One sentence did it.

That is the check's own purpose running backwards. It exists because "a copy that is wrong and unreachable cannot fail today, and is exactly what somebody reaches for tomorrow"; a module that stays hidden because somebody once explained it is the same defect, protected by prose.

**Excluding docstrings cannot lose a real edge** — a docstring is never the argument to `import_module`, so nothing is reached only by one. The looser rule tried first (count a string only when the whole string is a dotted path) stranded thirty-three modules that real string edges do reach, and is now refused by `test_a_dynamic_import_string_still_reaches`.

## What it revealed

Two modules were being held out of the record by exactly that kind of sentence:

| module | defines | production imports it from |
|---|---|---|
| `matrixark_mcp_budget_pack` | `select_token_budgeted_refs` | `matrixark_mcp_core_ref_selection`, via `matrixark_mcp_core` |
| `matrixark_mcp_dashboard` | `latest_async_pipeline_rows` | `matrixark_mcp_async_readiness` |

Each is a second copy of a name the live tree serves elsewhere, which is what makes reading one as current a real mistake rather than a tidiness point. Three comments stated that the gateway reaches the first of them; it does not, and they now say so.

## Mutations

Fourteen tests. Each of these reddens at least one:

| mutation | reddens |
|---|---|
| docstrings count as edges again | `test_a_function_docstring_is_not_either`, `test_a_method_docstring_is_not_either` |
| the docstring finder returns nothing | `test_a_function_docstring_is_not_either`, `test_a_method_docstring_is_not_either` |
| every string counts as a docstring | `test_a_string_that_is_not_the_first_statement_is_not_a_docstring` |
| no string is an edge at all | `test_a_dynamic_import_string_still_reaches` |
| the two modules leave the record | `test_each_is_recorded_as_unreachable`, `test_the_set_is_exactly_what_is_recorded` |
| one is named as its own live copy | `test_the_live_copy_is_the_one_production_reaches` |

`main` is currently red on 15 tests unrelated to this change (3 from #1130, fixed by #1139; 12 budget/floor tests reproduced on a clean `main` checkout). This branch adds none of them.
