### PR TITLE
The compressor is built once, not once per record

### DIFF
--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -4704,6 +4704,72 @@ mod tests {
         set_wal_segment_bytes_for_test(None);
     }
 
+    /// What compressing a record costs the append that writes it.
+    ///
+    /// The fused writer exists so an append does not build the record twice: it declares the
+    /// frame's length up front and lets the encoder append straight into the buffer that goes to
+    /// the file. Compression cannot use it -- the compressed length is not knowable until the
+    /// payload has been compressed -- so that arm builds the payload into its own buffer, hands it
+    /// to the compressor, and frames the result.
+    ///
+    /// Compression became the default after the fused writer landed, so every append now takes the
+    /// arm the fused writer was written to avoid. This measures what that is worth in allocations
+    /// and bytes, which is the question a default flip should have been able to answer.
+    #[test]
+    #[ignore]
+    #[cfg(feature = "alloc-probe")]
+    fn what_compression_costs_an_append() {
+        for value_len in [64usize, 1024, 4096] {
+            let measure = |compress: bool| -> (f64, f64) {
+                std::env::set_var("TS_WAL_COMPRESS_RECORDS", if compress { "1" } else { "0" });
+                let dir = tempfile::tempdir().unwrap();
+                let store = LocalWriteAheadLogStore::new(dir.path());
+                let runs = 32usize;
+                // warm the piece and any once-only work
+                store
+                    .append(
+                        1,
+                        Command::StringSet {
+                            key: "warm".to_string(),
+                            value: incompressible_seeded(value_len, 9_999),
+                        },
+                    )
+                    .unwrap();
+
+                let probe = crate::alloc_probe::Probe::start();
+                for index in 0..runs {
+                    store
+                        .append(
+                            1,
+                            Command::StringSet {
+                                key: format!("k{index:06}"),
+                                value: incompressible_seeded(value_len, index as u64),
+                            },
+                        )
+                        .unwrap();
+                }
+                let counts = probe.stop();
+                (
+                    counts.allocs as f64 / runs as f64,
+                    counts.alloc_bytes as f64 / runs as f64,
+                )
+            };
+
+            let (off_allocs, off_bytes) = measure(false);
+            let (on_allocs, on_bytes) = measure(true);
+            std::env::remove_var("TS_WAL_COMPRESS_RECORDS");
+
+            println!(
+                "  COMPALLOC value {value_len:>5}B | off {off_allocs:>5.1} allocs {off_bytes:>8.0} B | on {on_allocs:>5.1} allocs {on_bytes:>8.0} B | compression adds {:>5.1} allocs {:>8.0} B ({:>5.2}x the bytes)",
+                on_allocs - off_allocs,
+                on_bytes - off_bytes,
+                on_bytes / off_bytes.max(1.0),
+            );
+
+            assert!(on_allocs > 0.0, "the probe must observe appends at {value_len}B");
+        }
+    }
+
     /// A payload the record compressor cannot shrink.
     ///
     /// These tests are about block geometry, rolling and truncation, and every one of them used a

--- a/crates/temporalstore-rust/src/wal_proto.rs
+++ b/crates/temporalstore-rust/src/wal_proto.rs
@@ -103,11 +103,37 @@ pub(crate) fn compress_records_enabled() -> bool {
 /// None for a payload under the floor, and None when the compressed form is not actually smaller.
 /// The second check is the page store's: compression that does not pay is written uncompressed
 /// rather than trusted to pay on average.
+/// The compressor, kept for the life of the thread rather than built per record.
+///
+/// `zstd::stream::encode_all` builds a fresh compression context on every call, and a level-3
+/// context is tens of kilobytes. Measured per append, with an incompressible payload so the
+/// figures are the machinery and not the data: at a 1 KiB value compression added 6 allocations
+/// and 35,951 bytes, taking the append from 1,159 to 37,110 bytes -- 32x, for a record that is
+/// barely a kilobyte. At 4 KiB it added 45,167 bytes.
+///
+/// The context does not depend on the payload, so there is no reason to build one per record.
+/// `bulk::Compressor` holds it and reuses it. What remains per record is the output buffer, which
+/// is the compressed bytes themselves and cannot be avoided here.
+///
+/// Thread-local rather than shared: the compressor is `&mut` to use, so sharing it across threads
+/// would need a lock on the append path, and appends are the thing this is trying not to slow
+/// down.
+thread_local! {
+    static RECORD_COMPRESSOR: std::cell::RefCell<Option<zstd::bulk::Compressor<'static>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
 fn compress_payload(encoded: &[u8]) -> Option<Vec<u8>> {
     if encoded.len() < COMPRESSION_MIN_BYTES {
         return None;
     }
-    let compressed = zstd::stream::encode_all(encoded, COMPRESSION_LEVEL).ok()?;
+    let compressed = RECORD_COMPRESSOR.with(|cell| {
+        let mut slot = cell.borrow_mut();
+        if slot.is_none() {
+            *slot = zstd::bulk::Compressor::new(COMPRESSION_LEVEL).ok();
+        }
+        slot.as_mut()?.compress(encoded).ok()
+    })?;
     (compressed.len() < encoded.len()).then_some(compressed)
 }
 


### PR DESCRIPTION
`compress_payload` called `zstd::stream::encode_all`, which builds a fresh compression context on
every call. A level-3 context is tens of kilobytes, and it does not depend on the payload, so every
append was allocating one and throwing it away.

Measured per append, with an incompressible payload so the numbers are the machinery rather than
the data:

| value | before | after |
|---|---|---|
| 1 KiB | 15.0 allocations, 37,110 B | 14.0 allocations, 4,400 B |
| 4 KiB | 15.1 allocations, 49,499 B | 14.1 allocations, 16,799 B |

About 32.7 KB an append, at any size -- a constant, which is what a fixed-size context looks like.
Against the same append with compression off, the overhead falls from 32x the record's own bytes to
3.8x. A 64-byte value is unchanged because it never reaches the compressor: anything under
`COMPRESSION_MIN_BYTES` is written raw.

`bulk::Compressor` holds the context and reuses it. It is thread-local rather than shared, because
using it takes `&mut`, and sharing one would put a lock on the append path -- which is the path
this is trying not to slow down. What is still allocated per record is the output buffer, and that
is the compressed bytes themselves.

This matters more than a normal allocation change because of when it arrived. The fused writer was
built so an append does not construct the record twice; compression cannot use it, since a frame
declares its length before a compressed payload has one. Compression then became the default, so
every append takes the arm the fused writer was written to avoid, and it was carrying a context
allocation on top.

Compressed records still read back: the compression tests are 14 passed, and the wal module is 97
passed with 0 failed.

The read side has the same shape -- `decode_all` builds a decompression context per call -- and is
left alone here. Sizing a reusable decompressor needs an upper bound on the decompressed length,
which is a separate question from this one.
