### PR TITLE
Fourteen integration test binaries have never run in CI

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -112,10 +112,19 @@ jobs:
       # for visibility but is NOT yet a required gate: the tree carries a small
       # number of known, pre-existing baseline failures. Flip continue-on-error
       # off once the baseline is fully green.
+      #
+      # `--no-fail-fast` is what makes "for visibility" true of more than the lib.
+      # cargo stops at the first failing TARGET, not the first failing test, and the
+      # two known lib failures were stopping it before it reached any of the fourteen
+      # binaries under `tests/` -- the whole integration suite, including
+      # `wal_single_barrier_recovery`, never ran. `continue-on-error` does not help:
+      # it stops the step failing the job, which is why this reported success, and has
+      # no effect on cargo's own stopping. The run for mx#1180 printed two
+      # `test result:` lines for a command asked to run fifteen targets.
       - name: cargo test (lib + integration, single-threaded, release)
         timeout-minutes: 45
         continue-on-error: true
-        run: cargo test --release -p temporalstore-rust --lib --tests -- --test-threads=1
+        run: cargo test --release -p temporalstore-rust --lib --tests --no-fail-fast -- --test-threads=1
 
       # Bin unit tests are not covered by --lib/--tests, so a failing test in a
       # service binary can sit on main unnoticed. Run the proxy bin's suite as a


### PR DESCRIPTION
`cargo test --release -p temporalstore-rust --lib --tests` runs the **lib** target first. The tree
carries known lib failures, and cargo's fail-fast is **per target**, not per test — so it stops
there. Every binary under `crates/temporalstore-rust/tests/` never runs.

`continue-on-error: true` does not help. It stops the failing *step* from failing the *job* — which
is why the check reports success — and has no effect on cargo's own stopping.

## This PR's own CI run proves both halves

| | before (#1180's run) | after (this PR) |
|---|---|---|
| `test result:` lines | **2** | **54** |
| targets reporting | lib + proxy bin | 12 failed, 42 ok |
| failing tests visible | 2 | **24** |

**21 failing tests were invisible.** Among them:

```
single_barrier_data_page_loss_after_dump_rebuilds_from_wal        ... FAILED
single_barrier_full_page_loss_no_dump_rebuilds_from_wal           ... FAILED
single_barrier_non_idempotent_counter_applies_exactly_once        ... FAILED
single_barrier_evict_then_crash_before_dump_does_not_resurrect    ... FAILED
server_raft_control_scale_up_down_preserves_serving               ... FAILED
raft_control_routes_list_add_remove_and_trigger_snapshot          ... FAILED
readiness_gate_failure_lines_include_service_next_actions         ... FAILED
grafana_metrics_coverage_contract_covers_dashboard_alerts_...     ... FAILED
```

The first four are `tests/wal_single_barrier_recovery.rs` — the crash-recovery suite for the
durability defect where a single-barrier ack can leave a record that cannot rebuild its value. **It
had never run in CI, and it fails.** That is the difference between "we believe this is still
broken" and "CI says so", and it is currently the stated reason not to change the WAL's encoding.

A third lib failure also appears (`table_write_refreshes_topology_after_meta_changed_without_write_retry_budget`),
so the lib baseline is 3, not 2.

## Scope

The step stays `continue-on-error`, so **this does not turn the suite into a gate** — it delivers
the visibility the step's own comment says it is for. Nothing here fixes any of the 24; they were
already failing, just unseen.

Runtime: the full run took **112.88 s** for the lib plus the integration targets, against
`timeout-minutes: 45`. The cost I flagged as unknown is now measured and small.
