### PR TITLE
A catalog list that stopped at its limit says so

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -3641,6 +3641,15 @@ def _headers_map(scope: Json) -> dict[str, str]:
     return {k.decode("latin-1").lower(): v.decode("latin-1") for k, v in scope.get("headers", [])}
 
 
+#: The most rows /v1/skills and /v1/resources will return, whatever is asked for.
+#:
+#: Named because the page held its own copy of the number and clamped to it before sending, so the
+#: two had to agree and nothing made them. The page now sends what was typed and reports what came
+#: back. Two other routes cap at 500 as well; those are different policies that happen to share a
+#: number, and folding them in here would couple them.
+CATALOG_LIST_LIMIT_MAX = 500
+
+
 def _ok_body(result: Any) -> Json:
     return result if isinstance(result, dict) else {"result": result}
 
@@ -5511,7 +5520,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
             args: Json = {"scope": catalog_scope}
             limit = _qc("limit")
             if limit and limit.strip().isdigit():
-                args["limit"] = min(int(limit), 500)
+                args["limit"] = min(int(limit), CATALOG_LIST_LIMIT_MAX)
             if is_skills:
                 if str(_qc("include_disabled") or "").strip().lower() in ("1", "true", "yes"):
                     args["include_disabled"] = True
@@ -5533,7 +5542,14 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
             except Exception as exc:
                 return await _json(send, _classify_backend_error(exc),
                                    _failure(scope, "backend_error", exc))
-            return await _json(send, 200, _ok_body(result))
+            body = _ok_body(result)
+            # What was actually applied, not what was asked for. A caller asking for 5,000 gets 500
+            # rows and, without this, no way to tell that from a catalogue holding exactly 500 -- so
+            # a truncated list reads as the whole of one.
+            body["limit_max"] = CATALOG_LIST_LIMIT_MAX
+            if "limit" in args:
+                body["limit"] = args["limit"]
+            return await _json(send, 200, body)
 
         # ---- enable / disable a skill (auth + skill:manage) ----------------------------------
         # Listing skills without being able to retire one leaves a customer with a catalog that

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -3307,7 +3307,10 @@ CATALOG_JS = r"""
       if (v) { parts.push(f + "_id=" + encodeURIComponent(v)); }
     });
     var limit = parseInt($("limit").value, 10);
-    parts.push("limit=" + (limit > 0 ? Math.min(limit, 500) : 100));
+    /* Sent as typed. Clamping here meant the page held its own copy of the gateway's maximum,
+       which is a second place for that number to be wrong -- and it hid the clamp from the person
+       who typed the bigger one. The response says what was applied. */
+    parts.push("limit=" + (limit > 0 ? limit : 100));
     return parts;
   }
 
@@ -3423,6 +3426,27 @@ CATALOG_JS = r"""
          clicking would show. */
       $("skillsCount").textContent = " " + skills.length;
       $("resourcesCount").textContent = " " + resources.length;
+      /* A list that stopped at its limit is not the catalogue. Read from what came back, per list,
+         because one can be cut while the other is not -- and the filter above runs in the browser,
+         so it narrows what was already cut rather than reaching past the cut.
+         Only written when there IS something to say: the auto-refresh sets its own message here
+         and a blank write would take it away. */
+      var cut = [];
+      [["Skills", bodies[0], (bodies[0].skills || []).length],
+       ["Resources", bodies[1], (bodies[1].resources || []).length]].forEach(function (pair) {
+        var applied = Number(pair[1].limit);
+        if (applied > 0 && pair[2] >= applied) { cut.push(pair[0] + " at " + applied); }
+      });
+      var most = Number(bodies[0].limit_max || bodies[1].limit_max) || 0;
+      var asked = parseInt($("limit").value, 10);
+      var note = cut.length
+        ? cut.join(" and ") + " \u2014 the list stopped at the limit, so there may be more."
+        : "";
+      if (most && asked > most) {
+        note += (note ? " " : "") + "The most this endpoint returns is " + most + "; "
+              + asked + " was asked for.";
+      }
+      if (note) { say($("listMsg"), note, "info"); }
       /* One filter covers both lists, and only one is visible. With Skills open, a query matching
          only Resources would empty the list and read as "nothing found" while the match sat one
          tab away -- so when the open tab has none and the other has some, say where they are. */

