### PR TITLE
One worker's counters are not the deployment's

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -4589,7 +4589,13 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
             if denied is not None:
                 return await _json(send, 403, denied)
             usage = _usage_rows_visible_to(key_record, meter.snapshot(), tenant, account)
-            return await _json(send, 200, {"status": "ok", "usage": usage, "count": len(usage)})
+            # The meter is in-process. On a multi-worker deployment these are the counters of
+            # whichever worker answered this request and no other, so the totals are a share of
+            # the deployment's traffic rather than the whole of it -- and a key used only through
+            # another worker is missing entirely, which reads as "not used". The count is what
+            # the sibling reads already report; without it a caller cannot tell the difference.
+            return await _json(send, 200, {"status": "ok", "usage": usage, "count": len(usage),
+                                           "workers": _worker_count()})
 
         # ---- the audit log (auth + admin:audit) ------------------------------------------------
         # The scope catalogue publishes admin:audit as "Read the audit log" and nothing served one.

--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -868,7 +868,21 @@
           tb.appendChild(tr);
         });
         $("usageTable").style.display = usage.length ? "" : "none";
-        if (!usage.length) showMsg("usageMsg", "ok", "No usage recorded yet (enforced mode only).");
+        /* The meter is per PROCESS. With more than one worker these totals are one worker's
+           share, and a key used only through another worker is absent -- which reads exactly like
+           a key nobody used. Said on both the empty and the populated case, because the empty one
+           is the more misleading of the two. */
+        var workers = Number(data && data.workers) || 1;
+        var share = workers > 1
+          ? " These are one worker's counters and this deployment runs " + workers
+            + ": a key used through another worker is not counted here."
+          : "";
+        if (!usage.length) {
+          showMsg("usageMsg", "ok",
+                  "No usage recorded yet (enforced mode only)." + share);
+        } else if (share) {
+          showMsg("usageMsg", "ok", share.replace(/^ /, ""));
+        }
       })
       .catch(function (e) { showMsg("usageMsg", "err", "Usage read failed: " + e.message); });
   }

--- a/tools/portal/usage_share_harness.js
+++ b/tools/portal/usage_share_harness.js
@@ -1,0 +1,44 @@
+// Runs the SHIPPED loadUsage against a DOM stub. Reading the source would pass on a function that
+// builds the sentence and never shows it.
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const input = JSON.parse(process.argv[3]);
+
+const start = page.indexOf("  function loadUsage() {");
+if (start < 0) throw new Error("loadUsage not found");
+let depth = 0, end = -1;
+for (let i = page.indexOf("{", start); i < page.length; i++) {
+  if (page[i] === "{") depth++;
+  else if (page[i] === "}") { depth--; if (depth === 0) { end = i + 1; break; } }
+}
+
+const shown = [];
+const nodes = {
+  usageTable: {
+    style: {},
+    querySelector: () => ({ innerHTML: "", appendChild() {} }),
+  },
+};
+const scope = {
+  $: (id) => nodes[id] || { style: {}, innerHTML: "", appendChild() {} },
+  hideMsg: () => {},
+  showMsg: (id, kind, text) => shown.push({ id, kind, text }),
+  escapeHtml: (s) => String(s == null ? "" : s),
+  fmtTime: () => "",
+  gwBase: () => "http://gw",
+  apiFetch: () => Promise.resolve(input.response),
+  document: { createElement: () => ({ innerHTML: "" }) },
+};
+
+const names = Object.keys(scope);
+const loadUsage = new Function(...names, page.slice(start, end) + "; return loadUsage;")(
+  ...names.map((k) => scope[k]));
+
+loadUsage();
+setTimeout(() => {
+  process.stdout.write(JSON.stringify({
+    shown,
+    tableShown: nodes.usageTable.style.display,
+  }));
+}, 0);

