### PR TITLE
The third model role is alertable

### DIFF
--- a/docs/ops/matrixark-gateway-dashboard.json
+++ b/docs/ops/matrixark-gateway-dashboard.json
@@ -239,6 +239,56 @@
       ]
     },
     {
+      "id": 18,
+      "type": "stat",
+      "title": "Summaries",
+      "description": "Whether node summaries come from a model. Separate from Extraction because they can differ: an Anthropic extraction provider returns rule-written summaries.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "rules only",
+                  "color": "red",
+                  "index": 0
+                }
+              }
+            },
+            {
+              "type": "value",
+              "options": {
+                "1": {
+                  "text": "model",
+                  "color": "green",
+                  "index": 1
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "min(matrixark_gateway_summary_model_active{instance=~\"$instance\"})",
+          "legendFormat": "summaries"
+        }
+      ]
+    },
+    {
       "id": 3,
       "type": "stat",
       "title": "Config warnings",
@@ -250,7 +300,7 @@
       "gridPos": {
         "h": 4,
         "w": 6,
-        "x": 12,
+        "x": 18,
         "y": 4
       },
       "fieldConfig": {
@@ -276,29 +326,6 @@
           "refId": "A",
           "expr": "max(matrixark_gateway_config_warnings{instance=~\"$instance\"})",
           "legendFormat": "warnings"
-        }
-      ]
-    },
-    {
-      "id": 4,
-      "type": "stat",
-      "title": "Requests in flight",
-      "description": "Requests being served right now. A number that climbs and does not come back down is the edge queueing behind a slow backend.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 18,
-        "y": 4
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "sum(matrixark_gateway_requests_in_flight{instance=~\"$instance\"})",
-          "legendFormat": "in flight"
         }
       ]
     },
@@ -585,44 +612,6 @@
       ]
     },
     {
-      "id": 16,
-      "type": "timeseries",
-      "title": "Worker resident memory",
-      "description": "Resident and peak memory of each gateway worker. Per worker, and deliberately not summed: resident sets share pages, so adding the workers together produces a figure larger than the machine is using. The `source` label says how the number was read -- /proc/self/status is exact, ru_maxrss is a peak only, and a series that switches between them is not comparable across the switch. Several gateway settings ask an operator to trade memory for speed -- the page and block index caches, the hot record cache, whether embeddings are stored at all -- and this is the half of that trade you can watch.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 36
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "bytes",
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 8
-          }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "matrixark_gateway_worker_resident_bytes",
-          "legendFormat": "resident {{source}} {{instance}}"
-        },
-        {
-          "refId": "B",
-          "expr": "matrixark_gateway_worker_peak_bytes",
-          "legendFormat": "peak {{source}} {{instance}}"
-        }
-      ]
-    },
-    {
       "id": 17,
       "type": "stat",
       "title": "Workers",
@@ -657,6 +646,67 @@
           "refId": "A",
           "expr": "max(matrixark_gateway_workers)",
           "legendFormat": "workers"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Requests in flight",
+      "description": "Requests being served right now. A number that climbs and does not come back down is the edge queueing behind a slow backend.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 32
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(matrixark_gateway_requests_in_flight{instance=~\"$instance\"})",
+          "legendFormat": "in flight"
+        }
+      ]
+    },
+    {
+      "id": 16,
+      "type": "timeseries",
+      "title": "Worker resident memory",
+      "description": "Resident and peak memory of each gateway worker. Per worker, and deliberately not summed: resident sets share pages, so adding the workers together produces a figure larger than the machine is using. The `source` label says how the number was read -- /proc/self/status is exact, ru_maxrss is a peak only, and a series that switches between them is not comparable across the switch. Several gateway settings ask an operator to trade memory for speed -- the page and block index caches, the hot record cache, whether embeddings are stored at all -- and this is the half of that trade you can watch.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "matrixark_gateway_worker_resident_bytes",
+          "legendFormat": "resident {{source}} {{instance}}"
+        },
+        {
+          "refId": "B",
+          "expr": "matrixark_gateway_worker_peak_bytes",
+          "legendFormat": "peak {{source}} {{instance}}"
         }
       ]
     }

