### PR TITLE
Nine functions written out twice, now written once

### DIFF
--- a/tools/matrixark_mcp_budget_pack.py
+++ b/tools/matrixark_mcp_budget_pack.py
@@ -325,75 +325,10 @@ def candidate_memory_layer_name(candidate: Json) -> str:
     return context_class or ref_type or "unknown"
 
 
-def local_context_budget(args: Json) -> Json:
-    raw_items = args.get("local_context", [])
-    if raw_items is None:
-        raw_items = []
-    if not isinstance(raw_items, list):
-        raise MatrixArkError("local_context must be an array")
-    items: list[Json] = []
-    text_hashes: set[int] = set()
-    token_total = 0
-    for index, item in enumerate(raw_items):
-        if isinstance(item, str):
-            text = item
-            source = f"local:{index}"
-            ref_type = "local_context"
-        elif isinstance(item, dict):
-            text = str(item.get("text") or item.get("content") or "")
-            source = str(item.get("source") or item.get("ref") or f"local:{index}")
-            ref_type = str(item.get("ref_type") or "local_context")
-        else:
-            raise MatrixArkError("local_context items must be strings or objects")
-        text = clip_context_text(text)
-        if not text:
-            continue
-        item_tokens = token_count(text)
-        token_total += item_tokens
-        text_hashes.update(context_text_hashes(text))
-        items.append(
-            {
-                "ref_type": ref_type,
-                "source": source,
-                "text": text,
-                "token_estimate": item_tokens,
-                "text_hash": stable_hash(text[:512]),
-            }
-        )
-    explicit_tokens = args.get("local_context_tokens")
-    token_source = "estimated_from_local_context"
-    if explicit_tokens is not None:
-        if not isinstance(explicit_tokens, int) or explicit_tokens < 0:
-            raise MatrixArkError("local_context_tokens must be a non-negative integer")
-        token_total = max(token_total, explicit_tokens)
-        token_source = "agent_provided_local_context_tokens"
-    raw_safety_margin = args.get("local_context_safety_margin_tokens")
-    if raw_safety_margin is None:
-        raw_safety_margin = os.environ.get("MATRIXARK_LOCAL_CONTEXT_SAFETY_MARGIN_TOKENS")
-    if raw_safety_margin is None:
-        raw_max_context = args.get("max_context_tokens", DEFAULT_MAX_CONTEXT_TOKENS)
-        try:
-            max_context_tokens = max(0, int(raw_max_context or DEFAULT_MAX_CONTEXT_TOKENS))
-        except (TypeError, ValueError):
-            max_context_tokens = DEFAULT_MAX_CONTEXT_TOKENS
-        safety_margin_tokens = min(512, max_context_tokens // 20)
-        safety_margin_source = "matrixark_default_5_percent_capped"
-    else:
-        try:
-            safety_margin_tokens = int(raw_safety_margin or 0)
-        except (TypeError, ValueError):
-            raise MatrixArkError("local_context_safety_margin_tokens must be a non-negative integer")
-        safety_margin_source = "agent_provided_safety_margin" if "local_context_safety_margin_tokens" in args else "env_safety_margin"
-    if safety_margin_tokens < 0:
-        raise MatrixArkError("local_context_safety_margin_tokens must be a non-negative integer")
-    return {
-        "items": items,
-        "token_estimate": token_total,
-        "text_hashes": text_hashes,
-        "token_source": token_source,
-        "safety_margin_tokens": safety_margin_tokens,
-        "safety_margin_source": safety_margin_source,
-    }
+try:  # the implementation lives in matrixark_mcp_core_packing; this module re-exports it
+    from tools.matrixark_mcp_core_packing import local_context_budget
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_packing import local_context_budget
 
 
 def compact_local_context_refs(local_budget: Json) -> list[Json]:

--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -4737,47 +4737,10 @@ def synthesize_context_node_summary(
     provider_meta["execution_mode"] = "deterministic_fallback"
     return fallback_summary, provider_meta
 
-def scope_matches(record_scope: Json, query_scope: Json) -> bool:
-    if not query_scope:
-        return True
-    sharing_scope = str(record_scope.get("sharing_scope") or "").strip().lower()
-    if sharing_scope == "global_shared":
-        return True
-    if sharing_scope == "tenant_shared":
-        for field in ["account_id", "account_hash", "tenant_id", "tenant_hash"]:
-            query_value = query_scope.get(field)
-            record_value = record_scope.get(field)
-            if query_value and record_value and query_value != record_value:
-                return False
-        return True
-    explicit_keys = set(query_scope.get("_explicit_scope_keys", []))
-    record_scope_key = str(record_scope.get("scope_key") or "")
-    if record_scope_key:
-        if not scope_key_matches_query(record_scope_key, query_scope, explicit_keys):
-            return False
-        if set(record_scope.keys()).issubset({"scope_key"}):
-            return True
-    for key, value in query_scope.items():
-        if str(key).startswith("_"):
-            continue
-        if key == "scope_key":
-            continue
-        if key == "agent_name" and key not in record_scope:
-            continue
-        if key in {"team", "project"} and key not in record_scope and record_scope_key:
-            continue
-        if key in {"agent_name", "team", "project"} and key not in explicit_keys:
-            continue
-        if key in {"account_id", "tenant_id", "account_hash", "tenant_hash"} and record_scope_key and key not in record_scope:
-            continue
-        if key in {"user_id", "user_hash"} and "user_id" not in explicit_keys:
-            continue
-        if key in {"session_id", "session_hash"}:
-            if "session_id" not in explicit_keys or session_scope_mode(query_scope) == "prefer":
-                continue
-        if record_scope.get(key) != value:
-            return False
-    return True
+try:  # the implementation lives in matrixark_mcp_access_scope; this module re-exports it
+    from tools.matrixark_mcp_access_scope import scope_matches
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_access_scope import scope_matches
 
 
 def candidate_access_scope(record: Json) -> Json:

--- a/tools/matrixark_mcp_core_compact.py
+++ b/tools/matrixark_mcp_core_compact.py
@@ -309,52 +309,10 @@ def attach_context_placement(record: Json, *, scope_key: str = "", node_hash: An
     return record
 
 
-def compact_record_lifecycle_fields(record: Json) -> Json:
-    record_type = str(record.get("record_type") or "")
-    if record_type not in COMPACT_TIMESTAMP_RECORD_TYPES:
-        return record
-    compacted = dict(record)
-    if str(compacted.get("scope_key") or ""):
-        for field in COMPACT_DERIVED_SCOPE_FIELDS:
-            compacted.pop(field, None)
-        if record_type in COMPACT_TOPOLOGY_SCOPE_STRING_RECORD_TYPES:
-            for field in COMPACT_TOPOLOGY_SCOPE_STRING_FIELDS:
-                compacted.pop(field, None)
-    if record_type == "context_event":
-        # event_time_key + parent hash/type is the serving key; the fully
-        # expanded string is debug-only noise in hot records.
-        compacted.pop("context_event_key", None)
-    if record_type == "context_embedding":
-        model_name = str(compacted.get("model") or "")
-        if model_name:
-            compacted.setdefault("model_ref", embedding_model_ref_for_name(model_name))
-            compacted.pop("model_hash", None)
-    if compacted.get("created_at_ms") is not None and compacted.get("updated_at_ms") is not None:
-        try:
-            created_at_ms = int(compacted.get("created_at_ms"))
-            updated_at_ms = int(compacted.get("updated_at_ms"))
-        except (TypeError, ValueError):
-            created_at_ms = None
-            updated_at_ms = None
-        if created_at_ms is not None and created_at_ms == updated_at_ms:
-            compacted.pop("created_at_ms", None)
-    node_path = compacted.get("node_path")
-    if isinstance(node_path, list) and compacted.get("depth") is not None:
-        try:
-            depth = int(compacted.get("depth"))
-        except (TypeError, ValueError):
-            depth = None
-        if depth == len(node_path):
-            compacted.pop("depth", None)
-    if record_type == "context_node" and isinstance(node_path, list) and node_path:
-        if str(compacted.get("node_name") or "") == str(node_path[-1]):
-            compacted.pop("node_name", None)
-    if record_type in TOPOLOGY_DERIVED_PATH_RECORD_TYPES:
-        compacted.pop("parent_path", None)
-        compacted.pop("child_path", None)
-        compacted.pop("child_name", None)
-        compacted.pop("depth", None)
-    return compacted
+try:  # the implementation lives in matrixark_mcp_serving_records; this module re-exports it
+    from tools.matrixark_mcp_serving_records import compact_record_lifecycle_fields
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_serving_records import compact_record_lifecycle_fields
 
 
 def compact_storage_record(record: Json) -> Json:

--- a/tools/matrixark_mcp_extraction_runtime.py
+++ b/tools/matrixark_mcp_extraction_runtime.py
@@ -73,59 +73,10 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
     from matrixark_mcp_text import text_from_messages
 
 
-def openai_compatible_one_pass_memory_extraction(envelope: Json, *, prior_context: Json) -> Json:
-    messages = envelope["messages"]
-    indexed = "\n".join(f"{index}. {message.get('role', 'user')}: {message.get('content', '')}" for index, message in enumerate(messages))
-    source_event_ids = envelope.get("source_event_ids", [])
-    source_refs = [str(ref) for ref in source_event_ids] if isinstance(source_event_ids, list) and source_event_ids else [str(index) for index, _ in enumerate(messages)]
-    system = "Return only JSON. You are a one-pass memory extractor for MatrixArk."
-    user = (
-        "Extract memory from this logical conversation batch in one pass. "
-        "Return JSON with keys classification, event_type, batch_summary, entities, segments, indexes. "
-        "Entities must use a stable concise entity_name and a separate state sentence; do not copy the same phrase into both. "
-        "Each entity shape: {entity_type, entity_name, state, confidence, field_patches}; operator is optional and MatrixArk will coerce it to the actual runtime operator. "
-        "Segments shape: {topic, coordinate_tuples, message_indexes, saliency_score, summary_text}. "
-        "Use event_type values like approval_state, budget_update, deadline, procedure, correction, status_update.\n\n"
-        f"Conversation:\n{indexed}\n\nJSON:"
-    )
-    raw = openai_compatible_json_call(system=system, user=user)
-    batch_text = text_from_messages(messages)
-    entities = normalize_extracted_entities(raw.get("entities"), fallback_text=batch_text, source_refs=source_refs, extracted_by="openai_compatible")
-    if not entities:
-        if require_oss_understanding():
-            raise MatrixArkError("OpenAI-compatible extraction returned no entities")
-        entities = extract_batch_entities(messages, envelope)
-        for entity in entities:
-            entity["extracted_by"] = "deterministic_fallback"
-    segments = normalize_extracted_segments(raw.get("segments"), messages)
-    if not segments:
-        if require_oss_understanding():
-            raise MatrixArkError("OpenAI-compatible extraction returned no segments")
-        segments, _segment_meta = detect_memory_segments(messages, {**envelope, "segment_provider": "deterministic"})
-    event_type = re.sub(r"[^a-z0-9_]+", "_", str(raw.get("event_type") or infer_event_type(batch_text)).lower()).strip("_") or "session"
-    classification = re.sub(r"[^A-Z0-9_]+", "_", str(raw.get("classification") or "BATCH_MEMORY").upper()).strip("_") or "BATCH_MEMORY"
-    indexes = raw.get("indexes") if isinstance(raw.get("indexes"), list) else []
-    normalized_indexes = [str(item) for item in indexes if isinstance(item, str)]
-    normalized_indexes = ordered_unique(normalized_indexes + [context_index_name("event_type", event_type), context_index_name("classification", classification)])
-    return {
-        "mode": "matrixark_one_pass_schema_openai_compatible",
-        "understanding_provider": "openai_compatible",
-        "schema": ONE_PASS_MEMORY_SCHEMA,
-        "classification": classification,
-        "status": str(raw.get("status") or "observed"),
-        "event_type": event_type,
-        "entities": entities,
-        "segments": segments,
-        "segment_provider": {"provider": "openai_compatible", "execution_mode": "llm_json", "model": EXTRACTION_LLM_MODEL, "fallback_used": False, "segment_count": len(segments)},
-        "indexes": normalized_indexes[:8],
-        "batch_summary": summarize_text(str(raw.get("batch_summary") or raw.get("summary") or batch_text), limit=700),
-        "message_count": len(messages),
-        "token_count_estimate": len(tokens(batch_text)),
-        "prior_context": prior_context.get("level", ""),
-        "prior_refs": prior_context.get("refs", []),
-        "prior_message_count": len(prior_context.get("messages", [])),
-        "prior_summary_count": len(prior_context.get("summaries", [])),
-    }
+try:  # the implementation lives in matrixark_mcp_core_extraction; this module re-exports it
+    from tools.matrixark_mcp_core_extraction import openai_compatible_one_pass_memory_extraction
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_extraction import openai_compatible_one_pass_memory_extraction
 
 
 def openai_compatible_resource_facts(chunk: Any, *, chunk_metadata: Json, envelope: Json, raw_uri: str, resource_version: str) -> list[Json]:
@@ -141,75 +92,10 @@ def openai_compatible_resource_facts(chunk: Any, *, chunk_metadata: Json, envelo
     return normalize_extracted_facts(raw.get("facts"), chunk=chunk, chunk_metadata=chunk_metadata, raw_uri=raw_uri, resource_version=resource_version, provider="openai_compatible")
 
 
-def compact_internal_extraction(envelope: Json, *, prior_context: Json) -> Json:
-    """Rules-first internal extraction used by the local MCP MVP.
-
-    Production MatrixArk can replace this with OSS/OpenAI/provider extraction,
-    but callers still see the same Mem0-style envelope contract.
-    """
-
-    provider = understanding_provider(envelope)
-    if provider == "oss_encoder":
-        return oss_encoder_compact_extraction(envelope, prior_context=prior_context)
-
-    text = text_from_messages(envelope["messages"]).lower()
-    if envelope["kind"] == "feedback":
-        positive = any(term in text for term in ["yes", "confirmed", "approved", "correct", "looks good"])
-        negative = any(term in text for term in ["no", "wrong", "incorrect", "reject", "not correct"])
-        prior_level = prior_context.get("level", "")
-        if not prior_level:
-            return {
-                "mode": "matrixark_internal",
-                "classification": "AMBIGUOUS",
-                "quality_warning": "short feedback lacks prior context",
-                "prior_refs": [],
-            }
-        warning = ""
-        if prior_level == "user":
-            warning = "session_id missing; used user_id fallback for prior context"
-        prior_refs = prior_context.get("refs", [])
-        if positive:
-            return {
-                "mode": "matrixark_internal",
-                "classification": "CONFIRMATION",
-                "status": "accepted",
-                "prior_context": prior_level,
-                "prior_refs": prior_refs,
-                "prior_message_count": len(prior_context.get("messages", [])),
-                "prior_summary_count": len(prior_context.get("summaries", [])),
-                "quality_warning": warning,
-            }
-        if negative:
-            return {
-                "mode": "matrixark_internal",
-                "classification": "CORRECTION",
-                "status": "rejected",
-                "prior_context": prior_level,
-                "prior_refs": prior_refs,
-                "prior_message_count": len(prior_context.get("messages", [])),
-                "prior_summary_count": len(prior_context.get("summaries", [])),
-                "quality_warning": warning,
-            }
-        return {
-            "mode": "matrixark_internal",
-            "classification": "FEEDBACK",
-            "status": "observed",
-            "prior_context": prior_level,
-            "prior_refs": prior_refs,
-            "prior_message_count": len(prior_context.get("messages", [])),
-            "prior_summary_count": len(prior_context.get("summaries", [])),
-            "quality_warning": warning,
-        }
-    return {
-        "mode": "matrixark_internal",
-        "classification": "NEW_EVENT",
-        "status": "observed",
-        "prior_context": prior_context.get("level", ""),
-        "prior_refs": prior_context.get("refs", []),
-        "prior_message_count": len(prior_context.get("messages", [])),
-        "prior_summary_count": len(prior_context.get("summaries", [])),
-        "quality_warning": "",
-    }
+try:  # the implementation lives in matrixark_mcp_core_extraction; this module re-exports it
+    from tools.matrixark_mcp_core_extraction import compact_internal_extraction
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_extraction import compact_internal_extraction
 
 
 ONE_PASS_MEMORY_SCHEMA: Json = {
@@ -361,48 +247,7 @@ def resource_extraction_mode(envelope: Json) -> str:
     return "matrixark_resource_schema"
 
 
-def extract_resource_facts(chunk: Any, *, chunk_metadata: Json, envelope: Json, raw_uri: str, resource_version: str) -> list[Json]:
-    """Extract cited resource facts through the same provider-shaped contract as messages.
-
-    The local implementation is deterministic for CI. OSS/OpenAI-compatible
-    providers should emit the same fields so storage, indexes, and replay stay
-    unchanged.
-    """
-    mode = resource_extraction_mode(envelope)
-    provider = understanding_provider(envelope)
-    if provider in {"openai", "openai_compatible", "openai_compatible_llm"}:
-        try:
-            model_facts = openai_compatible_resource_facts(
-                chunk,
-                chunk_metadata=chunk_metadata,
-                envelope=envelope,
-                raw_uri=raw_uri,
-                resource_version=resource_version,
-            )
-            if model_facts or require_oss_understanding():
-                return model_facts
-        except MatrixArkError:
-            if require_oss_understanding():
-                raise
-    facts: list[Json] = []
-    for fact_schema in matched_resource_fact_schemas(chunk.text, chunk.metadata):
-        fact_event_type = str(fact_schema["fact_type"])
-        fact_entity_type = str(fact_schema["entity_type"])
-        fact_value = extract_resource_fact_value(chunk.text, fact_event_type)
-        facts.append(
-            {
-                "mode": mode,
-                "classification": "RESOURCE_FACT",
-                "event_type": fact_event_type,
-                "entity_type": fact_entity_type,
-                "status": "observed",
-                "value": fact_value,
-                "entity_name": resource_fact_entity_name(fact_schema, fact_value, chunk_metadata, raw_uri),
-                "confidence": 0.82 if fact_event_type != "resource_fact" else 0.68,
-                "source_chunk_hash": chunk.chunk_hash,
-                "source_ref": chunk.source_ref,
-                "resource_version": resource_version,
-                "extraction_provider": understanding_provider(envelope),
-            }
-        )
-    return facts
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from tools.matrixark_mcp_core import extract_resource_facts
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import extract_resource_facts

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -2612,69 +2612,10 @@ def memory_layer_budget_question_reason(question_type: str) -> str:
     return "normal_queries_keep_profile_and_cross_session_budget compact so same-session context dominates"
 
 
-def codex_outcome_event_segment_layer_fractions(question_type: str, *, outcome_query: bool = False) -> Json:
-    normalized_question_type = str(question_type or "fact").strip().lower()
-    defaults: Json = {
-        "same_session_codex_outcome_event": 0.22,
-        "cross_session_codex_outcome_event": 0.20,
-        "same_session_codex_outcome_segment": 0.20,
-        "cross_session_codex_outcome_segment": 0.18,
-    }
-    if outcome_query:
-        defaults.update(
-            {
-                "same_session_codex_outcome_event": 0.45,
-                "cross_session_codex_outcome_event": 0.42,
-                "same_session_codex_outcome_segment": 0.38,
-                "cross_session_codex_outcome_segment": 0.36,
-            }
-        )
-    elif normalized_question_type in {"current_state", "latest"}:
-        defaults.update(
-            {
-                "same_session_codex_outcome_event": 0.35,
-                "cross_session_codex_outcome_event": 0.30,
-                "same_session_codex_outcome_segment": 0.30,
-                "cross_session_codex_outcome_segment": 0.28,
-            }
-        )
-    elif normalized_question_type == "profile_memory":
-        defaults.update(
-            {
-                "same_session_codex_outcome_event": 0.25,
-                "cross_session_codex_outcome_event": 0.35,
-                "same_session_codex_outcome_segment": 0.22,
-                "cross_session_codex_outcome_segment": 0.32,
-            }
-        )
-    elif normalized_question_type in {"multi_hop", "date"}:
-        defaults.update(
-            {
-                "same_session_codex_outcome_event": 0.35,
-                "cross_session_codex_outcome_event": 0.35,
-                "same_session_codex_outcome_segment": 0.32,
-                "cross_session_codex_outcome_segment": 0.32,
-            }
-        )
-    elif normalized_question_type == "benchmark_quality":
-        defaults.update(
-            {
-                "same_session_codex_outcome_event": 0.42,
-                "cross_session_codex_outcome_event": 0.45,
-                "same_session_codex_outcome_segment": 0.35,
-                "cross_session_codex_outcome_segment": 0.40,
-            }
-        )
-    elif normalized_question_type in {"broad_exploration", "evidence"}:
-        defaults.update(
-            {
-                "same_session_codex_outcome_event": 0.38,
-                "cross_session_codex_outcome_event": 0.35,
-                "same_session_codex_outcome_segment": 0.34,
-                "cross_session_codex_outcome_segment": 0.32,
-            }
-        )
-    return defaults
+try:  # the implementation lives in matrixark_mcp_retrieve_pre_refresh; this module re-exports it
+    from tools.matrixark_mcp_retrieve_pre_refresh import codex_outcome_event_segment_layer_fractions
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_retrieve_pre_refresh import codex_outcome_event_segment_layer_fractions
 
 
 def auto_memory_selection_policy_budget_tokens(

--- a/tools/matrixark_mcp_segments.py
+++ b/tools/matrixark_mcp_segments.py
@@ -30,62 +30,10 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
 _OSS_SEGMENT_MODEL_CACHE: dict[str, Any] = {}
 
 
-def detect_memory_segments(messages: list[Json], envelope: Json | None = None) -> tuple[list[Json], Json]:
-    envelope = envelope or {}
-    provider = str(envelope.get("segment_provider") or os.getenv("MATRIXARK_SEGMENT_PROVIDER", "deterministic")).strip().lower()
-    if provider in {"oss_encoder", "oss-encoder", "embedding"}:
-        segments = oss_encoder_memory_segments(messages)
-        return segments, {
-            "provider": "oss_encoder",
-            "execution_mode": "oss_embedding_model",
-            "model": embedding_model_name(),
-            "fallback_used": False,
-            "segment_count": len(segments),
-        }
-    if provider in {"", "deterministic", "rules", "local"}:
-        if require_oss_understanding():
-            raise MatrixArkError("deterministic segmentation is disabled because MATRIXARK_REQUIRE_OSS_UNDERSTANDING=1")
-        return intelligent_memory_segments(messages), {
-            "provider": "deterministic",
-            "execution_mode": "rules",
-            "model": "matrixark-local-segmentation-v1",
-            "fallback_used": False,
-        }
-
-    fallback_enabled = bool(envelope.get("segment_provider_fallback", False)) or provider in {"oss-fallback", "oss_with_fallback"} or os.getenv("MATRIXARK_SEGMENT_PROVIDER_FALLBACK", "").lower() in {"1", "true", "yes"}
-    if provider in {"oss", "oss-fallback", "oss_with_fallback"}:
-        model = str(envelope.get("segment_model") or os.getenv("MATRIXARK_SEGMENT_MODEL", "Qwen/Qwen2.5-0.5B-Instruct"))
-        model_path = str(envelope.get("segment_model_path") or os.getenv("MATRIXARK_SEGMENT_MODEL_PATH", ""))
-        max_new_tokens = int(envelope.get("segment_max_new_tokens") or os.getenv("MATRIXARK_SEGMENT_MAX_NEW_TOKENS", "512"))
-        try:
-            raw = oss_model_memory_segments(
-                messages,
-                model=model,
-                model_path=model_path,
-                max_new_tokens=max_new_tokens,
-                local_only=fallback_enabled,
-            )
-            segments = normalize_model_segments(raw, messages)
-            return segments, {
-                "provider": "oss",
-                "execution_mode": "oss_model",
-                "model": model_path or model,
-                "fallback_used": False,
-                "segment_count": len(segments),
-            }
-        except Exception as exc:  # pragma: no cover - optional local model stack.
-            if not fallback_enabled:
-                raise MatrixArkError(f"OSS segment provider failed: {exc}") from exc
-            segments = intelligent_memory_segments(messages)
-            return segments, {
-                "provider": "oss",
-                "execution_mode": "rules_fallback",
-                "model": model_path or model,
-                "fallback_used": True,
-                "fallback_reason": str(exc),
-                "segment_count": len(segments),
-            }
-    raise MatrixArkError("segment_provider must be deterministic, oss, or oss-fallback")
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from tools.matrixark_mcp_core import detect_memory_segments
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import detect_memory_segments
 
 
 def build_segment_prompt(messages: list[Json]) -> str:
@@ -141,46 +89,10 @@ def oss_model_memory_segments(messages: list[Json], *, model: str, model_path: s
     return parse_first_json_object(response)
 
 
-def normalize_model_segments(raw: Any, messages: list[Json]) -> list[Json]:
-    if isinstance(raw, list):
-        raw_segments = raw
-    elif isinstance(raw, dict) and isinstance(raw.get("segments"), list):
-        raw_segments = raw["segments"]
-    else:
-        raise MatrixArkError("OSS segment provider must return {segments:[...]}")
-    max_index = len(messages) - 1
-    normalized: list[Json] = []
-    for raw_segment in raw_segments[:12]:
-        if not isinstance(raw_segment, dict):
-            continue
-        topic = re.sub(r"[^a-z0-9_]+", "_", str(raw_segment.get("topic") or "model_segment").lower()).strip("_") or "model_segment"
-        coordinate_tuples = normalize_coordinate_tuples(raw_segment.get("coordinate_tuples"), max_index)
-        message_indexes = normalize_message_indexes(raw_segment.get("message_indexes"), coordinate_tuples, max_index)
-        if not message_indexes:
-            continue
-        if not coordinate_tuples:
-            coordinate_tuples = contiguous_ranges(message_indexes)
-        segment_text = "\n".join(f"{index}: {messages[index].get('content', '')}" for index in message_indexes)
-        saliency = raw_segment.get("saliency_score", 0.85)
-        try:
-            saliency_score = max(0.0, min(1.0, float(saliency)))
-        except (TypeError, ValueError):
-            saliency_score = 0.85
-        summary_text = str(raw_segment.get("summary_text") or summarize_text(segment_text, limit=420))
-        normalized.append(
-            {
-                "topic": topic,
-                "coordinate_tuples": coordinate_tuples,
-                "message_indexes": message_indexes,
-                "saliency_score": round(saliency_score, 6),
-                "summary_text": summarize_text(summary_text, limit=420),
-                "text": segment_text,
-                "non_contiguous": len(coordinate_tuples) > 1,
-                "detected_by": "oss_model",
-            }
-        )
-    normalized.sort(key=lambda item: (-item["saliency_score"], item["topic"]))
-    return normalized
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from tools.matrixark_mcp_core import normalize_model_segments
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import normalize_model_segments
 
 
 def normalize_coordinate_tuples(value: Any, max_index: int) -> list[list[int]]:


### PR DESCRIPTION
`tools/` carries 206 groups of byte-identical function bodies — about 3,139 lines of the same code
written out more than once. The shape is an extraction that was started and never finished:
modules were split out of `matrixark_mcp_core.py`, and the copy left behind stayed live on its own
import path. So both copies are reachable, and which one a caller gets is decided by its import
line rather than by anything deliberate.

This collapses nine of them. The body moves nowhere: the module that keeps it is unchanged, and the
other module imports it.

## Why each copy chosen is the safe one

Four checks, each excluding a way this could go wrong quietly:

- **Signatures compared separately from bodies.** A body hash ignores parameters, so two functions
  whose defaults differ hash identically; merging those would change the answer at every call site
  relying on a default. Groups whose interfaces differ are left alone.
- **Module-level definitions only.** Collected from the module body rather than by walking the
  whole tree, so nothing inside a class is touched — a method replaced by a module-level import
  would leave its class without the attribute. Anything taking `self`/`cls`, or carrying a
  decorator, is refused too.
- **Direction derived from the module graph.** The importing module is always one that ALREADY
  reaches the module keeping the body, so the graph gains no edge and no cycle can appear. Pairs
  that reach each other both ways are left for a later change that gives the body a third home.
- **Counting a use includes calls inside the defining module.** An earlier version of the
  analysis called a private helper dead because nothing imports it, when it is called ten lines
  below itself.

## How it is verified

By **object identity**, not by reading the code: after the change, `owner.f is importer.f` for
every consolidated function. Comparing sources, or calling both and comparing answers, would pass
just as well with two copies still present.

Each module's `__all__` still resolves — the import binds the name — which matters because
`__all__` and string literals are what keep several of these copies reachable at all.

## One pair deliberately left alone

`build_shared_context_policy` stays duplicated. Three tests encode that particular pair on purpose:
two assert the copies are two DISTINCT objects, because the test above them loops over both to
check each honours an environment ceiling — collapse them and that loop silently covers one module
twice while continuing to pass. The third lists the module as one that reads a setting through
`live_int`, which stops being true once the body moves.

No coverage is actually lost by consolidating it — the module keeping the body still holds the read
and is still scanned — but changing what three tests assert deserves its own review rather than a
line inside a bulk cleanup.

## Result

Nine functions, 482 lines. The whole `tools/` suite (381 files) ran before and after, the before run
against a full worktree at the same commit — a tools-only tree fails dozens of files on missing
`crates/`, `docs/` and `config/` directories, and comparing against that would let a real regression
hide among phantom failures.

341 pass / 40 fail before, 342 pass / 39 fail after, with **zero tests failing only after**. All 39
remaining failures fail identically on both trees. The single difference is one test that failed
before and passes now, which reproduces as flaky when run on its own.
