### PR TITLE
The failures panel names the incident it prints

### DIFF
--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -1094,6 +1094,16 @@ SETUP_BODY = """
       newest first. Route, method and status only &mdash; no key, no tenant, nothing about who
       asked. Counters tell you seven requests failed; this tells you whether that was a minute ago
       or last Tuesday.</p>
+    <!-- The id was already printed in its own column and named nowhere. It is the whole route from
+         "something failed" to the traceback, and it is not guessable: the token appears in the
+         caller's response body AND in this worker's log, and joining the two is the only way to
+         see what the gateway declined to tell the caller. -->
+    <p class="hint" style="margin-top:0">An <b>incident</b> is the token the gateway gave the
+      caller in place of the error. The same token is in this worker&rsquo;s log, at ERROR level
+      under the logger <code>matrixark.gateway</code>, with the traceback the caller was not
+      given &mdash; so <code>grep</code> the id there. A dash means the request was refused
+      rather than broken: a 401 for a wrong key mints no incident, because nothing went wrong
+      inside.</p>
     <div id="failures"><div class="empty">Nothing yet.</div></div>
   </section>
 

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -594,6 +594,16 @@
       newest first. Route, method and status only &mdash; no key, no tenant, nothing about who
       asked. Counters tell you seven requests failed; this tells you whether that was a minute ago
       or last Tuesday.</p>
+    <!-- The id was already printed in its own column and named nowhere. It is the whole route from
+         "something failed" to the traceback, and it is not guessable: the token appears in the
+         caller's response body AND in this worker's log, and joining the two is the only way to
+         see what the gateway declined to tell the caller. -->
+    <p class="hint" style="margin-top:0">An <b>incident</b> is the token the gateway gave the
+      caller in place of the error. The same token is in this worker&rsquo;s log, at ERROR level
+      under the logger <code>matrixark.gateway</code>, with the traceback the caller was not
+      given &mdash; so <code>grep</code> the id there. A dash means the request was refused
+      rather than broken: a 401 for a wrong key mints no incident, because nothing went wrong
+      inside.</p>
     <div id="failures"><div class="empty">Nothing yet.</div></div>
   </section>
 

--- a/tools/test_matrixark_the_failures_panel_names_the_incident.py
+++ b/tools/test_matrixark_the_failures_panel_names_the_incident.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The panel printed an incident id and said nothing about what it was for.
+
+The token is the whole route from "something failed" to the traceback: the gateway returns it to
+the caller in place of the error, and logs the same token with the exception. Joining the two is
+the only way to see what the caller was deliberately not told. The failures panel printed the id in
+its own column and named it nowhere, so the one thing on that table that leads anywhere read as an
+opaque string.
+
+A sentence of explanation is only worth adding if it stays true, so each claim it makes is checked
+against the code here rather than left to be read once and drift:
+
+* the logger it names is the logger the gateway logs incidents to;
+* the level it names is the level they are logged at;
+* a dash really does mean no incident was minted -- the refusals it cites return their own body and
+  never reach the failure path.
+"""
+from __future__ import annotations
+
+import ast
+import io
+import os
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+
+
+def read(path: str) -> str:
+    with io.open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+PAGE = read(os.path.join(PORTAL, "setup_portal.html"))
+GATEWAY = read(os.path.join(TOOLS, "matrixark_v1_gateway.py"))
+
+
+class ThePanelExplainsTheColumnTest(unittest.TestCase):
+
+    def test_the_panel_says_what_an_incident_is(self) -> None:
+        self.assertIn("An <b>incident</b> is the token the gateway gave the", PAGE)
+
+    def test_it_still_prints_the_column_it_explains(self) -> None:
+        """The floor: an explanation of a column that is gone is worse than none."""
+        self.assertIn("<th>Incident</th>", PAGE)
+
+
+class EveryClaimItMakesIsTrueTest(unittest.TestCase):
+
+    def test_the_logger_it_names_is_the_one_incidents_go_to(self) -> None:
+        self.assertIn("<code>matrixark.gateway</code>", PAGE)
+        self.assertIn('_GATEWAY_LOG = logging.getLogger("matrixark.gateway")', GATEWAY)
+
+    def test_the_level_it_names_is_the_level_they_are_logged_at(self) -> None:
+        self.assertIn("at ERROR level", PAGE)
+        tree = ast.parse(GATEWAY)
+        calls = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "_incident":
+                for sub in ast.walk(node):
+                    if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Attribute) \
+                            and isinstance(sub.func.value, ast.Name) \
+                            and sub.func.value.id == "_GATEWAY_LOG":
+                        calls.append(sub.func.attr)
+        self.assertEqual(["error"], calls,
+                         "the incident is no longer logged at the level the panel names")
+
+    def test_the_token_really_does_reach_the_caller(self) -> None:
+        """The sentence says the same token is in both places. If the body stopped carrying it,
+        the instruction to grep for it would send somebody looking for nothing."""
+        self.assertIn('"incident": _incident(scope, code, exc),', GATEWAY)
+
+    def test_a_refusal_mints_no_incident(self) -> None:
+        """The claim behind the dash. An unauthorized reply is its own body and never goes through
+        the failure path, so nothing is logged and nothing is there to look up."""
+        self.assertIn('return await _json(send, 401, {"error": "unauthorized"})', GATEWAY)
+        tree = ast.parse(GATEWAY)
+        minted = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) \
+                    and node.func.id == "_incident":
+                minted.add(node.lineno)
+        self.assertTrue(minted, "nothing mints an incident, so the column cannot fill")
+        for line in minted:
+            context = GATEWAY.splitlines()[line - 1]
+            self.assertNotIn("unauthorized", context)
+
+
+class TheExplanationIsWhereTheTableIsTest(unittest.TestCase):
+    """It belongs beside the column, not in a document somebody would have to already know about."""
+
+    def test_it_sits_in_the_failures_panel(self) -> None:
+        panel = PAGE[PAGE.index("Recent failures"):]
+        panel = panel[:panel.index('<div id="failures"')]
+        self.assertIn("An <b>incident</b> is", panel)
+
+    def test_the_builder_and_the_page_agree(self) -> None:
+        """The page is emitted; the builder is what to edit."""
+        self.assertIn("An <b>incident</b> is the token the gateway gave the",
+                      read(os.path.join(PORTAL, "build_portal_pages.py")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The incident token is the whole route from "something failed" to the traceback. The gateway returns it to the caller **in place of** the error, and logs the same token with the exception — joining the two is the only way to see what the caller was deliberately not told.

The failures panel printed it in its own column and named it nowhere. The one thing on that table that leads anywhere read as an opaque string.

It now says:

> An **incident** is the token the gateway gave the caller in place of the error. The same token is in this worker's log, at ERROR level under the logger `matrixark.gateway`, with the traceback the caller was not given — so `grep` the id there. A dash means the request was refused rather than broken: a 401 for a wrong key mints no incident, because nothing went wrong inside.

## Every claim is checked against the code

A sentence is only worth adding if it stays true, so none of this is left to be read once and drift:

| the panel says | the test checks |
|---|---|
| the logger is `matrixark.gateway` | that is the logger `_incident` writes to |
| at ERROR level | `_incident` calls `_GATEWAY_LOG.error`, and only that |
| the same token reaches the caller | `_failure` still puts it in the body |
| a dash means no incident | the `401 unauthorized` replies never reach the failure path |
| there is a column to explain | `<th>Incident</th>` is still rendered |

## Mutations

Twelve tests. Each of these reddens at least one:

| mutation | reddens |
|---|---|
| the explanation is removed | `test_it_sits_in_the_failures_panel` |
| it names a logger nothing logs to | `test_the_logger_it_names_is_the_one_incidents_go_to` |
| it names the wrong level | `test_the_level_it_names_is_the_level_they_are_logged_at` |
| the gateway logs incidents at another level | `test_the_level_it_names_is_the_level_they_are_logged_at` |
| the token stops reaching the caller | `test_the_token_really_does_reach_the_caller` |
| the column it explains is dropped | `test_it_still_prints_the_column_it_explains` |

The setup page is emitted from `build_portal_pages.py`, so the builder is edited and the page regenerated; `test_matrixark_portal_pages` passes.

`main` is currently red on two engine-flag-inventory tests (`TS_BLOCK_INDEX_CHECKSUMS` was added without regenerating the document); #1178, #1179 and #1180 are all addressing it. This branch adds nothing to that.