--- a/tools/test_matrixark_one_workers_counters_are_not_the_deployments.py
+++ b/tools/test_matrixark_one_workers_counters_are_not_the_deployments.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The per-key meter counts one process, and the panel is called "Live edge usage".
+
+`GET /v1/admin/api_key_usage` returns the in-process edge counters. On a deployment started with
+more than one worker those are the counters of whichever worker answered the request and no other,
+so the totals are a share of the traffic rather than the whole of it.
+
+The empty case is the more misleading of the two: a key used only through another worker is absent
+from this worker's meter, which reads exactly like a key nobody used. Somebody checking whether a
+key is live, or reading these numbers for billing, is wrong by a factor of the worker count.
+
+The gateway already knows the number. `_worker_count()` exists for this reason -- its own docstring
+says a live value is applied to "the environment of whichever worker served the request, and no
+other" -- and two sibling reads already report it. This one did not, so a caller could not tell.
+
+The panel is checked by RUNNING the shipped `loadUsage` against a DOM stub. Reading the source
+would pass on a function that builds the sentence and never shows it.
+"""
+from __future__ import annotations
+
+import ast
+import io
+import json
+import os
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+HARNESS = os.path.join(PORTAL, "usage_share_harness.js")
+PAGE = os.path.join(PORTAL, "api_key_portal.html")
+
+
+def render(usage: list, workers) -> dict:
+    payload = {"response": {"status": "ok", "usage": usage, "count": len(usage)}}
+    if workers is not None:
+        payload["response"]["workers"] = workers
+    out = subprocess.run(["node", HARNESS, PAGE, json.dumps(payload)],
+                         capture_output=True, text=True, timeout=300)
+    if out.returncode != 0:
+        raise AssertionError(out.stderr[-800:])
+    return json.loads(out.stdout)
+
+
+def said(result: dict) -> str:
+    return " ".join(entry["text"] for entry in result["shown"])
+
+
+ROW = [{"api_key_hash": "h", "total": 7}]
+
+
+class ThePanelSaysWhoseCountersTheseAreTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    def test_an_empty_meter_on_several_workers_says_why(self) -> None:
+        """The misleading case: a key used through another worker reads as a key nobody used."""
+        text = said(render([], 4))
+        self.assertIn("this deployment runs 4", text)
+        self.assertIn("not counted here", text)
+
+    def test_rows_on_several_workers_say_it_too(self) -> None:
+        text = said(render(ROW, 4))
+        self.assertIn("one worker's counters", text)
+
+    def test_a_single_worker_is_told_nothing_extra(self) -> None:
+        """The floor. A caveat on every deployment is a caveat nobody reads -- and on one worker
+        the counters ARE the deployment's."""
+        self.assertNotIn("one worker's counters", said(render(ROW, 1)))
+        self.assertNotIn("one worker's counters", said(render([], 1)))
+
+    def test_the_empty_message_still_says_it_is_empty(self) -> None:
+        """The caveat is added to the existing sentence, not swapped for it."""
+        self.assertIn("No usage recorded yet", said(render([], 4)))
+        self.assertIn("No usage recorded yet", said(render([], 1)))
+
+    def test_a_response_without_the_field_is_treated_as_one_worker(self) -> None:
+        """An older gateway behind a newer page says nothing, rather than guessing a number."""
+        self.assertNotIn("one worker's counters", said(render(ROW, None)))
+
+    def test_the_table_still_appears_and_still_hides(self) -> None:
+        """The floor for all of the above: the panel's actual job must be unchanged."""
+        self.assertEqual("", render(ROW, 4)["tableShown"])
+        self.assertEqual("none", render([], 4)["tableShown"])
+
+
+class TheEndpointReportsItTest(unittest.TestCase):
+
+    @staticmethod
+    def _source() -> str:
+        with io.open(os.path.join(TOOLS, "matrixark_v1_gateway.py"), encoding="utf-8") as handle:
+            return handle.read()
+
+    def test_the_usage_response_carries_the_count(self) -> None:
+        self.assertIn('"workers": _worker_count()', self._source())
+
+    def test_it_asks_the_same_helper_the_other_reads_ask(self) -> None:
+        """One answer to the question. A second way of counting workers is a second answer that
+        can disagree with the warning about workers not sharing a store."""
+        self.assertGreaterEqual(self._source().count("_worker_count()"), 3)
+
+    def test_the_helper_is_defined_once(self) -> None:
+        tree = ast.parse(self._source())
+        found = [node for node in ast.walk(tree)
+                 if isinstance(node, ast.FunctionDef) and node.name == "_worker_count"]
+        self.assertEqual(1, len(found))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`GET /v1/admin/api_key_usage` returns the **in-process** edge meter, and the panel reading it is called *Live edge usage*. On a deployment started with more than one worker those are the counters of whichever worker answered the request and no other — so the totals are a share of the traffic, not the whole of it.

**The empty case is the more misleading of the two.** A key used only through another worker is absent from this worker's meter, which reads exactly like a key nobody used. "No usage recorded yet" was shown to somebody checking whether a key is live, on a deployment where it was.

The gateway already knows the number. `_worker_count()` exists for exactly this reason — its own docstring says a live value is applied to "the environment of whichever worker served the request, and no other" — and two sibling reads already report it. This one did not, so a caller could not tell.

## What the panel says now

| workers | meter | shown |
|---|---|---|
| 1 | empty | `No usage recorded yet (enforced mode only).` |
| 4 | empty | that, **plus** `These are one worker's counters and this deployment runs 4: a key used through another worker is not counted here.` |
| 4 | rows | the caveat |
| 1 | rows | nothing extra — on one worker the counters *are* the deployment's |
| field absent | either | nothing — an older gateway behind a newer page stays quiet rather than guessing a number |

## Mutations

Nine tests. The panel is checked by **running** the shipped `loadUsage` against a DOM stub; reading the source would pass on a function that builds the sentence and never shows it.

| mutation | reddens |
|---|---|
| the endpoint stops reporting the count | `test_the_usage_response_carries_the_count` |
| the panel never says it | `test_an_empty_meter_on_several_workers_says_why` |
| it says it on every deployment | `test_a_single_worker_is_told_nothing_extra` |
| the caveat replaces the empty message | `test_the_empty_message_still_says_it_is_empty` |
| a missing field is guessed as many | `test_a_response_without_the_field_is_treated_as_one_worker` |
| the table stops being shown | `test_the_table_still_appears_and_still_hides` |
