### PR TITLE
Two guards caught what three merges put in, and nobody moved them

### DIFF
--- a/tools/test_matrixark_a_docstring_is_not_an_import.py
+++ b/tools/test_matrixark_a_docstring_is_not_an_import.py
@@ -36,7 +36,16 @@ import unittest
 TOOLS = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, TOOLS)
 
-import test_a_module_only_tests_reach_is_not_live as guard  # noqa: E402
+
+def _guard():
+    """The module this one checks, imported on use.
+
+    Importing it at import time reorders `unittest discover`, which is the thing
+    the cross-import guard exists to prevent -- so this module does not do it.
+    """
+    import test_a_module_only_tests_reach_is_not_live as guard
+
+    return guard
 
 
 def graph_for(source: str, targets=("matrixark_mcp_core",)) -> set:
@@ -44,7 +53,7 @@ def graph_for(source: str, targets=("matrixark_mcp_core",)) -> set:
     modules = {"caller": ("tools/caller.py", ast.parse(source))}
     for name in targets:
         modules[name] = ("tools/%s.py" % name, ast.parse(""))
-    return guard._edges(modules).get("caller", set())
+    return _guard()._edges(modules).get("caller", set())
 
 
 class ADocstringIsNotAnEdgeTest(unittest.TestCase):
@@ -100,7 +109,7 @@ class TheTwoPackersAreRealTest(unittest.TestCase):
                    for n in tree.body)
 
     def test_each_is_recorded_as_unreachable(self) -> None:
-        recorded = {name for group in guard.UNREACHABLE.values() for name in group}
+        recorded = {name for group in _guard().UNREACHABLE.values() for name in group}
         for module in self.PACKERS:
             self.assertIn(module, recorded)
 
@@ -116,7 +125,7 @@ class TheTwoPackersAreRealTest(unittest.TestCase):
 
     def test_the_live_copy_is_the_one_production_reaches(self) -> None:
         """The floor for the test above: a duplicate only matters if the OTHER one is live."""
-        _library, reachable = guard.reachable_from_production()
+        _library, reachable = _guard().reachable_from_production()
         for module, (_function, live) in self.PACKERS.items():
             with self.subTest(module=module):
                 self.assertIn(live, reachable)

--- a/tools/test_matrixark_the_encoder_summary_asks_the_classifier.py
+++ b/tools/test_matrixark_the_encoder_summary_asks_the_classifier.py
@@ -41,7 +41,12 @@ PROVIDER_NAMES = {"deterministic", "openai_compatible", "openai_compatible_llm",
 # The classifier's own sets, which are the one place this may be written.
 CLASSIFIER_SETS = {"_OPENAI_EXTRACTION_PROVIDERS", "_ANTHROPIC_EXTRACTION_PROVIDERS",
                    "_API_EMBEDDING_PROVIDERS", "_OSS_EMBEDDING_PROVIDERS",
-                   "_DELIBERATE_FALLBACK_PROVIDERS"}
+                   "_DELIBERATE_FALLBACK_PROVIDERS",
+                   # What the summary path maps onto the model route and what it
+                   # treats as that route directly. Named for the same reason as
+                   # the others: so the mirror test reads the writer's literals
+                   # rather than restating them.
+                   "_SUMMARY_OSS_ALIASES", "_SUMMARY_MODEL_PROVIDERS"}
 PARTICIPATING = ("MATRIXARK_EMBEDDING_PROVIDER", "MATRIXARK_EMBEDDING_MODEL",
                  "MATRIXARK_EMBED_DRAINER")
 


### PR DESCRIPTION

Both failures are on main, on every open pull request, and neither has anything
to do with the branch it fails on. They are the two guards doing their job while
what they guard moved underneath them.

A test module imported another test module at import time. That reorders
`unittest discover` and can fail tests it has nothing to do with -- in CI, while
passing locally -- which is exactly what the cross-import guard forbids, and it
named the file. Its three uses are all inside functions, so the import moves to
the point of use.

Not by adding the file to the guard's list of known offenders: that silences a
guard with its own exception list rather than fixing what it found.

The summary path added two sets of provider names -- what it maps onto the model
route, and what it treats as that route directly. They follow the rule the guard
enforces, which is that such a set must be a named constant so the mirror test
can read the writer's own literals instead of restating them. Their comment says
so. Only the registry of sanctioned names was not extended, so they read as
inline classification.

Registering them does not weaken the guard. The paired test walks that same list
and fails if an entry is missing or empty, so a name added there has to keep
existing to keep passing.

Both verified the honest way: they fail on clean main and pass with this.