### PR TITLE
A onebox could not see whether its page cache was working

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -896,6 +896,9 @@ fn render_prometheus_metrics(
          matrixark_backend_command_latency_max_ms{{backend=\"rust\"}} {}\n",
         latency_max_ms, latency_max_ms
     ));
+    // The engine's own series, which include the page-cache counters. Appended rather than
+    // re-rendered: see engine_prometheus_metrics.
+    output.push_str(&engine_prometheus_metrics());
     output
 }
 
@@ -4071,6 +4074,38 @@ fn record_log_proxy_addr() -> Option<String> {
 fn engine_cache() -> &'static Mutex<BTreeMap<PathBuf, RecordStore>> {
     static ENGINE_CACHE: OnceLock<Mutex<BTreeMap<PathBuf, RecordStore>>> = OnceLock::new();
     ENGINE_CACHE.get_or_init(|| Mutex::new(BTreeMap::new()))
+}
+
+/// The engine's own Prometheus text, for the engine this process holds open.
+///
+/// `TemporalEngine::prometheus_metrics` already renders the page-cache counters and the engine
+/// binary serves them on its own `/metrics`. A onebox does not run that binary -- it runs this
+/// proxy -- so those counters existed and nothing published them here. Appending what the engine
+/// already renders keeps ONE set of names across both surfaces: a dashboard or alert written
+/// against the engine works unchanged against a proxy, which a proxy-specific family would not.
+///
+/// Emitted only when this process holds exactly one local engine. The engine labels its series by
+/// `shard_id`, and every engine here loads the same default shard, so two of them would emit two
+/// series with identical labels -- which is a malformed scrape rather than more information. One
+/// engine is the onebox case this exists for; a proxy fanned out over several record-log prefixes
+/// keeps the request counters it always had.
+fn engine_prometheus_metrics() -> String {
+    let cache = match engine_cache().lock() {
+        Ok(cache) => cache,
+        // A poisoned lock must not cost the rest of the response; the request counters above it
+        // are still true.
+        Err(_) => return String::new(),
+    };
+    let mut local = cache.values().filter_map(|store| match store {
+        RecordStore::Local(engine) => Some(engine),
+        // A remote table keeps no local page cache, so it has nothing to report.
+        RecordStore::Remote(_) => None,
+    });
+    let engine = match (local.next(), local.next()) {
+        (Some(engine), None) => engine,
+        _ => return String::new(),
+    };
+    engine.prometheus_metrics()
 }
 
 fn cached_engine_count() -> usize {


### PR DESCRIPTION
A onebox reports 54 Prometheus series and not one of them says anything about the page cache —
the cache whose size `MATRIXARK_RUST_PROXY_CACHE_BYTES` sets, at up to 2 GiB per engine. There is
no hit rate to look at, so the only numbers justifying that grant are from offline runs rather
than from the process actually serving.

The counters were never missing. `TemporalEngine::prometheus_metrics` already renders them:

```
temporalstore_cache_operations_total{shard_id, kind}   memory_hits, disk_hits, misses, memory_evictions
temporalstore_cache_bytes{shard_id, tier}
temporalstore_page_store_operations_total{shard_id, kind}
```

The engine binary serves those on its own `/metrics`. A onebox does not run that binary — it runs
this proxy, which rendered only its own request counters. So the metrics existed and nothing on
this path published them.

This appends what the engine already renders.

## Why not a proxy-specific family

The first version of this added a `matrixark_engine_cache_*` family of seven series. That was the
wrong shape: a second set of names for counters that already exist, each needing its own dashboard
panel, its own alert rule and its own entry in the coverage document, and free to drift from the
engine's set the moment either changed. Reusing the engine's rendering keeps ONE set of names
across both surfaces, so a dashboard or alert written against the engine works unchanged against a
proxy — and the coverage document needs no new section, because no new family exists.

## One engine only, deliberately

The series are emitted only when the process holds exactly one local engine. The engine labels by
`shard_id` and every engine here loads the same default shard, so two of them would emit two series
with identical labels — a malformed scrape rather than more information. One engine is the onebox
case this exists for; a proxy fanned out over several record-log prefixes keeps the request
counters it always had. A remote-backed store contributes nothing, having no local page cache.

## Verification

`cargo check --bins` passes. That claim needed a positive control to be worth anything: this file
is reached through `src/bin/../matrixark_rust_proxy_impl.rs`, so `--lib` alone does not compile it
and a green `--lib` run says nothing. With a deliberate syntax error added, `--bins` fails as it
must; with the error removed it succeeds.

`test_matrixark_engine_dashboard_coverage` still passes — the conformance validator discovers every
non-test Rust file and fails a family that exists without being described, which is exactly what a
new family would have tripped.
