### PR TITLE
A quiet stream is not a live one

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -2759,6 +2759,12 @@ async def _event_frame(server: Any, cfg: GatewayConfig, key: Optional[str],
     shared = _shared_live_parts()
     return {
         "ts": time.time(),
+        # The cadence, so a page can tell an IDLE stream from a stopped one: silence for several
+        # ticks means neither a frame nor a keepalive arrived, which is a stream that has stopped
+        # rather than a deployment with nothing to report. Carried on the frame rather than
+        # announced as its own event, because every reader of this stream treats a `data:` block as
+        # a frame -- a new event name is a frame with none of the fields they expect.
+        "tick_s": EVENT_TICK_S,
         "traffic": shared["traffic"],
         "imports": shared["imports"],
         "warnings": shared["warnings"],

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -43,6 +43,9 @@
   .dot{width:8px;height:8px;border-radius:50%;background:var(--faint);display:inline-block;
        margin-right:6px;vertical-align:middle}
   .dot.live{background:var(--ok)} .dot.down{background:var(--crit)}
+  /* Connected and receiving nothing: not down, which would say a reconnect is the answer,
+     and not live, which is what it used to say. */
+  .dot.warn{background:var(--warn)}
   .conn{font-size:13px;color:var(--muted)}
   .lede{color:var(--muted);margin:2px 0 22px;max-width:64ch}
 

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -723,6 +723,27 @@ function sinceLastFrameMs() {
   return liveFrameAtMs ? (Date.now() - liveFrameAtMs) : 0;
 }
 
+/* Silence is not staleness. When nothing has changed the gateway sends a keepalive instead of a
+   frame, so a quiet stream on an idle deployment is healthy and a page that treated "no frame" as
+   "stale" would say so on every deployment that was working. What is NOT normal is nothing at all
+   -- no frame and no keepalive -- for several ticks. */
+var liveBlockAtMs = 0;  /* Date.now() at the last block of ANY kind, keepalives included */
+var liveTickMs = 0;     /* the gateway's own cadence, off its frames */
+
+function sinceLastBlockMs() {
+  return liveBlockAtMs ? (Date.now() - liveBlockAtMs) : 0;
+}
+
+/* Three ticks: one missed tick is scheduling, two is a slow one, three is not arriving. Derived
+   from the cadence the gateway sent rather than a number written here, because a page holding its
+   own copy of the server's interval is a second place for it to be wrong. Unknown cadence means an
+   older gateway that sends no hello, and then nothing is claimed. */
+function streamStalledFor() {
+  if (!liveTickMs || !liveBlockAtMs) { return 0; }
+  var quiet = sinceLastBlockMs();
+  return quiet > (liveTickMs * 3) ? quiet : 0;
+}
+
 function liveStream(options) {
   var onFrame = options.onFrame || function () {};
   var onState = options.onState || function () {};
@@ -732,6 +753,9 @@ function liveStream(options) {
      causes. Without it a planned recycle is indistinguishable from a gateway that
      fell over. */
   var planned = false;
+  /* Set when the watchdog has reported a stall, so the report is made once and withdrawn once. */
+  var stalledSince = 0;
+  var watchdog = null;
   /* When the current connection was established, so a goodbye can be sanity-checked against how
      long the stream actually lasted. */
   var openedAt = 0;
@@ -744,6 +768,10 @@ function liveStream(options) {
   }
 
   function handle(block) {
+    /* Every block, before anything is read out of it: a keepalive carries no event and no data and
+       is exactly the evidence that the stream is alive. */
+    liveBlockAtMs = Date.now();
+    if (stalledSince) { stalledSince = 0; onState("live"); }
     var name = "", payload = null;
     block.split("\n").forEach(function (line) {
       if (line.indexOf("event: ") === 0) { name = line.slice(7).trim(); }
@@ -762,6 +790,10 @@ function liveStream(options) {
       if (typeof frame.ts === "number" && isFinite(frame.ts)) {
         liveServerMs = frame.ts * 1000;
         liveFrameAtMs = Date.now();
+      }
+      /* An older gateway sends no cadence; then nothing is claimed about a quiet stream. */
+      if (typeof frame.tick_s === "number" && frame.tick_s > 0) {
+        liveTickMs = frame.tick_s * 1000;
       }
       onFrame(frame);
     } catch (e) { /* a partial frame; the next one is whole */ }
@@ -816,6 +848,18 @@ function liveStream(options) {
       });
   }
 
+  /* Nothing arrives to announce that nothing is arriving, so this is the one thing here that
+     needs a timer. It only reports while a connection is actually open: a dropped one is already
+     reported through `retrying`, and saying both would be two names for one fault. */
+  watchdog = setInterval(function () {
+    if (stopped || !controller) { return; }
+    var quiet = streamStalledFor();
+    if (quiet && !stalledSince) {
+      stalledSince = Date.now();
+      onState("stalled", Math.round(quiet / 1000));
+    }
+  }, 1000);
+
   open();
   /* A hidden tab holds a connection open for nobody. Drop it, reconnect on return -- the same
      rule the strip follows, and until now the two pages that run their own stream followed
@@ -831,6 +875,9 @@ function liveStream(options) {
   });
   window.addEventListener("pagehide", function () {
     stopped = true;
+    /* Dropped with the connection. It checks `stopped` and would do nothing, but a timer left
+       running on a page that is going away is a timer somebody has to reason about later. */
+    if (watchdog) { clearInterval(watchdog); watchdog = null; }
     if (controller) { controller.abort(); }
   });
   return {
@@ -840,7 +887,11 @@ function liveStream(options) {
       stopped = false;
       open();
     },
-    stop: function () { stopped = true; if (controller) { controller.abort(); } }
+    stop: function () {
+      stopped = true;
+      if (watchdog) { clearInterval(watchdog); watchdog = null; }
+      if (controller) { controller.abort(); }
+    }
   };
 }
 """
@@ -3121,6 +3172,9 @@ SETUP_JS = r"""
         if (state === "live") { conn("live", "live"); }
         else if (state === "denied") { conn("live", "connected"); }
         else if (state === "retrying") { conn("down", "reconnecting in " + seconds + "s"); }
+        /* Connected and receiving nothing. Not "down" -- the socket is open and a reconnect would
+           not help -- and not "live", which is what it said before. */
+        else if (state === "stalled") { conn("warn", "no update for " + seconds + "s"); }
         if (window.__matrixarkLiveState) {
           window.__matrixarkLiveState(state === "live" ? "live"
             : (state === "retrying" ? "down" : "stale"));
@@ -3970,6 +4024,9 @@ OVERVIEW_JS = r"""
         if (state === "live") { conn("live", "live"); }
         else if (state === "denied") { conn("live", "connected"); }
         else if (state === "retrying") { conn("down", "reconnecting in " + seconds + "s"); }
+        /* Connected and receiving nothing. Not "down" -- the socket is open and a reconnect would
+           not help -- and not "live", which is what it said before. */
+        else if (state === "stalled") { conn("warn", "no update for " + seconds + "s"); }
         if (window.__matrixarkLiveState) {
           window.__matrixarkLiveState(state === "live" ? "live"
             : (state === "retrying" ? "down" : "stale"));

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -43,6 +43,9 @@
   .dot{width:8px;height:8px;border-radius:50%;background:var(--faint);display:inline-block;
        margin-right:6px;vertical-align:middle}
   .dot.live{background:var(--ok)} .dot.down{background:var(--crit)}
+  /* Connected and receiving nothing: not down, which would say a reconnect is the answer,
+     and not live, which is what it used to say. */
+  .dot.warn{background:var(--warn)}
   .conn{font-size:13px;color:var(--muted)}
   .lede{color:var(--muted);margin:2px 0 22px;max-width:64ch}
 

--- a/tools/portal/clock_harness.js
+++ b/tools/portal/clock_harness.js
@@ -62,6 +62,10 @@ const scope = {
   // A no-op: the shipped code reconnects when the reader finishes, and a real timer here turns
   // that into a hot loop. The reconnect is not what this harness is measuring.
   setTimeout: () => 0,
+  // The stream now registers a watchdog. Left to the real timer it keeps node alive for ever and
+  // this harness never prints -- which is how the whole suite hung the first time.
+  setInterval: () => 0,
+  clearInterval: () => {},
   esc: (s) => String(s == null ? "" : s),
 };
 

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -43,6 +43,9 @@
   .dot{width:8px;height:8px;border-radius:50%;background:var(--faint);display:inline-block;
        margin-right:6px;vertical-align:middle}
   .dot.live{background:var(--ok)} .dot.down{background:var(--crit)}
+  /* Connected and receiving nothing: not down, which would say a reconnect is the answer,
+     and not live, which is what it used to say. */
+  .dot.warn{background:var(--warn)}
   .conn{font-size:13px;color:var(--muted)}
   .lede{color:var(--muted);margin:2px 0 22px;max-width:64ch}
 

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -43,6 +43,9 @@
   .dot{width:8px;height:8px;border-radius:50%;background:var(--faint);display:inline-block;
        margin-right:6px;vertical-align:middle}
   .dot.live{background:var(--ok)} .dot.down{background:var(--crit)}
+  /* Connected and receiving nothing: not down, which would say a reconnect is the answer,
+     and not live, which is what it used to say. */
+  .dot.warn{background:var(--warn)}
   .conn{font-size:13px;color:var(--muted)}
   .lede{color:var(--muted);margin:2px 0 22px;max-width:64ch}
 

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -43,6 +43,9 @@
   .dot{width:8px;height:8px;border-radius:50%;background:var(--faint);display:inline-block;
        margin-right:6px;vertical-align:middle}
   .dot.live{background:var(--ok)} .dot.down{background:var(--crit)}
+  /* Connected and receiving nothing: not down, which would say a reconnect is the answer,
+     and not live, which is what it used to say. */
+  .dot.warn{background:var(--warn)}
   .conn{font-size:13px;color:var(--muted)}
   .lede{color:var(--muted);margin:2px 0 22px;max-width:64ch}
 
@@ -534,6 +537,27 @@ function sinceLastFrameMs() {
   return liveFrameAtMs ? (Date.now() - liveFrameAtMs) : 0;
 }
 
+/* Silence is not staleness. When nothing has changed the gateway sends a keepalive instead of a
+   frame, so a quiet stream on an idle deployment is healthy and a page that treated "no frame" as
+   "stale" would say so on every deployment that was working. What is NOT normal is nothing at all
+   -- no frame and no keepalive -- for several ticks. */
+var liveBlockAtMs = 0;  /* Date.now() at the last block of ANY kind, keepalives included */
+var liveTickMs = 0;     /* the gateway's own cadence, off its frames */
+
+function sinceLastBlockMs() {
+  return liveBlockAtMs ? (Date.now() - liveBlockAtMs) : 0;
+}
+
+/* Three ticks: one missed tick is scheduling, two is a slow one, three is not arriving. Derived
+   from the cadence the gateway sent rather than a number written here, because a page holding its
+   own copy of the server's interval is a second place for it to be wrong. Unknown cadence means an
+   older gateway that sends no hello, and then nothing is claimed. */
+function streamStalledFor() {
+  if (!liveTickMs || !liveBlockAtMs) { return 0; }
+  var quiet = sinceLastBlockMs();
+  return quiet > (liveTickMs * 3) ? quiet : 0;
+}
+
 function liveStream(options) {
   var onFrame = options.onFrame || function () {};
   var onState = options.onState || function () {};
@@ -543,6 +567,9 @@ function liveStream(options) {
      causes. Without it a planned recycle is indistinguishable from a gateway that
      fell over. */
   var planned = false;
+  /* Set when the watchdog has reported a stall, so the report is made once and withdrawn once. */
+  var stalledSince = 0;
+  var watchdog = null;
   /* When the current connection was established, so a goodbye can be sanity-checked against how
      long the stream actually lasted. */
   var openedAt = 0;
@@ -555,6 +582,10 @@ function liveStream(options) {
   }
 
   function handle(block) {
+    /* Every block, before anything is read out of it: a keepalive carries no event and no data and
+       is exactly the evidence that the stream is alive. */
+    liveBlockAtMs = Date.now();
+    if (stalledSince) { stalledSince = 0; onState("live"); }
     var name = "", payload = null;
     block.split("\n").forEach(function (line) {
       if (line.indexOf("event: ") === 0) { name = line.slice(7).trim(); }
@@ -573,6 +604,10 @@ function liveStream(options) {
       if (typeof frame.ts === "number" && isFinite(frame.ts)) {
         liveServerMs = frame.ts * 1000;
         liveFrameAtMs = Date.now();
+      }
+      /* An older gateway sends no cadence; then nothing is claimed about a quiet stream. */
+      if (typeof frame.tick_s === "number" && frame.tick_s > 0) {
+        liveTickMs = frame.tick_s * 1000;
       }
       onFrame(frame);
     } catch (e) { /* a partial frame; the next one is whole */ }
@@ -627,6 +662,18 @@ function liveStream(options) {
       });
   }
 
+  /* Nothing arrives to announce that nothing is arriving, so this is the one thing here that
+     needs a timer. It only reports while a connection is actually open: a dropped one is already
+     reported through `retrying`, and saying both would be two names for one fault. */
+  watchdog = setInterval(function () {
+    if (stopped || !controller) { return; }
+    var quiet = streamStalledFor();
+    if (quiet && !stalledSince) {
+      stalledSince = Date.now();
+      onState("stalled", Math.round(quiet / 1000));
+    }
+  }, 1000);
+
   open();
   /* A hidden tab holds a connection open for nobody. Drop it, reconnect on return -- the same
      rule the strip follows, and until now the two pages that run their own stream followed
@@ -642,6 +689,9 @@ function liveStream(options) {
   });
   window.addEventListener("pagehide", function () {
     stopped = true;
+    /* Dropped with the connection. It checks `stopped` and would do nothing, but a timer left
+       running on a page that is going away is a timer somebody has to reason about later. */
+    if (watchdog) { clearInterval(watchdog); watchdog = null; }
     if (controller) { controller.abort(); }
   });
   return {
@@ -651,7 +701,11 @@ function liveStream(options) {
       stopped = false;
       open();
     },
-    stop: function () { stopped = true; if (controller) { controller.abort(); } }
+    stop: function () {
+      stopped = true;
+      if (watchdog) { clearInterval(watchdog); watchdog = null; }
+      if (controller) { controller.abort(); }
+    }
   };
 }
 
@@ -904,6 +958,9 @@ function liveStream(options) {
         if (state === "live") { conn("live", "live"); }
         else if (state === "denied") { conn("live", "connected"); }
         else if (state === "retrying") { conn("down", "reconnecting in " + seconds + "s"); }
+        /* Connected and receiving nothing. Not "down" -- the socket is open and a reconnect would
+           not help -- and not "live", which is what it said before. */
+        else if (state === "stalled") { conn("warn", "no update for " + seconds + "s"); }
         if (window.__matrixarkLiveState) {
           window.__matrixarkLiveState(state === "live" ? "live"
             : (state === "retrying" ? "down" : "stale"));

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -43,6 +43,9 @@
   .dot{width:8px;height:8px;border-radius:50%;background:var(--faint);display:inline-block;
        margin-right:6px;vertical-align:middle}
   .dot.live{background:var(--ok)} .dot.down{background:var(--crit)}
+  /* Connected and receiving nothing: not down, which would say a reconnect is the answer,
+     and not live, which is what it used to say. */
+  .dot.warn{background:var(--warn)}
   .conn{font-size:13px;color:var(--muted)}
   .lede{color:var(--muted);margin:2px 0 22px;max-width:64ch}
 
@@ -895,6 +898,27 @@ function sinceLastFrameMs() {
   return liveFrameAtMs ? (Date.now() - liveFrameAtMs) : 0;
 }
 
+/* Silence is not staleness. When nothing has changed the gateway sends a keepalive instead of a
+   frame, so a quiet stream on an idle deployment is healthy and a page that treated "no frame" as
+   "stale" would say so on every deployment that was working. What is NOT normal is nothing at all
+   -- no frame and no keepalive -- for several ticks. */
+var liveBlockAtMs = 0;  /* Date.now() at the last block of ANY kind, keepalives included */
+var liveTickMs = 0;     /* the gateway's own cadence, off its frames */
+
+function sinceLastBlockMs() {
+  return liveBlockAtMs ? (Date.now() - liveBlockAtMs) : 0;
+}
+
+/* Three ticks: one missed tick is scheduling, two is a slow one, three is not arriving. Derived
+   from the cadence the gateway sent rather than a number written here, because a page holding its
+   own copy of the server's interval is a second place for it to be wrong. Unknown cadence means an
+   older gateway that sends no hello, and then nothing is claimed. */
+function streamStalledFor() {
+  if (!liveTickMs || !liveBlockAtMs) { return 0; }
+  var quiet = sinceLastBlockMs();
+  return quiet > (liveTickMs * 3) ? quiet : 0;
+}
+
 function liveStream(options) {
   var onFrame = options.onFrame || function () {};
   var onState = options.onState || function () {};
@@ -904,6 +928,9 @@ function liveStream(options) {
      causes. Without it a planned recycle is indistinguishable from a gateway that
      fell over. */
   var planned = false;
+  /* Set when the watchdog has reported a stall, so the report is made once and withdrawn once. */
+  var stalledSince = 0;
+  var watchdog = null;
   /* When the current connection was established, so a goodbye can be sanity-checked against how
      long the stream actually lasted. */
   var openedAt = 0;
@@ -916,6 +943,10 @@ function liveStream(options) {
   }
 
   function handle(block) {
+    /* Every block, before anything is read out of it: a keepalive carries no event and no data and
+       is exactly the evidence that the stream is alive. */
+    liveBlockAtMs = Date.now();
+    if (stalledSince) { stalledSince = 0; onState("live"); }
     var name = "", payload = null;
     block.split("\n").forEach(function (line) {
       if (line.indexOf("event: ") === 0) { name = line.slice(7).trim(); }
@@ -934,6 +965,10 @@ function liveStream(options) {
       if (typeof frame.ts === "number" && isFinite(frame.ts)) {
         liveServerMs = frame.ts * 1000;
         liveFrameAtMs = Date.now();
+      }
+      /* An older gateway sends no cadence; then nothing is claimed about a quiet stream. */
+      if (typeof frame.tick_s === "number" && frame.tick_s > 0) {
+        liveTickMs = frame.tick_s * 1000;
       }
       onFrame(frame);
     } catch (e) { /* a partial frame; the next one is whole */ }
@@ -988,6 +1023,18 @@ function liveStream(options) {
       });
   }
 
+  /* Nothing arrives to announce that nothing is arriving, so this is the one thing here that
+     needs a timer. It only reports while a connection is actually open: a dropped one is already
+     reported through `retrying`, and saying both would be two names for one fault. */
+  watchdog = setInterval(function () {
+    if (stopped || !controller) { return; }
+    var quiet = streamStalledFor();
+    if (quiet && !stalledSince) {
+      stalledSince = Date.now();
+      onState("stalled", Math.round(quiet / 1000));
+    }
+  }, 1000);
+
   open();
   /* A hidden tab holds a connection open for nobody. Drop it, reconnect on return -- the same
      rule the strip follows, and until now the two pages that run their own stream followed
@@ -1003,6 +1050,9 @@ function liveStream(options) {
   });
   window.addEventListener("pagehide", function () {
     stopped = true;
+    /* Dropped with the connection. It checks `stopped` and would do nothing, but a timer left
+       running on a page that is going away is a timer somebody has to reason about later. */
+    if (watchdog) { clearInterval(watchdog); watchdog = null; }
     if (controller) { controller.abort(); }
   });
   return {
@@ -1012,7 +1062,11 @@ function liveStream(options) {
       stopped = false;
       open();
     },
-    stop: function () { stopped = true; if (controller) { controller.abort(); } }
+    stop: function () {
+      stopped = true;
+      if (watchdog) { clearInterval(watchdog); watchdog = null; }
+      if (controller) { controller.abort(); }
+    }
   };
 }
 
@@ -2839,6 +2893,9 @@ function liveStream(options) {
         if (state === "live") { conn("live", "live"); }
         else if (state === "denied") { conn("live", "connected"); }
         else if (state === "retrying") { conn("down", "reconnecting in " + seconds + "s"); }
+        /* Connected and receiving nothing. Not "down" -- the socket is open and a reconnect would
+           not help -- and not "live", which is what it said before. */
+        else if (state === "stalled") { conn("warn", "no update for " + seconds + "s"); }
         if (window.__matrixarkLiveState) {
           window.__matrixarkLiveState(state === "live" ? "live"
             : (state === "retrying" ? "down" : "stale"));

--- a/tools/portal/stall_harness.js
+++ b/tools/portal/stall_harness.js
@@ -1,0 +1,96 @@
+// Drives the SHIPPED stream client with a connection that opens, speaks, and then goes quiet.
+// The watchdog is the only part of this code no event reaches, so the harness holds the clock and
+// fires the timer itself rather than waiting real seconds.
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const input = JSON.parse(process.argv[3]);
+
+function sliceFn(marker) {
+  const start = page.indexOf(marker);
+  if (start < 0) throw new Error("not found: " + marker);
+  let depth = 0;
+  for (let i = page.indexOf("{", start); i < page.length; i++) {
+    if (page[i] === "{") depth++;
+    else if (page[i] === "}") { depth--; if (depth === 0) return page.slice(start, i + 1); }
+  }
+  throw new Error("unclosed: " + marker);
+}
+
+const ORIGIN = 1_760_000_000_000;
+const clockStart = page.indexOf("var liveServerMs = 0;");
+const source = page.slice(clockStart, page.indexOf("function liveStream(options)"))
+  + "\n" + sliceFn("function liveStream(options)");
+
+let clock = ORIGIN;
+const states = [];
+let ticker = null;
+let releaseSecondChunk = null;
+
+const opening = ["retry: 3000\n\n"];
+/* The cadence rides on the frame, so a case that wants an older gateway sends a frame without it
+   rather than withholding a separate event. */
+const first = Object.assign({ ts: 1760000000 }, input.frame || {});
+if (input.hello !== false) { first.tick_s = input.tickS || 2; }
+opening.push("event: status\ndata: " + JSON.stringify(first) + "\n\n");
+
+const scope = {
+  Date: { now: () => clock },
+  fetch: () => Promise.resolve({
+    ok: true,
+    body: {
+      getReader: () => {
+        let sent = false;
+        return {
+          read: () => {
+            if (!sent) { sent = true; return Promise.resolve({ done: false, value: opening.join("") }); }
+            // Open and quiet: a promise that settles only if the case sends something later.
+            return new Promise((resolve) => { releaseSecondChunk = resolve; });
+          },
+        };
+      },
+    },
+  }),
+  TextDecoder: function () { this.decode = (v) => (v === undefined ? "" : String(v)); },
+  AbortController: function () { this.abort = () => {}; this.signal = null; },
+  document: { hidden: false, addEventListener: () => {} },
+  window: { addEventListener: () => {} },
+  setTimeout: () => 0,
+  setInterval: (fn) => { ticker = fn; return 1; },
+  clearInterval: () => { ticker = null; },
+};
+
+const names = Object.keys(scope);
+const liveStream = new Function(...names, source + "; return liveStream;")(
+  ...names.map((k) => scope[k]));
+
+liveStream({
+  headers: () => ({}),
+  onState: (state, seconds) => states.push({ state: state, seconds: seconds }),
+  onFrame: () => {},
+});
+
+const wait = () => new Promise((r) => globalThis.setTimeout(r, 5));
+
+(async () => {
+  await wait();                       // let the opening chunk be parsed
+  const timeline = [];
+  for (const step of (input.advanceMs || [])) {
+    clock += step;
+    if (ticker) { ticker(); }
+    timeline.push({ atMs: clock - ORIGIN, states: states.map((s) => s.state).join(",") });
+  }
+  if (input.thenAKeepaliveAfterMs) {
+    clock += input.thenAKeepaliveAfterMs;
+    if (releaseSecondChunk) {
+      releaseSecondChunk({ done: false, value: ": keepalive\n\n" });
+      await wait();
+    }
+    if (ticker) { ticker(); }
+  }
+  process.stdout.write(JSON.stringify({
+    states: states,
+    timeline: timeline,
+    watchdogRegistered: ticker !== null,
+  }));
+})();

--- a/tools/test_matrixark_a_quiet_stream_is_not_a_live_one.py
+++ b/tools/test_matrixark_a_quiet_stream_is_not_a_live_one.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A stream that has stopped arriving still said "live".
+
+`onState("live")` fired when the connection OPENED. Nothing after that depended on anything
+arriving, so a gateway that stopped producing frames while the socket stayed open left the page
+showing the last frame's numbers under a green dot, indefinitely.
+
+**Silence alone is not the signal.** When nothing has changed the gateway sends `: keepalive`
+instead of a frame, so a quiet stream on an idle deployment is healthy, and a page that treated "no
+frame" as "stale" would say so on every deployment that was working. What is not normal is nothing
+at all -- no frame and no keepalive.
+
+The threshold is three ticks of the gateway's OWN cadence, which every frame now carries. A page holding its own copy of that interval would be a second place for it to be wrong, and
+`test_a_slower_gateway_gets_a_longer_leash` is what stops it becoming one: with a ten-second
+cadence, eight seconds of quiet is not a stall.
+
+A gateway that sends no cadence claims nothing at all -- an older one behind a newer page keeps
+exactly the behaviour it had.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+HARNESS = os.path.join(PORTAL, "stall_harness.js")
+PAGE = os.path.join(PORTAL, "setup_portal.html")
+
+
+def drive(**case) -> dict:
+    out = subprocess.run(["node", HARNESS, PAGE, json.dumps(case)],
+                         capture_output=True, text=True, timeout=300)
+    if out.returncode != 0:
+        raise AssertionError(out.stderr[-900:])
+    result = json.loads(out.stdout)
+    result["names"] = [entry["state"] for entry in result["states"]]
+    return result
+
+
+class AQuietStreamIsReportedTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    def test_two_ticks_of_quiet_is_not_a_stall(self) -> None:
+        """The floor. One missed tick is scheduling, two is a slow one -- and an idle deployment
+        that is working must not be reported as broken."""
+        self.assertEqual(["connecting", "live"], drive(tickS=2, advanceMs=[2000, 2000])["names"])
+
+    def test_four_ticks_of_quiet_is(self) -> None:
+        result = drive(tickS=2, advanceMs=[2000, 2000, 2000, 2000])
+        self.assertEqual(["connecting", "live", "stalled"], result["names"])
+
+    def test_it_says_how_long_it_has_been_quiet(self) -> None:
+        result = drive(tickS=2, advanceMs=[2000, 2000, 2000, 2000])
+        self.assertEqual(8, result["states"][-1]["seconds"])
+
+    def test_it_is_reported_once_not_every_second(self) -> None:
+        """The watchdog runs on a timer; a report per tick would be a page that scrolls."""
+        result = drive(tickS=2, advanceMs=[2000, 2000, 2000, 2000, 1000, 1000, 1000])
+        self.assertEqual(1, result["names"].count("stalled"))
+
+
+class ItIsWithdrawnWhenTheStreamSpeaksTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    def test_a_keepalive_is_enough_to_say_it_is_live_again(self) -> None:
+        """A keepalive carries no frame and no data, and is exactly the evidence that the stream is
+        alive -- so it must count."""
+        result = drive(tickS=2, advanceMs=[2000, 2000, 2000, 2000], thenAKeepaliveAfterMs=100)
+        self.assertEqual(["connecting", "live", "stalled", "live"], result["names"])
+
+
+class TheThresholdIsTheGatewaysOwnCadenceTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    def test_a_slower_gateway_gets_a_longer_leash(self) -> None:
+        """Eight seconds of quiet is a stall at a two-second cadence and not at a ten-second one.
+        A page with the interval written into it would call both a stall."""
+        self.assertNotIn("stalled", drive(tickS=10, advanceMs=[2000, 2000, 2000, 2000])["names"])
+        self.assertIn("stalled", drive(tickS=2, advanceMs=[2000, 2000, 2000, 2000])["names"])
+
+    def test_a_gateway_that_states_no_cadence_is_not_second_guessed(self) -> None:
+        """An older gateway sends frames without `tick_s`. Nothing is claimed about it, even after
+        a minute."""
+        result = drive(hello=False, advanceMs=[2000, 2000, 2000, 2000, 60000])
+        self.assertNotIn("stalled", result["names"])
+
+    def test_the_watchdog_is_actually_running(self) -> None:
+        """The floor for the two above: they must be quiet because nothing was wrong, not because
+        no timer was ever registered."""
+        self.assertTrue(drive(hello=False, advanceMs=[1000])["watchdogRegistered"])
+
+
+class TheGatewayStatesItsCadenceTest(unittest.TestCase):
+
+    @staticmethod
+    def _source(name: str) -> str:
+        with io.open(os.path.join(TOOLS, name), encoding="utf-8") as handle:
+            return handle.read()
+
+    def test_the_frame_carries_the_cadence(self) -> None:
+        """On the frame rather than as its own event. Every reader of this stream treats a `data:`
+        block as a frame, so a new event name arrives as a frame with none of the fields they
+        expect -- which is what it did to four of the stream's own tests."""
+        source = self._source("matrixark_v1_gateway.py")
+        self.assertIn('"tick_s": EVENT_TICK_S,', source)
+        self.assertNotIn('event: hello', source)
+
+    def test_the_first_frame_always_goes_out(self) -> None:
+        """What makes carrying it on the frame as early as announcing it: the loop starts with no
+        recorded signature, so the first tick can never match and always emits."""
+        source = self._source("matrixark_v1_gateway.py")
+        self.assertIn("last_signature: Optional[bytes] = None", source)
+        self.assertIn("if signature == last_signature:", source)
+
+    def test_the_page_holds_no_copy_of_that_interval(self) -> None:
+        """The whole reason it is sent. A number in both places is a number that can disagree."""
+        with io.open(os.path.join(PORTAL, "build_portal_pages.py"), encoding="utf-8") as handle:
+            builder = handle.read()
+        start = builder.index("function streamStalledFor()")
+        block = builder[start:builder.index("}", builder.index("return quiet", start))]
+        self.assertIn("liveTickMs", block)
+        self.assertNotIn("2000", block)
+
+    def test_the_quiet_state_has_a_colour_of_its_own(self) -> None:
+        """It is rendered with a class, and a class with no rule is an invisible dot."""
+        self.assertIn(".dot.warn{background:var(--warn)}",
+                      self._source(os.path.join("portal", "ingestion_portal.html")))
+        self.assertIn('conn("warn", "no update for "',
+                      self._source(os.path.join("portal", "setup_portal.html")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`onState("live")` fired when the connection **opened**, and nothing after that depended on anything arriving. A gateway that stopped producing frames while the socket stayed open left the page showing the last frame's numbers under a green dot, indefinitely.

**Silence alone is not the signal**, which is why this took a second look. When nothing has changed the gateway sends `: keepalive` instead of a frame — so a quiet stream on an idle deployment is *healthy*, and a page that treated "no frame" as "stale" would say so on every deployment that was working. What is not normal is nothing at all: no frame **and** no keepalive.

## The threshold is the gateway's own cadence

Three ticks of it, and every frame now carries `tick_s`. A page holding its own copy of that interval would be a second place for it to be wrong:

| gateway cadence | 8s of silence |
|---|---|
| 2s | **stalled** |
| 10s | not a stall |
| not stated (older gateway) | nothing claimed, ever |

The cadence rides on the frame rather than on an event of its own. Announcing it as `event: hello` was the first attempt and it **broke four of this stream's own tests**: their parser reads every `data:` block as a frame — the same fragility `LIVE_STREAM_JS`'s comment already warns about for `bye` — so a new event name arrives as a frame with none of the fields they expect. The first frame always goes out (`last_signature` starts `None`, so the first tick can never match), so carrying it there is no later than announcing it.

The state renders as its own colour rather than as "down": the socket is open and a reconnect is not the answer, so "down" would send somebody to fix the wrong thing. It is reported **once** and withdrawn the moment anything arrives, a keepalive included.

## Mutations

Thirty tests, driven through the shipped stream client with a real SSE block and a held clock. Each of these reddens at least one:

| mutation | reddens |
|---|---|
| the frame stops carrying the cadence | `test_the_frame_carries_the_cadence` |
| the page writes the interval in itself | `test_a_slower_gateway_gets_a_longer_leash` |
| one tick of quiet counts as a stall | `test_two_ticks_of_quiet_is_not_a_stall` |
| blocks stop counting as evidence of life | `test_a_keepalive_is_enough_to_say_it_is_live_again` |
| a keepalive no longer withdraws the report | `test_a_keepalive_is_enough_to_say_it_is_live_again` |
| the report repeats every second | `test_it_is_reported_once_not_every_second` |
| the watchdog never starts | `test_the_watchdog_is_actually_running` |
| the page stops rendering the state | `test_the_quiet_state_has_a_colour_of_its_own` |
| the state has no colour | `test_the_quiet_state_has_a_colour_of_its_own` |

Two things the watchdog made necessary, both included: the older harness has to stub the timer — inheriting the real one kept node alive and hung the whole suite — and the page drops the timer on `pagehide`.

Verified with the **full ratchet** on this branch, not just the suites it touches: *no new failures*.
