### PR TITLE
Byte payloads are encoded into the output instead of into a String first

### DIFF
--- a/crates/temporalstore-rust/src/bytes_serde.rs
+++ b/crates/temporalstore-rust/src/bytes_serde.rs
@@ -207,13 +207,28 @@ pub mod pairs {
         }
     }
 
+    /// One value's base64, written straight into the output.
+    ///
+    /// `STANDARD.encode` allocates a fresh `String` for every entry only to hand it to the
+    /// serializer and drop it -- one allocation per pair, sized 1.33x the value. `collect_str`
+    /// lets the format write the encoding out as it is produced. The bytes on the wire are
+    /// identical, same alphabet and same padding, which
+    /// `the_pairs_encoding_is_what_encode_produced` holds for every remainder class.
+    struct Base64Value<'a>(&'a [u8]);
+
+    impl serde::Serialize for Base64Value<'_> {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            serializer.collect_str(&base64::display::Base64Display::new(self.0, &STANDARD))
+        }
+    }
+
     pub fn serialize<S: Serializer>(
         pairs: &[(String, Vec<u8>)],
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
         let mut seq = serializer.serialize_seq(Some(pairs.len()))?;
         for (name, bytes) in pairs {
-            seq.serialize_element(&(name, STANDARD.encode(bytes)))?;
+            seq.serialize_element(&(name, Base64Value(bytes)))?;
         }
         seq.end()
     }
@@ -287,4 +302,64 @@ mod tests {
             assert_eq!(decoded, command, "payload changed across the round trip");
         }
     }
+}
+
+#[cfg(test)]
+mod pairs_encoding_tests {
+    use super::pairs;
+    use base64::engine::general_purpose::STANDARD;
+    use base64::Engine;
+
+    /// The encoding is byte for byte what `STANDARD.encode` produced.
+    ///
+    /// Values stream through `collect_str` now instead of being encoded into a `String` first.
+    /// Base64 pads by remainder, so every remainder class is covered -- 0, 1 and 2 bytes over a
+    /// multiple of three -- plus the empty value and the full byte range.
+    #[test]
+    fn the_pairs_encoding_is_what_encode_produced() {
+        let cases: Vec<Vec<u8>> = vec![
+            Vec::new(),
+            b"a".to_vec(),
+            b"ab".to_vec(),
+            b"abc".to_vec(),
+            b"abcd".to_vec(),
+            (0u8..=255).collect(),
+            br#"{"body":"a message","record_type":"raw_event"}"#.to_vec(),
+        ];
+        for value in cases {
+            let input = vec![("field".to_string(), value.clone())];
+            let mut out = Vec::new();
+            {
+                let mut ser = serde_json::Serializer::new(&mut out);
+                pairs::serialize(&input, &mut ser).expect("the pairs serialise");
+            }
+            let expected = serde_json::to_vec(&vec![("field", STANDARD.encode(&value))])
+                .expect("the reference form serialises");
+            assert_eq!(
+                String::from_utf8_lossy(&out),
+                String::from_utf8_lossy(&expected),
+                "the encoding moved for a {}-byte value",
+                value.len()
+            );
+        }
+    }
+
+    /// And a value still survives the round trip.
+    #[test]
+    fn the_pairs_encoding_round_trips() {
+        let input: Vec<(String, Vec<u8>)> = vec![
+            ("a".to_string(), Vec::new()),
+            ("b".to_string(), (0u8..=255).collect()),
+            ("c".to_string(), b"abcd".to_vec()),
+        ];
+        let mut out = Vec::new();
+        {
+            let mut ser = serde_json::Serializer::new(&mut out);
+            pairs::serialize(&input, &mut ser).expect("serialises");
+        }
+        let mut de = serde_json::Deserializer::from_slice(&out);
+        let back = pairs::deserialize(&mut de).expect("deserialises");
+        assert_eq!(back, input, "a value did not survive the round trip");
+    }
+
 }


### PR DESCRIPTION
A JSON document has no byte type, so byte payloads go out as base64. The encoder built that base64 with `STANDARD.encode`, which allocates a fresh `String` per pair — sized 1.33x the value — only to hand it to the serializer and drop it.

The values stream through `collect_str` now, so the format writes the encoding as it is produced. Nothing on the wire changes: same alphabet, same padding.

Measured with the allocation probe, both forms in the same process:

| pairs | before | after |
|---|---|---|
| 8 | 15.0 | 7.0 |
| 32 | 41.0 | 9.0 |

Per pair that is 1.083 allocations down to 0.083, and the bytes allocated for 32 pairs fall from 6784 to 4992. Every command carrying byte payloads pays this, not just the raw-event ingest that led here.

`the_pairs_encoding_is_what_encode_produced` compares the output byte for byte against what `STANDARD.encode` produced — across the empty value, all three base64 remainder classes, and the full 0-255 byte range — because these payloads are read back by the datanode. A round-trip test covers decode.

Found while accounting for the last two allocations per message on the ingest path. I had first blamed the internally-tagged `Command` enum and was about to hand-write a borrowed struct for the hot call site; measuring it against an untagged struct of identical shape gave 38.0 vs 38.0 and byte-identical output. Serde writes internally-tagged struct variants directly — the `Content` buffering that makes tagging expensive is a deserialize concern. The real cost was this `String`.