### PR TITLE
A page of shards cost the cluster instead of the page

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -1672,7 +1672,9 @@ impl MetaState {
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct MetaState {
-    shards: HashMap<ShardId, ShardLocation>,
+    /// Kept in shard order so a page of them is a range rather than a scan
+    /// of everything above the cursor.
+    shards: BTreeMap<ShardId, ShardLocation>,
     servers: BTreeMap<String, ServerMetaInfo>,
     proxies: BTreeMap<String, ProxyMetaInfo>,
     proxy_groups: BTreeMap<String, ProxyGroupInfo>,

--- a/crates/temporalstore-rust/src/meta/lifecycle.rs
+++ b/crates/temporalstore-rust/src/meta/lifecycle.rs
@@ -202,25 +202,25 @@ impl SingleNodeMeta {
             request.limit.min(LIST_SHARDS_DEFAULT_LIMIT)
         };
 
-        let mut ids = state
-            .shards
-            .keys()
-            .copied()
-            .filter(|shard_id| *shard_id > request.after_shard_id)
-            .collect::<Vec<_>>();
-        ids.sort_unstable();
-
         // Which shards this answer will carry, decided before anything is
         // looked up for them. Naming the table that owns a shard used to be
         // done by building that map for every shard in the cluster -- walking
         // every table, over every shard it declares, cloning its namespace and
         // its name for each -- and then using at most one page of it.
+        //
+        // The map is kept in shard order, so this walks from the cursor rather
+        // than over everything above it: a page costs the page. It used to cost
+        // the cluster, which made paging through one quadratic.
         let mut page = Vec::new();
         let mut next_after_shard_id = None;
-        for shard_id in ids {
-            let Some(location) = state.shards.get(&shard_id) else {
-                continue;
-            };
+        for (shard_id, location) in state
+            .shards
+            .range((
+                std::ops::Bound::Excluded(request.after_shard_id),
+                std::ops::Bound::Unbounded,
+            ))
+        {
+            let shard_id = *shard_id;
             if !request.server_addr.is_empty() && location.server_addr != request.server_addr {
                 continue;
             }

--- a/crates/temporalstore-rust/src/meta/snapshot_ops.rs
+++ b/crates/temporalstore-rust/src/meta/snapshot_ops.rs
@@ -56,7 +56,7 @@ impl SingleNodeMeta {
             }
         }
         let mut restored = MetaState {
-            shards: snapshot.shards,
+            shards: snapshot.shards.into_iter().collect(),
             servers: snapshot.servers,
             proxies: snapshot.proxies,
             proxy_groups: snapshot.proxy_groups,
@@ -136,7 +136,11 @@ impl MetaSnapshot {
         MetaSnapshot {
             format_version: 1,
             created_at_ms: now_ms(),
-            shards: state.shards.clone(),
+            shards: state
+                .shards
+                .iter()
+                .map(|(shard_id, location)| (*shard_id, location.clone()))
+                .collect(),
             servers: state.servers.clone(),
             proxies: state.proxies.clone(),
             proxy_groups: state.proxy_groups.clone(),


### PR DESCRIPTION
Listing shards hands back a page at a time, in shard order. The map they live in was unordered, so producing that page meant visiting every shard above the cursor and sorting what came back. The cost of a page was the size of the cluster, and paging through all of it was quadratic.

The giveaway is the last page. It carries four rows and cost 58us at 16,384 shards -- fourteen microseconds a row, against half a microsecond for a full page. The price was the cluster, not the page.

| shards | before | after |
|---|---|---|
| 4,096, first page | 124.5us | 33.3us |
| 16,384, first page | 548.5us | 33.1us |
| 16,384, last page (4 rows) | 58.0us | 0.7us |

Flat now, at every cluster size.

## The map is ordered instead

An ordered map answers the same question with a range scan from the cursor. Nothing else about the map changes: the lookups, inserts and removals are the same calls on the same keys.

The snapshot keeps its own shape, so nothing on the wire moves. The two are converted where a state is built from a snapshot and where one is taken.

## The lookups did not get slower

Point lookups become logarithmic rather than constant, and shard lookups sit on the topology path, so that was the thing to check rather than assume. Measured in the same interleaved run:

| operation | before | after |
|---|---|---|
| topology, full build | 43.00us | 26.83us |
| calibration plan | 28.07us | 22.94us |
| topology, caller is current | 0.32us | 0.25us |
| a proxy heartbeat | 0.23us | 0.20us |

Faster, not slower. Building a topology walks a table's shards, which are a contiguous range of ids: in an ordered map that is a range scan, where before it was a scattered lookup per shard. The locality is worth more than the logarithm costs.

## Measuring

Arms interleaved and each run more than once, because the box is shared. The same arm measured 26.83us for a topology build in one window and 51.82us in another, half an hour apart, with the code unchanged -- so only numbers from within a single interleaved run are compared here.
