### PR TITLE
The shared-flag floor follows the consolidation it counts

### DIFF
--- a/tools/test_flag_readers_agree.py
+++ b/tools/test_flag_readers_agree.py
@@ -45,9 +45,21 @@ _ENV_BOOL = re.compile(
     r'env_bool\(\s*["\']([A-Z][A-Z0-9_]{3,})["\']\s*,\s*(True|False)\s*\)')
 ONE_VOCABULARY = ("<env_bool>",)
 
-# Twenty-one when this was written. Asserted so a scan that stops matching fails rather than
-# reporting that every reader agrees.
-EXPECTED_SHARED_FLOOR = 15
+# Twenty-one when this was written, fifteen a while later, fourteen now. Asserted so a scan that
+# stops matching fails rather than reporting that every reader agrees.
+#
+# This counts flags read from MORE THAN ONE production site, so it falls whenever a duplicate reader
+# is consolidated away -- which is work being done deliberately, not damage. The last two both came
+# off that: #1171 removed a time-index builder nothing called, which held the second read of
+# MATRIXARK_CONTEXT_EVENT_TIME_INDEX_FULL_PAYLOAD, and #1182 removed a function written out twice,
+# which held the second read of MATRIXARK_SEGMENT_PROVIDER_FALLBACK. Both flags are still read; each
+# is now read once.
+#
+# So a change that removes a duplicate reader is expected to lower this number, and should lower it
+# in the same change. Leaving it stale does not fail that change -- it fails every other branch in
+# the repository, because this runs against a recorded baseline and a floor nobody moved reads as a
+# new failure on work that never touched it.
+EXPECTED_SHARED_FLOOR = 14
 
 
 def _production_sources() -> List[str]:


### PR DESCRIPTION
`test_the_scan_still_finds_shared_flags` asserts the scan finds at least EXPECTED_SHARED_FLOOR flags
read from more than one production site. It finds 14 and the floor says 15, so it fails on main --
and because the suite runs against a recorded baseline, it then fails on every open branch as a new
failure on work that never touched it.

Nothing is broken. The number counts flags read from MORE THAN ONE site, so consolidating a
duplicate reader lowers it by design, and two merges just did:

  * #1171 removed four time-index builders nothing called. One held the second read of
    MATRIXARK_CONTEXT_EVENT_TIME_INDEX_FULL_PAYLOAD.
  * #1182 removed thirty-seven functions written out twice. One held the second read of
    MATRIXARK_SEGMENT_PROVIDER_FALLBACK.

Both flags are still read. Each is now read once, which is what both merges were for.

Lowering the floor is what this guard expects rather than a weakening of it: the comment beside it
already records twenty-one when it was written and fifteen afterwards. This makes it fourteen and
writes down the part that was missing -- that a change removing a duplicate reader should lower it in
the same change, because leaving it stale does not fail that change, it fails everybody else's.

The guard keeps doing its job. It exists so a scan that quietly stops matching fails loudly instead
of reporting that every remaining reader agrees, and `test_no_two_readers_disagree` still passes on
the fourteen it finds.