### PR TITLE
Twenty-six more functions written out twice, now written once

### DIFF
--- a/tools/convert_external_baseline_csv_to_benchmark_report.py
+++ b/tools/convert_external_baseline_csv_to_benchmark_report.py
@@ -389,12 +389,10 @@ def to_float(value: str | None) -> float | None:
         return None
 
 
-def percentile(values: list[float], pct: float) -> float | None:
-    if not values:
-        return None
-    ordered = sorted(values)
-    index = int((len(ordered) - 1) * pct / 100.0)
-    return round(ordered[index], 4)
+try:  # the implementation lives in summarize_oss_memory_benchmark_artifacts; this module re-exports it
+    from .summarize_oss_memory_benchmark_artifacts import percentile
+except ImportError:  # Direct script execution from tools/.
+    from summarize_oss_memory_benchmark_artifacts import percentile
 
 
 def safe_div(numerator: float, denominator: float) -> float:

--- a/tools/matrixark_mcp_core_compact.py
+++ b/tools/matrixark_mcp_core_compact.py
@@ -252,29 +252,10 @@ def attach_storage_route(record: Json) -> Json:
     return record
 
 
-def context_placement_key(record: Json, *, scope_key: str = "", node_hash: Any = None) -> str:
-    explicit = str(record.get("placement_key") or "")
-    if explicit:
-        return explicit
-    scope_key = scope_key or str(record.get("scope_key") or "")
-    if not scope_key:
-        scope = record.get("scope") if isinstance(record.get("scope"), dict) else {}
-        scope_key = canonical_scope_key(scope) if scope else ""
-    if node_hash is None:
-        node_hash = record.get("node_hash") or record.get("node_id")
-    try:
-        node_hash_int = int(node_hash or 0)
-    except (TypeError, ValueError):
-        node_hash_int = 0
-    if scope_key and node_hash_int:
-        return f"context:{scope_key}:node={node_hash_int}"
-    if scope_key:
-        return f"context:{scope_key}"
-    try:
-        tenant_hash = int(record.get("tenant_hash") or 0)
-    except (TypeError, ValueError):
-        tenant_hash = 0
-    return f"context:t={tenant_hash}" if tenant_hash else ""
+try:  # the implementation lives in matrixark_mcp_event_keys; this module re-exports it
+    from .matrixark_mcp_event_keys import context_placement_key
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_event_keys import context_placement_key
 
 
 def attach_context_placement(record: Json, *, scope_key: str = "", node_hash: Any = None) -> Json:

