### PR TITLE
Stop re-hashing every page record for a field nobody reads

### DIFF
--- a/crates/temporalstore-rust/src/block_store/record.rs
+++ b/crates/temporalstore-rust/src/block_store/record.rs
@@ -823,6 +823,22 @@ pub(super) fn max_page_id_in_slab_file(
     Ok(max_page_id)
 }
 
+/// TS_BLOCK_INDEX_CHECKSUMS: recompute and record a hex digest per page record while inspecting.
+///
+/// Default OFF. `inspect_slab` runs at every engine open, and this hashes each payload a second
+/// time -- `decode_page_record` has already verified the stored checksum -- then allocates a
+/// 64-character String for it. Measured on a live-store copy, slab verification ran at 13.5 MB/s
+/// against hundreds of MB/s for sha256 alone. Nothing in the crate reads the field; it is kept for
+/// hand-inspecting a slab.
+fn block_index_checksums_enabled() -> bool {
+    std::env::var("TS_BLOCK_INDEX_CHECKSUMS")
+        .map(|value| {
+            let value = value.trim().to_ascii_lowercase();
+            value == "1" || value == "true" || value == "yes"
+        })
+        .unwrap_or(false)
+}
+
 pub(super) fn inspect_slab(slab: &[u8], page_slab_id: u64) -> BlockStoreSlabReport {
     let mut report = BlockStoreSlabReport {
         page_slab_id,
@@ -905,7 +921,12 @@ pub(super) fn inspect_slab(slab: &[u8], page_slab_id: u64) -> BlockStoreSlabRepo
                     deleted: decoded.logical_len == 0,
                     block_in_log: false,
                     routing_bucket: header.routing_bucket,
-                    checksum: Some(sha256_hex(&decoded.payload)),
+                    // Re-hashing the payload here doubled the sha256 work of every engine open
+                    // to fill a field no caller reads. `decode_page_record` above has already
+                    // verified this record's stored checksum. Opt in with
+                    // TS_BLOCK_INDEX_CHECKSUMS=1 when inspecting a slab by hand.
+                    checksum: block_index_checksums_enabled()
+                        .then(|| sha256_hex(&decoded.payload)),
                 });
                 report.block_index_count = report.block_index_entries.len() as u64;
                 if decoded.compression == PageRecordCompression::Zstd {


### PR DESCRIPTION
`inspect_slab` runs on every engine open. For each page record it verifies the stored checksum
inside `decode_page_record` — and then hashes the payload a **second** time and hex-encodes it into a
64-character `String`, to fill `BlockStoreBlockIndexReport::checksum`.

Nothing reads that field. `block_index_entries` appears only in its own struct definition and in
tests, no test asserts the checksum, and the field is `skip_serializing_if = "Option::is_none"`, so
omitting it is wire-compatible.

It is now behind `TS_BLOCK_INDEX_CHECKSUMS=1`, default off. Kept rather than deleted because it is a
genuine diagnostic for hand-inspecting a slab — it just should not be computed for every record of
every open when no caller wants it.

### On the performance claim: I could not measure one

The motivation was cold start. Slab verification on a live-store copy runs at about **13.5 MB/s**
where sha256 on this hardware does hundreds, and this is one of two full passes per record.

But this box cannot resolve the effect. Three alternated pairs on the same copy:

| | runs | mean | spread |
|---|---|---|---|
| base | 116.2 / 44.6 / 38.5 s | 66.5 s | **3.0x** |
| with this change | 62.2 / 99.3 / 32.2 s | 64.6 s | **3.1x** |

Both arms swing 3x from page-cache state alone and the means differ by 3%, which is noise. An
earlier attempt at the same problem — parallelising the slab fan-out — produced an apparent 1.5x
that dissolved under the same test, so this is stated plainly rather than dressed up.

**So this is a cleanup on the merits of the code, not a measured speedup:** provably redundant work
removed from a hot path, with the diagnostic still available on request. If cold start is attacked
again, the target is the per-record verification rate itself.

### Tests

`cargo test --release -p temporalstore-rust --lib block_store` — 64 passed.
