### PR TITLE
The ages on the portal were measured against the browser's clock

### DIFF
--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -692,6 +692,37 @@ LIVE_STREAM_JS = r"""
    the alternative is the key in a query string, and a credential in a URL ends up in every access
    log and proxy trace between here and the gateway. Same wire format either way; only the
    reconnect is ours to write. */
+/* ---------- the deployment's clock ----------
+ *
+ * Every frame carries the SERVER's `ts` and nothing read it, so "14s ago" was the BROWSER's clock
+ * minus a server timestamp, clamped at zero. On a machine whose clock runs behind the gateway's,
+ * every failure read "0s ago" for ever -- on the one panel whose stated job is to say whether
+ * something happened a minute ago or last Tuesday.
+ *
+ * Extrapolated from the last frame rather than sampled per call: frames arrive every few seconds,
+ * so the elapsed part is small, and a page that has seen no frame yet falls back to the browser's
+ * clock, which is what it had before. */
+var liveServerMs = 0;   /* the server's clock at the last frame */
+var liveFrameAtMs = 0;  /* Date.now() when that frame arrived */
+
+function serverNowMs() {
+  if (!liveFrameAtMs) { return Date.now(); }
+  return liveServerMs + (Date.now() - liveFrameAtMs);
+}
+
+/* How far the browser's clock is from the gateway's, positive when the browser is BEHIND. Worth
+   reporting because every other timestamp on these pages is rendered with toLocaleString() from
+   that same clock, so one wrong clock makes all of them wrong together. */
+function clockSkewMs() {
+  return liveFrameAtMs ? (liveServerMs - liveFrameAtMs) : 0;
+}
+
+/* How long since state last arrived. A connection that is open but silent leaves the page showing
+   the last frame's numbers, and the strip still says "live". */
+function sinceLastFrameMs() {
+  return liveFrameAtMs ? (Date.now() - liveFrameAtMs) : 0;
+}
+
 function liveStream(options) {
   var onFrame = options.onFrame || function () {};
   var onState = options.onState || function () {};
@@ -724,7 +755,16 @@ function liveStream(options) {
        the fields blanks the traffic table, the failures panel and the strip, every ten minutes. */
     if (name === "bye") { planned = true; return; }
     if (name !== "status" || !payload) { return; }
-    try { onFrame(JSON.parse(payload)); } catch (e) { /* a partial frame; the next one is whole */ }
+    try {
+      var frame = JSON.parse(payload);
+      /* Recorded before the handler runs, so anything the handler renders reads the clock of the
+         frame it is rendering rather than the one before it. */
+      if (typeof frame.ts === "number" && isFinite(frame.ts)) {
+        liveServerMs = frame.ts * 1000;
+        liveFrameAtMs = Date.now();
+      }
+      onFrame(frame);
+    } catch (e) { /* a partial frame; the next one is whole */ }
   }
 
   /* A stream is closed on purpose once it reaches its maximum age, and the gateway says so before
@@ -3140,20 +3180,37 @@ SETUP_JS = r"""
   /* Seconds, not a clock time: "14s ago" is read at a glance, a timestamp has to be subtracted from
      now in your head first. */
   function agoText(at) {
-    var seconds = Math.max(0, Math.round(Date.now() / 1000 - Number(at || 0)));
+    /* The deployment's clock, not this browser's: `at` is a server timestamp and subtracting a
+       local clock from it measures the difference between two machines as well as the age. */
+    var seconds = Math.max(0, Math.round(serverNowMs() / 1000 - Number(at || 0)));
     if (seconds < 60) { return seconds + "s ago"; }
     if (seconds < 3600) { return Math.round(seconds / 60) + "m ago"; }
     return Math.round(seconds / 3600) + "h ago";
+  }
+
+  /* Five seconds: below that the difference cannot change how any of these ages read, and a
+     caveat on every deployment is a caveat nobody reads. */
+  var CLOCK_SKEW_NOTICE_MS = 5000;
+
+  function clockNoteHtml() {
+    var skew = clockSkewMs();
+    if (Math.abs(skew) < CLOCK_SKEW_NOTICE_MS) { return ""; }
+    var seconds = Math.round(Math.abs(skew) / 1000);
+    return '<div class="msg info">This browser\u2019s clock is ' + seconds + 's '
+      + (skew > 0 ? "behind" : "ahead of") + ' the gateway\u2019s. The ages below are measured '
+      + 'against the gateway, so they are right \u2014 but every absolute time on these pages is '
+      + 'rendered from this browser, so those are out by the same amount.</div>';
   }
 
   function renderFailures(list) {
     var rows = list || [];
     if (!rows.length) {
       /* Said plainly: an empty panel and one that never loaded look identical otherwise. */
-      $("failures").innerHTML = '<div class="empty">No failures recorded on this worker.</div>';
+      $("failures").innerHTML = clockNoteHtml()
+        + '<div class="empty">No failures recorded on this worker.</div>';
       return;
     }
-    $("failures").innerHTML =
+    $("failures").innerHTML = clockNoteHtml() +
       "<table><thead><tr><th>When</th><th>Status</th><th>Method</th><th>Route</th>" +
       "<th>Incident</th></tr></thead>" +
       "<tbody>" + rows.map(function (row) {

--- a/tools/portal/clock_harness.js
+++ b/tools/portal/clock_harness.js
@@ -1,0 +1,92 @@
+// Drives the SHIPPED live-stream parser with a real SSE block, then asks the SHIPPED agoText and
+// clockNoteHtml what they say. Setting the clock variables directly would test my arithmetic, not
+// the code that reads `ts` off a frame -- which is the part that did not exist.
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const input = JSON.parse(process.argv[3]);
+
+function slice(startMarker) {
+  const start = page.indexOf(startMarker);
+  if (start < 0) throw new Error("not found: " + startMarker);
+  let depth = 0, i = page.indexOf("{", start);
+  for (; i < page.length; i++) {
+    if (page[i] === "{") depth++;
+    else if (page[i] === "}") { depth--; if (depth === 0) return page.slice(start, i + 1); }
+  }
+  throw new Error("unclosed: " + startMarker);
+}
+
+// The clock block is plain statements, not a function: take it up to `function liveStream`.
+const clockStart = page.indexOf("var liveServerMs = 0;");
+const clockBlock = page.slice(clockStart, page.indexOf("function liveStream(options)"));
+
+const parts = [
+  clockBlock,
+  slice("function liveStream(options)"),
+  "var CLOCK_SKEW_NOTICE_MS = " +
+    /var CLOCK_SKEW_NOTICE_MS = (\d+);/.exec(page)[1] + ";",
+  slice("function clockNoteHtml()"),
+  slice("  function agoText(at)"),
+  slice("  function renderFailures(list)"),
+];
+
+// A browser whose clock is `input.browserOffsetMs` away from real time.
+const REAL_NOW = 1_760_000_000_000;
+const browserNow = () => REAL_NOW + (input.browserOffsetMs || 0);
+
+const frames = input.frames || [];
+const sse = frames.map((f) => "event: status\ndata: " + JSON.stringify(f) + "\n\n").join("");
+
+const nodes = {};
+const scope = {
+  Date: { now: browserNow },
+  fetch: () => Promise.resolve({
+    ok: true,
+    body: {
+      getReader: () => {
+        let sent = false;
+        return {
+          read: () => Promise.resolve(sent
+            ? { done: true }
+            : ((sent = true), { done: false, value: sse })),
+        };
+      },
+    },
+  }),
+  TextDecoder: function () { this.decode = (v) => (v === undefined ? "" : String(v)); },
+  AbortController: function () { this.abort = () => {}; this.signal = null; },
+  document: { hidden: false, addEventListener: () => {} },
+  $: (id) => (nodes[id] = nodes[id] || { innerHTML: "" }),
+  window: { addEventListener: () => {} },
+  // A no-op: the shipped code reconnects when the reader finishes, and a real timer here turns
+  // that into a hot loop. The reconnect is not what this harness is measuring.
+  setTimeout: () => 0,
+  esc: (s) => String(s == null ? "" : s),
+};
+
+const names = Object.keys(scope);
+const api = new Function(...names, parts.join("\n") + `
+  return { liveStream: liveStream, agoText: agoText, clockNoteHtml: clockNoteHtml,
+           serverNowMs: serverNowMs, clockSkewMs: clockSkewMs,
+           sinceLastFrameMs: sinceLastFrameMs, renderFailures: renderFailures };
+`)(...names.map((k) => scope[k]));
+
+const before = { ago: api.agoText(input.at), skew: api.clockSkewMs() };
+api.liveStream({ onFrame: () => {}, onState: () => {}, headers: () => ({}) });
+
+setTimeout(() => {
+  process.stdout.write(JSON.stringify({
+    before,
+    after: {
+      ago: api.agoText(input.at),
+      skewMs: api.clockSkewMs(),
+      serverNowMs: api.serverNowMs(),
+      note: api.clockNoteHtml(),
+      panel: (api.renderFailures(input.failures || []),
+              (nodes.failures || { innerHTML: "" }).innerHTML),
+      emptyPanel: (api.renderFailures([]),
+                   (nodes.failures || { innerHTML: "" }).innerHTML),
+    },
+  }));
+}, 10);

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -503,6 +503,37 @@
    the alternative is the key in a query string, and a credential in a URL ends up in every access
    log and proxy trace between here and the gateway. Same wire format either way; only the
    reconnect is ours to write. */
+/* ---------- the deployment's clock ----------
+ *
+ * Every frame carries the SERVER's `ts` and nothing read it, so "14s ago" was the BROWSER's clock
+ * minus a server timestamp, clamped at zero. On a machine whose clock runs behind the gateway's,
+ * every failure read "0s ago" for ever -- on the one panel whose stated job is to say whether
+ * something happened a minute ago or last Tuesday.
+ *
+ * Extrapolated from the last frame rather than sampled per call: frames arrive every few seconds,
+ * so the elapsed part is small, and a page that has seen no frame yet falls back to the browser's
+ * clock, which is what it had before. */
+var liveServerMs = 0;   /* the server's clock at the last frame */
+var liveFrameAtMs = 0;  /* Date.now() when that frame arrived */
+
+function serverNowMs() {
+  if (!liveFrameAtMs) { return Date.now(); }
+  return liveServerMs + (Date.now() - liveFrameAtMs);
+}
+
+/* How far the browser's clock is from the gateway's, positive when the browser is BEHIND. Worth
+   reporting because every other timestamp on these pages is rendered with toLocaleString() from
+   that same clock, so one wrong clock makes all of them wrong together. */
+function clockSkewMs() {
+  return liveFrameAtMs ? (liveServerMs - liveFrameAtMs) : 0;
+}
+
+/* How long since state last arrived. A connection that is open but silent leaves the page showing
+   the last frame's numbers, and the strip still says "live". */
+function sinceLastFrameMs() {
+  return liveFrameAtMs ? (Date.now() - liveFrameAtMs) : 0;
+}
+
 function liveStream(options) {
   var onFrame = options.onFrame || function () {};
   var onState = options.onState || function () {};
@@ -535,7 +566,16 @@ function liveStream(options) {
        the fields blanks the traffic table, the failures panel and the strip, every ten minutes. */
     if (name === "bye") { planned = true; return; }
     if (name !== "status" || !payload) { return; }
-    try { onFrame(JSON.parse(payload)); } catch (e) { /* a partial frame; the next one is whole */ }
+    try {
+      var frame = JSON.parse(payload);
+      /* Recorded before the handler runs, so anything the handler renders reads the clock of the
+         frame it is rendering rather than the one before it. */
+      if (typeof frame.ts === "number" && isFinite(frame.ts)) {
+        liveServerMs = frame.ts * 1000;
+        liveFrameAtMs = Date.now();
+      }
+      onFrame(frame);
+    } catch (e) { /* a partial frame; the next one is whole */ }
   }
 
   /* A stream is closed on purpose once it reaches its maximum age, and the gateway says so before

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -854,6 +854,37 @@
    the alternative is the key in a query string, and a credential in a URL ends up in every access
    log and proxy trace between here and the gateway. Same wire format either way; only the
    reconnect is ours to write. */
+/* ---------- the deployment's clock ----------
+ *
+ * Every frame carries the SERVER's `ts` and nothing read it, so "14s ago" was the BROWSER's clock
+ * minus a server timestamp, clamped at zero. On a machine whose clock runs behind the gateway's,
+ * every failure read "0s ago" for ever -- on the one panel whose stated job is to say whether
+ * something happened a minute ago or last Tuesday.
+ *
+ * Extrapolated from the last frame rather than sampled per call: frames arrive every few seconds,
+ * so the elapsed part is small, and a page that has seen no frame yet falls back to the browser's
+ * clock, which is what it had before. */
+var liveServerMs = 0;   /* the server's clock at the last frame */
+var liveFrameAtMs = 0;  /* Date.now() when that frame arrived */
+
+function serverNowMs() {
+  if (!liveFrameAtMs) { return Date.now(); }
+  return liveServerMs + (Date.now() - liveFrameAtMs);
+}
+
+/* How far the browser's clock is from the gateway's, positive when the browser is BEHIND. Worth
+   reporting because every other timestamp on these pages is rendered with toLocaleString() from
+   that same clock, so one wrong clock makes all of them wrong together. */
+function clockSkewMs() {
+  return liveFrameAtMs ? (liveServerMs - liveFrameAtMs) : 0;
+}
+
+/* How long since state last arrived. A connection that is open but silent leaves the page showing
+   the last frame's numbers, and the strip still says "live". */
+function sinceLastFrameMs() {
+  return liveFrameAtMs ? (Date.now() - liveFrameAtMs) : 0;
+}
+
 function liveStream(options) {
   var onFrame = options.onFrame || function () {};
   var onState = options.onState || function () {};
@@ -886,7 +917,16 @@ function liveStream(options) {
        the fields blanks the traffic table, the failures panel and the strip, every ten minutes. */
     if (name === "bye") { planned = true; return; }
     if (name !== "status" || !payload) { return; }
-    try { onFrame(JSON.parse(payload)); } catch (e) { /* a partial frame; the next one is whole */ }
+    try {
+      var frame = JSON.parse(payload);
+      /* Recorded before the handler runs, so anything the handler renders reads the clock of the
+         frame it is rendering rather than the one before it. */
+      if (typeof frame.ts === "number" && isFinite(frame.ts)) {
+        liveServerMs = frame.ts * 1000;
+        liveFrameAtMs = Date.now();
+      }
+      onFrame(frame);
+    } catch (e) { /* a partial frame; the next one is whole */ }
   }
 
   /* A stream is closed on purpose once it reaches its maximum age, and the gateway says so before
@@ -2858,20 +2898,37 @@ function liveStream(options) {
   /* Seconds, not a clock time: "14s ago" is read at a glance, a timestamp has to be subtracted from
      now in your head first. */
   function agoText(at) {
-    var seconds = Math.max(0, Math.round(Date.now() / 1000 - Number(at || 0)));
+    /* The deployment's clock, not this browser's: `at` is a server timestamp and subtracting a
+       local clock from it measures the difference between two machines as well as the age. */
+    var seconds = Math.max(0, Math.round(serverNowMs() / 1000 - Number(at || 0)));
     if (seconds < 60) { return seconds + "s ago"; }
     if (seconds < 3600) { return Math.round(seconds / 60) + "m ago"; }
     return Math.round(seconds / 3600) + "h ago";
+  }
+
+  /* Five seconds: below that the difference cannot change how any of these ages read, and a
+     caveat on every deployment is a caveat nobody reads. */
+  var CLOCK_SKEW_NOTICE_MS = 5000;
+
+  function clockNoteHtml() {
+    var skew = clockSkewMs();
+    if (Math.abs(skew) < CLOCK_SKEW_NOTICE_MS) { return ""; }
+    var seconds = Math.round(Math.abs(skew) / 1000);
+    return '<div class="msg info">This browser\u2019s clock is ' + seconds + 's '
+      + (skew > 0 ? "behind" : "ahead of") + ' the gateway\u2019s. The ages below are measured '
+      + 'against the gateway, so they are right \u2014 but every absolute time on these pages is '
+      + 'rendered from this browser, so those are out by the same amount.</div>';
   }
 
   function renderFailures(list) {
     var rows = list || [];
     if (!rows.length) {
       /* Said plainly: an empty panel and one that never loaded look identical otherwise. */
-      $("failures").innerHTML = '<div class="empty">No failures recorded on this worker.</div>';
+      $("failures").innerHTML = clockNoteHtml()
+        + '<div class="empty">No failures recorded on this worker.</div>';
       return;
     }
-    $("failures").innerHTML =
+    $("failures").innerHTML = clockNoteHtml() +
       "<table><thead><tr><th>When</th><th>Status</th><th>Method</th><th>Route</th>" +
       "<th>Incident</th></tr></thead>" +
       "<tbody>" + rows.map(function (row) {

--- a/tools/test_matrixark_the_ages_are_measured_against_the_deployment.py
+++ b/tools/test_matrixark_the_ages_are_measured_against_the_deployment.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+""""14s ago" was this browser's clock minus a server timestamp.
+
+Every live frame carries the gateway's own `ts`, and no page read it. `agoText` computed
+``Date.now() / 1000 - at`` where `at` comes from the server, and clamped the result at zero -- so
+the number measured the difference between two machines as much as the age of the thing.
+
+Measured through the shipped code, for a failure recorded 90 seconds before the gateway's clock:
+
+    browser in step with the gateway     2m ago     (right)
+    browser 60s BEHIND                   30s ago    (wrong)
+    browser 60s AHEAD                    3m ago     (wrong)
+
+A browser far enough behind reads "0s ago" for everything, for ever -- on the one panel whose
+stated job is to tell you whether a failure was a minute ago or last Tuesday.
+
+The stream now records the server's clock from each frame and `agoText` measures against it. The
+skew is reported too, because it is not only these ages that were wrong: every absolute time on
+these pages is rendered with `toLocaleString()` from the same browser clock, so one wrong clock
+makes all of them wrong together, and only this panel can notice.
+
+**Driven through the shipped stream parser.** Setting the clock variables directly would test the
+arithmetic rather than the part that did not exist -- reading `ts` off a frame.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+HARNESS = os.path.join(PORTAL, "clock_harness.js")
+PAGE = os.path.join(PORTAL, "setup_portal.html")
+
+#: The gateway's clock in these cases, and a failure recorded 90 seconds before it.
+SERVER_TS = 1760000000
+FAILED_AT = SERVER_TS - 90
+
+
+FAILURE_ROW = [{"at": FAILED_AT, "status": 500, "method": "POST", "route": "/v1/ingest"}]
+
+
+def drive(browser_offset_ms: int, frames=None, at: int = FAILED_AT) -> dict:
+    payload = {"browserOffsetMs": browser_offset_ms, "at": at, "failures": FAILURE_ROW,
+               "frames": [{"ts": SERVER_TS}] if frames is None else frames}
+    out = subprocess.run(["node", HARNESS, PAGE, json.dumps(payload)],
+                         capture_output=True, text=True, timeout=300)
+    if out.returncode != 0:
+        raise AssertionError(out.stderr[-900:])
+    return json.loads(out.stdout)
+
+
+class TheAgeIsTheDeploymentsTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    def test_a_browser_in_step_is_unchanged(self) -> None:
+        """The floor: this is what the panel already showed, and it must keep showing it."""
+        result = drive(0)
+        self.assertEqual("2m ago", result["before"]["ago"])
+        self.assertEqual("2m ago", result["after"]["ago"])
+
+    def test_a_browser_behind_the_gateway_used_to_read_the_age_short(self) -> None:
+        result = drive(-60_000)
+        self.assertEqual("30s ago", result["before"]["ago"], "the defect is not reproduced")
+        self.assertEqual("2m ago", result["after"]["ago"])
+
+    def test_a_browser_ahead_of_the_gateway_used_to_read_it_long(self) -> None:
+        result = drive(60_000)
+        self.assertEqual("3m ago", result["before"]["ago"], "the defect is not reproduced")
+        self.assertEqual("2m ago", result["after"]["ago"])
+
+    def test_a_browser_far_behind_no_longer_reads_zero_for_everything(self) -> None:
+        """The worst form: the clamp at zero turned every age into "0s ago" and nothing said why."""
+        result = drive(-3_600_000)
+        self.assertEqual("0s ago", result["before"]["ago"])
+        self.assertEqual("2m ago", result["after"]["ago"])
+
+
+class TheSkewIsReportedTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    def test_it_says_which_way_the_browser_is_wrong(self) -> None:
+        behind = drive(-60_000)["after"]["note"]
+        ahead = drive(60_000)["after"]["note"]
+        self.assertIn("60s behind", behind)
+        self.assertIn("60s ahead of", ahead)
+
+    def test_it_says_nothing_when_the_clocks_agree(self) -> None:
+        self.assertEqual("", drive(0)["after"]["note"])
+
+    def test_a_small_difference_is_not_worth_a_notice(self) -> None:
+        """Below five seconds it cannot change how any of these ages read, and a caveat on every
+        deployment is a caveat nobody reads."""
+        self.assertEqual("", drive(-3_000)["after"]["note"])
+        self.assertEqual("2m ago", drive(-3_000)["after"]["ago"])
+
+    def test_the_notice_says_absolute_times_are_still_wrong(self) -> None:
+        """The reason it is worth saying at all: the ages are fixed, the other timestamps on these
+        pages are not, because they are rendered from the browser."""
+        self.assertIn("every absolute time on these pages", drive(-60_000)["after"]["note"])
+
+
+class TheNoticeReachesThePanelTest(unittest.TestCase):
+    """Computing the sentence is not showing it. `renderFailures` is run and its output read."""
+
+    def setUp(self) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    def test_the_panel_carries_the_notice(self) -> None:
+        panel = drive(-60_000)["after"]["panel"]
+        self.assertIn("60s behind", panel)
+
+    def test_the_empty_panel_carries_it_too(self) -> None:
+        """A deployment with no failures still has a wrong clock, and every other timestamp on the
+        page is still being read against it."""
+        self.assertIn("60s behind", drive(-60_000)["after"]["emptyPanel"])
+
+    def test_the_panel_still_shows_the_failures(self) -> None:
+        """The floor: the notice must be added to the table, not put in place of it."""
+        panel = drive(-60_000)["after"]["panel"]
+        self.assertIn("2m ago", panel)
+        self.assertIn("/v1/ingest", panel)
+
+    def test_a_panel_on_a_correct_clock_carries_no_notice(self) -> None:
+        panel = drive(0)["after"]["panel"]
+        self.assertNotIn("browser", panel)
+        self.assertIn("2m ago", panel)
+
+
+class AFrameWithoutAClockChangesNothingTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    def test_a_frame_with_no_ts_leaves_the_browser_clock_in_use(self) -> None:
+        """An older gateway, or a frame that carries no clock, must not invent one."""
+        result = drive(-60_000, frames=[{"traffic": {}}])
+        self.assertEqual(result["before"]["ago"], result["after"]["ago"])
+        self.assertEqual(0, result["after"]["skewMs"])
+        self.assertEqual("", result["after"]["note"])
+
+    def test_before_any_frame_the_browser_clock_is_used(self) -> None:
+        """The page renders once before the first frame arrives; it must not show nothing."""
+        self.assertEqual("30s ago", drive(-60_000, frames=[])["before"]["ago"])
+
+
+class TheGatewayStillSendsItTest(unittest.TestCase):
+    """All of the above rests on the frame carrying `ts`. If it stops, the pages fall back to the
+    browser's clock silently -- which is the state this change is fixing."""
+
+    def test_the_frame_carries_the_servers_clock(self) -> None:
+        with io.open(os.path.join(TOOLS, "matrixark_v1_gateway.py"), encoding="utf-8") as handle:
+            source = handle.read()
+        self.assertIn('"ts": time.time(),', source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Every live frame carries the gateway's own `ts`. **No page read it.** `agoText` computed `Date.now() / 1000 - at` where `at` is a *server* timestamp, and clamped the result at zero — so the number measured the difference between two machines as much as the age of the thing it described.

Measured through the shipped code, for a failure recorded 90 seconds before the gateway's clock:

| browser clock | shown before | shown now |
|---|---|---|
| in step with the gateway | `2m ago` | `2m ago` |
| 60s **behind** | `30s ago` | `2m ago` |
| 60s **ahead** | `3m ago` | `2m ago` |
| an hour behind | `0s ago` | `2m ago` |

That last row is the shape that hurts: a browser far enough behind reads `0s ago` for everything, for ever — on the one panel whose stated job is *"whether that was a minute ago or last Tuesday"*.

## What changes

- the shared stream records the server's clock from each frame and extrapolates locally between them
- `agoText` measures against that
- a frame carrying no `ts` leaves the browser's clock in use rather than inventing one, so an older gateway behind a newer page behaves exactly as before
- the skew is reported when it exceeds 5s

The skew is worth saying because the ages were not the only casualties: **every absolute time on these pages is rendered with `toLocaleString()` from the same browser clock**, so one wrong clock makes all of them wrong together, and only this panel is in a position to notice. Below five seconds nothing is said — it cannot change how any age reads.

## Mutations

Nineteen tests, driven through the shipped stream parser with a real SSE block. Setting the clock variables directly would test the arithmetic rather than the part that did not exist — reading `ts` off a frame.

| mutation | reddens |
|---|---|
| the age goes back to the browser clock | `test_a_browser_behind_the_gateway_used_to_read_the_age_short` |
| the frame's clock is never recorded | `test_a_browser_ahead_of_the_gateway_used_to_read_it_long` |
| a frame with no `ts` is treated as having one | `test_a_frame_with_no_ts_leaves_the_browser_clock_in_use` |
| the skew notice never appears | `test_it_says_which_way_the_browser_is_wrong` |
| the skew notice always appears | `test_a_small_difference_is_not_worth_a_notice` |
| the notice loses its direction | `test_it_says_which_way_the_browser_is_wrong` |
| the notice stops reaching the panel | `test_the_panel_carries_the_notice` |
| the gateway stops sending its clock | `test_the_frame_carries_the_servers_clock` |

**One survived the first run.** The notice reaching the *panel* was never asserted — only the function that builds it, which is the same "computes the sentence and never shows it" trap these harnesses exist to catch. It now has four tests, including that the table is still rendered beneath it.

The setup and overview pages are emitted from `build_portal_pages.py`, so the builder is edited and the pages regenerated; `test_matrixark_portal_pages` passes.
