### PR TITLE
Thirty-seven more functions written out twice, now written once

### DIFF
--- a/tools/matrixark_agent_hook.py
+++ b/tools/matrixark_agent_hook.py
@@ -464,29 +464,10 @@ def agent_context_from_payload(payload: Json, *, agent: str, event: str, session
     }
 
 
-def payload_resource_uri(payload: Json) -> str:
-    return first_string_at(
-        payload,
-        [
-            ["raw_uri"],
-            ["rawUri"],
-            ["uri"],
-            ["url"],
-            ["path"],
-            ["file_path"],
-            ["filePath"],
-            ["resource_path"],
-            ["resourcePath"],
-            ["document_path"],
-            ["documentPath"],
-            ["params", "raw_uri"],
-            ["params", "uri"],
-            ["params", "path"],
-            ["metadata", "raw_uri"],
-            ["metadata", "uri"],
-            ["metadata", "path"],
-        ],
-    )
+try:  # the implementation lives in matrixark_codex_hook; this module re-exports it
+    from .matrixark_codex_hook import payload_resource_uri
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_codex_hook import payload_resource_uri
 
 
 def payload_resource_type(payload: Json, raw_uri: str) -> str:

--- a/tools/matrixark_mcp_budget_pack.py
+++ b/tools/matrixark_mcp_budget_pack.py
@@ -91,38 +91,16 @@ def context_text_hashes(text: str) -> set[int]:
     return {stable_hash(variant) for variant in variants if variant}
 
 
-def normalize_message_role(role: Any) -> str:
-    role_name = str(role or "").strip().lower()
-    role_aliases = {
-        "human": "user",
-        "prompt": "user",
-        "assistant_response": "assistant",
-        "agent": "assistant",
-        "ai": "assistant",
-        "bot": "assistant",
-        "llm": "assistant",
-        "model": "assistant",
-        "tool_result": "tool",
-        "tool-output": "tool",
-        "tooloutput": "tool",
-        "tool_output": "tool",
-        "function": "tool",
-        "function_call_output": "tool",
-        "custom_tool_call_output": "tool",
-        "tool_call_output": "tool",
-    }
-    return role_aliases.get(role_name, role_name)
+try:  # the implementation lives in matrixark_mcp_core_identity; this module re-exports it
+    from .matrixark_mcp_core_identity import normalize_message_role
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_identity import normalize_message_role
 
 
-def entity_current_state_key(candidate: Json) -> tuple[str, str] | None:
-    if str(candidate.get("ref_type") or "") != "entity":
-        return None
-    metadata = candidate.get("metadata", {}) if isinstance(candidate.get("metadata"), dict) else {}
-    entity_type = str(candidate.get("entity_type") or metadata.get("entity_type") or "").strip().lower()
-    entity_name = str(candidate.get("entity_name") or metadata.get("entity_name") or "").strip().lower()
-    if not entity_type or not entity_name:
-        return None
-    return entity_type, entity_name
+try:  # the implementation lives in matrixark_mcp_core_ref_selection; this module re-exports it
+    from .matrixark_mcp_core_ref_selection import entity_current_state_key
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_ref_selection import entity_current_state_key
 
 
 def prefer_profile_entities_for_current_state(candidates: list[Json], question_type: str) -> list[Json]:
