### PR TITLE
One test attribute per test

### DIFF
--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -1448,7 +1448,6 @@ mod tests {
     }
 
     #[test]
-    #[test]
     fn a_delta_record_written_with_the_old_field_names_still_loads() {
         // The record-level names are short now. `items` and `meta` are NOT among them: whole-index
         // and delta records are told apart on read by the PRESENCE of those two keys, so renaming
@@ -1718,7 +1717,6 @@ mod tests {
         }
     }
 
-    #[test]
     #[test]
     fn an_index_item_written_with_the_old_field_names_still_loads() {
         // The names are short now because they repeat once per ITEM for the life of the log.


### PR DESCRIPTION
Two tests in `index_log.rs` carry `#[test]` twice. The compiler warns, and the test harness
registers and runs each of them twice -- `a_delta_record_written_with_the_old_field_names_still_loads`
and `an_index_item_written_with_the_old_field_names_still_loads` both appear twice in the run.

Neither is wrong, just doubled, so this drops one attribute from each.

The reason to bother: a doubled `#[test]` is what a STOLEN one looks like from the build log. When a
block of attributes is inserted just above a `fn` instead of above that function's own `#[test]`, the
inserted item ends up with two attributes and the function below it silently loses its only one --
it stops being collected, passes by never running, and the sole signal is a "duplicated attribute"
warning somewhere in the output. With these two standing, that warning is already normal here.

A scan of every `.rs` file in the crate for the other half of that shape -- a documented, zero-argument
function inside a test file with no `#[test]` and no caller -- finds none, so nothing is currently
failing to run. This just removes the noise that would hide the next one.