--- a/tools/portal/catalog_limit_harness.js
+++ b/tools/portal/catalog_limit_harness.js
@@ -1,0 +1,60 @@
+// Runs the SHIPPED catalog `load` against stubs. Reading the source would pass on a page that
+// computes the sentence and never shows it, which is the mistake this whole family of checks
+// exists to catch.
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const input = JSON.parse(process.argv[3]);
+
+const start = page.indexOf("  function load(keepMessage) {");
+if (start < 0) throw new Error("load not found");
+let depth = 0, end = -1;
+for (let i = page.indexOf("{", start); i < page.length; i++) {
+  if (page[i] === "{") depth++;
+  else if (page[i] === "}") { depth--; if (depth === 0) { end = i + 1; break; } }
+}
+
+const said = [];
+const values = {
+  filter: input.filter || "",
+  rtype: "",
+  limit: String(input.typed),
+};
+const el = (id) => ({
+  value: values[id] !== undefined ? values[id] : "",
+  checked: false,
+  textContent: "",
+  innerHTML: "",
+  getAttribute: () => "false",
+});
+const nodes = {};
+const $ = (id) => (nodes[id] = nodes[id] || el(id));
+
+const bodies = input.bodies;
+const scope = {
+  $,
+  query: () => ["limit=" + values.limit],
+  auth: () => ({}),
+  conn: () => {},
+  say: (node, text, cls) => said.push({ text, cls }),
+  esc: (s) => String(s == null ? "" : s),
+  matches: () => true,
+  renderSummary: () => {},
+  skillsHtml: () => "",
+  resourcesHtml: () => "",
+  fetch: (url) => Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(url.indexOf("/v1/skills") === 0 ? bodies[0] : bodies[1]),
+  }),
+  Promise,
+};
+
+const names = Object.keys(scope);
+const load = new Function(...names, page.slice(start, end) + "; return load;")(
+  ...names.map((k) => scope[k]));
+
+load(input.keepMessage === true);
+setTimeout(() => {
+  process.stdout.write(JSON.stringify({ said }));
+}, 5);

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -653,7 +653,10 @@
       if (v) { parts.push(f + "_id=" + encodeURIComponent(v)); }
     });
     var limit = parseInt($("limit").value, 10);
-    parts.push("limit=" + (limit > 0 ? Math.min(limit, 500) : 100));
+    /* Sent as typed. Clamping here meant the page held its own copy of the gateway's maximum,
+       which is a second place for that number to be wrong -- and it hid the clamp from the person
+       who typed the bigger one. The response says what was applied. */
+    parts.push("limit=" + (limit > 0 ? limit : 100));
     return parts;
   }
 
@@ -769,6 +772,27 @@
          clicking would show. */
       $("skillsCount").textContent = " " + skills.length;
       $("resourcesCount").textContent = " " + resources.length;
+      /* A list that stopped at its limit is not the catalogue. Read from what came back, per list,
+         because one can be cut while the other is not -- and the filter above runs in the browser,
+         so it narrows what was already cut rather than reaching past the cut.
+         Only written when there IS something to say: the auto-refresh sets its own message here
+         and a blank write would take it away. */
+      var cut = [];
+      [["Skills", bodies[0], (bodies[0].skills || []).length],
+       ["Resources", bodies[1], (bodies[1].resources || []).length]].forEach(function (pair) {
+        var applied = Number(pair[1].limit);
+        if (applied > 0 && pair[2] >= applied) { cut.push(pair[0] + " at " + applied); }
+      });
+      var most = Number(bodies[0].limit_max || bodies[1].limit_max) || 0;
+      var asked = parseInt($("limit").value, 10);
+      var note = cut.length
+        ? cut.join(" and ") + " \u2014 the list stopped at the limit, so there may be more."
+        : "";
+      if (most && asked > most) {
+        note += (note ? " " : "") + "The most this endpoint returns is " + most + "; "
+              + asked + " was asked for.";
+      }
+      if (note) { say($("listMsg"), note, "info"); }
       /* One filter covers both lists, and only one is visible. With Skills open, a query matching
          only Resources would empty the list and read as "nothing found" while the match sat one
          tab away -- so when the open tab has none and the other has some, say where they are. */