@@ -181,13 +159,10 @@ def prefer_profile_entities_for_current_state(candidates: list[Json], question_t
     return adjusted
 
 
-def is_stale_or_superseded_candidate(candidate: Json) -> bool:
-    if bool(candidate.get("stale_or_superseded") or candidate.get("stale")):
-        return True
-    if candidate.get("superseded_by_ref_hash") or candidate.get("superseded_by_entity_hash"):
-        return True
-    version_state = str(candidate.get("version_state") or candidate.get("current_state_policy") or "").strip().lower()
-    return version_state in {"stale", "superseded", "historical_superseded"}
+try:  # the implementation lives in matrixark_mcp_core_ref_selection; this module re-exports it
+    from .matrixark_mcp_core_ref_selection import is_stale_or_superseded_candidate
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_ref_selection import is_stale_or_superseded_candidate
 
 
 def carries_pending_async_marker(candidate: Json) -> bool:

--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -486,26 +486,20 @@ MATRIXARK_ROLE_SCOPE_LIMITS: dict[str, set[str] | None] = {
 
 
 
-def scope_from_serving_record(record: Json) -> Json:
-    scope = record.get("scope")
-    if isinstance(scope, dict) and scope:
-        return scope
-    scope_key = str(record.get("scope_key") or "")
-    return {"scope_key": scope_key} if scope_key else {}
+try:  # the implementation lives in matrixark_mcp_identity; this module re-exports it
+    from .matrixark_mcp_identity import scope_from_serving_record
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_identity import scope_from_serving_record
 
 
 def node_id_ref(node_hash: int) -> Json:
     return {"node_hash": node_hash, "node_id": node_hash}
 
 
-def compact_model_slug(model_name: str) -> str:
-    cleaned = str(model_name or "").replace("\\", "/").strip().strip("/")
-    if not cleaned:
-        return "model"
-    parts = [part for part in cleaned.split("/") if part]
-    tail = "/".join(parts[-2:]) if len(parts) >= 2 else parts[0]
-    slug = re.sub(r"[^a-zA-Z0-9]+", "_", tail).strip("_").lower()
-    return (slug or "model")[:40]
+try:  # the implementation lives in matrixark_mcp_models; this module re-exports it
+    from .matrixark_mcp_models import compact_model_slug
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_models import compact_model_slug
 
 
 def embedding_model_ref_for_name(model_name: str) -> str:
@@ -3628,12 +3622,10 @@ except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_scoring import cosine
 
 
-def clamp01(value: Any, default: float = 0.0) -> float:
-    try:
-        number = float(value)
-    except (TypeError, ValueError):
-        number = default
-    return max(0.0, min(1.0, number))
+try:  # the implementation lives in matrixark_mcp_scoring; this module re-exports it
+    from .matrixark_mcp_scoring import clamp01
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_scoring import clamp01
 
 
 def normalized_dense_score(value: float) -> float:

--- a/tools/matrixark_mcp_core_candidate_policy.py
+++ b/tools/matrixark_mcp_core_candidate_policy.py
@@ -53,18 +53,10 @@ except ImportError:  # top-level path (matrixark_mcp_core)
 __all__ = ['sharing_scope_from_candidate', 'is_shared_resource_candidate', 'is_shared_skill_candidate', 'is_pending_async_candidate', 'bounded_max_children_scored_per_parent', 'score_recall_candidate', 'numeric_field', 'apply_statistical_operator', 'latest_record', 'merge_ranked_paths', 'candidate_codex_outcome_terms', 'inferred_memory_selection_policies_for_candidate', 'candidate_memory_selection_policies', 'candidate_is_feature_profile_memory', 'memory_selection_policy_ref_boost', 'question_type_ref_boost']
 
 
-def sharing_scope_from_candidate(candidate: Json) -> str:
-    for source in [candidate, candidate.get("access_scope", {}), candidate.get("metadata", {}), candidate.get("scope", {})]:
-        if isinstance(source, dict):
-            value = str(source.get("sharing_scope") or "").strip().lower()
-            if value:
-                return value
-    node_path = [str(part).lower() for part in candidate.get("node_path", []) if str(part)]
-    if node_path[:2] == ["global", "shared"]:
-        return "global_shared"
-    if len(node_path) >= 2 and node_path[0].startswith("tenant:") and node_path[1] == "shared":
-        return "tenant_shared"
-    return "private_user"
+try:  # the implementation lives in matrixark_mcp_access_scope; this module re-exports it
+    from .matrixark_mcp_access_scope import sharing_scope_from_candidate
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_access_scope import sharing_scope_from_candidate
 
 
 def is_shared_resource_candidate(candidate: Json) -> bool:
@@ -146,15 +138,10 @@ def score_recall_candidate(candidate: Json, ranking: Json, *, reference_time_ms:
     }
 
 
-def numeric_field(record: Json, field: str = "value") -> float | None:
-    for source in [record, record.get("metadata", {}), record.get("envelope", {}).get("metadata", {})]:
-        if not isinstance(source, dict) or field not in source:
-            continue
-        try:
-            return float(source[field])
-        except (TypeError, ValueError):
-            return None
-    return None
+try:  # the implementation lives in matrixark_mcp_scoring; this module re-exports it
+    from .matrixark_mcp_scoring import numeric_field
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_scoring import numeric_field
 
 
 def apply_statistical_operator(operator: str, records: list[Json], *, field: str = "value") -> float | int | None:

--- a/tools/matrixark_mcp_core_compact.py
+++ b/tools/matrixark_mcp_core_compact.py
@@ -121,15 +121,10 @@ HOT_EMBEDDING_LINEAGE_FIELDS = {
 }
 
 
-def compact_hot_context_embedding_record(record: Json) -> Json:
-    compacted = dict(record)
-    for field in EMBEDDING_LINEAGE_DEBUG_FIELDS:
-        compacted.pop(field, None)
-    if str(compacted.get("record_type") or "") != "context_embedding":
-        return compacted
-    for field in HOT_EMBEDDING_LINEAGE_FIELDS:
-        compacted.pop(field, None)
-    return compacted
+try:  # the implementation lives in matrixark_mcp_serving_records; this module re-exports it
+    from .matrixark_mcp_serving_records import compact_hot_context_embedding_record
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_serving_records import compact_hot_context_embedding_record
 
 
 def legacy_hook_type_from_codex_event(event: Any) -> str:
@@ -193,19 +188,10 @@ def compact_record_scope(record: Json) -> Json:
     return compacted
 
 
-def _record_debug_ref(record: Json) -> tuple[str, Any]:
-    record_type = str(record.get("record_type") or "")
-    if record_type == "context_event":
-        return "event", record.get("event_id_hash")
-    if record_type == "context_entity":
-        return "entity", record.get("entity_hash")
-    if record_type == "context_segment":
-        return "segment", record.get("segment_hash")
-    if record_type == "resource_chunk":
-        return "resource_chunk", record.get("chunk_hash")
-    if record_type == "skill_section":
-        return "skill_section", record.get("section_hash")
-    return record_type, record.get("ref_hash")
+try:  # the implementation lives in matrixark_mcp_serving_records; this module re-exports it
+    from .matrixark_mcp_serving_records import _record_debug_ref
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_serving_records import _record_debug_ref
 
 
 def context_event_timestamp_ms(record: Json) -> int:

--- a/tools/matrixark_mcp_core_identity.py
+++ b/tools/matrixark_mcp_core_identity.py
@@ -107,29 +107,10 @@ class MatrixArkNotFoundError(MatrixArkError):
     """
 
 
-def is_retryable_temporalstore_error(error: Any) -> bool:
-    text = str(error).lower()
-    retryable_fragments = (
-        "slot not found",
-        "partition info not found",
-        "partition no primary",
-        "no primary",
-        "not ready",
-        "unavailable",
-        "timed out",
-        "timeout",
-        "connection refused",
-        "connection reset",
-        "temporarily unavailable",
-        "server is busy",
-        # The engine's load-window statuses: a shard that has not loaded yet, or is mid
-        # WAL-replay ("shard_not_loaded: shard is recovering"), answers again once the load
-        # completes. Treating these as terminal made callers give up -- or worse, serve the
-        # store as empty -- during exactly the window a retry would have covered.
-        "not loaded",
-        "recovering",
-    )
-    return any(fragment in text for fragment in retryable_fragments)
+try:  # the implementation lives in matrixark_mcp_errors; this module re-exports it
+    from .matrixark_mcp_errors import is_retryable_temporalstore_error
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_errors import is_retryable_temporalstore_error
 
 
 def parse_host_port(address: str) -> tuple[str, int] | None:
@@ -316,15 +297,10 @@ def identity_hashes(account_id: str, tenant_id: str, user_id: str = "", session_
     return hashes
 
 
-def scope_key_from_hashes(tenant_hash: int, user_hash: int = 0, session_hash: int = 0, agent_hash: int = 0) -> str:
-    parts = [f"t={int(tenant_hash)}"]
-    if user_hash:
-        parts.append(f"u={int(user_hash)}")
-    if session_hash:
-        parts.append(f"s={int(session_hash)}")
-    if agent_hash:
-        parts.append(f"a={int(agent_hash)}")
-    return "|".join(parts) + "|"
+try:  # the implementation lives in matrixark_mcp_identity; this module re-exports it
+    from .matrixark_mcp_identity import scope_key_from_hashes
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_identity import scope_key_from_hashes
 
 
 def scope_key_prefix_for_query(query_scope: Json) -> str:
@@ -338,17 +314,10 @@ def scope_key_prefix_for_query(query_scope: Json) -> str:
     return scope_key_from_hashes(tenant_hash, user_hash, session_hash, agent_hash)
 
 
-def parse_scope_key(scope_key: str) -> dict[str, int]:
-    parsed: dict[str, int] = {}
-    for part in str(scope_key or "").split("|"):
-        if not part or "=" not in part:
-            continue
-        key, value = part.split("=", 1)
-        try:
-            parsed[key] = int(value)
-        except ValueError:
-            continue
-    return parsed
+try:  # the implementation lives in matrixark_mcp_identity; this module re-exports it
+    from .matrixark_mcp_identity import parse_scope_key
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_identity import parse_scope_key
 
 
 def session_scope_mode(query_scope: Json) -> str:

--- a/tools/matrixark_mcp_core_scoring.py
+++ b/tools/matrixark_mcp_core_scoring.py
@@ -152,24 +152,10 @@ def hybrid_origin_score(query_terms: set[str], text: str, embedding_score: float
     return round(clamp01(0.55 * dense + 0.35 * sparse + 0.10 * node), 6)
 
 
-def time_decay_score(
-    record_time_ms: Any,
-    *,
-    reference_time_ms: int,
-    freshness_tolerance_ms: int,
-    half_life_ms: int,
-) -> float:
-    try:
-        event_time_ms = int(record_time_ms)
-    except (TypeError, ValueError):
-        return 0.5
-    age_ms = max(0, reference_time_ms - event_time_ms)
-    if age_ms <= freshness_tolerance_ms:
-        return 1.0
-    decay_age = age_ms - freshness_tolerance_ms
-    half_life_ms = max(1, half_life_ms)
-    # Fast initial decay, then slower long-tail decay for durable memories.
-    return round(math.exp(-math.sqrt(decay_age / half_life_ms)), 6)
+try:  # the implementation lives in matrixark_mcp_scoring; this module re-exports it
+    from .matrixark_mcp_scoring import time_decay_score
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_scoring import time_decay_score
 
 
 def business_instance_weight(*sources: Json) -> float | None:

--- a/tools/matrixark_mcp_entity_ops.py
+++ b/tools/matrixark_mcp_entity_ops.py
@@ -16,45 +16,22 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
     from matrixark_mcp_summaries import summarize_text
 
 
-def entity_patch(search: str, replace: str, *, field: str = "state") -> Json:
-    return {
-        "field": field,
-        "patch": f"<< SEARCH\n{search}\n====\n{replace}\n>> REPLACE",
-    }
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import entity_patch
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import entity_patch
 
 
-def parse_entity_patch(patch_text: str) -> tuple[str, str] | None:
-    match = re.search(
-        r"<<\s*SEARCH\s*\n(?P<search>.*?)\n====\s*\n(?P<replace>.*?)\n>>\s*REPLACE",
-        patch_text,
-        flags=re.DOTALL,
-    )
-    if not match:
-        return None
-    return match.group("search").strip(), match.group("replace").strip()
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import parse_entity_patch
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import parse_entity_patch
 
 
-def edit_distance(left: str, right: str) -> int:
-    if left == right:
-        return 0
-    if not left:
-        return len(right)
-    if not right:
-        return len(left)
-    previous = list(range(len(right) + 1))
-    for i, left_char in enumerate(left, start=1):
-        current = [i]
-        for j, right_char in enumerate(right, start=1):
-            cost = 0 if left_char == right_char else 1
-            current.append(
-                min(
-                    current[j - 1] + 1,
-                    previous[j] + 1,
-                    previous[j - 1] + cost,
-                )
-            )
-        previous = current
-    return previous[-1]
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import edit_distance
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import edit_distance
 
 
 def best_span_by_edit_distance(text: str, search: str) -> tuple[int, int, float]:

--- a/tools/matrixark_mcp_extraction_normalization.py
+++ b/tools/matrixark_mcp_extraction_normalization.py
@@ -45,20 +45,10 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
     from matrixark_mcp_text import text_from_messages
 
 
-def normalize_entity_operator(raw_operator: Any, entity_type: str) -> str:
-    """Return the operator actually used by runtime entity maintenance.
-
-    LLM_MERGE is a future/optional production operator because it implies a
-    separate LLM merge pass. The current online runtime applies field patches
-    deterministically, so serving records should say EUA_MERGE unless the LLM
-    merge feature is explicitly enabled.
-    """
-    if entity_type in {"confirmation", "correction"}:
-        return "LATEST"
-    operator = str(raw_operator or DEFAULT_ENTITY_MERGE_OPERATOR).strip().upper() or DEFAULT_ENTITY_MERGE_OPERATOR
-    if operator == "LLM_MERGE" and not ENABLE_LLM_MERGE_OPERATOR:
-        return DEFAULT_ENTITY_MERGE_OPERATOR
-    return operator
+try:  # the implementation lives in matrixark_mcp_core_extraction; this module re-exports it
+    from .matrixark_mcp_core_extraction import normalize_entity_operator
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_extraction import normalize_entity_operator
 
 
 def normalize_source_role(raw_role: Any) -> str:
@@ -316,39 +306,16 @@ CODEX_OUTCOME_BENCHMARK_RE = re.compile(
 )
 
 
-def codex_outcome_fact_kind(line: str) -> str:
-    normalized = " ".join(str(line or "").split()).strip().lower()
-    if not normalized:
-        return ""
-    has_real_blocker = bool(
-        re.search(r"\b(?:blocked|blocker|failure|error|missing|rejected|fatal)\b", normalized)
-        or re.search(r"\b[1-9]\d*\s+(?:failed|failures|errors)\b", normalized)
-        or (re.search(r"\bfailed\b", normalized) and not re.search(r"\b0\s+failed\b", normalized))
-    )
-    if normalized.startswith("next:") or re.search(r"\b(?:next|follow[- ]?up)\b", normalized):
-        return "next"
-    if normalized.startswith("blocker:") or has_real_blocker:
-        return "blocker"
-    if normalized.startswith("validation:") or CODEX_OUTCOME_VALIDATION_RE.search(normalized):
-        return "validation"
-    if normalized.startswith("outcome:") or CODEX_OUTCOME_PUBLISH_RE.search(normalized):
-        return "outcome"
-    if normalized.startswith("changed:") or CODEX_OUTCOME_CHANGE_RE.search(normalized):
-        return "changed"
-    if normalized.startswith("benchmark:") or CODEX_OUTCOME_BENCHMARK_RE.search(normalized):
-        return "benchmark"
-    return ""
+try:  # the implementation lives in matrixark_mcp_core_codex_outcome; this module re-exports it
+    from .matrixark_mcp_core_codex_outcome import codex_outcome_fact_kind
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_codex_outcome import codex_outcome_fact_kind
 
 
-def codex_outcome_entity_type(kind: str) -> str:
-    return {
-        "next": "codex_next_action",
-        "blocker": "codex_blocker",
-        "validation": "codex_validation",
-        "outcome": "codex_publish_outcome",
-        "changed": "codex_code_change",
-        "benchmark": "codex_benchmark_result",
-    }.get(str(kind or "").strip().lower(), "codex_outcome_fact")
+try:  # the implementation lives in matrixark_mcp_core_codex_outcome; this module re-exports it
+    from .matrixark_mcp_core_codex_outcome import codex_outcome_entity_type
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_codex_outcome import codex_outcome_entity_type
 
 
 CODEX_OUTCOME_ENTITY_TYPES = {

--- a/tools/matrixark_mcp_extraction_runtime.py
+++ b/tools/matrixark_mcp_extraction_runtime.py
@@ -222,19 +222,10 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
     )
 
 
-def infer_event_type(text: str) -> str:
-    lower = text.lower()
-    if any(term in lower for term in ["correct", "correction", "wrong", "instead", "updated", "changed"]):
-        return "correction"
-    if any(term in lower for term in ["yes", "confirmed", "approved", "looks good"]):
-        return "confirmation"
-    if any(term in lower for term in ["prefer", "favorite", "like", "love"]):
-        return "preference_update"
-    if any(term in lower for term in ["plan", "going to", "will ", "schedule"]):
-        return "plan_update"
-    if any(term in lower for term in ["work", "job", "role", "status", "position"]):
-        return "status_update"
-    return "dialogue_batch"
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import infer_event_type
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import infer_event_type
 
 
 

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -2456,13 +2456,10 @@ FEATURE_MEMORY_BUDGET_QUERY_RE = re.compile(
 )
 
 
-def _explicit_cross_session_requested(args: Json, ranking: Json) -> bool:
-    raw = args.get("cross_session", ranking.get("cross_session"))
-    if isinstance(raw, bool):
-        return raw
-    if isinstance(raw, dict):
-        return bool(raw.get("enabled"))
-    return False
+try:  # the implementation lives in matrixark_mcp_retrieve_pre_refresh; this module re-exports it
+    from .matrixark_mcp_retrieve_pre_refresh import _explicit_cross_session_requested
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_retrieve_pre_refresh import _explicit_cross_session_requested
 
 
 def feature_profile_memory_budget_query(args: Json, ranking: Json, *, question_type: str = "fact") -> bool:
@@ -2516,25 +2513,10 @@ def codex_outcome_budget_query(args: Json, ranking: Json, *, question_type: str 
     ))
 
 
-def codex_user_goal_budget_query(args: Json, ranking: Json, *, question_type: str = "fact") -> bool:
-    normalized_question_type = str(question_type or "fact").strip().lower()
-    if normalized_question_type not in {"profile_memory", "current_state", "latest", "multi_hop", "date"}:
-        return False
-    query = str(args.get("query") or ranking.get("query") or "").strip()
-    if not query:
-        return False
-    lower = query.lower()
-    return bool(
-        re.search(
-            r"\b(?:what|which|show|list|recall|remember|find)\b.{0,80}\b(?:goal|task|plan|requirement|request|asked|ask|instruction|directive)\b",
-            lower,
-        )
-        or re.search(
-            r"\b(?:goal|task|plan|requirement|request|instruction|directive)\b.{0,80}\b(?:codex|implement|fix|add|remove|replace|move|build|work)\b",
-            lower,
-        )
-        or re.search(r"\b(?:what did i ask|what have i asked|user asked|user request|current plan)\b", lower)
-    )
+try:  # the implementation lives in matrixark_mcp_retrieve_pre_refresh; this module re-exports it
+    from .matrixark_mcp_retrieve_pre_refresh import codex_user_goal_budget_query
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_retrieve_pre_refresh import codex_user_goal_budget_query
 
 
 def feature_scope_budget_query(args: Json, ranking: Json) -> bool:
@@ -2690,19 +2672,10 @@ def pre_retrieval_summary_refresh_memory_layer_budget_tokens(
     )
 
 
-def pre_retrieval_summary_refresh_enabled(args: Json, ranking: Json) -> bool:
-    value = (
-        args.get("pre_retrieval_summary_refresh")
-        if "pre_retrieval_summary_refresh" in args
-        else ranking.get("pre_retrieval_summary_refresh")
-        if "pre_retrieval_summary_refresh" in ranking
-        else PRE_RETRIEVAL_SUMMARY_REFRESH
-    )
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        return value.strip().lower() in {"1", "true", "yes", "auto", "bounded"}
-    return bool(value)
+try:  # the implementation lives in matrixark_mcp_retrieve_pre_refresh; this module re-exports it
+    from .matrixark_mcp_retrieve_pre_refresh import pre_retrieval_summary_refresh_enabled
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_retrieve_pre_refresh import pre_retrieval_summary_refresh_enabled
 
 
 def pre_retrieval_summary_refresh_explicitly_configured(args: Json, ranking: Json) -> bool:

--- a/tools/matrixark_mcp_local_ingest.py
+++ b/tools/matrixark_mcp_local_ingest.py
@@ -62,21 +62,10 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
     )
 
 
-def idle_commit_schedule(args: Json, envelope: Json, pending_event_count: int, pending_message_count: int) -> Json:
-    idle_timeout_ms = args.get("idle_commit_timeout_ms")
-    if idle_timeout_ms is None:
-        return {}
-    if not isinstance(idle_timeout_ms, int) or idle_timeout_ms < 0:
-        raise MatrixArkError("idle_commit_timeout_ms must be a non-negative integer")
-    deadline_ms = int(envelope.get("ingestion_time_ms") or 0) + idle_timeout_ms
-    return {
-        "idle_commit_timeout_ms": idle_timeout_ms,
-        "idle_commit_deadline_ms": deadline_ms,
-        "idle_commit_cutoff_ms": int(envelope.get("ingestion_time_ms") or 0),
-        "idle_commit_pending_event_count": pending_event_count,
-        "idle_commit_pending_message_count": pending_message_count,
-        "idle_commit_due": idle_timeout_ms == 0,
-    }
+try:  # the implementation lives in matrixark_mcp_async_ingest; this module re-exports it
+    from .matrixark_mcp_async_ingest import _idle_commit_schedule
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_async_ingest import _idle_commit_schedule
 
 
 def deferred_idle_auto_batch_result(

--- a/tools/matrixark_mcp_query.py
+++ b/tools/matrixark_mcp_query.py
@@ -189,14 +189,10 @@ def path_candidates_from_query(query: str) -> list[str]:
     return _ordered_unique(values)[:6]
 
 
-def _re_for_cjk_runs():
-    """The same CJK class the resource parser indexes with, so query and ingest agree."""
-    import re as _re_mod
-    ranges = (
-        "㐀-䶿一-鿿豈-﫿"
-        "぀-ヿ가-힯"
-    )
-    return _re_mod.compile("[" + ranges + "]{2,}")
+try:  # the implementation lives in matrixark_mcp_core_query_analysis; this module re-exports it
+    from .matrixark_mcp_core_query_analysis import _re_for_cjk_runs
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_query_analysis import _re_for_cjk_runs
 
 
 # Chinese has no spaces to split on, so the ingest side indexes overlapping character
@@ -460,19 +456,10 @@ def secondary_filter_terms_to_fields(groups: list[set[str]]) -> Json:
     return fields
 
 
-def infer_temporal_window(query: str, question_type: str, *, reference_time_ms: int) -> Json:
-    lower = query.lower()
-    if re.search(r"\b(current|currently|latest|now|still|today|valid)\b", lower) or question_type == "current_state":
-        return {"mode": "latest", "valid_as_of": "now", "reference_time_ms": reference_time_ms}
-    if re.search(r"\b(before|prior to|earlier than)\b", lower):
-        return {"mode": "before", "valid_as_of": "query_inferred", "reference_time_ms": reference_time_ms}
-    if re.search(r"\b(after|since|later than)\b", lower):
-        return {"mode": "after", "valid_as_of": "query_inferred", "reference_time_ms": reference_time_ms}
-    if re.search(r"\b(as of|valid as of|on)\b", lower):
-        return {"mode": "valid_as_of", "valid_as_of": "query_inferred", "reference_time_ms": reference_time_ms}
-    if re.search(r"\b(yesterday|tomorrow|last week|next week|last month|next month|last year|next year)\b", lower):
-        return {"mode": "relative", "valid_as_of": "query_inferred", "reference_time_ms": reference_time_ms}
-    return {"mode": "unbounded", "valid_as_of": "not_applicable", "reference_time_ms": reference_time_ms}
+try:  # the implementation lives in matrixark_mcp_core_query_analysis; this module re-exports it
+    from .matrixark_mcp_core_query_analysis import infer_temporal_window
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_query_analysis import infer_temporal_window
 
 
 def build_structured_query_plan(

--- a/tools/matrixark_mcp_segments.py
+++ b/tools/matrixark_mcp_segments.py
@@ -36,16 +36,10 @@ except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_core import detect_memory_segments
 
 
-def build_segment_prompt(messages: list[Json]) -> str:
-    indexed = "\n".join(f"{index}. {message.get('role', 'user')}: {message.get('content', '')}" for index, message in enumerate(messages))
-    return (
-        "You are MatrixArk's memory segmentation extractor. Identify high-saliency memory segments from the indexed conversation. "
-        "Prune greetings, acknowledgements, and filler. Merge semantically related non-contiguous messages into the same segment. "
-        "Return only valid JSON with this shape: "
-        '{"segments":[{"topic":"short_snake_case","coordinate_tuples":[[start,end]],"message_indexes":[0],"saliency_score":0.0,"summary_text":"short summary"}]} '
-        "Indexes are zero-based and coordinate end is inclusive. Do not include messages that are only filler.\n\n"
-        f"Conversation:\n{indexed}\n\nJSON:"
-    )
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import build_segment_prompt
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import build_segment_prompt
 
 
 def oss_model_memory_segments(messages: list[Json], *, model: str, model_path: str = "", max_new_tokens: int = 512, local_only: bool = False) -> Json:
@@ -95,39 +89,16 @@ except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_core import normalize_model_segments
 
 
-def normalize_coordinate_tuples(value: Any, max_index: int) -> list[list[int]]:
-    ranges: list[list[int]] = []
-    if not isinstance(value, list):
-        return ranges
-    for item in value:
-        if not isinstance(item, list) or len(item) != 2:
-            continue
-        try:
-            start = int(item[0])
-            end = int(item[1])
-        except (TypeError, ValueError):
-            continue
-        start = max(0, min(max_index, start))
-        end = max(0, min(max_index, end))
-        if end < start:
-            start, end = end, start
-        ranges.append([start, end])
-    return ranges
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import normalize_coordinate_tuples
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import normalize_coordinate_tuples
 
 
-def normalize_message_indexes(value: Any, coordinate_tuples: list[list[int]], max_index: int) -> list[int]:
-    indexes: set[int] = set()
-    if isinstance(value, list):
-        for item in value:
-            try:
-                index = int(item)
-            except (TypeError, ValueError):
-                continue
-            if 0 <= index <= max_index:
-                indexes.add(index)
-    for start, end in coordinate_tuples:
-        indexes.update(range(start, end + 1))
-    return sorted(indexes)
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import normalize_message_indexes
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import normalize_message_indexes
 
 def intelligent_memory_segments(messages: list[Json]) -> list[Json]:
     """Segment a batch into salient, event-centric memories.
@@ -227,17 +198,7 @@ def infer_segment_topic(text: str) -> str:
     return token_list[0] if token_list else "general"
 
 
-def contiguous_ranges(indexes: list[int]) -> list[list[int]]:
-    if not indexes:
-        return []
-    ordered = sorted(set(indexes))
-    ranges: list[list[int]] = []
-    start = previous = ordered[0]
-    for value in ordered[1:]:
-        if value == previous + 1:
-            previous = value
-            continue
-        ranges.append([start, previous])
-        start = previous = value
-    ranges.append([start, previous])
-    return ranges
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import contiguous_ranges
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import contiguous_ranges

--- a/tools/matrixark_mcp_summaries.py
+++ b/tools/matrixark_mcp_summaries.py
@@ -51,11 +51,10 @@ SUMMARY_LLM_MODEL = os.environ.get("MATRIXARK_EXTRACTION_MODEL", os.environ.get(
 SUMMARY_LLM_MAX_TOKENS = int(os.environ.get("MATRIXARK_SUMMARY_MAX_TOKENS", "900"))
 
 
-def summarize_text(text: str, *, limit: int = 220) -> str:
-    compact = " ".join(text.split())
-    if len(compact) <= limit:
-        return compact
-    return compact[: limit - 3] + "..."
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import summarize_text
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import summarize_text
 
 
 def deterministic_time_compression_summary(
@@ -75,11 +74,10 @@ def deterministic_time_compression_summary(
     )
 
 
-def time_compression_summary_provider_name() -> str:
-    provider = TIME_COMPRESSION_SUMMARY_PROVIDER.replace("-", "_")
-    if provider in {"", "local", "rules"}:
-        return "deterministic"
-    return provider
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import time_compression_summary_provider_name
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import time_compression_summary_provider_name
 
 
 def generate_time_compression_summary(
@@ -175,12 +173,10 @@ def generate_time_compression_summary(
         }
 
 
-def estimated_context_tokens(text: str) -> int:
-    """Cheap token estimate used for summary policy decisions."""
-    compact = " ".join(str(text).split())
-    if not compact:
-        return 0
-    return max(1, (len(compact) + 3) // 4)
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import estimated_context_tokens
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import estimated_context_tokens
 
 
 def node_l1_generation_policy(

--- a/tools/matrixark_pipeline_task_slim.py
+++ b/tools/matrixark_pipeline_task_slim.py
@@ -94,11 +94,10 @@ SLIMMED_FIELDS = (
 DEFAULT_DETAIL_RETAIN_PER_SCOPE = 50
 
 
-def _env_flag(name: str, default: bool) -> bool:
-    raw = os.environ.get(name)
-    if raw is None or str(raw).strip() == "":
-        return default
-    return str(raw).strip().lower() not in {"0", "false", "no", "off"}
+try:  # the implementation lives in matrixark_index_growth_bound; this module re-exports it
+    from .matrixark_index_growth_bound import _env_flag
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_index_growth_bound import _env_flag
 
 
 def _env_int(name: str, default: int) -> int:

--- a/tools/run_locomo_ingest_once.py
+++ b/tools/run_locomo_ingest_once.py
@@ -1259,14 +1259,10 @@ def append_benchmark_jsonl(path: Path, row: dict[str, Any]) -> None:
         handle.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
 
 
-def count_scoreable_questions(questions: list[dict[str, Any]]) -> int:
-    total = 0
-    for qa in questions:
-        question = str(qa.get("question") or "").strip()
-        answers = normalize_answers(qa.get("answer") or qa.get("answers"))
-        if question and answers:
-            total += 1
-    return total
+try:  # the implementation lives in convert_locomo_to_context_jsonl; this module re-exports it
+    from .convert_locomo_to_context_jsonl import count_scoreable_questions
+except ImportError:  # Direct script execution from tools/.
+    from convert_locomo_to_context_jsonl import count_scoreable_questions
 
 
 


### PR DESCRIPTION
Thirty-seven more functions that existed as two byte-identical copies are now one. The body stays
where it is; the other module imports it.

## Identical bodies were not a sufficient test, and that is the interesting part

Seventy-three pairs passed every structural check — same signature, module level, undecorated, and
an import direction that adds no edge to the module graph. **Thirty-six of them still had to be
refused**, because a function's free names resolve in whichever module holds it. The same source
text calls a different helper, or raises a different class, depending on where it lives:

```
optional_object: global 'MatrixArkError' differs
    matrixark_mcp_validation    -> matrixark_mcp_errors.MatrixArkError
    matrixark_mcp_core_identity -> matrixark_mcp_core_identity.MatrixArkError
```

Consolidating that one changed which exception `normalize_envelope` raises. The payload was still
correctly rejected, but `except` compares by identity, so the handler stopped matching and a
passing test began reporting an unhandled error. `test_ingest_envelope_schema` states the invariant
in its own import comment: *"Import both from the same module so assertRaises matches the raised
type."* The rest of the refusals are the same shape — each module carries its own `stable_hash`,
`safe_identifier`, `clamp01`, so collapsing would silently switch which one runs.

The check compares what each module actually binds every free name to, at runtime:

- **annotations are skipped.** Two modules each writing `Json = dict[str, Any]` bind distinct
  objects of identical meaning, and under `from __future__ import annotations` they are never
  evaluated. Counting them refused two thirds of the work for no behavioural reason.
- **classes and functions compare by identity**, because `except` does, and two functions are
  interchangeable only if they are the same object.
- **everything else compares by equality**, since equal values behave identically.

Six more pairs were refused because a test guards that duplication on purpose — asserting the two
copies are distinct objects, so that a loop covering both cannot silently collapse to covering one
twice.

## Verification

By **object identity**: `owner.f is importer.f` for all 46 consolidations now in the tree, with
every module's `__all__` still resolving. Comparing sources, or calling both and comparing answers,
would pass equally well with two copies still present.

The whole `tools/` suite (381 files) ran before and after at the same commit: **346 pass / 39 fail
on both, with zero tests failing only after**. All 39 remaining failures fail identically on both
trees.
