### PR TITLE
Context messages point at the request body instead of being copied out of it

### DIFF
--- a/crates/temporalstore-rust/src/http.rs
+++ b/crates/temporalstore-rust/src/http.rs
@@ -326,6 +326,14 @@ pub fn parse_json<T: DeserializeOwned>(body: &[u8]) -> Result<T, HttpError> {
     Ok(serde_json::from_slice(body)?)
 }
 
+/// Like `parse_json`, but for a request type that BORROWS from the body.
+///
+/// The caller keeps the body alive for as long as the parsed value, so serde can point at it
+/// instead of copying every string out of it.
+pub fn parse_json_borrowed<'a, T: serde::Deserialize<'a>>(body: &'a [u8]) -> Result<T, HttpError> {
+    Ok(serde_json::from_slice(body)?)
+}
+
 pub fn post_json<Req: Serialize, Res: DeserializeOwned>(
     addr: &str,
     path: &str,

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -5650,6 +5650,120 @@ mod tests {
         );
     }
 
+    /// Extract forwards its sources in one order: the messages, then `sources`, then `records`.
+    ///
+    /// The array is assembled from three origins and is heterogeneous -- built chat sources next
+    /// to values the caller shaped itself -- so it is exactly the kind of thing a rewrite
+    /// reorders without failing anything. Nothing held the order before this. Read off the
+    /// payload the proxy actually forwards, because that is what the datanode sees.
+    #[test]
+    fn extract_forwards_its_sources_in_one_order() {
+        let captured: std::sync::Arc<std::sync::Mutex<Vec<u8>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = std::sync::Arc::clone(&captured);
+        let (addr_tx, addr_rx) = std::sync::mpsc::channel::<String>();
+        std::thread::spawn(move || {
+            let listener = match std::net::TcpListener::bind("127.0.0.1:0") {
+                Ok(listener) => listener,
+                Err(_) => return,
+            };
+            let bound = match listener.local_addr() {
+                Ok(addr) => addr.to_string(),
+                Err(_) => return,
+            };
+            if addr_tx.send(bound).is_err() {
+                return;
+            }
+            let body = br#"{"status":{"ok":true,"code":"ok","message":""},"responses":[]}"#;
+            let head = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: keep-alive\r\n\r\n",
+                body.len()
+            );
+            for stream in listener.incoming().flatten() {
+                let mut stream = stream;
+                let mut scratch = [0u8; 8192];
+                loop {
+                    use std::io::{Read as _, Write as _};
+                    match stream.read(&mut scratch) {
+                        Ok(0) | Err(_) => break,
+                        Ok(read) => {
+                            sink.lock()
+                                .expect("capture lock")
+                                .extend_from_slice(&scratch[..read]);
+                            if stream.write_all(head.as_bytes()).is_err()
+                                || stream.write_all(body).is_err()
+                            {
+                                break;
+                            }
+                            let _ = stream.flush();
+                        }
+                    }
+                }
+            }
+        });
+        let backend = addr_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("the capturing backend must report its address");
+
+        let proxy = scoped_proxy(ProxyOptions::default());
+        proxy
+            .client()
+            .insert_cached_route_for_test(proxy.context_shard_id(0), backend.clone());
+
+        let body = serde_json::to_vec(&serde_json::json!({
+            "scope": {"tenant_id": "t", "account_id": "a", "user_id": "u", "session_id": "s"},
+            "messages": [
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "second"}
+            ],
+            "sources": [{"source_kind": "resource", "mark": "from sources"}],
+            "records": [{"source_kind": "resource", "mark": "from records"}],
+            "query": "q"
+        }))
+        .expect("body");
+
+        let (code, answered) = proxy.handle(crate::proxy::HttpRequest {
+            method: "POST".to_string(),
+            path: "/context/extract".to_string(),
+            body,
+        });
+        assert_eq!(code, 200, "{}", String::from_utf8_lossy(&answered));
+
+        let forwarded =
+            String::from_utf8_lossy(&captured.lock().expect("capture lock")).to_string();
+        let body_at = forwarded
+            .find("\r\n\r\n")
+            .map(|at| at + 4)
+            .expect("the forwarded request has a header terminator");
+        let request: serde_json::Value = serde_json::from_str(forwarded[body_at..].trim_end())
+            .expect("the forwarded body is JSON");
+        let sources = request["sources"]
+            .as_array()
+            .expect("the forwarded body carries sources");
+
+        assert_eq!(sources.len(), 4, "sources: {sources:?}");
+        // The two built from messages come first, in message order.
+        for (idx, expected_body) in [(0usize, "first"), (1, "second")] {
+            assert_eq!(sources[idx]["source_kind"], "chat");
+            assert_eq!(sources[idx]["body"], expected_body);
+            let id = sources[idx]["source_id"]
+                .as_str()
+                .expect("a chat source carries an id");
+            assert!(
+                id.starts_with("chat:") && id.ends_with(&format!(":s:{idx}")),
+                "the chat source id lost its shape or its index: {id}"
+            );
+        }
+        // Then what the caller supplied, sources before records, each exactly as it arrived.
+        assert_eq!(
+            sources[2]["mark"], "from sources",
+            "a caller-supplied source moved or was rewritten"
+        );
+        assert_eq!(
+            sources[3]["mark"], "from records",
+            "records must follow sources, unchanged"
+        );
+    }
     /// A raw event's title falls back the way it always did: its own, then the role, then
     /// "message".
     ///

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -3765,14 +3765,14 @@ mod tests {
         let probe = crate::alloc_probe::Probe::start();
         for _ in 0..ITERS {
             let parsed =
-                crate::http::parse_json::<context::ProxyContextIngestRequest>(&ingest_body);
+                crate::http::parse_json_borrowed::<context::ProxyContextIngestRequest>(&ingest_body);
             std::hint::black_box(&parsed);
         }
         let counts = probe.stop();
         rows.push(("  of which: parse the body", counts.allocs / ITERS as u64, counts.alloc_bytes / ITERS as u64));
 
         let parsed_once =
-            crate::http::parse_json::<context::ProxyContextIngestRequest>(&ingest_body)
+            crate::http::parse_json_borrowed::<context::ProxyContextIngestRequest>(&ingest_body)
                 .expect("body parses");
         let probe = crate::alloc_probe::Probe::start();
         for _ in 0..ITERS {
@@ -4062,6 +4062,44 @@ mod tests {
         ));
 
 
+        // SCRATCH: the INGEST path, and how it scales with messages. This is the hot path
+        // /v1/ingest uses, so its per-message slope is the one that matters most.
+        for msgs in [1usize, 8, 32] {
+            let ibody = serde_json::to_vec(&serde_json::json!({
+                "scope": {"tenant_id": "t", "account_id": "a", "user_id": "u", "session_id": "s"},
+                "messages": (0..msgs)
+                    .map(|i| serde_json::json!({
+                        "role": "user",
+                        "content": format!("message number {i} with some content"),
+                    }))
+                    .collect::<Vec<_>>(),
+            }))
+            .expect("ingest body");
+            let in_proxy = scoped_proxy(ProxyOptions::default());
+            in_proxy
+                .client()
+                .insert_cached_route_for_test(in_proxy.context_shard_id(0), quiet.clone());
+            let (code, _) = in_proxy.handle(crate::proxy::HttpRequest {
+                method: "POST".to_string(),
+                path: "/context/ingest".to_string(),
+                body: ibody.clone(),
+            });
+            let probe = crate::alloc_probe::Probe::start();
+            for _ in 0..ITERS {
+                let out = in_proxy.handle(crate::proxy::HttpRequest {
+                    method: "POST".to_string(),
+                    path: "/context/ingest".to_string(),
+                    body: ibody.clone(),
+                });
+                std::hint::black_box(&out);
+            }
+            let c = probe.stop();
+            println!(
+                "    INGEST  msgs={msgs:<3} {:>7.3} allocs/call {:>9.1} bytes  [code {code}]",
+                c.allocs as f64 / ITERS as f64,
+                c.alloc_bytes as f64 / ITERS as f64
+            );
+        }
         // SCRATCH: the EXTRACT path, and how it scales with messages. Sources are borrowed
         // from the request, so the per-message slope is what to watch here.
         for msgs in [1usize, 8, 32] {
@@ -5268,8 +5306,11 @@ mod tests {
             "max_events": 3,
             "provider": {}
         });
+        // Parsed from BYTES, not from a `Value`: the request borrows from the body it was
+        // parsed out of, so it needs a buffer to point at.
+        let ingest_bytes = serde_json::to_vec(&ingest_body).expect("the ingest body serialises");
         let ingest: context::ProxyContextIngestRequest =
-            serde_json::from_value(ingest_body.clone()).expect("the known-good ingest body parses");
+            serde_json::from_slice(&ingest_bytes).expect("the known-good ingest body parses");
         // The values landed, so these names are the ones serde matches on.
         assert_eq!(ingest.query, "q");
         assert_eq!(ingest.start_time_ms, 11);

--- a/crates/temporalstore-rust/src/proxy/context.rs
+++ b/crates/temporalstore-rust/src/proxy/context.rs
@@ -21,6 +21,7 @@
 //! routing `/execute` uses (`crate::client::shard_id_for_key`) and looks up the
 //! owning datanode through the metaserver topology. The `/v1` gateway sends raw
 //! identifiers only -- the proxy owns all hashing.
+use std::borrow::Cow;
 use std::fmt::Write as _;
 use super::*;
 
@@ -48,24 +49,30 @@ pub struct ProxyContextScope {
     pub session_id: String,
 }
 
+/// One inbound message, borrowed from the request body.
+///
+/// `Cow` rather than `String`: serde hands back a borrow of the body whenever the JSON string
+/// needs no unescaping, which is the ordinary case, and falls back to an owned copy when it
+/// does. Every message used to cost two allocations here -- role and content -- before the
+/// proxy looked at it.
 #[derive(Debug, Clone, Deserialize, Default)]
-pub struct ProxyContextMessage {
-    #[serde(default)]
-    pub role: String,
-    #[serde(default)]
-    pub content: String,
+pub struct ProxyContextMessage<'a> {
+    #[serde(default, borrow)]
+    pub role: Cow<'a, str>,
+    #[serde(default, borrow)]
+    pub content: Cow<'a, str>,
     #[serde(default)]
     pub timestamp_ms: Option<u64>,
-    #[serde(default)]
-    pub title: Option<String>,
+    #[serde(default, borrow)]
+    pub title: Option<Cow<'a, str>>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
-pub struct ProxyContextIngestRequest {
+pub struct ProxyContextIngestRequest<'a> {
     #[serde(default)]
     pub scope: ProxyContextScope,
-    #[serde(default)]
-    pub messages: Vec<ProxyContextMessage>,
+    #[serde(default, borrow)]
+    pub messages: Vec<ProxyContextMessage<'a>>,
     /// Pre-shaped low-level sources (`ContextExtractRequest` json). `shard_id`
     /// and `tenant_hash` are re-stamped by the proxy.
     #[serde(default)]
@@ -411,7 +418,7 @@ impl ProxyService {
     /// routed `/execute` `HashMultiSet` (a single raw write, NO extraction, no
     /// embeddings/summaries). Reuses the proxy's cached-route execute path, so it
     /// is one datanode write regardless of message count.
-    pub(super) fn context_ingest(&self, request: ProxyContextIngestRequest) -> (u16, Vec<u8>) {
+    pub(super) fn context_ingest(&self, request: ProxyContextIngestRequest<'_>) -> (u16, Vec<u8>) {
         self.inner
             .context_ingest_requests
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -442,7 +449,7 @@ impl ProxyService {
             // message. The other site keeps its `String`, because it hands ownership on.
             let title: std::borrow::Cow<'_, str> = match message.title.as_deref() {
                 Some(value) if !value.is_empty() => std::borrow::Cow::Borrowed(value),
-                _ if !message.role.is_empty() => std::borrow::Cow::Borrowed(&message.role),
+                _ if !message.role.is_empty() => std::borrow::Cow::Borrowed(message.role.as_ref()),
                 _ => std::borrow::Cow::Borrowed("message"),
             };
             // Orders raw events by (timestamp, call, index within the call), all
@@ -463,9 +470,9 @@ impl ProxyService {
             // The field names and their order are the same, because these records are read
             // back by everything downstream.
             let value = serde_json::to_string(&RawEventRecord {
-                body: &message.content,
+                body: message.content.as_ref(),
                 record_type: "raw_event",
-                role: &message.role,
+                role: message.role.as_ref(),
                 timestamp_ms,
                 title: &title,
             })
@@ -496,7 +503,7 @@ impl ProxyService {
     /// datanode's `/context/ingest_extract` (full extraction). Used on commit /
     /// finalize. When no messages/sources are supplied, replay the buffered
     /// `raw_event` records for the scope and extract those.
-    pub(super) fn context_extract(&self, request: ProxyContextIngestRequest) -> (u16, Vec<u8>) {
+    pub(super) fn context_extract(&self, request: ProxyContextIngestRequest<'_>) -> (u16, Vec<u8>) {
         self.inner
             .context_extract_requests
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -526,7 +533,7 @@ impl ProxyService {
                 match message.title.as_deref().filter(|value| !value.is_empty()) {
                     Some(title) => title,
                     None if message.role.is_empty() => "message",
-                    None => message.role.as_str(),
+                    None => message.role.as_ref(),
                 }
             })
             .collect();
@@ -541,7 +548,7 @@ impl ProxyService {
                 tenant_hash,
                 &ids[idx],
                 titles[idx],
-                &message.content,
+                message.content.as_ref(),
                 message.timestamp_ms.unwrap_or(now + idx as u64),
             )));
         }
@@ -833,6 +840,36 @@ mod ingest_key_tests {
         }
     }
 
+    /// A message points at the body when it can, and copies only when it must.
+    ///
+    /// This is the whole point of the `Cow`: serde hands back a borrow of the request body
+    /// whenever the JSON string needs no unescaping, and an owned copy when it does. Both arms
+    /// are asserted, because a change that quietly stopped borrowing would still be CORRECT and
+    /// would give back every allocation this saved without failing anything else.
+    #[test]
+    fn a_message_borrows_the_body_unless_it_needs_unescaping() {
+        let plain = br#"{"messages":[{"role":"user","content":"plain text"}]}"#;
+        let parsed: ProxyContextIngestRequest =
+            serde_json::from_slice(plain).expect("the plain body parses");
+        assert_eq!(parsed.messages[0].content, "plain text");
+        assert!(
+            matches!(parsed.messages[0].content, Cow::Borrowed(_)),
+            "a message needing no unescaping was still copied out of the body"
+        );
+
+        let escaped = br#"{"messages":[{"role":"user","content":"a \"quoted\" and \\ backslash"}]}"#;
+        let parsed: ProxyContextIngestRequest =
+            serde_json::from_slice(escaped).expect("the escaped body parses");
+        assert_eq!(
+            parsed.messages[0].content,
+            r#"a "quoted" and \ backslash"#,
+            "an escaped message did not come back as the text it stands for"
+        );
+        assert!(
+            matches!(parsed.messages[0].content, Cow::Owned(_)),
+            "an escaped message cannot be a borrow of the body it was unescaped from"
+        );
+    }
     /// A chat source is byte-identical however it is built.
     ///
     /// The extract path renders sources straight from borrowed parts; the replay path still

--- a/crates/temporalstore-rust/src/proxy/context.rs
+++ b/crates/temporalstore-rust/src/proxy/context.rs
@@ -49,6 +49,72 @@ pub struct ProxyContextScope {
     pub session_id: String,
 }
 
+/// Deserialises `Option<String>`-shaped JSON while still pointing at the body.
+///
+/// `#[serde(borrow)]` borrows a bare `Cow<'a, str>`, but NOT one inside an `Option`: serde's own
+/// `Deserialize` for `Option<T>` delegates to `T`, and that path always allocates. A titled
+/// message therefore copied its title out of the body even though every other field pointed at
+/// it. `a_message_borrows_the_body_unless_it_needs_unescaping` asserts both arms of this too.
+///
+/// `null` and an absent field both stay `None`, which is what `Option` accepted before.
+fn optional_borrowed_str<'de: 'a, 'a, D>(deserializer: D) -> Result<Option<Cow<'a, str>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct Inner<'a>(std::marker::PhantomData<&'a ()>);
+
+    impl<'de: 'a, 'a> serde::de::Visitor<'de> for Inner<'a> {
+        type Value = Cow<'a, str>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("a string")
+        }
+
+        /// The whole point: the body outlives the request, so this hands back a pointer into it.
+        fn visit_borrowed_str<E>(self, value: &'de str) -> Result<Self::Value, E> {
+            Ok(Cow::Borrowed(value))
+        }
+
+        /// Reached when the string needed unescaping, so there is nothing in the body to point at.
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+            Ok(Cow::Owned(value.to_string()))
+        }
+
+        fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+            Ok(Cow::Owned(value))
+        }
+    }
+
+    struct Outer<'a>(std::marker::PhantomData<&'a ()>);
+
+    impl<'de: 'a, 'a> serde::de::Visitor<'de> for Outer<'a> {
+        type Value = Option<Cow<'a, str>>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("a string or null")
+        }
+
+        fn visit_none<E>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_unit<E>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer
+                .deserialize_str(Inner(std::marker::PhantomData))
+                .map(Some)
+        }
+    }
+
+    deserializer.deserialize_option(Outer(std::marker::PhantomData))
+}
+
 /// One inbound message, borrowed from the request body.
 ///
 /// `Cow` rather than `String`: serde hands back a borrow of the body whenever the JSON string