--- a/tools/test_matrixark_a_list_that_stopped_at_its_limit_says_so.py
+++ b/tools/test_matrixark_a_list_that_stopped_at_its_limit_says_so.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A catalog list that stopped at its limit is not the catalogue.
+
+`GET /v1/skills` and `/v1/resources` cap at 500 rows however many are asked for, and returned no
+sign of it. A tenant holding 4,000 skills got 500, a summary card reading "500 skills", and no way
+to tell that from a deployment holding exactly 500.
+
+The cap was written down twice: the page clamped to 500 before sending, and the gateway clamped to
+500 on arrival. Two copies of one number that had to agree, with nothing making them -- and the
+page's copy also hid the clamp from the person who typed the larger number, the same defect as a
+select that quietly rewrites an off-list value.
+
+The page now sends what was typed and reports what came back:
+
+* a list whose length reached the applied limit says so, per list, since one can be cut while the
+  other is not;
+* asking for more than the endpoint serves says what the maximum is.
+
+**Only written when there is something to say.** The auto-refresh writes its own message into the
+same element, and a blank write would take it away.
+
+The page is checked by RUNNING the shipped `load`, because a page that computes the sentence and
+never shows it would pass a source read.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+HARNESS = os.path.join(PORTAL, "catalog_limit_harness.js")
+PAGE = os.path.join(PORTAL, "catalog_portal.html")
+
+
+def writes(skills: int, resources: int, typed: int, applied=None, cap=500,
+           keep_message: bool = False) -> list:
+    """Every write the panel makes into the message element, in order.
+
+    `keep_message` is the auto-refresh path: it does NOT clear the element first, because the
+    refresh has just written its own message there.
+    """
+    applied = min(typed, cap) if applied is None else applied
+
+    def body(key: str, count: int) -> dict:
+        out = {key: [{"name": "x%d" % i} for i in range(count)]}
+        if cap is not None:
+            out["limit_max"] = cap
+        if applied:
+            out["limit"] = applied
+        return out
+
+    payload = {"typed": typed, "keepMessage": keep_message,
+               "bodies": [body("skills", skills), body("resources", resources)]}
+    out = subprocess.run(["node", HARNESS, PAGE, json.dumps(payload)],
+                         capture_output=True, text=True, timeout=300)
+    if out.returncode != 0:
+        raise AssertionError(out.stderr[-800:])
+    return json.loads(out.stdout)["said"]
+
+
+def load(skills: int, resources: int, typed: int, applied=None, cap=500) -> str:
+    """What the panel says for a response of this shape. `applied` defaults to the real clamp."""
+    return " ".join(entry["text"]
+                    for entry in writes(skills, resources, typed, applied, cap)
+                    if entry["text"])
+
+
+class ThePanelSaysWhenTheListWasCutTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    def test_a_list_at_the_limit_says_so(self) -> None:
+        said = load(skills=100, resources=4, typed=100)
+        self.assertIn("Skills at 100", said)
+        self.assertIn("there may be more", said)
+
+    def test_it_names_which_list_was_cut(self) -> None:
+        """One can be cut while the other is not, and "the list" would not say which."""
+        self.assertIn("Resources at 100", load(skills=4, resources=100, typed=100))
+        self.assertNotIn("Skills at", load(skills=4, resources=100, typed=100))
+
+    def test_both_are_named_when_both_were_cut(self) -> None:
+        said = load(skills=500, resources=500, typed=5000)
+        self.assertIn("Skills at 500 and Resources at 500", said)
+
+    def test_a_list_under_the_limit_says_nothing(self) -> None:
+        """The floor. A note on every listing is a note nobody reads, and these lists are almost
+        always short."""
+        self.assertEqual("", load(skills=3, resources=4, typed=100))
+
+    def test_asking_for_more_than_it_serves_is_told_so(self) -> None:
+        """The half the page used to hide by clamping before it sent."""
+        said = load(skills=10, resources=10, typed=5000)
+        self.assertIn("The most this endpoint returns is 500", said)
+        self.assertIn("5000 was asked for", said)
+
+    def test_a_response_without_the_fields_says_nothing(self) -> None:
+        """An older gateway behind a newer page stays quiet rather than inventing a cap."""
+        self.assertEqual("", load(skills=100, resources=100, typed=100, applied=0, cap=None))
+
+
+class ItDoesNotTakeAwaySomebodyElsesMessageTest(unittest.TestCase):
+    """The auto-refresh writes "this list has been refreshed" into the same element and then calls
+    `load(true)`, which deliberately does not clear it. A blank write from here would take that
+    message away a fraction of a second after it appeared."""
+
+    def setUp(self) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    def test_nothing_to_say_writes_nothing_at_all(self) -> None:
+        self.assertEqual([], writes(skills=3, resources=4, typed=100, keep_message=True))
+
+    def test_something_to_say_still_says_it_on_that_path(self) -> None:
+        """The floor: silence must be because there was nothing to say, not because this path is
+        silent."""
+        said = writes(skills=100, resources=4, typed=100, keep_message=True)
+        self.assertEqual(1, len(said))
+        self.assertIn("Skills at 100", said[0]["text"])
+
+    def test_the_ordinary_path_still_clears_first(self) -> None:
+        """Unchanged behaviour: a fresh listing starts from a blank message."""
+        said = writes(skills=3, resources=4, typed=100, keep_message=False)
+        self.assertEqual([""], [entry["text"] for entry in said])
+
+
+class TheGatewayReportsWhatItApplied(unittest.TestCase):
+
+    @staticmethod
+    def _source() -> str:
+        with io.open(os.path.join(TOOLS, "matrixark_v1_gateway.py"), encoding="utf-8") as handle:
+            return handle.read()
+
+    def test_the_cap_is_named_once(self) -> None:
+        source = self._source()
+        self.assertIn("CATALOG_LIST_LIMIT_MAX = 500", source)
+        self.assertIn("min(int(limit), CATALOG_LIST_LIMIT_MAX)", source)
+
+    def test_the_response_carries_both(self) -> None:
+        source = self._source()
+        self.assertIn('body["limit_max"] = CATALOG_LIST_LIMIT_MAX', source)
+        self.assertIn('body["limit"] = args["limit"]', source)
+
+    def test_the_page_no_longer_holds_its_own_copy(self) -> None:
+        """The point of naming it. A second copy in the browser is a second place to be wrong."""
+        with io.open(os.path.join(PORTAL, "build_portal_pages.py"), encoding="utf-8") as handle:
+            builder = handle.read()
+        self.assertNotIn("Math.min(limit, 500)", builder)
+        with io.open(PAGE, encoding="utf-8") as handle:
+            self.assertNotIn("Math.min(limit, 500)", handle.read())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`GET /v1/skills` and `/v1/resources` cap at **500 rows** however many are asked for, and returned no sign of it. A tenant holding 4,000 skills got 500, a summary card reading "500 skills", and no way to tell that from a deployment holding exactly 500.