--- a/tools/matrixark_mcp_core_identity.py
+++ b/tools/matrixark_mcp_core_identity.py
@@ -357,49 +357,16 @@ def scope_key_matches_query(record_scope_key: str, query_scope: Json, explicit_k
     return True
 
 
-def canonical_scope_key(scope: Json) -> str:
-    scope_key = str(scope.get("scope_key") or "")
-    if scope_key:
-        return scope_key
-    tenant_hash = int(scope.get("tenant_hash") or 0)
-    if not tenant_hash:
-        return ""
-    return scope_key_from_hashes(
-        tenant_hash,
-        int(scope.get("user_hash") or 0),
-        int(scope.get("session_hash") or 0),
-        int(scope.get("agent_hash") or 0),
-    )
+try:  # the implementation lives in matrixark_mcp_identity; this module re-exports it
+    from .matrixark_mcp_identity import canonical_scope_key
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_identity import canonical_scope_key
 
 
-def cache_scope_key(scope: Json) -> tuple:
-    """A scope key safe to put in a CACHE key, which canonical_scope_key is not.
-
-    canonical_scope_key returns "" for a scope carrying neither scope_key nor tenant_hash -- which
-    is exactly the shape of the documented public scope, {tenant_id, user_id, session_id}. Empty
-    is a fine answer to "what is this scope's canonical name"; it is a dangerous one for a cache
-    key, because every tenant then shares one entry and the second to ask a question is served the
-    first one's answer.
-
-    Reproduced against a shared adapter called with raw scopes: tenant B asked for its own data
-    and was given tenant A's, from both the retrieval-records cache and the context-pack cache.
-    The MCP entry point normalises the scope first, so the served paths are not affected today --
-    but nothing here said so, and a caller that skips normalisation gets cross-tenant answers with
-    no error to notice.
-
-    So this falls back to the raw identifiers rather than to "". It returns a tuple so the two
-    cases can never collide with each other.
-    """
-    canonical = canonical_scope_key(scope)
-    if canonical:
-        return ("k", canonical)
-    return (
-        "raw",
-        str(scope.get("tenant_id") or ""),
-        str(scope.get("user_id") or ""),
-        str(scope.get("session_id") or ""),
-        str(scope.get("agent_id") or ""),
-    )
+try:  # the implementation lives in matrixark_mcp_identity; this module re-exports it
+    from .matrixark_mcp_identity import cache_scope_key
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_identity import cache_scope_key
 
 
 def serving_scope_ref(scope: Json) -> Json:

--- a/tools/matrixark_mcp_core_node_tree.py
+++ b/tools/matrixark_mcp_core_node_tree.py
@@ -54,21 +54,20 @@ def node_prefixes(node_path: list[str]) -> list[list[str]]:
     return [node_path[: index + 1] for index in range(len(node_path))]
 
 
-def node_path_tuple(node_path: Any) -> tuple[str, ...]:
-    if not isinstance(node_path, list):
-        return ()
-    return tuple(str(part) for part in node_path if str(part))
+try:  # the implementation lives in matrixark_mcp_tree; this module re-exports it
+    from .matrixark_mcp_tree import node_path_tuple
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_tree import node_path_tuple
 
 
 def starts_with_path(path: tuple[str, ...], prefix: tuple[str, ...]) -> bool:
     return len(path) >= len(prefix) and path[: len(prefix)] == prefix
 
 
-def top_scored_nodes(nodes: list[Json], limit: int) -> list[Json]:
-    return sorted(
-        nodes,
-        key=lambda item: (-float(item.get("score", 0.0)), int(item.get("depth", 0)), str(item.get("node_path", []))),
-    )[:limit]
+try:  # the implementation lives in matrixark_mcp_tree; this module re-exports it
+    from .matrixark_mcp_tree import top_scored_nodes
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_tree import top_scored_nodes
 
 
 def tree_first_traversal(

--- a/tools/matrixark_mcp_core_scoring.py
+++ b/tools/matrixark_mcp_core_scoring.py
@@ -158,43 +158,22 @@ except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_scoring import time_decay_score
 
 
-def business_instance_weight(*sources: Json) -> float | None:
-    for source in sources:
-        if not isinstance(source, dict):
-            continue
-        for field in ["business_weight", "business_score", "importance", "priority"]:
-            if field in source:
-                return clamp01(source.get(field))
-    return None
+try:  # the implementation lives in matrixark_mcp_scoring; this module re-exports it
+    from .matrixark_mcp_scoring import business_instance_weight
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_scoring import business_instance_weight
 
 
-def business_type_score(type_name: str, type_weights: Json) -> float:
-    if not type_name:
-        return 0.5
-    normalized = type_name.lower()
-    if normalized in type_weights:
-        return clamp01(type_weights[normalized], 0.5)
-    if "approval" in normalized or "budget" in normalized:
-        return 0.9
-    if "correction" in normalized or "confirmation" in normalized:
-        return 1.0
-    if "preference" in normalized or "plan" in normalized or "status" in normalized:
-        return 0.75
-    return 0.5
+try:  # the implementation lives in matrixark_mcp_scoring; this module re-exports it
+    from .matrixark_mcp_scoring import business_type_score
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_scoring import business_type_score
 
 
-def business_score_for_candidate(candidate: Json, type_weights: Json) -> float:
-    instance = business_instance_weight(candidate, candidate.get("metadata", {}), candidate.get("scope", {}))
-    if instance is not None:
-        return instance
-    type_name = str(
-        candidate.get("event_type")
-        or candidate.get("entity_type")
-        or candidate.get("topic")
-        or candidate.get("ref_type")
-        or ""
-    )
-    return business_type_score(type_name, type_weights)
+try:  # the implementation lives in matrixark_mcp_scoring; this module re-exports it
+    from .matrixark_mcp_scoring import business_score_for_candidate
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_scoring import business_score_for_candidate
 
 
 def final_recall_score(origin_score: float, time_score: float, business_score: float, weights: Json) -> float:

--- a/tools/matrixark_mcp_extraction_normalization.py
+++ b/tools/matrixark_mcp_extraction_normalization.py
@@ -744,43 +744,10 @@ def clean_patch_value(value: str) -> str:
     return summarize_text(" ".join(value.split()).strip(" ,;:-"), limit=180)
 
 
-def canonical_entity_name(entity_type: str, value: str) -> str:
-    compact_value = " ".join(str(value or "").split()).strip(" ,;:-")
-    if entity_type in {
-        "preference",
-        "location",
-        "job_status",
-        "current_plan",
-        "family_profile",
-        "identity_profile",
-        "communication_profile",
-        "memory_feature_profile",
-        "workspace_profile",
-        "correction",
-        "confirmation",
-        "assistant_decision",
-        "tool_evidence",
-        *CODEX_OUTCOME_ENTITY_TYPES,
-    }:
-        return entity_type
-    if entity_type == "approval_state":
-        subject = compact_value
-        subject_patterns = [
-            r"^(?:the\s+)?(.+?)\s+(?:is|was|are|were|has been|have been)\s+(?:approved|required|missing|blocked|ready|done|complete|needed)\b",
-            r"^(?:the\s+)?(.+?)\s+as\s+(?:a\s+|an\s+|the\s+)?(?:blocker|requirement|approval|decision|status)\b",
-            r"^(?:the\s+)?(.+?)\s+after\b",
-            r"^(?:the\s+)?(.+?)\s+before\b",
-            r"^(?:the\s+)?(.+?)\s+because\b",
-            r"^(?:the\s+)?(.+?)\s+as\b",
-        ]
-        for pattern in subject_patterns:
-            match = re.search(pattern, subject, flags=re.IGNORECASE)
-            if match:
-                subject = match.group(1)
-                break
-        subject = re.sub(r"^(?:the|a|an)\s+", "", subject, flags=re.IGNORECASE).strip(" ,;:-")
-        return summarize_text(subject or compact_value, limit=80) if (subject or compact_value) else entity_type
-    return compact_value[:80] if compact_value else entity_type
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import canonical_entity_name
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import canonical_entity_name
 
 
 def entity_retention_priority(entity: Json) -> int:

--- a/tools/matrixark_mcp_resources.py
+++ b/tools/matrixark_mcp_resources.py
@@ -146,18 +146,10 @@ def debug_resource_metadata(metadata: Json) -> Json:
     return debug
 
 
-def source_locator_from_ref(source_ref: str, raw_uri: str) -> str:
-    source_ref = str(source_ref or "")
-    raw_uri = str(raw_uri or "")
-    if not source_ref:
-        return ""
-    if raw_uri and source_ref == raw_uri:
-        return ""
-    if raw_uri and source_ref.startswith(raw_uri + "#"):
-        return source_ref.partition("#")[2]
-    if "#" in source_ref:
-        return source_ref.partition("#")[2]
-    return source_ref
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import source_locator_from_ref
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import source_locator_from_ref
 
 
 def source_ref_from_locator(raw_uri: str, source_locator: str) -> str:
@@ -424,11 +416,10 @@ def resolve_raw_resource_for_ingest(args: Json, envelope: Json, raw_uri: str, re
     return result
 
 
-def infer_resource_suffix(resource_type: str, raw_uri: str) -> str:
-    suffix = (resource_type or "").lower().lstrip(".")
-    if not suffix and raw_uri and raw_uri != "inline-resource":
-        suffix = Path(raw_uri).suffix.lower().lstrip(".")
-    return suffix or "txt"
+try:  # the implementation lives in matrixark_mcp_core_resource_io; this module re-exports it
+    from .matrixark_mcp_core_resource_io import infer_resource_suffix
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_resource_io import infer_resource_suffix
 
 
 def rewrite_chunk_uris(chunks: list[Any], *, parse_uri: str, stored_raw_uri: str) -> list[Any]:
@@ -466,14 +457,10 @@ def rewrite_chunk_uris(chunks: list[Any], *, parse_uri: str, stored_raw_uri: str
     return rewritten
 
 
-def cleanup_temp_paths(paths: list[str]) -> None:
-    for path_text in paths:
-        try:
-            path = Path(path_text)
-            if path.exists() and path.is_dir() and path.name.startswith("matrixark-"):
-                shutil.rmtree(path, ignore_errors=True)
-        except Exception:
-            pass
+try:  # the implementation lives in matrixark_mcp_core_resource_io; this module re-exports it
+    from .matrixark_mcp_core_resource_io import cleanup_temp_paths
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_resource_io import cleanup_temp_paths
 
 
 def aggregate_parse_warnings_from_chunks(chunks: list[Any]) -> list[str]:

--- a/tools/matrixark_mcp_session_runtime.py
+++ b/tools/matrixark_mcp_session_runtime.py
@@ -494,17 +494,10 @@ def session_event_message_count(records: list[Json]) -> int:
     return sum(len(messages_from_event_record(record)) for record in records)
 
 
-def session_events_by_message_limit(records: list[Json], limit: int | None) -> list[Json]:
-    if limit is None:
-        return records
-    selected: list[Json] = []
-    message_count = 0
-    for record in records:
-        selected.append(record)
-        message_count += max(1, len(messages_from_event_record(record)))
-        if message_count >= limit:
-            break
-    return selected
+try:  # the implementation lives in matrixark_mcp_local_adapter; this module re-exports it
+    from .matrixark_mcp_local_adapter import session_events_by_message_limit
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_local_adapter import session_events_by_message_limit
 
 
 def append_session_commit_task_progress(

--- a/tools/probe_oss_reader_memory_capability.py
+++ b/tools/probe_oss_reader_memory_capability.py
@@ -159,12 +159,10 @@ def call_reader(base_url: str, model: str, question: str, context: str, *, timeo
         return f"reader_error:{type(exc).__name__}:{exc}"
 
 
-def probe_reader(base_url: str) -> bool:
-    try:
-        with urllib.request.urlopen(base_url.rstrip("/") + "/models", timeout=10) as resp:
-            return 200 <= resp.status < 300
-    except Exception:
-        return False
+try:  # the implementation lives in check_oss_model_readiness; this module re-exports it
+    from .check_oss_model_readiness import endpoint_reachable
+except ImportError:  # Direct script execution from tools/.
+    from check_oss_model_readiness import endpoint_reachable
 
 
 def answer_matches(answer: str, accepted: list[str]) -> bool:
@@ -189,12 +187,10 @@ def percentile(values: list[float], pct: float) -> float:
     return round(ordered[low] * (1 - frac) + ordered[high] * frac, 3)
 
 
-def finish(report: dict[str, Any], path: str, started: float, code: int) -> int:
-    report["duration_seconds"] = round(time.time() - started, 3)
-    report["ready"] = code == 0 and not report.get("blockers")
-    Path(path).write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
-    print(path)
-    return code
+try:  # the implementation lives in run_external_baseline_direct_retrieval; this module re-exports it
+    from .run_external_baseline_direct_retrieval import finish
+except ImportError:  # Direct script execution from tools/.
+    from run_external_baseline_direct_retrieval import finish
 
 
 if __name__ == "__main__":

--- a/tools/run_context_shared_cases.py
+++ b/tools/run_context_shared_cases.py
@@ -112,16 +112,10 @@ def run_command(command: str, cwd: Path) -> None:
     subprocess.run(command, cwd=cwd, shell=True, check=True)
 
 
-def render_native_command(template: str, corpus: Path, case: str, native_repo: Path | None) -> str:
-    values = {
-        "corpus": shlex.quote(str(corpus)),
-        "case": shlex.quote(case),
-    }
-    if native_repo is not None:
-        values["native_repo"] = shlex.quote(str(native_repo))
-    if any(f"{{{key}}}" in template for key in values):
-        return template.format(**values)
-    return f"{template} --corpus {shlex.quote(str(corpus))} --case {shlex.quote(case)}"
+try:  # the implementation lives in run_raft_shared_cases; this module re-exports it
+    from .run_raft_shared_cases import render_native_command
+except ImportError:  # Direct script execution from tools/.
+    from run_raft_shared_cases import render_native_command
 
 
 def main() -> int:

--- a/tools/run_control_plane_shared_cases.py
+++ b/tools/run_control_plane_shared_cases.py
@@ -152,16 +152,10 @@ def run_command(command: str, cwd: Path) -> None:
         subprocess.run(command, cwd=cwd, shell=True, check=True)
 
 
-def render_native_command(template: str, corpus: Path, case: str, native_repo: Path | None) -> str:
-    values = {
-        "corpus": shlex.quote(str(corpus)),
-        "case": shlex.quote(case),
-    }
-    if native_repo is not None:
-        values["native_repo"] = shlex.quote(str(native_repo))
-    if any(f"{{{key}}}" in template for key in values):
-        return template.format(**values)
-    return f"{template} --corpus {shlex.quote(str(corpus))} --case {shlex.quote(case)}"
+try:  # the implementation lives in run_raft_shared_cases; this module re-exports it
+    from .run_raft_shared_cases import render_native_command
+except ImportError:  # Direct script execution from tools/.
+    from run_raft_shared_cases import render_native_command
 
 
 def main() -> int:

--- a/tools/run_external_baseline_direct_retrieval.py
+++ b/tools/run_external_baseline_direct_retrieval.py
@@ -286,50 +286,16 @@ def extract_candidate_hint(question: str, context: str) -> str:
     return best_sentence[:500]
 
 
-def call_reader(
-    base_url: str,
-    model: str,
-    question: str,
-    context: str,
-    *,
-    timeout: float,
-    max_tokens: int,
-) -> str:
-    payload = {
-        "model": model,
-        "messages": [
-            {
-                "role": "system",
-                "content": OSS_READER_SYSTEM_PROMPT,
-            },
-            {
-                "role": "user",
-                "content": f"Question: {question}\nContext:\n{context}\nAnswer:",
-            },
-        ],
-        "temperature": 0,
-        "max_tokens": max_tokens,
-    }
-    req = urllib.request.Request(
-        base_url.rstrip("/") + "/chat/completions",
-        data=json.dumps(payload).encode("utf-8"),
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            data = json.loads(resp.read().decode("utf-8", errors="replace"))
-        return str(data["choices"][0]["message"]["content"]).strip()
-    except Exception as exc:
-        return f"reader_error:{type(exc).__name__}:{exc}"
+try:  # the implementation lives in run_external_baseline_longmem_source_retrieval; this module re-exports it
+    from .run_external_baseline_longmem_source_retrieval import call_reader
+except ImportError:  # Direct script execution from tools/.
+    from run_external_baseline_longmem_source_retrieval import call_reader
 
 
-def probe_reader(base_url: str) -> bool:
-    try:
-        with urllib.request.urlopen(base_url.rstrip("/") + "/models", timeout=10) as resp:
-            return 200 <= resp.status < 300
-    except Exception:
-        return False
+try:  # the implementation lives in check_oss_model_readiness; this module re-exports it
+    from .check_oss_model_readiness import endpoint_reachable
+except ImportError:  # Direct script execution from tools/.
+    from check_oss_model_readiness import endpoint_reachable
 
 
 def answer_matches(expected: str, actual: str, context: str) -> bool:
@@ -362,25 +328,16 @@ def token_count(text: str) -> int:
     return len(WORD_RE.findall(text))
 
 
-def reduction_percent(retrieved: int, source: int) -> float:
-    if source <= 0:
-        return 0.0
-    return round(100.0 * (1.0 - (retrieved / source)), 4)
+try:  # the implementation lives in run_external_baseline_longmem_source_retrieval; this module re-exports it
+    from .run_external_baseline_longmem_source_retrieval import reduction_percent
+except ImportError:  # Direct script execution from tools/.
+    from run_external_baseline_longmem_source_retrieval import reduction_percent
 
 
-def percentile(values: list[float], pct: float) -> float:
-    if not values:
-        return 0.0
-    ordered = sorted(values)
-    if len(ordered) == 1:
-        return round(ordered[0], 3)
-    rank = (len(ordered) - 1) * (pct / 100.0)
-    low = math.floor(rank)
-    high = math.ceil(rank)
-    if low == high:
-        return round(ordered[int(rank)], 3)
-    value = ordered[low] * (high - rank) + ordered[high] * (rank - low)
-    return round(value, 3)
+try:  # the implementation lives in run_external_baseline_longmem_source_retrieval; this module re-exports it
+    from .run_external_baseline_longmem_source_retrieval import percentile
+except ImportError:  # Direct script execution from tools/.
+    from run_external_baseline_longmem_source_retrieval import percentile
 
 
 def load_matrixark_reference(path: str) -> dict[str, Any]:

--- a/tools/run_external_baseline_locomo_source_retrieval.py
+++ b/tools/run_external_baseline_locomo_source_retrieval.py
@@ -562,25 +562,16 @@ def normalized_model_name(value: Any) -> str:
     return re.sub(r"[^a-z0-9._:-]+", "", str(value or "").strip().lower())
 
 
-def percentile(values: list[float], pct: float) -> float:
-    if not values:
-        return 0.0
-    ordered = sorted(values)
-    if len(ordered) == 1:
-        return round(ordered[0], 3)
-    rank = (len(ordered) - 1) * (pct / 100.0)
-    low = math.floor(rank)
-    high = math.ceil(rank)
-    if low == high:
-        return round(ordered[int(rank)], 3)
-    value = ordered[low] * (high - rank) + ordered[high] * (rank - low)
-    return round(value, 3)
+try:  # the implementation lives in run_external_baseline_longmem_source_retrieval; this module re-exports it
+    from .run_external_baseline_longmem_source_retrieval import percentile
+except ImportError:  # Direct script execution from tools/.
+    from run_external_baseline_longmem_source_retrieval import percentile
 
 
-def reduction_percent(retrieved: int, source: int) -> float:
-    if source <= 0:
-        return 0.0
-    return round(100.0 * (1.0 - (retrieved / source)), 4)
+try:  # the implementation lives in run_external_baseline_longmem_source_retrieval; this module re-exports it
+    from .run_external_baseline_longmem_source_retrieval import reduction_percent
+except ImportError:  # Direct script execution from tools/.
+    from run_external_baseline_longmem_source_retrieval import reduction_percent
 
 
 def finish_with_contract_gate(report: dict[str, Any], path: str, started: float, require_contract: bool) -> int:

--- a/tools/run_external_baseline_longmem_source_retrieval.py
+++ b/tools/run_external_baseline_longmem_source_retrieval.py
@@ -448,12 +448,10 @@ def call_reader(base_url: str, model: str, question: str, context: str, *, timeo
         return f"reader_error:{type(exc).__name__}:{exc}"
 
 
-def probe_reader(base_url: str) -> bool:
-    try:
-        with urllib.request.urlopen(base_url.rstrip("/") + "/models", timeout=10) as resp:
-            return 200 <= resp.status < 300
-    except Exception:
-        return False
+try:  # the implementation lives in check_oss_model_readiness; this module re-exports it
+    from .check_oss_model_readiness import endpoint_reachable
+except ImportError:  # Direct script execution from tools/.
+    from check_oss_model_readiness import endpoint_reachable
 
 
 def answer_matches(expected: str, actual: str) -> bool:

--- a/tools/run_ingestion_shared_cases.py
+++ b/tools/run_ingestion_shared_cases.py
@@ -82,16 +82,10 @@ def run_command(command: str, cwd: Path) -> None:
     subprocess.run(command, cwd=cwd, shell=True, check=True)
 
 
-def render_native_command(template: str, corpus: Path, case: str, native_repo: Path | None) -> str:
-    values = {
-        "corpus": shlex.quote(str(corpus)),
-        "case": shlex.quote(case),
-    }
-    if native_repo is not None:
-        values["native_repo"] = shlex.quote(str(native_repo))
-    if any(f"{{{key}}}" in template for key in values):
-        return template.format(**values)
-    return f"{template} --corpus {shlex.quote(str(corpus))} --case {shlex.quote(case)}"
+try:  # the implementation lives in run_raft_shared_cases; this module re-exports it
+    from .run_raft_shared_cases import render_native_command
+except ImportError:  # Direct script execution from tools/.
+    from run_raft_shared_cases import render_native_command
 
 
 def main() -> int:


### PR DESCRIPTION
Twenty-six more functions that existed as several byte-identical copies are now one. The body stays
where it is and the other modules import it.

This round extends the analysis in three ways, each because something went wrong without it.

## Groups of more than two

The rules were never specific to pairs, but the tool only handled them, so `stable_hash` — three
copies — sat in a skip bucket **while blocking three other groups**, which could not consolidate
while a helper they both call resolved differently in each module. One copy owns the body and every
other imports it. Generalising unlocked a cascade, and the work now runs to a fixpoint: refusals
are transitive, so consolidating a helper unblocks its callers on the next pass. Three passes
converged.

## Cycles are checked cumulatively

Each group was checked against the import graph as it was at the start of the pass. Two groups can
each be cycle-free alone and together close one — which is how `matrixark_mcp_core` ended up
partially initialised, a circular import that no single decision was responsible for. Every
accepted edge now joins the working graph before the next group is considered.

## A consolidation must not change what production reaches

Choosing an owner inside a module production does not reach makes the importer depend on it, which
turns a dead island live. That is an architectural change and not something to do as a side effect
of removing duplication. `test_a_module_only_tests_reach_is_not_live` records that set — 7 islands,
43 modules — and it noticed:

```
NO LONGER UNREACHABLE (wired up or deleted -- take them out of the list):
  ['matrixark_mcp_session_runtime']
```

The tempting response is to edit the recorded list. The right one is to leave the island alone.
That guard's own record is now what the analysis consults; approximating it as "some non-test
module imports it" is a different question, because a module imported only by other unreachable
modules still has inbound imports — and a second module was wired up before that became clear.

## Still refused

Twenty-six groups remain, and the reasons are worth stating because they are not oversights:

- **11 blocked by `MatrixArkError`**, which is two classes in different modules rather than a
  duplicated function. Collapsing exception classes changes what `except` clauses catch and is its
  own change.
- the rest read a helper — `safe_identifier`, `now_ms`, `tokens` — that each module binds
  differently, so consolidating would switch which one runs. Some of those helpers are themselves
  genuinely different functions that happen to share a name.

## Verification

By **object identity**: `owner.f is importer.f` for all 72 consolidations in the tree, every
module's `__all__` still resolving, and every file still parsing.

The whole `tools/` suite (381 files) ran before and after, with the control **pinned to this exact
commit** so main cannot move underneath it: **345 pass / 40 fail on both, zero tests failing only
after.** All 40 remaining failures fail identically on both trees.
