### PR TITLE
Opening a store decoded every page in it to find one number

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -30,7 +30,8 @@ use paths::{
 use record::{
     decode_page_record, default_page_record_compression_enabled,
     default_page_record_compression_level, default_page_record_compression_min_bytes,
-    encode_page_record, inspect_slab, logical_range_from_slab, sha256_hex, summarize_slab,
+    encode_page_record, inspect_slab, logical_range_from_slab, max_page_id_in_slab_file,
+    sha256_hex, summarize_slab,
     PageRecordCompression,
 };
 use self::band_manifest::*;

--- a/crates/temporalstore-rust/src/block_store/record.rs
+++ b/crates/temporalstore-rust/src/block_store/record.rs
@@ -2,7 +2,8 @@
 // Copyright 2026 MatrixArkAI
 
 use std::collections::BTreeSet;
-use std::io::Cursor;
+use std::fs::File;
+use std::io::{BufReader, Cursor, Read, Seek};
 
 use sha2::{Digest, Sha256};
 
@@ -738,6 +739,88 @@ pub(super) fn summarize_slab(
         physical_offset = physical_offset.saturating_add(record_len);
     }
     Ok(summary)
+}
+
+/// The widest header any supported version writes.
+///
+/// v7 and v8 are the same width (v8 reclaimed the checksum's spare bytes but placed fields the
+/// interior padding used to align), so this covers every version. Taking the larger of the two
+/// keeps it correct if either constant moves.
+const PAGE_RECORD_WIDEST_HEADER_LEN: usize = if PAGE_RECORD_HEADER_LEN > PAGE_RECORD_V7_HEADER_LEN
+{
+    PAGE_RECORD_HEADER_LEN
+} else {
+    PAGE_RECORD_V7_HEADER_LEN
+};
+
+/// Read buffer for the page-id scan.
+///
+/// Sized so a bufferful spans many records rather than one: at the ~300-byte records the live
+/// store holds, this is ~800 per fill, which is the difference between thousands of reads for a
+/// segment and millions.
+const PAGE_RECORD_SCAN_BUFFER_BYTES: usize = 256 * 1024;
+
+/// The largest page id recorded in one slab, read from record headers alone.
+///
+/// `next_page_id_at` wants a single number per slab. It used to get it from `inspect_slab`, which
+/// decodes every record to build a whole block-index report -- a zstd decompression, a checksum
+/// verify, a second SHA-256 hex-encoded into a `String`, and one report struct per page -- and
+/// then keeps only `last_page_id`. On a store whose pages are large and compressed that is tens
+/// of gigabytes of decompress-and-hash to produce one integer, and it is paid on every open.
+///
+/// The page id and the record length both live in the header, so the walk never needs a payload.
+/// Stepping the file by `header_len + stored_len` touches only headers, which is why this takes a
+/// `File` rather than a `&[u8]`: the slab never has to be read into memory at all.
+///
+/// It reads through a `BufReader` rather than seeking per record. Records here are small -- the
+/// live store holds ~3.4M of them averaging ~300 bytes -- so a seek and a read for each is
+/// millions of syscalls, and measured SLOWER than reading the whole segment. `seek_relative`
+/// drops buffered bytes in place when the destination is already in the buffer, so a run of
+/// small records costs one read per bufferful while a large record still seeks.
+///
+/// Halting is deliberately `inspect_slab`'s: a record that does not parse ends the walk, and the
+/// ids found before it stand. `LocalBlockStore::with_options` fences a torn tail on the active
+/// slab precisely because this scan halts early. Returning an error instead would reach the
+/// caller's `unwrap_or_default()` and reset the counter to 0 -- page-id reuse, and stale reads.
+pub(super) fn max_page_id_in_slab_file(
+    file: File,
+    slab_len: u64,
+    page_slab_id: u64,
+) -> Result<Option<u64>, BlockStoreError> {
+    let mut reader = BufReader::with_capacity(PAGE_RECORD_SCAN_BUFFER_BYTES, file);
+    let mut max_page_id: Option<u64> = None;
+    let mut offset: u64 = 0;
+    let mut header = [0_u8; PAGE_RECORD_WIDEST_HEADER_LEN];
+    while offset < slab_len {
+        let remaining = slab_len - offset;
+        let want = (PAGE_RECORD_WIDEST_HEADER_LEN as u64).min(remaining) as usize;
+        if reader.read_exact(&mut header[..want]).is_err() {
+            break;
+        }
+        let head = &header[..want];
+        if !head.starts_with(PAGE_RECORD_MAGIC) {
+            break;
+        }
+        let address =
+            BlockAddress::from_parts(page_slab_id, offset, 0, None, None, None, None, None);
+        let parsed = match parse_page_record_header(head, &address) {
+            Ok(parsed) => parsed,
+            Err(_) => break,
+        };
+        if let Some(page_id) = parsed.page_id {
+            max_page_id = Some(max_page_id.map_or(page_id, |current: u64| current.max(page_id)));
+        }
+        let record_len = parsed.header_len.saturating_add(parsed.stored_len) as u64;
+        if record_len == 0 || remaining < record_len {
+            break;
+        }
+        // Step over the payload without reading it. The header read above may have run past
+        // this record's end (a record shorter than the widest header) or stopped short of it,
+        // so the skip is signed; `seek_relative` handles both inside the buffer.
+        reader.seek_relative(record_len as i64 - want as i64)?;
+        offset += record_len;
+    }
+    Ok(max_page_id)
 }
 
 pub(super) fn inspect_slab(slab: &[u8], page_slab_id: u64) -> BlockStoreSlabReport {

--- a/crates/temporalstore-rust/src/block_store/slab_ids.rs
+++ b/crates/temporalstore-rust/src/block_store/slab_ids.rs
@@ -126,8 +126,13 @@ pub(crate) fn latest_slab_id_at(root: &Path) -> Result<u64, BlockStoreError> {
 pub(crate) fn next_page_id_at(root: &Path) -> Result<u64, BlockStoreError> {
     let mut max_page_id = None;
     for page_slab_id in slab_ids_at(root)? {
-        let bytes = fs::read(slab_path(root, page_slab_id))?;
-        if let Some(slab_max) = inspect_slab(&bytes, page_slab_id).last_page_id {
+        // Header-only walk. This used to `fs::read` the whole slab and hand it to `inspect_slab`,
+        // which decodes and hashes every page to build a report that is discarded but for one
+        // field. Opening the file and stepping it by record length reads the headers and nothing
+        // else, so the cost stops tracking the size of the pages.
+        let file = File::open(slab_path(root, page_slab_id))?;
+        let slab_len = file.metadata()?.len();
+        if let Some(slab_max) = max_page_id_in_slab_file(file, slab_len, page_slab_id)? {
             max_page_id =
                 Some(max_page_id.map_or(slab_max, |current: u64| current.max(slab_max)));
         }
@@ -137,3 +142,99 @@ pub(crate) fn next_page_id_at(root: &Path) -> Result<u64, BlockStoreError> {
         .unwrap_or_default())
 }
 
+#[cfg(test)]
+mod next_page_id_scan_tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// Short enough to stay under the compression floor, so a flipped byte fails the CHECKSUM
+    /// rather than the decompressor. The subject is a record whose HEADER is perfectly intact.
+    fn small_payload(tag: u8) -> Vec<u8> {
+        vec![tag; 64]
+    }
+
+    /// Write one slab holding a record per page id, and report where each record starts.
+    fn slab_with(root: &Path, page_slab_id: u64, page_ids: &[u64]) -> Vec<usize> {
+        let mut bytes = Vec::new();
+        let mut starts = Vec::new();
+        for (index, page_id) in page_ids.iter().enumerate() {
+            starts.push(bytes.len());
+            let encoded = encode_page_record(
+                &small_payload(index as u8 + 1),
+                *page_id,
+                None,
+                None,
+                0,
+                BlockStoreOptions::default(),
+            )
+            .expect("encode page record");
+            bytes.extend_from_slice(&encoded.bytes);
+        }
+        fs::create_dir_all(root).expect("create slab root");
+        fs::write(slab_path(root, page_slab_id), &bytes).expect("write slab");
+        starts
+    }
+
+    /// A corrupt PAYLOAD must not lower the next page id.
+    ///
+    /// This is the case that tells the two scans apart, and it is a correctness point rather
+    /// than a speed one. Taking the id from `inspect_slab` meant decoding every record, so a
+    /// single unreadable payload ended the walk and every page id behind it went uncounted.
+    /// `next_page_id` then came back LOW -- which is page-id reuse, and the stale reads that
+    /// follow it. A header walk never consults the payload, so the ids behind it still stand.
+    #[test]
+    fn a_corrupt_payload_does_not_lower_the_next_page_id() {
+        let dir = tempdir().expect("tempdir");
+        let root = dir.path();
+        let starts = slab_with(root, 0, &[4, 9]);
+
+        // Flip a byte inside the SECOND record's payload, past its header. Magic, version,
+        // lengths and page id are untouched, so the walk can still step over the record.
+        let path = slab_path(root, 0);
+        let mut bytes = fs::read(&path).expect("read slab");
+        let payload_at = starts[1] + PAGE_RECORD_HEADER_LEN;
+        bytes[payload_at] ^= 0xff;
+        fs::write(&path, &bytes).expect("write slab");
+
+        // The highest id is still 9, so the next one is 10. Decoding the payloads would have
+        // halted at the damaged record and answered 5.
+        assert_eq!(next_page_id_at(root).expect("scan"), 10);
+    }
+
+    /// A torn HEADER still ends the walk.
+    ///
+    /// The active-slab fencing in `with_options` is built on this scan halting early, so the
+    /// change above must not turn into "read past anything". Once the magic is gone the file is
+    /// no longer a chain of records and there is nothing further to trust.
+    #[test]
+    fn a_torn_header_halts_the_walk() {
+        let dir = tempdir().expect("tempdir");
+        let root = dir.path();
+        let starts = slab_with(root, 0, &[4, 9]);
+
+        let path = slab_path(root, 0);
+        let mut bytes = fs::read(&path).expect("read slab");
+        bytes[starts[1]] ^= 0xff;
+        fs::write(&path, &bytes).expect("write slab");
+
+        assert_eq!(next_page_id_at(root).expect("scan"), 5);
+    }
+
+    /// The ordinary case, which had no coverage at all: the counter clears the highest id
+    /// across every slab, not merely the last one written.
+    #[test]
+    fn the_next_page_id_clears_every_slab() {
+        let dir = tempdir().expect("tempdir");
+        let root = dir.path();
+        slab_with(root, 0, &[1, 6]);
+        slab_with(root, 1, &[3, 2]);
+        assert_eq!(next_page_id_at(root).expect("scan"), 7);
+    }
+
+    /// An empty root has no ids to clear, and must not answer as though it did.
+    #[test]
+    fn an_empty_root_starts_at_zero() {
+        let dir = tempdir().expect("tempdir");
+        assert_eq!(next_page_id_at(dir.path()).expect("scan"), 0);
+    }
+}


### PR DESCRIPTION
Opening a block store asks one question of each slab: what is the highest page id in it, so the
next append can start above it. It answered by decoding the slab.

`next_page_id_at` read every page segment whole and handed each to `inspect_slab`, which builds a
complete block index report — per record a zstd decompression, a checksum verify, a **second**
SHA-256 hex-encoded into a `String`, and a report struct pushed to a `Vec` — and then kept one
field of it. Everything else was allocated and dropped.

Measured on a store of 1,017 MB across 119 segments holding **3,434,580 page records**, that is
per open:

| | before | after |
|---|---|---|
| zstd decompressions | 3,434,580 | 0 |
| SHA-256 computations | 6,869,160 | 0 |
| report `Vec` built, then dropped | ~655 MB | 0 |
| segment bytes held in memory at once | up to 264 MB | 0 |

The page id and the record length both live in the header, so the walk never needs a payload.
`max_page_id_in_slab_file` steps the file by `header_len + stored_len`, reading headers only.

It reads through a `BufReader` rather than seeking per record. That detail is load-bearing: these
records average ~300 bytes, so a seek and a read for each is millions of syscalls, and measured
**slower** than reading the whole segment (9,688 ms against 811 ms on the same files).
`seek_relative` drops buffered bytes in place when the destination is already buffered, so a run
of small records costs one read per bufferful while a large record still seeks.

## This also stops the counter going backwards

Under the old code a corrupt **payload** ended the walk, because reaching the page id meant
decoding the record. Every page id behind the damaged record then went uncounted and
`next_page_id` came back **low** — which is page-id reuse, and the stale reads that follow it.
A header walk never consults the payload, so those ids still stand.

Halting on a torn **header** is unchanged and deliberate. `LocalBlockStore::with_options` fences a
torn tail on the active slab precisely because this scan stops early; returning an error instead
would reach the caller's `unwrap_or_default()` and reset the counter to 0.

## Tests

`next_page_id_at` had no test at all. It now has four, and one of them tells the two
implementations apart rather than passing either way:

- `a_corrupt_payload_does_not_lower_the_next_page_id` — a record whose header is intact and whose
  payload is not. Decoding the payloads answers 5; reading the headers answers 10.
- `a_torn_header_halts_the_walk` — the fencing behaviour the active-slab truncation depends on.
- `the_next_page_id_clears_every_slab` — the highest id across slabs, not merely the last written.
- `an_empty_root_starts_at_zero`.
