### PR TITLE
The one document that lists every engine knob was missing one

### DIFF
--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -8,7 +8,7 @@ within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 289 of them, read by 90 functions.
+There are 290 of them, read by 91 functions.
 
 Deleting unreachable code is not the lever. An earlier version of this document argued that
 by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
@@ -46,12 +46,12 @@ Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 289 |
-| booleans whose default this could read off the source | 49 |
+| total | 290 |
+| booleans whose default this could read off the source | 50 |
 | numbers whose default this could read off the source | 70 |
 | **defaulting on, and set by nothing** | 5 |
 | offered on the portal | 28 |
-| **that nothing in this repository sets** | 156 |
+| **that nothing in this repository sets** | 157 |
 | documented as keeping an older path alive | 5 |
 | reaching more than two files | 15 |
 | whose doc comment is really about another flag | 43 |
@@ -354,7 +354,7 @@ Read only by the benchmark harnesses. Never consulted on a serving path.
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_SELECTED_ID_LIMIT` | 128 | script | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_SOURCE_ORDER_RANKING` | off | script | 1 | — |
 
-## behaviour (61)
+## behaviour (62)
 
 Everything else that changes what the engine does.
 
@@ -379,6 +379,7 @@ Everything else that changes what the engine does.
 | `TEMPORALSTORE_RUST_CODEX_EVENT_LOG_ENABLE` | — | nothing | 1 | — |
 | `TS_BLOB_PEER_FETCH` | off | nothing | 1 | — |
 | `TS_BLOB_RUNTIME_THREADS` | 4 | nothing | 1 | — |
+| `TS_BLOCK_INDEX_CHECKSUMS` | off | nothing | 1 | — |
 | `TS_CACHE_DISK_TIER` | — | test | 1 | — |
 | `TS_COLD_SCAN_NO_CACHE_FILL` | on | config, test, portal | 1 | — |
 | `TS_DATA_RAFT_READ_MODE` | — | config | 1 | — |

