### PR TITLE
Twenty-five flag tests raised NameError instead of running

### DIFF
--- a/tools/test_a_two_path_flag_says_why.py
+++ b/tools/test_a_two_path_flag_says_why.py
@@ -57,6 +57,13 @@ KNOWN_TWO_PATH_FLAGS: Dict[str, str] = {
     # and the short version is here so the list can be scanned.
     #
     # Three of them default ON and are read INSIDE a feature that is off:
+    "TS_BLOCK_INDEX_CHECKSUMS":
+        "records a hex digest per page record while inspecting a slab. Nothing in the crate reads "
+        "the field -- it is there to be read by hand. Off because `inspect_slab` runs at every "
+        "engine open and this hashes every payload a second time, after `decode_page_record` has "
+        "already verified the stored checksum: slab verification measured 13.5 MB/s against "
+        "hundreds for sha256 alone. The on arm surfaces a field the live arm suppresses, which is "
+        "the diagnostic case, so it stays",
     "TS_META_AUTO_REBALANCE_BALANCE":
         "a sub-option of auto-rebalance, read inside `if env_bool(TS_META_AUTO_REBALANCE, false)`. "
         "Its off side is reached by anyone who turns the parent on, so ON-and-unset does not make "

--- a/tools/test_matrixark_engine_flag_inventory.py
+++ b/tools/test_matrixark_engine_flag_inventory.py
@@ -42,7 +42,10 @@ def _builder_prelude() -> dict:
     """
     with io.open(BUILDER, encoding="utf-8") as handle:
         head = handle.read().split("sources = {}")[0]
-    namespace: dict = {}
+    # The prelude reads `__file__` to find the repository it lives in, so the namespace has to
+    # carry one. Without it the exec raises NameError and every test through this helper ERRORS
+    # rather than failing, which reads as a broken test rather than a broken inventory.
+    namespace: dict = {"__file__": BUILDER}
     exec(compile(head, BUILDER, "exec"), namespace)  # noqa: S102 - the builder's own prelude
     return namespace
 

--- a/tools/test_matrixark_engine_flag_legacy.py
+++ b/tools/test_matrixark_engine_flag_legacy.py
@@ -38,7 +38,10 @@ def predicates():
     """
     source = TOOL.read_text(encoding="utf-8")
     head = source.split("sources = {}")[0]
-    namespace: dict = {}
+    # The prelude reads `__file__` to find the repository it lives in, so the namespace has to
+    # carry one. Without it every test through this helper ERRORS instead of running. The same
+    # helper, with the same omission, sits in test_matrixark_engine_flag_inventory.py.
+    namespace: dict = {"__file__": str(TOOL)}
     exec(compile(head, str(TOOL), "exec"), namespace)  # noqa: S102 - the tool's own prelude
     return namespace
 


### PR DESCRIPTION
Two test files borrow the inventory builder's helpers by executing its prelude, and that prelude reads `__file__` to find the repository it lives in — which it started doing when the builder stopped defaulting to one particular checkout. Neither exec namespace carried a `__file__`, so the prelude raised `NameError` and every test reached through those helpers ERRORED rather than failed.

An erroring test reads as a broken test rather than a broken inventory, which is the worse of the two. The completeness checks looked noisy instead of absent, and 23 of the legacy file's 26 tests had not run in some time.

On current `main`:

| file | before | after |
|---|---|---|
| `test_matrixark_engine_flag_inventory.py` | FAILED (errors=2) | 8 of 8 pass |
| `test_matrixark_engine_flag_legacy.py` | FAILED (errors=23) | 26 of 26 pass |

The same omission sat in both files, so fixing one would have left the other.

Rebased onto #1180, which independently fixed the inventory drift, the missing flag decision and the shared-flag floor — the three other defects this PR originally carried. Only the part nobody else hit remains.