### PR TITLE
A datanode URL with no scheme is discarded, host and port

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -412,10 +412,8 @@ class GatewayConfig:
         # Enforced-mode hashed keystore: {api_key_hash -> {tenant_id, account_id}}.
         self.hashed_keys: dict[str, Json] = fields.get("hashed_keys", {})
         # Datanode blob target, parsed for the http.client proxy.
-        parsed = urlparse(str(self.datanode_url))
-        self.blob_scheme = parsed.scheme or "http"
-        self.blob_host = parsed.hostname or "127.0.0.1"
-        self.blob_port = parsed.port or (443 if self.blob_scheme == "https" else 17102)
+        self.blob_scheme, self.blob_host, self.blob_port, self.datanode_url_usable = \
+            datanode_target(self.datanode_url)
         # Injectable so tests can proxy without a network; production builds an http.client conn.
         self.blob_connection_factory: Callable[["GatewayConfig"], Any] = fields.get(
             "blob_connection_factory", _default_blob_connection
@@ -2034,10 +2032,30 @@ def _model_config_snapshot() -> Json:
             "switch off so the configuration says what the deployment does."
         )
 
+    # Which address the datanode calls actually go to, beside the string that was configured.
+    # They differ silently whenever the URL cannot be parsed, and that is the one case where the
+    # configured value tells a reader nothing about where the traffic went.
+    _datanode_configured = _env("MATRIXARK_DATANODE_URL") or ""
+    _dn_scheme, _dn_host, _dn_port, _dn_usable = datanode_target(
+        _datanode_configured or "http://127.0.0.1:17102")
+    datanode_address = {
+        "configured": _datanode_configured,
+        "effective": "%s://%s:%s" % (_dn_scheme, _dn_host, _dn_port),
+        "usable": bool(_dn_usable),
+    }
+    if _datanode_configured and not _dn_usable:
+        warnings.append(
+            "Datanode URL (" + _datanode_configured + ") has no scheme, so no host could be read "
+            "from it and neither the host nor the port is being used. Calls are going to "
+            + datanode_address["effective"] + " instead. Write it as "
+            "http://" + _datanode_configured + "."
+        )
+
     return {
         "status": "ok",
         "extraction": extraction,
         "embedding": embedding,
+        "datanode_address": datanode_address,
         # The third model role, and the one called most: extraction runs once per ingest, and every
         # context node gets a summary. It had no block here at all, so a deployment writing its
         # summaries with rules looked exactly like one writing them with a model.
@@ -3660,6 +3678,31 @@ def _headers_map(scope: Json) -> dict[str, str]:
 #: back. Two other routes cap at 500 as well; those are different policies that happen to share a
 #: number, and folding them in here would couple them.
 CATALOG_LIST_LIMIT_MAX = 500
+
+
+def datanode_target(url: Any) -> Tuple[str, str, int, bool]:
+    """The address the gateway will really use for the datanode, and whether the URL gave it.
+
+    `urlparse` reads `datanode:9000` as scheme `datanode` with no netloc, so BOTH the hostname and
+    the port come back empty and the defaults win: a deployment configured for `datanode:9000`
+    talks to `127.0.0.1:17102`, which is a working-looking address that is not the one anybody
+    asked for. The fourth value says whether the URL produced a host at all, so a caller can say
+    so instead of reporting the fallback as if it had been chosen.
+
+    The fallback itself is unchanged. Pointing the connection at the host the operator wrote would
+    move live traffic on the strength of a string that has never been parsed successfully; saying
+    what is happening is the part that is unambiguously right.
+    """
+    parsed = urlparse(str(url or ""))
+    scheme = parsed.scheme or "http"
+    # `parsed.port` raises on a malformed port rather than returning None.
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+    host = parsed.hostname
+    return (scheme, host or "127.0.0.1",
+            port or (443 if scheme == "https" else 17102), bool(host))
 
 
 def _ok_body(result: Any) -> Json:

--- a/tools/test_matrixark_a_datanode_url_with_no_scheme_is_discarded.py
+++ b/tools/test_matrixark_a_datanode_url_with_no_scheme_is_discarded.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A datanode URL with no scheme is thrown away, host and port, and nothing said so.
+
+`urlparse("datanode:9000")` reads `datanode` as the SCHEME and leaves the netloc empty, so both
+`hostname` and `port` come back empty and the defaults win:
+
+    configured  datanode:9000   ->  the gateway talks to 127.0.0.1:17102
+
+Not a failure anybody sees. `127.0.0.1:17102` is a plausible address, so on a box where something
+answers there the deployment appears to work against the wrong datanode, and where nothing answers
+the checklist reports "could not connect to the datanode" and sends the reader to check that their
+datanode process is running -- which it is, at the address they configured and the gateway never
+used.
+
+The fallback is deliberately unchanged. Pointing the connection at the host the operator wrote
+would move live traffic on the strength of a string that has never parsed; saying where the calls
+are actually going is the part that is unambiguously right, and it makes the misconfiguration
+obvious in one line.
+
+The parse lives in one function now. It was three lines inside `GatewayConfig.__init__`, and the
+snapshot needed the same answer -- a second copy would have been a second thing to be wrong.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+import matrixark_v1_gateway as gw  # noqa: E402
+
+
+def snapshot(datanode_url=None) -> dict:
+    script = ("import json, matrixark_v1_gateway as gw;"
+              "print(json.dumps(gw._model_config_snapshot()))")
+    environ = dict(os.environ)
+    environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = "/nonexistent/matrixark-datanode-test.json"
+    if datanode_url is None:
+        environ.pop("MATRIXARK_DATANODE_URL", None)
+    else:
+        environ["MATRIXARK_DATANODE_URL"] = datanode_url
+    out = subprocess.run([sys.executable, "-c", script], cwd=TOOLS, env=environ,
+                         capture_output=True, text=True, timeout=300)
+    if out.returncode != 0:
+        raise AssertionError(out.stderr[-800:])
+    return json.loads(out.stdout)
+
+
+def warned(snap: dict) -> str:
+    hits = [w for w in snap.get("warnings", []) if "Datanode URL" in w]
+    return hits[0] if hits else ""
+
+
+class TheParseIsOneFunctionTest(unittest.TestCase):
+    """`GatewayConfig` and the snapshot need the same answer; two copies is two answers."""
+
+    def test_a_url_with_a_scheme_is_read_whole(self) -> None:
+        self.assertEqual(("http", "datanode", 9000, True),
+                         gw.datanode_target("http://datanode:9000"))
+
+    def test_a_url_with_no_scheme_yields_no_host(self) -> None:
+        scheme, host, port, usable = gw.datanode_target("datanode:9000")
+        self.assertFalse(usable, "the defect is not reproduced")
+        self.assertEqual("127.0.0.1", host)
+        self.assertEqual(17102, port)
+
+    def test_https_keeps_its_own_default_port(self) -> None:
+        self.assertEqual(("https", "dn", 443, True), gw.datanode_target("https://dn"))
+
+    def test_an_empty_url_is_the_local_default(self) -> None:
+        self.assertEqual(("http", "127.0.0.1", 17102, False), gw.datanode_target(""))
+
+    def test_a_malformed_port_does_not_raise(self) -> None:
+        """`urlparse().port` raises on a bad port rather than returning None, and this runs while
+        a request is being served."""
+        scheme, host, port, usable = gw.datanode_target("http://dn:notaport")
+        self.assertEqual(17102, port)
+        self.assertTrue(usable)
+
+    def test_the_config_object_uses_it(self) -> None:
+        """The whole point of naming it: the connection and the report agree by construction."""
+        cfg = gw.GatewayConfig(datanode_url="datanode:9000")
+        self.assertEqual("127.0.0.1", cfg.blob_host)
+        self.assertEqual(17102, cfg.blob_port)
+        self.assertFalse(cfg.datanode_url_usable)
+
+
+class TheSnapshotSaysWhereTheCallsGoTest(unittest.TestCase):
+
+    def test_it_reports_both_the_configured_and_the_effective_address(self) -> None:
+        block = snapshot("datanode:9000")["datanode_address"]
+        self.assertEqual("datanode:9000", block["configured"])
+        self.assertIn("127.0.0.1:17102", block["effective"])
+        self.assertFalse(block["usable"])
+
+    def test_a_good_url_reports_itself(self) -> None:
+        block = snapshot("http://datanode:9000")["datanode_address"]
+        self.assertEqual("http://datanode:9000", block["effective"])
+        self.assertTrue(block["usable"])
+
+    def test_the_warning_names_the_value_the_address_and_the_remedy(self) -> None:
+        text = warned(snapshot("datanode:9000"))
+        self.assertIn("datanode:9000", text)
+        self.assertIn("127.0.0.1:17102", text)
+        self.assertIn("http://datanode:9000", text, "the remedy is not spelled out")
+
+    def test_a_usable_url_is_not_warned_about(self) -> None:
+        """The floor. A warning on every deployment is a warning nobody reads."""
+        self.assertEqual("", warned(snapshot("http://datanode:9000")))
+
+    def test_an_unset_url_is_not_warned_about(self) -> None:
+        """Unset is the documented default, not a misconfiguration."""
+        self.assertEqual("", warned(snapshot(None)))
+        self.assertTrue(snapshot(None)["datanode_address"]["usable"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`urlparse("datanode:9000")` reads `datanode` as the **scheme** and leaves the netloc empty, so both `hostname` and `port` come back empty and the defaults win:

```
configured  MATRIXARK_DATANODE_URL=datanode:9000
the gateway talks to  127.0.0.1:17102
```

The configured host **and** port are discarded, and nothing said so.

It is not a failure anybody sees. `127.0.0.1:17102` is a plausible address: on a box where something answers there, the deployment appears to work against the wrong datanode; where nothing answers, the readiness checklist reports *"The gateway could not connect to the datanode"* and tells the reader to check that their datanode process is running — which it is, at the address they configured and the gateway never used.

## What changes

- the parse is one named function, `datanode_target()`. It was three lines inside `GatewayConfig.__init__`, and the snapshot needs the same answer — a second copy would be a second thing to be wrong, which is how the connection and the report come to disagree.
- the model snapshot carries `datanode_address`: what was **configured**, what is **effective**, and whether the URL was usable.
- a warning fires only when a URL was set and yielded no host, naming the value, the address calls are actually going to, and the remedy.

| configured | effective | warned |
|---|---|---|
| `http://datanode:9000` | `http://datanode:9000` | no |
| `datanode:9000` | `datanode://127.0.0.1:17102` | **yes** |
| *(unset)* | `http://127.0.0.1:17102` | no — that is the documented default |

**The fallback is deliberately unchanged.** Pointing the connection at the host the operator wrote would move live traffic on the strength of a string that has never parsed successfully. Saying where the calls are actually going is the part that is unambiguously right, and it makes the misconfiguration obvious in one line. Redirecting can be a separate decision.

## Mutations

Eleven tests. Each of these reddens at least one:

| mutation | reddens |
|---|---|
| the snapshot stops reporting the address | `test_a_good_url_reports_itself` |
| it always calls the URL usable | `test_a_url_with_no_scheme_yields_no_host` |
| the warning never fires | `test_the_warning_names_the_value_the_address_and_the_remedy` |
| it warns on a good URL too | `test_a_usable_url_is_not_warned_about` |
| the warning stops naming the remedy | `test_the_warning_names_the_value_the_address_and_the_remedy` |
| the warning stops naming where calls go | `test_the_warning_names_the_value_the_address_and_the_remedy` |
| the config object parses it separately again | `test_the_config_object_uses_it` |
| a malformed port raises again | `test_a_malformed_port_does_not_raise` |

That last one is a real edge the inline version had: `urlparse().port` **raises** `ValueError` on a bad port rather than returning `None`, and this runs while a request is being served.