--- a/tools/matrixark_gateway_metrics.py
+++ b/tools/matrixark_gateway_metrics.py
@@ -472,6 +472,12 @@ def config_health_lines(snapshot: Optional[Json] = None) -> List[str]:
         embedding_provider = str((snapshot.get("embedding") or {}).get("provider")
                                  or embedding_provider)
     deterministic = {"", "deterministic", "rules", "local"}
+    # `writes` is what the model-config snapshot already decided, through the one classifier that
+    # mirrors the summariser. Absent -- an older snapshot, or none passed -- reports 0 rather than
+    # guessing: a metric that invents a healthy answer is worse than one that is missing.
+    summary_by_model = 0
+    if isinstance(snapshot, dict):
+        summary_by_model = 1 if (snapshot.get("summary") or {}).get("writes") == "model" else 0
     return [
         "# HELP matrixark_gateway_config_warnings Model-configuration warnings currently raised.",
         "# TYPE matrixark_gateway_config_warnings gauge",
@@ -486,6 +492,19 @@ def config_health_lines(snapshot: Optional[Json] = None) -> List[str]:
         "# TYPE matrixark_gateway_embedding_semantic gauge",
         "matrixark_gateway_embedding_semantic %d"
         % (0 if embedding_provider.strip().lower() in deterministic else 1),
+        # The third role, and the one called most: extraction runs once per ingest and every
+        # context node gets a summary. Two of the three roles were alertable and this was not, so a
+        # deployment whose summaries quietly stopped coming from a model looked exactly like one
+        # whose summaries never did.
+        #
+        # Taken from the snapshot's own answer rather than re-derived from the provider name. The
+        # set above cannot decide this one: an ANTHROPIC extraction provider is a real model for
+        # extraction and returns rule-written summaries, so the same name means 1 on one line and
+        # 0 on this one.
+        "# HELP matrixark_gateway_summary_model_active 1 when node summaries are written by a "
+        "model, 0 when they are written by rules.",
+        "# TYPE matrixark_gateway_summary_model_active gauge",
+        "matrixark_gateway_summary_model_active %d" % summary_by_model,
     ]
 
 

--- a/tools/temporalstore-prometheus/matrixark-gateway-alerts.yml
+++ b/tools/temporalstore-prometheus/matrixark-gateway-alerts.yml
@@ -34,6 +34,18 @@ groups:
             Intended for a dev deployment; in production it means the memories being written are
             much thinner than the customer expects.
 
+      - alert: MatrixArkSummariesNotUsingAModel
+        expr: matrixark_gateway_summary_model_active == 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Node summaries are being written by rules ({{ $labels.instance }})"
+          description: >-
+            No extraction model is configured, so ingest stores only what the local rules extract.
+            Intended for a dev deployment; in production it means the memories being written are
+            much thinner than the customer expects.
+
       - alert: MatrixArkGatewayConfigWarnings
         expr: matrixark_gateway_config_warnings > 0
         for: 30m

