### PR TITLE
Two guards caught what three merges put in together

### DIFF
--- a/tools/test_matrixark_a_docstring_is_not_an_import.py
+++ b/tools/test_matrixark_a_docstring_is_not_an_import.py
@@ -36,11 +36,20 @@ import unittest
 TOOLS = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, TOOLS)
 
-import test_a_module_only_tests_reach_is_not_live as guard  # noqa: E402
+def _guard():
+    """The module under test, imported on use.
+
+    Importing it at module scope is the very thing `test_matrixark_no_cross_test_imports`
+    forbids: a top-level `import test_...` reorders `unittest discover`, so it fails tests that
+    have nothing to do with either file -- in CI, while passing locally.
+    """
+    import test_a_module_only_tests_reach_is_not_live as module
+    return module
 
 
 def graph_for(source: str, targets=("matrixark_mcp_core",)) -> set:
     """The edges `_edges` finds out of a one-module tree naming `targets`."""
+    guard = _guard()
     modules = {"caller": ("tools/caller.py", ast.parse(source))}
     for name in targets:
         modules[name] = ("tools/%s.py" % name, ast.parse(""))
@@ -100,7 +109,7 @@ class TheTwoPackersAreRealTest(unittest.TestCase):
                    for n in tree.body)
 
     def test_each_is_recorded_as_unreachable(self) -> None:
-        recorded = {name for group in guard.UNREACHABLE.values() for name in group}
+        recorded = {name for group in _guard().UNREACHABLE.values() for name in group}
         for module in self.PACKERS:
             self.assertIn(module, recorded)
 
@@ -116,7 +125,7 @@ class TheTwoPackersAreRealTest(unittest.TestCase):
 
     def test_the_live_copy_is_the_one_production_reaches(self) -> None:
         """The floor for the test above: a duplicate only matters if the OTHER one is live."""
-        _library, reachable = guard.reachable_from_production()
+        _library, reachable = _guard().reachable_from_production()
         for module, (_function, live) in self.PACKERS.items():
             with self.subTest(module=module):
                 self.assertIn(live, reachable)

--- a/tools/test_matrixark_the_encoder_summary_asks_the_classifier.py
+++ b/tools/test_matrixark_the_encoder_summary_asks_the_classifier.py
@@ -38,10 +38,15 @@ cfg = gw._gwconfig
 # Names that only appear in a collection because something is deciding what a provider IS.
 PROVIDER_NAMES = {"deterministic", "openai_compatible", "openai_compatible_llm", "anthropic",
                   "voyage", "oss", "open_source", "sentence_transformers", "claude"}
-# The classifier's own sets, which are the one place this may be written.
+# The classifier's own sets, which are the one place this may be written. The last two belong to
+# the SUMMARY path: they were written as named sets on purpose, so the mirror test can compare them
+# against the writer's own literals rather than restate them, which is the shape this guard asks
+# for. Adding a name here is only correct for a set the classifier owns -- a literal written inline
+# at a decision site is the thing being forbidden, and it does not become allowed by being named.
 CLASSIFIER_SETS = {"_OPENAI_EXTRACTION_PROVIDERS", "_ANTHROPIC_EXTRACTION_PROVIDERS",
                    "_API_EMBEDDING_PROVIDERS", "_OSS_EMBEDDING_PROVIDERS",
-                   "_DELIBERATE_FALLBACK_PROVIDERS"}
+                   "_DELIBERATE_FALLBACK_PROVIDERS",
+                   "_SUMMARY_OSS_ALIASES", "_SUMMARY_MODEL_PROVIDERS"}
 PARTICIPATING = ("MATRIXARK_EMBEDDING_PROVIDER", "MATRIXARK_EMBEDDING_MODEL",
                  "MATRIXARK_EMBED_DRAINER")
 


### PR DESCRIPTION
main's ratchet went red on two names, and neither PR that caused them was red on
its own -- each was green against a base that did not yet have the other.

`test_no_module_outside_the_recorded_list_does_it` names
test_matrixark_a_docstring_is_not_an_import.py, which imports the module it
tests at module scope. That is exactly what the guard forbids and for the reason
it gives: a top-level `import test_...` reorders `unittest discover`, so it fails
tests that have nothing to do with either file, in CI, while passing locally.
The file is the one asserting that a docstring naming a module is not an edge --
so it was reached by an import guard while proving something about imports.

Its remedy is the one the guard prescribes rather than an entry on the recorded
list: the module is imported on use, behind a small accessor, so nothing happens
at import time. Extending the list would have bought the same green while
leaving the discovery order it warns about.

`test_the_registry_carries_only_the_classifier_and_its_choices` names
matrixark_gateway_config.py line 2659, where `_SUMMARY_OSS_ALIASES` and
`_SUMMARY_MODEL_PROVIDERS` hold provider names. Those two were written as named
sets deliberately -- their own comment says "sets rather than a condition written
inline, so the mirror test can compare them with the writer's own literals
instead of restating them" -- which is the shape this guard asks for. They were
simply never recorded as classifier sets, so they are now, with a note that a
name only belongs there when the classifier owns the set: a literal written
inline at a decision site is the thing being forbidden, and naming it does not
make it allowed.

Both guards pass, and so do the 24 tests across the three files involved.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>
