### PR TITLE
WAL record compression does nothing without binary records, and the portal did not say so

### DIFF
--- a/crates/temporalstore-rust/src/wal_proto.rs
+++ b/crates/temporalstore-rust/src/wal_proto.rs
@@ -110,6 +110,12 @@ const COMPRESSION_MIN_BYTES: usize = 256;
 /// The variable now opts OUT, like `TS_WAL_BINARY_RECORDS` and `TS_WAL_BINARY_FRAME` beside it --
 /// and for the same reason it is safe to flip either way: which encoding a payload is in is a
 /// property of the payload, not of this flag.
+///
+/// IT DOES NOTHING WITHOUT `TS_WAL_BINARY_RECORDS`. The compressor is reached only from `encode`
+/// below, and `encode_wal_payload` calls that only when `binary_records_enabled()`; the JSON arm
+/// writes `serde_json::to_vec` straight out. So on a deployment that turns binary records off this
+/// flag reads as on, reports as on, and compresses nothing. Turn binary records on first, or the
+/// log stays raw JSON.
 pub(crate) fn compress_records_enabled() -> bool {
     !matches!(
         std::env::var("TS_WAL_COMPRESS_RECORDS")

--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -771,11 +771,16 @@ SETTINGS: List[Setting] = [
     Setting("storage_engine.wal_compress_records", "storage_engine",
             "TS_WAL_COMPRESS_RECORDS",
             "Compress log records", "bool", "1", "restart",
-            "On, a log record is zstd-compressed before it is written. Measured on one live "
-            "segment -- 151 records averaging 13.5 KB -- this is 8.61x, which on a 698 MB log is "
-            "about 617 MB back. It ships ON: it spends write CPU to buy disk, and 8.61x is a large "
-            "enough return that a deployment which would rather keep the CPU is the one that "
-            "should have to say so. Turn it off where write latency is the scarce thing. Reading "
+            "On, a log record is zstd-compressed before it is written. IT NEEDS "
+            "TS_WAL_BINARY_RECORDS ON: the compressor is reached only from the protobuf encoder, "
+            "so a deployment writing JSON records has this on, reports it on, and compresses "
+            "nothing. Expect about 3.8x on the records, not the 8.61x an earlier note quoted -- "
+            "that came from one segment of 151 records averaging 13.5 KB, and real documents here "
+            "average 426 B, far too small to amortise a dictionary. Records of 256 bytes and over, "
+            "95.2% of the raw bytes, reach 4.36x. It ships ON: it spends write CPU to buy disk, "
+            "and that is a large enough return that a deployment which would rather keep the CPU "
+            "is the one that should have to say so. Turn it off where write latency is the scarce "
+            "thing. Reading "
             "never "
             "consults it: a payload says what encoding it is in, so a log written across a change "
             "reads end to end and turning it off again is not a one-way door. Records below 256 "


### PR DESCRIPTION
`TS_WAL_COMPRESS_RECORDS` is opt-out, so it reads as on by default and the inventory records it that
way. But the compressor is only ever reached from `wal_proto::encode`, and `encode_wal_payload`
calls that **only when binary records are on**:

```rust
fn encode_wal_payload(record) {
    if binary_records_enabled() { return wal_proto::encode(record); }  // compression lives here
    ... serde_json::to_vec(record) ...                                 // and nowhere else
}
```

`compress_records_enabled()` has exactly two call sites, and the other is the no-compression fast
path — so that is the whole story. **On a deployment that turns binary records off, this flag is on,
reports on, and compresses nothing.**

## That deployment exists

The live one-box unit sets `TS_WAL_BINARY_RECORDS=0`, and its WAL is about **329 MB of uncompressed
JSON**. The newest sealed piece carries a binary frame header and then plain text, and recompresses
whole-file at 10.8×.

## The help also quoted a return the flag cannot deliver

It said 8.61×, "about 617 MB back" on a 698 MB log. That figure came from **one segment of 151
records averaging 13.5 KB**.

Measured over 60 pieces of the live log:

| | ratio | |
|---|---|---|
| per-record zlib | **3.79×** | real documents, mean **426 B** |
| records ≥ 256 B | 4.36× | 95.2% of the raw bytes |
| whole-stream | 9.37× | shares a dictionary across records — **not** achievable per record |

A small record cannot amortise a dictionary. The help now says about 3.8× and explains why the older
number was larger. The whole-stream 9.37× is deliberately still not quoted: citing it would be the
same error in the other direction.

## Scope

Nothing is enabled or disabled here — this is the doc comment and the portal help. Turning binary
records on is a durable-format decision for an operator, and both flags' own help already covers
what that costs.

47 tests green across `test_matrixark_engine_flag_inventory`, `test_a_two_path_flag_says_why`,
`test_flag_readers_agree`, `test_matrixark_gateway_config_audit` and
`test_a_setting_declares_the_default_the_code_applies`.