--- a/tools/test_matrixark_the_third_model_role_is_alertable.py
+++ b/tools/test_matrixark_the_third_model_role_is_alertable.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Two of the three model roles were alertable. The one called most was not.
+
+`matrixark_gateway_extraction_model_active` and `matrixark_gateway_embedding_semantic` are gauges
+with panels and alerts, for the reason `config_health_lines` gives: a misconfigured deployment is
+indistinguishable from a healthy one at the API surface, so a dashboard charting only rate and
+latency shows it as perfectly healthy for months.
+
+Summaries had neither, and they are the role called most -- extraction runs once per ingest and
+**every context node gets a summary** that retrieval then walks.
+
+The case that makes it a third series rather than a label on an existing one:
+
+    extraction provider   extraction_model_active   summary_model_active
+    openai_compatible     1                         1
+    anthropic             1                         0
+    deterministic         0                         0
+
+An Anthropic deployment is a real model for extraction and returns rule-written summaries. On the
+existing metric it reads as fully model-backed. The set of names `config_health_lines` uses to
+decide the other two cannot express that -- the SAME provider name means 1 on one line and 0 on
+this one -- so this value is taken from the snapshot's own `summary.writes`, which is decided by
+the one classifier that mirrors the summariser.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import re
+import subprocess
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(TOOLS)
+sys.path.insert(0, TOOLS)
+
+import matrixark_gateway_metrics as metrics  # noqa: E402
+
+SERIES = "matrixark_gateway_summary_model_active"
+
+
+def emitted(extraction: str) -> dict:
+    """The gauges a deployment with this extraction provider would publish."""
+    script = ("import json, matrixark_v1_gateway as gw, matrixark_gateway_metrics as m;"
+              "s = gw._model_config_snapshot();"
+              "print(json.dumps({'writes': s['summary']['writes'],"
+              " 'lines': m.config_health_lines(s)}))")
+    environ = dict(os.environ)
+    environ["MATRIXARK_UNDERSTANDING_PROVIDER"] = extraction
+    environ.pop("MATRIXARK_SUMMARY_PROVIDER", None)
+    environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = "/nonexistent/matrixark-summary-metric-test.json"
+    out = subprocess.run([sys.executable, "-c", script], cwd=TOOLS, env=environ,
+                         capture_output=True, text=True, timeout=300)
+    if out.returncode != 0:
+        raise AssertionError(out.stderr[-800:])
+    payload = json.loads(out.stdout)
+    values = {}
+    for line in payload["lines"]:
+        if line.startswith("matrixark_"):
+            name, _, value = line.partition(" ")
+            values[name] = int(float(value))
+    payload["values"] = values
+    return payload
+
+
+class TheSeriesSaysWhatTheOthersCannotTest(unittest.TestCase):
+
+    def test_a_model_deployment_reports_one(self) -> None:
+        self.assertEqual(1, emitted("openai_compatible")["values"][SERIES])
+
+    def test_a_rules_deployment_reports_zero(self) -> None:
+        self.assertEqual(0, emitted("deterministic")["values"][SERIES])
+
+    def test_anthropic_is_a_model_for_extraction_and_rules_for_summaries(self) -> None:
+        """The whole reason this is a third series. If it agreed with extraction on every
+        provider it would be a duplicate of it."""
+        values = emitted("anthropic")["values"]
+        self.assertEqual(1, values["matrixark_gateway_extraction_model_active"])
+        self.assertEqual(0, values[SERIES])
+
+    def test_it_does_not_simply_track_extraction(self) -> None:
+        """The floor for the test above, stated over the whole set: the two series must disagree
+        somewhere, or one of them is noise."""
+        pairs = {(emitted(p)["values"]["matrixark_gateway_extraction_model_active"],
+                  emitted(p)["values"][SERIES])
+                 for p in ("openai_compatible", "anthropic", "deterministic")}
+        self.assertIn((1, 0), pairs, "the two series agree everywhere; one is redundant")
+
+    def test_it_matches_what_the_snapshot_says(self) -> None:
+        """One answer to the question. The gauge and the portal must not be able to disagree."""
+        for provider in ("openai_compatible", "anthropic", "deterministic"):
+            with self.subTest(provider=provider):
+                payload = emitted(provider)
+                self.assertEqual(1 if payload["writes"] == "model" else 0,
+                                 payload["values"][SERIES])
+
+
+class ItDoesNotInventAHealthyAnswerTest(unittest.TestCase):
+    """A metric that guesses is worse than one that is missing: it is charted as fact."""
+
+    def test_no_snapshot_reports_zero_rather_than_one(self) -> None:
+        lines = metrics.config_health_lines(None)
+        value = [l for l in lines if l.startswith(SERIES + " ")]
+        self.assertEqual([SERIES + " 0"], value)
+
+    def test_a_snapshot_without_a_summary_block_reports_zero(self) -> None:
+        """An older snapshot, from a gateway that predates the block."""
+        lines = metrics.config_health_lines({"warnings": []})
+        self.assertIn(SERIES + " 0", lines)
+
+
+class ItIsChartedAndAlertedLikeTheOthersTest(unittest.TestCase):
+
+    @staticmethod
+    def _dashboard() -> dict:
+        path = os.path.join(REPO, "docs", "ops", "matrixark-gateway-dashboard.json")
+        with io.open(path, encoding="utf-8") as handle:
+            return json.load(handle)
+
+    @staticmethod
+    def _alerts() -> str:
+        path = os.path.join(TOOLS, "temporalstore-prometheus", "matrixark-gateway-alerts.yml")
+        with io.open(path, encoding="utf-8") as handle:
+            return handle.read()
+
+    def test_a_panel_charts_it(self) -> None:
+        exprs = [t.get("expr", "") for p in self._dashboard()["panels"]
+                 for t in p.get("targets", [])]
+        self.assertTrue(any(SERIES in e for e in exprs), "the series is charted nowhere")
+
+    def test_the_three_roles_sit_together(self) -> None:
+        """Read as a set or not at all: three separate answers to "is this deployment using a
+        model" are only useful side by side."""
+        wanted = {"matrixark_gateway_embedding_semantic",
+                  "matrixark_gateway_extraction_model_active", SERIES}
+        rows = {}
+        for panel in self._dashboard()["panels"]:
+            exprs = " ".join(t.get("expr", "") for t in panel.get("targets", []))
+            for series in wanted:
+                if series in exprs:
+                    rows[series] = panel["gridPos"]["y"]
+        self.assertEqual(wanted, set(rows), rows)
+        self.assertEqual(1, len(set(rows.values())), "the three roles are on different rows: %s" % rows)
+
+    def test_no_two_panels_overlap(self) -> None:
+        """Moving a panel to make room is how two end up in the same cell."""
+        seen = set()
+        for panel in self._dashboard()["panels"]:
+            grid = panel["gridPos"]
+            for x in range(grid["x"], grid["x"] + grid["w"]):
+                for y in range(grid["y"], grid["y"] + grid["h"]):
+                    self.assertNotIn((x, y), seen,
+                                     "two panels occupy (%d,%d); one is %r" % (x, y, panel["title"]))
+                    seen.add((x, y))
+
+    def test_an_alert_fires_on_it(self) -> None:
+        text = self._alerts()
+        self.assertIn("MatrixArkSummariesNotUsingAModel", text)
+        self.assertIn(SERIES + " == 0", text)
+
+    def test_the_alert_says_what_is_happening_not_what_is_set(self) -> None:
+        text = self._alerts()
+        start = text.index("MatrixArkSummariesNotUsingAModel")
+        block = text[start:start + 700]
+        self.assertIn("written by rules", block)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two of the three model roles are alertable. The one called most was not.