--- a/tools/test_a_two_path_flag_says_why.py
+++ b/tools/test_a_two_path_flag_says_why.py
@@ -77,6 +77,13 @@ KNOWN_TWO_PATH_FLAGS: Dict[str, str] = {
         "same opt-out",
     # The rest default OFF. Retiring one of those deletes a hatch rather than a dead arm, and each
     # is a behaviour an operator asks for:
+    "TS_BLOCK_INDEX_CHECKSUMS":
+        "records a sha256 per page record while inspecting a slab. Default OFF because "
+        "`inspect_slab` runs at EVERY engine open and this hashes each payload a second time -- "
+        "`decode_page_record` has already verified the stored checksum -- to fill a field no "
+        "caller reads: measured at 13.5 MB/s against hundreds of MB/s for sha256 alone. The ON "
+        "arm is the only way to get a per-record digest when hand-inspecting a slab, which is "
+        "something the OFF arm cannot give, so it is a hatch and not a dead branch",
     "TS_BLOB_PEER_FETCH":
         "cross-peer blob availability -- a local miss fetches from a peer instead of failing. "
         "Opt-in, and the engine says so at the read",

--- a/tools/test_flag_readers_agree.py
+++ b/tools/test_flag_readers_agree.py
@@ -45,9 +45,18 @@ _ENV_BOOL = re.compile(
     r'env_bool\(\s*["\']([A-Z][A-Z0-9_]{3,})["\']\s*,\s*(True|False)\s*\)')
 ONE_VOCABULARY = ("<env_bool>",)
 
-# Twenty-one when this was written. Asserted so a scan that stops matching fails rather than
-# reporting that every reader agrees.
-EXPECTED_SHARED_FLOOR = 15
+# Twenty-one when this was written, 15 until mx#1171, 14 now. Asserted so a scan that stops
+# matching fails rather than reporting that every reader agrees.
+#
+# Each step down needs a named cause, or this control quietly becomes a rubber stamp. The last one:
+# mx#1171 removed `matrixark_mcp_event_keys.context_event_time_index_entries`, a builder nothing
+# called, and it was the SECOND production reader of
+# MATRIXARK_CONTEXT_EVENT_TIME_INDEX_FULL_PAYLOAD. That flag now has one reader
+# (`matrixark_temporal_direct_backend.py:1568`) and so is no longer shared.
+#
+# A flag leaving this set is not a loss -- one reader cannot disagree with itself. What the floor
+# guards against is the scan matching NOTHING, which looks the same as universal agreement.
+EXPECTED_SHARED_FLOOR = 14
 
 
 def _production_sources() -> List[str]:


### PR DESCRIPTION
`TS_BLOCK_INDEX_CHECKSUMS` reached the engine without the inventory being regenerated, so
`docs/ops/temporalstore-engine-flags.md` — the document whose whole claim is that it lists **every**
engine flag — listed 289 of 290.

Both inventory guards have been red on main since: `test_every_flag_named_in_the_engine_is_listed`
named the missing flag, and `test_regenerating_produces_the_same_document` said the document no
longer matches its source.

## Regenerated

`tools/build_engine_flag_inventory.py`, which is exactly what both failure messages ask for. The
only content change is the new row and the five counts that move with it:

| | before | after |
|---|---|---|
| flags | 289 | 290 |
| functions reading them | 90 | 91 |
| booleans with a source-readable default | 49 | 50 |
| set by nothing in this repository | 156 | 157 |
| behaviour section | 61 | 62 |

## And then the flag needed a decision, not just a row

Adding the row made the flag visible to `test_every_unselected_boolean_has_a_decision`, which
requires every boolean whose other arm nothing selects to **either carry a reason or lose the
branch**. That guard went red on this branch and nowhere else — which is the guard working. The
flag had been invisible while the document was stale.

**The decision is to keep it.** It arrived with #1166 — the commit the live engine is now built
from — as the fix for engine open re-hashing every page record. The two arms do different things:

- **OFF (default)** skips a second sha256 of every page payload at every engine open, which
  `decode_page_record` has already verified, to fill a field no caller reads. Measured at
  **13.5 MB/s** against hundreds of MB/s for sha256 alone.
- **ON** is the only way to get a per-record digest when hand-inspecting a slab.

The ON arm gives something the OFF arm cannot, so it is a hatch and not a dead branch. Recorded in
the OFF-default group with that reason.

## Verification

23 tests across `test_a_two_path_flag_says_why` and `test_matrixark_engine_flag_inventory`, green.

## And a third: a dead reader made a flag stop being shared

`test_the_scan_still_finds_shared_flags` asserts the scan finds at least N flags read from more
than one production site -- a control, so that a scan which stops matching fails loudly instead of
the real assertion reporting that every reader agrees. It went red on main after #1171.

**#1171 was mine.** It removed `matrixark_mcp_event_keys.context_event_time_index_entries`, a
builder nothing called -- and that builder was the **second production reader** of
`MATRIXARK_CONTEXT_EVENT_TIME_INDEX_FULL_PAYLOAD`. The flag now has one reader
(`matrixark_temporal_direct_backend.py:1568`), so it is no longer shared: 15 -> 14.

Verified by running the scan and printing that flag's readers, not by inferring it from the number.
**Lowering a floor without naming what left is how a working control becomes a rubber stamp**, so
the cause sits beside the constant along with the two earlier steps down.

A flag leaving this set is not a loss -- one reader cannot disagree with itself. What the floor
guards against is the scan matching *nothing*, which looks identical to universal agreement.

## Verification

25 tests across `test_flag_readers_agree`, `test_a_two_path_flag_says_why` and
`test_matrixark_engine_flag_inventory`, green.

Name-diffed against main: this branch removes **all three** of main's NEW ratchet failures.