@@ -63,7 +129,7 @@ pub struct ProxyContextMessage<'a> {
     pub content: Cow<'a, str>,
     #[serde(default)]
     pub timestamp_ms: Option<u64>,
-    #[serde(default, borrow)]
+    #[serde(default, borrow, deserialize_with = "optional_borrowed_str")]
     pub title: Option<Cow<'a, str>>,
 }
 
@@ -882,6 +948,45 @@ mod ingest_key_tests {
         assert!(
             matches!(parsed.messages[0].content, Cow::Owned(_)),
             "an escaped message cannot be a borrow of the body it was unescaped from"
+        );
+        // `title` is the awkward one: Option<Cow<'a, str>> with both `default` and `borrow`, so
+        // it has to borrow through the Option, own through it when unescaping is needed, and
+        // still be None when the field is absent.
+        let titled = br#"{"messages":[{"role":"user","content":"c","title":"a plain title"}]}"#;
+        let parsed: ProxyContextIngestRequest =
+            serde_json::from_slice(titled).expect("the titled body parses");
+        let title = parsed.messages[0].title.as_ref().expect("the title parsed");
+        assert_eq!(title, "a plain title");
+        assert!(
+            matches!(title, Cow::Borrowed(_)),
+            "a title needing no unescaping was still copied out of the body"
+        );
+
+        let titled = br#"{"messages":[{"role":"user","content":"c","title":"a \"quoted\" title"}]}"#;
+        let parsed: ProxyContextIngestRequest =
+            serde_json::from_slice(titled).expect("the escaped-title body parses");
+        let title = parsed.messages[0].title.as_ref().expect("the title parsed");
+        assert_eq!(title, r#"a "quoted" title"#);
+        assert!(
+            matches!(title, Cow::Owned(_)),
+            "an escaped title cannot be a borrow of the body"
+        );
+
+        let untitled = br#"{"messages":[{"role":"user","content":"c"}]}"#;
+        let parsed: ProxyContextIngestRequest =
+            serde_json::from_slice(untitled).expect("the untitled body parses");
+        assert!(
+            parsed.messages[0].title.is_none(),
+            "an absent title must stay absent, not become an empty string"
+        );
+
+        // An explicit null, which `Option` accepted before the borrowing visitor replaced it.
+        let nulled = br#"{"messages":[{"role":"user","content":"c","title":null}]}"#;
+        let parsed: ProxyContextIngestRequest =
+            serde_json::from_slice(nulled).expect("a null title parses");
+        assert!(
+            parsed.messages[0].title.is_none(),
+            "an explicit null title must still read as absent"
         );
     }
     /// A chat source is byte-identical however it is built.

--- a/crates/temporalstore-rust/src/proxy/context.rs
+++ b/crates/temporalstore-rust/src/proxy/context.rs
@@ -440,7 +440,8 @@ impl ProxyService {
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
             % 100_000_000;
 
-        let mut entries: Vec<(String, Vec<u8>)> = Vec::new();
+        // One entry per message, and the count is known before the loop starts.
+        let mut entries: Vec<(String, Vec<u8>)> = Vec::with_capacity(request.messages.len());
         for (idx, message) in request.messages.iter().enumerate() {
             let timestamp_ms = message.timestamp_ms.unwrap_or(now);
             // Borrowed in all three cases. The record this feeds takes `title: &str`, so the owned
@@ -469,15 +470,28 @@ impl ProxyService {
             // `Value::String` copy of role, title and body -- only to render it and drop it.
             // The field names and their order are the same, because these records are read
             // back by everything downstream.
-            let value = serde_json::to_string(&RawEventRecord {
-                body: message.content.as_ref(),
-                record_type: "raw_event",
-                role: message.role.as_ref(),
-                timestamp_ms,
-                title: &title,
-            })
-            .unwrap_or_default();
-            entries.push((field, value.into_bytes()));
+            // Written into a buffer sized for this record. `to_string` starts from serde_json's
+            // own 128 and grows, which a raw event clears often enough to cost a second
+            // allocation on a third of them; the field names and punctuation below are 88 bytes.
+            let mut value =
+                Vec::with_capacity(96 + message.content.len() + message.role.len() + title.len());
+            if serde_json::to_writer(
+                &mut value,
+                &RawEventRecord {
+                    body: message.content.as_ref(),
+                    record_type: "raw_event",
+                    role: message.role.as_ref(),
+                    timestamp_ms,
+                    title: &title,
+                },
+            )
+            .is_err()
+            {
+                // What `to_string(..).unwrap_or_default()` did: an unserialisable record becomes
+                // an empty value rather than a partial one.
+                value.clear();
+            }
+            entries.push((field, value));
         }
         if entries.is_empty() {
             // Nothing to buffer (e.g. pre-shaped records only) -- still a fast ack.

--- a/crates/temporalstore-rust/src/proxy/handle.rs
+++ b/crates/temporalstore-rust/src/proxy/handle.rs
@@ -2,6 +2,7 @@
 // Copyright 2026 MatrixArkAI
 
 //! ProxyService::handle request dispatcher, split from proxy.rs.
+use crate::http::parse_json_borrowed;
 use super::*;
 
 impl ProxyService {
@@ -685,7 +686,7 @@ impl ProxyService {
                 }
             }
             ("POST", "/context/ingest") | ("POST", "/ProxyService/ContextIngest") => {
-                match parse_json::<context::ProxyContextIngestRequest>(&request.body) {
+                match parse_json_borrowed::<context::ProxyContextIngestRequest>(&request.body) {
                     Ok(req) => self.context_ingest(req),
                     Err(err) => {
                         self.inc_bad_request();
@@ -696,7 +697,7 @@ impl ProxyService {
             ("POST", "/context/extract")
             | ("POST", "/context/ingest_extract")
             | ("POST", "/ProxyService/ContextExtract") => {
-                match parse_json::<context::ProxyContextIngestRequest>(&request.body) {
+                match parse_json_borrowed::<context::ProxyContextIngestRequest>(&request.body) {
                     Ok(req) => self.context_extract(req),
                     Err(err) => {
                         self.inc_bad_request();


### PR DESCRIPTION
Four changes to the two `/context/*` write paths, all measured with the allocation probe against a quiet backend.

**Messages borrow the body.** Every inbound message carried two owned `String`s — role and content — copied out of the request before the proxy looked at either. They are `Cow<str>` now with serde borrowing: a borrow of the body whenever the JSON string needs no unescaping, an owned copy when it does. `parse_json` requires `DeserializeOwned`, so a borrowing entry point sits beside it; the caller already owns the body for longer than the parsed request.

**A title borrows too.** `#[serde(borrow)]` borrows a bare `Cow`, but *not* one inside an `Option` — serde's `Deserialize for Option<T>` delegates to `T`, and that path always allocates. So role and content pointed at the body while title was still copied out of it, one allocation on every titled message. The benchmark messages carry no title, so nothing showed it; the test asserting the borrow is what found it. It now deserializes through a visitor that borrows or owns by the same rule, with an absent field and an explicit `null` both still reading as `None`.

**Each raw event is written into a buffer sized for it.** `entries` grew from empty although the message count is known before the loop, and each record went through `to_string`, which starts at serde_json's 128 bytes. Both are sized up front now, the record written with `to_writer` so the bytes are what the same serializer always produced.

**The order extract forwards its sources in is held.** That array is assembled from three origins and is heterogeneous — built chat sources beside values the caller shaped — and nothing held the order, which makes it exactly what a rewrite reorders without failing anything.

Per request:

| | before | after | per message |
|---|---|---|---|
| ingest, 1 / 8 / 32 msgs | 24.0 / 70.0 / 220.1 | **21.0 / 45.1 / 121.1** | 6.25 → **3.17** |
| extract, 1 / 8 / 32 msgs | 24.0 / 48.0 / 124.0 | **22.0 / 32.0 / 60.1** | 3.17 → **1.17** |

Ingest is the path `/v1/ingest` uses, so this adds a scaling row for it beside the one extract already had.

Both are near their floor now: what remains per message is the entry key and the record body on ingest, and the source id on extract — each of which has to be owned.

Tests assert the BORROW, not just correctness. A change that quietly stopped borrowing would still be correct and would hand back every allocation this saves without failing anything else.