`matrixark_gateway_extraction_model_active` and `matrixark_gateway_embedding_semantic` are gauges with panels and alerts, for the reason `config_health_lines` gives in its own docstring: a misconfigured deployment is indistinguishable from a healthy one at the API surface, so a dashboard charting only rate and latency shows it as perfectly healthy for months.

Summaries had **no metric, no panel and no alert** — and they are the role called most: extraction runs once per ingest, and *every* context node gets a summary that retrieval then walks.

## Why it is a third series and not a label on an existing one

| extraction provider | `extraction_model_active` | `summary_model_active` |
|---|---|---|
| `openai_compatible` | 1 | 1 |
| **`anthropic`** | **1** | **0** |
| `deterministic` | 0 | 0 |

An Anthropic deployment is a real model for extraction *and* returns rule-written summaries. On the existing metric it reads as fully model-backed while every node summary is written by rules.

The set of names `config_health_lines` uses for the other two **cannot express that** — the same provider name means 1 on one line and 0 on this one — so the value is taken from the snapshot's own `summary.writes`, decided by the one classifier that mirrors the summariser. A snapshot without a summary block reports `0`: a metric that invents a healthy answer is worse than one that is missing, because it is charted as fact.

## Layout

The three roles now sit on one row (`Retrieval mode`, `Extraction`, `Summaries`), with `Config warnings` moved right and `Requests in flight` taking the free slot on the datanode row. Three separate answers to "is this deployment using a model" are only useful side by side.

## Mutations

Fourteen tests. Each of these reddens at least one:

| mutation | reddens |
|---|---|
| the series is not emitted | `test_a_model_deployment_reports_one` |
| it copies the extraction answer | `test_anthropic_is_a_model_for_extraction_and_rules_for_summaries` |
| a missing snapshot reports healthy | `test_no_snapshot_reports_zero_rather_than_one` |
| the alert is removed | `test_an_alert_fires_on_it` |
| the alert watches the wrong series | `test_an_alert_fires_on_it` |
| the panel is removed | `test_a_panel_charts_it` |
| the three roles are split across rows | `test_the_three_roles_sit_together` |
| the new panel lands on another one | `test_no_two_panels_overlap` |

`test_it_does_not_simply_track_extraction` is the floor for the whole change: the two series must disagree somewhere, or one of them is noise.

Only the gateway dashboard and the gateway alert rules are touched — the engine dashboard is untouched.
