### PR TITLE
Four functions that close over nothing leave the 3,763-line retrieve body

### DIFF
--- a/tools/matrixark_local_adapter_retrieve.py
+++ b/tools/matrixark_local_adapter_retrieve.py
@@ -303,6 +303,86 @@ def _tenant_retrieval_limit(name: str, scope: Any, fallback: int) -> int:
         return fallback
 
 
+
+def first_explicit_bool(key: str, *sources: Json) -> bool | None:
+    """The first of these sources that states `key` explicitly, or None if none does.
+
+    "Explicitly" is the whole point: a missing key, None and "" all mean "did not say", and are
+    skipped so a later source can answer. Only a value that actually spells a boolean -- a bool, a
+    number, or one of the on/off words -- stops the search. Returning None rather than False keeps
+    "nobody said" distinguishable from "somebody said no", which is what lets the caller fall back
+    to its own default instead of silently taking the off arm.
+    """
+    for source in sources:
+        if not isinstance(source, dict) or key not in source:
+            continue
+        value = source.get(key)
+        if value in (None, ""):
+            continue
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            return bool(value)
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"1", "true", "yes", "on"}:
+                return True
+            if normalized in {"0", "false", "no", "off"}:
+                return False
+    return None
+
+def scope_from_node_path(node_path: Any) -> Json:
+    """Recover the access scope encoded in a node path, as far as the path states it.
+
+    A node path carries its scope as `tenant:`/`user:`/`session:` prefixed segments. Only the
+    segments actually present are returned, and empty values are dropped, so the result says what
+    the path KNOWS rather than filling gaps with blanks -- a caller comparing scopes must be able
+    to tell an absent field from an empty one.
+    """
+    if not isinstance(node_path, list):
+        return {}
+    recovered_scope: Json = {}
+    for part in node_path:
+        value = str(part or "")
+        if value.startswith("tenant:"):
+            recovered_scope["tenant_id"] = value.split(":", 1)[1]
+        elif value.startswith("user:"):
+            recovered_scope["user_id"] = value.split(":", 1)[1]
+        elif value.startswith("session:"):
+            recovered_scope["session_id"] = value.split(":", 1)[1]
+    return {key: value for key, value in recovered_scope.items() if value}
+
+def stored_encoder_name(record: Json) -> str:
+    """Which encoder wrote this record's vector.
+
+    Owner records carry it under `embedding_meta`, not at the top level: the separate
+    embedding row was folded into its owner and its fields ride along there. Reading only
+    the top level found nothing on every record a current ingest writes, so the check
+    silently never applied -- the shape of bug it exists to catch.
+    """
+    meta = record.get("embedding_meta")
+    if isinstance(meta, dict):
+        name = meta.get("model") or meta.get("model_ref") or ""
+        if name:
+            return str(name)
+    return str(record.get("model") or record.get("model_ref") or "")
+
+def profile_summary_scope_matches(record: Json, query_scope: Json) -> bool:
+    """Does this record's node path place it in a scope the query may see?
+
+    Delegates the comparison rather than repeating it: the path states only what it states, and
+    `scope_matches` owns what counts as a match. Kept separate from the general recovery path
+    because a profile summary is matched on its node path alone.
+    """
+    if record.get("record_type") != "context_summary":
+        return False
+    node_path = [str(part or "") for part in record.get("node_path", []) if str(part or "")]
+    if "profile:long_term_memory" not in node_path:
+        return False
+    path_scope = scope_from_node_path(node_path)
+    if query_scope.get("account_id") and not path_scope.get("account_id"):
+        path_scope = {**path_scope, "account_id": query_scope.get("account_id")}
+    return scope_matches(path_scope, query_scope)
 class _LocalAdapterRetrieveMixin:
     def retrieve(self, args: Json) -> Json:
         started_perf = time.perf_counter()
@@ -740,24 +820,6 @@ class _LocalAdapterRetrieveMixin:
                     recovered[key] = value
             return recovered
 
