### PR TITLE
Four time-index builders nothing calls, and they disagree with the ones that run

### DIFF
--- a/tools/matrixark_mcp_event_keys.py
+++ b/tools/matrixark_mcp_event_keys.py
@@ -73,67 +73,6 @@ def attach_context_event_time_key(record: Json) -> Json:
     return enriched
 
 
-def context_event_time_index_key(storage_prefix: str, record: Json) -> str:
-    enriched = attach_context_event_time_key(record)
-    parent_type = str(enriched.get("context_event_parent_type") or "context_node")
-    parent_hash = enriched.get("context_event_parent_hash") or 0
-    return f"{storage_prefix}:context_event_by_ingestion_time:{parent_type}:{parent_hash}"
-
-
-def context_event_time_index_field(record: Json) -> str:
-    event_hash = record.get("event_id_hash") or stable_hash(
-        json.dumps(record, sort_keys=True, separators=(",", ":"))
-    )
-    timestamp_ms = context_event_timestamp_ms(record)
-    return f"{context_event_time_key(timestamp_ms, event_hash):020d}:{event_hash}"
-
-
-def context_event_time_index_payload(record: Json) -> str:
-    scope_key = str(record.get("scope_key") or "")
-    if not scope_key:
-        scope = record.get("scope") if isinstance(record.get("scope"), dict) else {}
-        scope_key = canonical_scope_key(scope)
-    payload: Json = {
-        "record_type": "context_event_ref",
-        "ref_hash": int(record.get("event_id_hash") or 0),
-        "node_hash": int(record.get("node_hash") or 0),
-        "scope_key": scope_key,
-        "timestamp_key_ms": context_event_timestamp_ms(record),
-    }
-    payload["context_event_key"] = context_event_time_key(
-        payload["timestamp_key_ms"], payload["ref_hash"]
-    )
-    source_chunk_hash = record.get("source_chunk_hash")
-    if source_chunk_hash is not None:
-        payload["source_chunk_hash"] = source_chunk_hash
-    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
-
-
-def context_event_time_index_entries(storage_prefix: str, records: list[Json]) -> list[Json]:
-    entries: list[Json] = []
-    full_payload = env_bool("MATRIXARK_CONTEXT_EVENT_TIME_INDEX_FULL_PAYLOAD", False)
-    for record in records:
-        if record.get("record_type") != "context_event":
-            continue
-        if record.get("event_id_hash") is None:
-            continue
-        enriched = attach_context_event_time_key(record)
-        payload = (
-            json.dumps(enriched, sort_keys=True, separators=(",", ":"))
-            if full_payload
-            else context_event_time_index_payload(enriched)
-        )
-        entries.append(
-            {
-                "key": context_event_time_index_key(storage_prefix, enriched),
-                "field": context_event_time_index_field(enriched),
-                "value": payload,
-                "storage_route": record.get("storage_route") if isinstance(record.get("storage_route"), dict) else {},
-            }
-        )
-    return entries
-
-
 def context_placement_key(record: Json, *, scope_key: str = "", node_hash: Any = None) -> str:
     explicit = str(record.get("placement_key") or "")
     if explicit:


### PR DESCRIPTION
`context_event_time_index_{entries,key,field,payload}` in `matrixark_mcp_event_keys` form a closed
loop: `entries` calls the other three, and **nothing calls `entries`**.

Verified four ways — no exact call anywhere in `tools/`, no named import outside the module, no
`__all__`, no `getattr` access, and no test touches them.

Found by asking which flag accessors have no call site: this cluster is the consumer of
`MATRIXARK_CONTEXT_EVENT_TIME_INDEX_FULL_PAYLOAD` that no path reaches. The flag is read in two
places; only one of them runs.

## The live implementation is untouched

`_TemporalDirectBackendMixin._context_event_time_index_*` is reached from two call sites and stays
exactly as it is. This deliberately does **not** unify the two, because they disagree and unifying
would change what the live path writes:

| | live method | removed copy |
|---|---|---|
| **key**, segment-parented event | `…:context_event_by_ingestion_time:context_segment:999` | `…:context_node:0` — it never read `parent_segment_hash` |
| **field** | `{timestamp_ms:020d}:{hash}` | `{context_event_time_key(ts, hash):020d}:{hash}` |

On the field: `context_event_time_key` is `ts * FANOUT + (tiebreak % FANOUT)`, which **is**
order-preserving — so this was an incompatible *encoding*, not an ordering bug. I checked that
before writing it down; the composite looked like it broke the "lexical order is chronological"
property the live method's comment relies on, and it does not. An index written under both would
simply carry two field formats.

So the copy removed is the diverged one, and it is the one nothing calls. **61 lines.**

## Verification

- The module and its three consumers (`matrixark_mcp_serving_records`,
  `matrixark_temporal_direct_backend`, `matrixark_mcp_temporal_append`) still import.
- The 29 tests across the six suites that import either module: **green on `main` and green here**,
  same counts.
