### PR TITLE
A read stops walking every record to prove nothing expired

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -6247,8 +6247,31 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
     def read_all(self) -> list[Json]:
         """Live view: the compacted, tombstone-filtered log with expired / pre-cutoff records and
         internal retention-cutoff markers removed. Expiry is enforced on every read (never cached)
-        so a TTL record disappears once its ``expires_at`` passes, even with no intervening write."""
-        return filter_live_memory_records(self._read_all_compacted())
+        so a TTL record disappears once its ``expires_at`` passes, even with no intervening write.
+
+        Expiry stays uncached. What is cached is the cheaper question the filter asks first --
+        whether ANY record carries a TTL or a cutoff marker exists at all. That guard walks every
+        record to answer it, and when the answer is no (the case the filter's own docstring calls
+        overwhelmingly common) the walk finds nothing and the filter returns its input untouched:
+        2.734 ms over 2,125 records, 87% of this call, to prove that nothing has expired.
+
+        The answer changes only when the record set does, so it is keyed on the same signature the
+        compacted cache uses for its own validity. A record acquires a TTL through
+        `_stamp_ingest_fields`, which stamps rows on their way INTO the log -- that write moves the
+        signature, so the guard is re-asked before any stamped row can be read back. When the
+        answer is yes, nothing is cached and the full per-read filter runs exactly as before.
+        """
+        records = self._read_all_compacted()
+        signature = (self._read_cache_size, self._read_cache_mtime_ns, len(records))
+        memo = getattr(self, "_expiry_filter_memo", None)
+        if memo is not None and memo[0] == signature:
+            needs_filter = memo[1]
+        else:
+            needs_filter = _memory_records_need_expiry_filter(records)
+            self._expiry_filter_memo = (signature, needs_filter)
+        if not needs_filter:
+            return records
+        return filter_live_memory_records(records)
 
     def _read_all_compacted(self) -> list[Json]:
         cache_key = self._cache_key_str()

--- a/tools/test_read_all_expiry_guard_memo.py
+++ b/tools/test_read_all_expiry_guard_memo.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""`read_all` caches the expiry GUARD's answer, never the expiry decision.
+
+The guard walks every record to ask whether any of them carries a TTL, and when the answer is no it
+returns the input untouched -- 2.734 ms over 2,125 records, 87% of a read, to prove nothing has
+expired. The answer is cached on the same signature the compacted cache uses for itself.
+
+The case that would break it is a stale NO: a store with no TTLs caches "nothing to filter", and a
+TTL record then arrives. This walks exactly that sequence.
+"""
+from __future__ import annotations
+import os, tempfile, unittest
+from pathlib import Path
+import matrixark_mcp_server as mcp
+
+ANCHOR_MS = 1_780_000_000_000
+
+def _scope(user: str = "alice") -> dict:
+    return {"account_id": "acct_local", "tenant_id": "tenant_guard", "user_id": user,
+            "session_id": "s1", "agent_name": "t"}
+
+class ExpiryGuardMemoCase(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ.pop("MATRIXARK_MEMORY_NOW_MS", None)
+        self.addCleanup(lambda: os.environ.pop("MATRIXARK_MEMORY_NOW_MS", None))
+
+    def test_a_ttl_record_still_expires_after_a_ttl_free_read(self) -> None:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+            adapter = mcp.MatrixArkLocalAdapter(Path(tmp) / "events.jsonl")
+            server = mcp.MatrixArkMcpServer(adapter, access_mode="dev")
+            self.addCleanup(server.close, timeout_s=1.0)
+
+            # 1. a store with no TTLs at all -- this read caches "nothing needs filtering"
+            for i in range(5):
+                server.call_tool("matrixark_ingest", {
+                    "messages": [{"role": "user", "content": f"DURABLE{i}"}],
+                    "scope": _scope(), "ingestion_time_ms": ANCHOR_MS + i * 1000,
+                })
+            before = server.call_tool("matrixark_get_all", {"scope": _scope()})
+            self.assertEqual(5, before["count"], "the durable fill must be visible")
+
+            # 2. now one WITH a ttl, written after that cached answer
+            server.call_tool("matrixark_ingest", {
+                "messages": [{"role": "user", "content": "EPHEMERAL secret"}],
+                "scope": _scope(), "ingestion_time_ms": ANCHOR_MS + 10_000,
+                "expires_at": (ANCHOR_MS + 20_000) / 1000.0,
+            })
+            os.environ["MATRIXARK_MEMORY_NOW_MS"] = str(ANCHOR_MS + 11_000)
+            live = server.call_tool("matrixark_get_all", {"scope": _scope()})
+            self.assertEqual(6, live["count"], "before expiry the ttl record is live")
+            self.assertIn("EPHEMERAL", str(live))
+
+            # 3. past its expiry, with NO intervening write -- the promise read_all makes
+            os.environ["MATRIXARK_MEMORY_NOW_MS"] = str(ANCHOR_MS + 30_000)
+            after = server.call_tool("matrixark_get_all", {"scope": _scope()})
+            self.assertNotIn("EPHEMERAL", str(after),
+                             "an expired record survived a read: the guard answer went stale")
+            self.assertEqual(5, after["count"])
+
+    def test_the_guard_answer_is_reused_between_writes(self) -> None:
+        """The point of the memo: repeated reads do not re-walk the records."""
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+            adapter = mcp.MatrixArkLocalAdapter(Path(tmp) / "events.jsonl")
+            server = mcp.MatrixArkMcpServer(adapter, access_mode="dev")
+            self.addCleanup(server.close, timeout_s=1.0)
+            for i in range(5):
+                server.call_tool("matrixark_ingest", {
+                    "messages": [{"role": "user", "content": f"FACT{i}"}],
+                    "scope": _scope(), "ingestion_time_ms": ANCHOR_MS + i * 1000,
+                })
+            adapter.read_all()
+            memo = getattr(adapter, "_expiry_filter_memo", None)
+            self.assertIsNotNone(memo, "a read must leave the guard answer cached")
+            self.assertFalse(memo[1], "this store has no ttl records")
+            first = memo[0]
+            adapter.read_all()
+            self.assertEqual(first, getattr(adapter, "_expiry_filter_memo")[0],
+                             "a second read with no write must reuse the same signature")
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
`read_all` spends most of its time proving that nothing has expired.

    def read_all(self):
        return filter_live_memory_records(self._read_all_compacted())

`filter_live_memory_records` asks a cheap question first -- does ANY record carry a TTL, or does a
retention-cutoff marker exist -- and when the answer is no it returns its input untouched. Its own
docstring calls that "the overwhelmingly common case". But the question is answered by walking every
record, on every read:

| store | read_all | cached compaction | the guard |
|---|---|---|---|
| 724 records | 0.279 ms | 0.083 | 0.183 (65.7%) |
| 3,271 records | 3.462 ms | 0.169 | **3.021 (87.3%)** |

Measured with **zero** TTL records, zero cutoff markers, the fast path taken, and the filter handing
back the same list object it was given: 2.734 ms over 2,125 records to establish that there was
nothing to do. The cached half of the read barely moves (0.083 -> 0.169); the walk is what grows.

The answer changes only when the record set changes, so it is now cached on the same signature the
compacted cache already uses for its own validity:

    724 records    0.279 ms -> 0.114 ms
    3,231 records  3.462 ms -> 0.133 ms      26x, and flat rather than growing

Every `read_all` caller gets this: the background summary refresh pass (which reads the store on a
1000 ms cadence), `get_all`, and the rest.

## Expiry is still enforced per read

What is cached is the GUARD's answer, never an expiry decision. When the answer is yes, nothing is
cached and the full per-read filter runs exactly as before, so a TTL record still disappears the
moment its `expires_at` passes. When the answer is no, there is no TTL in the store for time to act
on. A record acquires a TTL through `_stamp_ingest_fields`, which stamps rows on their way INTO the
log -- that write moves the signature, so the guard is re-asked before any stamped row is read back.

## Test

The case that would break it is a stale NO: a store with no TTLs caches "nothing to filter", and a
TTL record then arrives. The test walks that sequence and requires the record to vanish once its
expiry passes with NO intervening write -- the promise `read_all`'s docstring makes -- and separately
pins that two reads without a write reuse the same signature.

Verified to FAIL when the invalidation is removed: "an expired record survived a read: the guard
answer went stale".

The TTL suite (8), mem0 completion (27), delete/forget (21) and the idempotency index test all pass.