-        def first_explicit_bool(key: str, *sources: Json) -> bool | None:
-            for source in sources:
-                if not isinstance(source, dict) or key not in source:
-                    continue
-                value = source.get(key)
-                if value in (None, ""):
-                    continue
-                if isinstance(value, bool):
-                    return value
-                if isinstance(value, (int, float)):
-                    return bool(value)
-                if isinstance(value, str):
-                    normalized = value.strip().lower()
-                    if normalized in {"1", "true", "yes", "on"}:
-                        return True
-                    if normalized in {"0", "false", "no", "off"}:
-                        return False
-            return None
 
         def annotate_session_continuity(candidate: Json, record: Json) -> Json:
             embedding_metadata = embedding_metadata_by_ref.get(
@@ -1072,19 +1134,6 @@ class _LocalAdapterRetrieveMixin:
             if source_scope:
                 node_scope_by_hash[source_node_hash] = source_scope
 
-        def scope_from_node_path(node_path: Any) -> Json:
-            if not isinstance(node_path, list):
-                return {}
-            recovered_scope: Json = {}
-            for part in node_path:
-                value = str(part or "")
-                if value.startswith("tenant:"):
-                    recovered_scope["tenant_id"] = value.split(":", 1)[1]
-                elif value.startswith("user:"):
-                    recovered_scope["user_id"] = value.split(":", 1)[1]
-                elif value.startswith("session:"):
-                    recovered_scope["session_id"] = value.split(":", 1)[1]
-            return {key: value for key, value in recovered_scope.items() if value}
 
         def recovered_record_scope(record: Json) -> Json:
             record_scope = candidate_access_scope(record)
@@ -1142,16 +1191,6 @@ class _LocalAdapterRetrieveMixin:
                 return False
             return True
 
-        def profile_summary_scope_matches(record: Json, query_scope: Json) -> bool:
-            if record.get("record_type") != "context_summary":
-                return False
-            node_path = [str(part or "") for part in record.get("node_path", []) if str(part or "")]
-            if "profile:long_term_memory" not in node_path:
-                return False
-            path_scope = scope_from_node_path(node_path)
-            if query_scope.get("account_id") and not path_scope.get("account_id"):
-                path_scope = {**path_scope, "account_id": query_scope.get("account_id")}
-            return scope_matches(path_scope, query_scope)
 
         if session_scope_mode(retrieval_scope) == "only":
             records = [
@@ -1302,20 +1341,6 @@ class _LocalAdapterRetrieveMixin:
         embedding_model_conflict_records = 0
         embedding_width_conflict_records = 0
 
-        def stored_encoder_name(record: Json) -> str:
-            """Which encoder wrote this record's vector.
-
-            Owner records carry it under `embedding_meta`, not at the top level: the separate
-            embedding row was folded into its owner and its fields ride along there. Reading only
-            the top level found nothing on every record a current ingest writes, so the check
-            silently never applied -- the shape of bug it exists to catch.
-            """
-            meta = record.get("embedding_meta")
-            if isinstance(meta, dict):
-                name = meta.get("model") or meta.get("model_ref") or ""
-                if name:
-                    return str(name)
-            return str(record.get("model") or record.get("model_ref") or "")
 
         def usable_vector(record: Json) -> list:
             """The record's vector, or nothing at all when it cannot be compared with the query's.

--- a/tools/test_a_nested_function_that_captures_nothing_is_hoisted.py
+++ b/tools/test_a_nested_function_that_captures_nothing_is_hoisted.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A nested function that captures nothing belongs at module scope.
+
+`retrieve` in `matrixark_local_adapter_retrieve` is the live retrieval entry point and the least
+readable code on that path: 3,718 lines, nesting depth 16, 744 branches. Most of its twenty nested
+`def`s genuinely close over its locals and cannot move -- relocating one of those would be a
+behaviour change dressed as tidying, and this guard does not ask for it.
+
+What it does ask is that a nested function which closes over NOTHING does not sit inside that body.
+Such a function is a plain module-level function that happens to be written 1,300 lines into a
+closure: it cannot be imported, cannot be tested on its own, and adds to the depth a reader has to
+hold. Three were found and moved (`first_explicit_bool`, `scope_from_node_path`,
+`stored_encoder_name`); this keeps the next one from accumulating.
+
+THE LIST IS DERIVED, NOT WRITTEN. The test recomputes which nested functions capture nothing, so it
+cannot go stale against a rename and cannot pass because someone edited a list. A named exemption
+would defeat it -- if a genuinely free function must stay nested, the honest fix is to give it a
+reason in code, not an entry here.
+
+The detector has one trap, and a static-only version gets it wrong: this module does
+`from ...matrixark_mcp_core import *`, so `Json`, `Any` and `scope_matches` are module-level at
+RUNTIME but invisible to an AST scan of the file. Reading the module's real namespace is what makes
+the answer right -- a static version reported all twenty as capturing something and would have
+passed vacuously forever.
+"""
+from __future__ import annotations
+
+import ast
+import builtins
+import importlib
+import inspect
+import unittest
+
+
+def _module():
+    try:
+        return importlib.import_module("tools.matrixark_local_adapter_retrieve")
+    except ImportError:
+        return importlib.import_module("matrixark_local_adapter_retrieve")
+
+
+def _bound_within(fn: ast.FunctionDef) -> set[str]:
+    """Every name the function binds itself: parameters, assignments, imports, except-as."""
+    names = {a.arg for a in fn.args.args + fn.args.kwonlyargs + fn.args.posonlyargs}
+    if fn.args.vararg:
+        names.add(fn.args.vararg.arg)
+    if fn.args.kwarg:
+        names.add(fn.args.kwarg.arg)
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
+            names.add(node.id)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)) and node is not fn:
+            names.add(node.name)
+        elif isinstance(node, ast.ExceptHandler) and node.name:
+            names.add(node.name)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                names.add((alias.asname or alias.name).split(".")[0])
+    return names
+
+
+class NestedFunctionsThatCaptureNothingAreHoistedTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.module = _module()
+        source = inspect.getsource(self.module)
+        self.tree = ast.parse(source)
+        self.retrieve = next(
+            (node for node in ast.walk(self.tree)
+             if isinstance(node, ast.FunctionDef) and node.name == "retrieve"), None)
+        self.assertIsNotNone(self.retrieve, "retrieve is gone; this guard is testing nothing")
+        # The module's REAL namespace, which is what makes star-imported names resolvable.
+        self.module_scope = set(dir(self.module)) | set(dir(builtins))
+
+    def _free_of_capture(self, parent: ast.FunctionDef) -> list[tuple[str, int]]:
+        free = []
+        for node in parent.body:
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            bound = _bound_within(node)
+            loaded = {n.id for n in ast.walk(node)
+                      if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load)}
+            if not (loaded - bound - self.module_scope):
+                free.append((node.name, node.lineno))
+        return free
+
+    def test_the_detector_can_see_a_captured_name(self) -> None:
+        """Positive control: without it, an over-broad module scope would pass everything."""
+        nested = [n for n in self.retrieve.body
+                  if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))]
+        self.assertTrue(nested, "no nested defs found; the detector is not looking at retrieve")
+        captured_somewhere = False
+        for node in nested:
+            bound = _bound_within(node)
+            loaded = {n.id for n in ast.walk(node)
+                      if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load)}
+            if loaded - bound - self.module_scope:
+                captured_somewhere = True
+                break
+        self.assertTrue(
+            captured_somewhere,
+            "not one nested function reads an enclosing local, which means the module scope used "
+            "here is too broad and the guard below would pass vacuously")
+
+    def test_no_nested_function_in_retrieve_captures_nothing(self) -> None:
+        """The rule. A closure over nothing is a module-level function in the wrong place."""
+        free = self._free_of_capture(self.retrieve)
+        self.assertEqual(
+            [], free,
+            "these nested functions in retrieve close over nothing, so they are plain functions "
+            "written inside a 3,700-line body -- unimportable, untestable on their own, and paid "
+            "for by every reader: %s. Move them to module scope."
+            % ", ".join("%s (line %d)" % (name, lineno) for name, lineno in free))
+
+    def test_the_hoisted_three_are_importable_and_behave(self) -> None:
+        """They were moved to be usable; check they actually are, and still answer correctly."""
+        for name in ("first_explicit_bool", "scope_from_node_path", "stored_encoder_name"):
+            self.assertTrue(
+                callable(getattr(self.module, name, None)),
+                "%s is not importable at module scope" % name)
+
+        first_explicit_bool = self.module.first_explicit_bool
+        self.assertIsNone(
+            first_explicit_bool("k", {}, {"k": None}, {"k": ""}),
+            "absent, None and empty must all read as 'nobody said', not as False -- the caller "
+            "distinguishes those to know whether it may apply its own default")
+        self.assertIs(True, first_explicit_bool("k", {"k": "yes"}))
+        self.assertIs(False, first_explicit_bool("k", {"k": "off"}))
+        self.assertIs(True, first_explicit_bool("k", {"k": None}, {"k": 1}),
+                      "a later source must still be able to answer after an unstated one")
+
+        scope_from_node_path = self.module.scope_from_node_path
+        self.assertEqual(
+            {"tenant_id": "t1", "session_id": "s9"},
+            scope_from_node_path(["tenant:t1", "user:", "session:s9"]),
+            "an empty segment must be dropped, not stored blank: a caller comparing scopes has to "
+            "tell an absent field from an empty one")
+        self.assertEqual({}, scope_from_node_path("not-a-list"))
+
+        stored_encoder_name = self.module.stored_encoder_name
+        self.assertEqual(
+            "e5", stored_encoder_name({"embedding_meta": {"model": "e5"}}),
+            "the encoder rides under embedding_meta on owner records; reading only the top level "
+            "found nothing on every record a current ingest writes")
+        self.assertEqual("top", stored_encoder_name({"model": "top"}))
+        self.assertEqual("", stored_encoder_name({}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`retrieve` in `matrixark_local_adapter_retrieve` is the live retrieval entry point and the least
readable code on that path. Measured across the six modules the hook actually executes:

| | depth | lines | branches | docstring |
|---|---|---|---|---|
| **`retrieve`** | **16** | **3763** | **744** | **none** |
| next worst (`_record_call_metrics`) | 7 | 143 | 46 | none |

It holds twenty nested `def`s. Seventeen genuinely close over its locals and **are left alone** —
moving one of those would be a behaviour change dressed as tidying. Four closed over nothing at all,
so they were plain module-level functions that happened to be written up to 1,300 lines inside a
closure: not importable, not testable on their own, and paid for by every reader.

Those four now sit at module scope: `first_explicit_bool`, `scope_from_node_path`,
`stored_encoder_name`, `profile_summary_scope_matches`. `retrieve` goes 3763 → 3708 lines.

## The criterion is mechanical, not my judgement

For each nested function: every `Name` it loads, minus its own bindings (parameters, assignments,
imports, `except ... as`), minus what resolves on the module **at runtime**. Zero left means it
captures nothing.

The runtime part matters. This module does `from matrixark_mcp_core import *`, so `Json`, `Any` and
`scope_matches` are module-level but invisible to a static scan of the file. A static-only version
of this check reported **all twenty** as capturing something and would have found nothing, forever.

## Hoisting cascades, and the guard caught it

The first pass moved three. The guard then failed on a fourth: `profile_summary_scope_matches`
closed over `scope_from_node_path` and nothing else, so once that reached module scope this one was
free too. The hoist now iterates to a fixpoint rather than taking a snapshot.

## The code is provably unchanged

Comparing each function's AST before and after:

```
first_explicit_bool              differs by an ADDED DOCSTRING only
scope_from_node_path             differs by an ADDED DOCSTRING only
stored_encoder_name              IDENTICAL
profile_summary_scope_matches    differs by an ADDED DOCSTRING only
retrieve body identical after removing the four defs: True
```

Three gained a docstring; `stored_encoder_name` already had one and is untouched.

## Guard

`test_a_nested_function_that_captures_nothing_is_hoisted.py`, 3 tests. **The list is derived, not
written** — it recomputes which nested functions capture nothing, so it cannot go stale against a
rename and cannot pass because someone edited a list. There is no named-exemption mechanism on
purpose: if a genuinely free function must stay nested, that needs a reason in code, not an entry
here.

It carries its own positive control (`test_the_detector_can_see_a_captured_name`): if not one nested
function reads an enclosing local, the module scope being used is too broad and the main assertion
would pass vacuously. That control is what a static-only detector fails.

The behavioural tests are real ones, not smoke: `first_explicit_bool` must return `None` rather than
`False` for absent/`None`/`""` — the caller distinguishes "nobody said" from "somebody said no" to
know whether it may apply its own default — and `scope_from_node_path` must drop an empty segment
rather than store it blank, because a caller comparing scopes has to tell an absent field from an
empty one.