The cap was written down **twice** — the page clamped to 500 before sending, the gateway clamped to 500 on arrival. Two copies of one number that had to agree, with nothing making them. The page's copy also hid the clamp from the person who typed the larger number, which is the same defect as a select that quietly rewrites an off-list value.

## What the panel says now

| skills | resources | typed | shown |
|---|---|---|---|
| 3 | 4 | 100 | *(nothing)* |
| 100 | 4 | 100 | `Skills at 100 — the list stopped at the limit, so there may be more.` |
| 4 | 100 | 100 | `Resources at 100 — …` |
| 500 | 500 | 5000 | `Skills at 500 and Resources at 500 — … The most this endpoint returns is 500; 5000 was asked for.` |
| 10 | 10 | 5000 | `The most this endpoint returns is 500; 5000 was asked for.` |
| fields absent | | | *(nothing — an older gateway behind a newer page invents no cap)* |

Named per list, because one can be cut while the other is not. The gateway names the cap once (`CATALOG_LIST_LIMIT_MAX`) and reports both what it applied and what its maximum is; the page holds no copy of the number.

**Only written when there is something to say.** The auto-refresh writes its own message into the same element and then calls `load(true)`, which deliberately does not clear it — a blank write from here would take that message away a fraction of a second after it appeared. That claim **survived the first mutation run** and now has its own test.

The catalog page is emitted from `build_portal_pages.py`, so the builder is edited and the page regenerated; the two drift guards pass.

## Mutations

Nineteen tests. Each of these reddens at least one:

| mutation | reddens |
|---|---|
| the response stops saying what it applied | `test_the_response_carries_both` |
| the response stops saying the maximum | `test_the_response_carries_both` |
| the cap goes back to a bare number | `test_the_cap_is_named_once` |
| the page clamps before sending again | `test_the_page_no_longer_holds_its_own_copy` |
| the page never says a list was cut | `test_a_list_at_the_limit_says_so` |
| it says it whenever anything came back | `test_a_list_under_the_limit_says_nothing` |
| a blank note overwrites the refresh message | `test_nothing_to_say_writes_nothing_at_all` |

The page is checked by **running** the shipped `load` against stubs — a page that computes the sentence and never shows it would pass a source read.

Two other routes also cap at 500. Those are different policies that happen to share a number, and folding them into this constant would couple them, so they are left alone.
