### PR TITLE
A shard pin could be set and read one at a time, but not surveyed

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -1146,6 +1146,21 @@ pub struct ShardListEntry {
     /// divergence check makes before it is willing to judge a server.
     #[serde(default)]
     pub owner_reports_loaded: Option<bool>,
+    /// Where this shard in particular was pinned, empty when it follows
+    /// whatever its table prefers.
+    ///
+    /// A pin that can only be read one shard at a time cannot answer the
+    /// question it exists for -- which shards are pinned, and where -- without a
+    /// request for every shard in the cluster.
+    #[serde(default)]
+    pub preferred_location: String,
+    /// When this shard first joined.
+    ///
+    /// Recorded so a shard that has been here for a week can be told from one
+    /// that arrived during the incident, which is a comparison across shards,
+    /// so it belongs where shards are listed.
+    #[serde(default)]
+    pub registered_at_ms: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -8575,6 +8590,111 @@ fn counting_resources_agrees_with_listing_them_and_counting_those() {
             peer.is_meta_change_muted(),
             "a peer inheriting a muted leader resumed making changes"
         );
+    }
+
+    #[test]
+    fn listing_shards_says_which_are_pinned_and_when_they_joined() {
+        let meta = SingleNodeMeta::default();
+        assert!(meta
+            .register_server(RegisterServerRequest {
+                numa_nodes: Vec::new(),
+                server_addr: "node-a".to_string(),
+                node_id: 1,
+                location: "rack-1".to_string(),
+                binary_version: "v1".to_string(),
+                registered_at_ms: 0,
+            })
+            .status
+            .ok);
+        assert!(meta
+            .add_table(AddTableRequest {
+                namespace: "ns".to_string(),
+                table_name: "t".to_string(),
+                first_shard_id: 1,
+                shard_count: 3,
+                replica_count: 1,
+                partition_version: 1,
+                serving_options: Default::default(),
+            })
+            .status
+            .ok);
+        for shard_id in 1..=3u64 {
+            assert!(meta
+                .register(RegisterShardRequest {
+                    shard_id,
+                    server_addr: "node-a".to_string(),
+                    registered_at_ms: 0,
+                })
+                .status
+                .ok);
+        }
+        // One of the three wants its own hardware.
+        assert!(meta
+            .pin_shard(ShardPinRequest {
+                shard_id: 2,
+                location: "rack-9".to_string(),
+            })
+            .status
+            .ok);
+
+        let listed = meta.list_shards(ListShardsRequest {
+            server_addr: String::new(),
+            after_shard_id: 0,
+            limit: 0,
+        });
+        assert!(listed.status.ok);
+        assert_eq!(listed.shards.len(), 3);
+
+        // The question the pin exists for -- which shards are pinned, and where
+        // -- answered from the listing rather than a request per shard.
+        let pinned = listed
+            .shards
+            .iter()
+            .filter(|entry| !entry.preferred_location.is_empty())
+            .map(|entry| (entry.shard_id, entry.preferred_location.clone()))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            pinned,
+            vec![(2, "rack-9".to_string())],
+            "the listing does not say which shard is pinned"
+        );
+
+        // And the unpinned ones say so rather than saying nothing.
+        for entry in &listed.shards {
+            if entry.shard_id != 2 {
+                assert!(
+                    entry.preferred_location.is_empty(),
+                    "shard {} is not pinned but the listing gives it a location",
+                    entry.shard_id
+                );
+            }
+        }
+
+        // The join time is carried too, and it is a real time rather than the
+        // zero the caller sent -- the metaserver stamps it on the way in.
+        for entry in &listed.shards {
+            assert!(
+                entry.registered_at_ms > 0,
+                "shard {} was listed without the time it joined",
+                entry.shard_id
+            );
+        }
+
+        // What the listing says matches what asking about that one shard says,
+        // so the two read paths cannot drift.
+        for entry in &listed.shards {
+            let one = meta.get(entry.shard_id).location.expect("registered");
+            assert_eq!(
+                one.preferred_location, entry.preferred_location,
+                "shard {}: the listing and the single read disagree on the pin",
+                entry.shard_id
+            );
+            assert_eq!(
+                one.registered_at_ms, entry.registered_at_ms,
+                "shard {}: the listing and the single read disagree on the join time",
+                entry.shard_id
+            );
+        }
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/meta/lifecycle.rs
+++ b/crates/temporalstore-rust/src/meta/lifecycle.rs
@@ -279,6 +279,8 @@ impl SingleNodeMeta {
                 latest_snapshot: location.latest_snapshot.clone(),
                 state: location.state,
                 owner_reports_loaded,
+                preferred_location: location.preferred_location.clone(),
+                registered_at_ms: location.registered_at_ms,
             });
         }
 

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -7156,6 +7156,9 @@ mod tests {
                                     // This stub does not model a datanode
                                     // reporting what it holds.
                                     owner_reports_loaded: None,
+                                    // Nor a pin, nor when the shard joined.
+                                    preferred_location: String::new(),
+                                    registered_at_ms: 0,
                                 })
                                 .collect(),
                             next_after_shard_id: None,
@@ -7245,6 +7248,9 @@ mod tests {
                                 // This stub does not model a datanode reporting
                                 // what it holds.
                                 owner_reports_loaded: None,
+                                // Nor a pin, nor when the shard joined.
+                                preferred_location: String::new(),
+                                registered_at_ms: 0,
                             })
                             .collect(),
                         next_after_shard_id: None,


### PR DESCRIPTION
A shard can be pinned to a location of its own, and the metaserver records when each shard joined. Both live on the shard, and both come back when you ask about one shard. Neither appeared when you listed them.

So "which shards are pinned, and where?" -- the question you ask before draining a node, or after a rebalance declined to move something -- cost one request per shard in the cluster. In practice that means it does not get asked.

The same holds for when a shard joined. It is recorded so a shard that has been here a week can be told from one that arrived during the incident, and that is a comparison across shards, so it belongs where shards are listed.

## What changed

Two fields on the listing entry, filled from the shard the entry describes. Both carry serde defaults, so a caller reading the older shape is unaffected.

Two stubs in the proxy tests synthesise a listing to answer a request with a fixed set of shards; neither models a pin or a join time, and both now say so rather than inventing values.

## Testing

Three shards, one of them pinned. The listing is asked which shards are pinned and answers with exactly the one, and the other two report no pin rather than reporting nothing.

The join time is checked to be a real stamp rather than the zero the caller sent, because the metaserver sets it on the way in and overwrites whatever arrived.

And every entry in the listing is compared against asking about that shard on its own. That is the check that matters here: this omission existed because the two read paths disagreed about what a shard is, and the check makes them disagree loudly.

Checked against mutations, one per field. Stop carrying the pin and the test fails saying the listing does not say which shard is pinned; stop carrying the join time and it fails naming the shard listed without one.

## Why only here

Servers, proxies and tables are listed by handing back their records as they are, so nothing can fall out of them. Shards are the one resource listed through a reduced entry built field by field -- which is why a field added to the shard did not reach the listing, and why this is the only listing with the problem.
