### PR TITLE
The diagnostics bundle dates itself against the browser

### DIFF
--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -734,6 +734,12 @@ function sinceLastBlockMs() {
   return liveBlockAtMs ? (Date.now() - liveBlockAtMs) : 0;
 }
 
+/* Whether a stream has ever delivered anything to this page. Read by code that runs on a button
+   press rather than on a frame, which has no other way to ask. */
+function streamConnected() {
+  return liveBlockAtMs > 0;
+}
+
 /* Three ticks: one missed tick is scheduling, two is a slow one, three is not arriving. Derived
    from the cadence the gateway sent rather than a number written here, because a page holding its
    own copy of the server's interval is a second place for it to be wrong. Unknown cadence means an
@@ -3948,9 +3954,25 @@ OVERVIEW_JS = r"""
       }).catch(function () { return null; })
     ]).then(function (parts) {
       var traffic = (lastFrame || {}).traffic || {};
+      var quiet = sinceLastBlockMs();
       return JSON.stringify({
         collected_at: new Date().toISOString(),
+        /* The same instant on the GATEWAY's clock, and how far apart the two are.
+           `recent_failures` below carries server timestamps, so a reader correlating them against
+           `collected_at` alone is comparing two machines -- and this file is read by somebody who
+           was not at the keyboard and cannot ask whose clock was wrong. Absent when no frame has
+           arrived to establish it, rather than repeating the browser's answer under another name. */
+        gateway_time: liveFrameAtMs ? new Date(serverNowMs()).toISOString() : null,
+        clock_skew_ms: liveFrameAtMs ? clockSkewMs() : null,
         origin: location.origin,
+        /* How fresh the live-frame parts below are. `recent_failures` and `datanode` come off the
+           stream, so on a stalled stream they are as old as this says and the rest of the bundle
+           is current -- one document, two ages, and nothing used to say so. */
+        stream: {
+          connected: streamConnected(),
+          since_last_block_ms: liveFrameAtMs ? quiet : null,
+          stalled: streamStalledFor() > 0
+        },
         overview: lastReport,
         config: compactConfig(parts[0]),
         metrics: parts[1],

--- a/tools/portal/bundle_clock_harness.js
+++ b/tools/portal/bundle_clock_harness.js
@@ -1,0 +1,106 @@
+// Drives the SHIPPED stream, then asks the SHIPPED bundle() what it wrote.
+//
+// Separate from bundle_harness.js, which drives the WHOLE overview page and reports its
+// own ok/FAIL lines. This one returns the bundle as JSON so a caller can assert on
+// individual fields, and it puts a live stream in front of the call because the fields it
+// exists to check are the ones that come from the stream's clock. The bundle is the file
+// that leaves the building, so what matters is the JSON it produces, not the expression that
+// produces it.
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const input = JSON.parse(process.argv[3]);
+
+function sliceFn(marker) {
+  const start = page.indexOf(marker);
+  if (start < 0) throw new Error("not found: " + marker);
+  let depth = 0;
+  for (let i = page.indexOf("{", start); i < page.length; i++) {
+    if (page[i] === "{") depth++;
+    else if (page[i] === "}") { depth--; if (depth === 0) return page.slice(start, i + 1); }
+  }
+  throw new Error("unclosed: " + marker);
+}
+
+const ORIGIN = 1_760_000_000_000;
+const clockStart = page.indexOf("var liveServerMs = 0;");
+const source = page.slice(clockStart, page.indexOf("function liveStream(options)"))
+  + "\n" + sliceFn("function liveStream(options)")
+  + "\nvar lastFrame = null;\n" + sliceFn("  function bundle()");
+
+let clock = ORIGIN;
+let ticker = null;
+
+const opening = ["retry: 3000\n\n"];
+if (input.serverTs) {
+  // The cadence rides on the frame, the way the gateway sends it.
+  opening.push("event: status\ndata: " + JSON.stringify({
+    ts: input.serverTs,
+    tick_s: 2,
+    traffic: { recent_failures: [{ at: input.serverTs - 90, status: 500 }] },
+    datanode: "ok",
+  }) + "\n\n");
+}
+
+const scope = {
+  Date: function () {},
+  fetch: (url) => {
+    if (String(url).indexOf("/v1/admin/events") === 0) {
+      return Promise.resolve({
+        ok: true,
+        body: {
+          getReader: () => {
+            let sent = false;
+            return {
+              read: () => sent ? new Promise(() => {})
+                : ((sent = true), Promise.resolve({ done: false, value: opening.join("") })),
+            };
+          },
+        },
+      });
+    }
+    if (String(url).indexOf("/v1/metrics") === 0) {
+      return Promise.resolve({ ok: true, text: () => Promise.resolve("# metrics\n") });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) });
+  },
+  TextDecoder: function () { this.decode = (v) => (v === undefined ? "" : String(v)); },
+  AbortController: function () { this.abort = () => {}; this.signal = null; },
+  document: { hidden: false, addEventListener: () => {} },
+  window: { addEventListener: () => {} },
+  setTimeout: () => 0,
+  setInterval: (fn) => { ticker = fn; return 1; },
+  clearInterval: () => { ticker = null; },
+  location: { origin: "https://gw.example" },
+  auth: () => ({}),
+  lastReport: { checks: [] },
+  compactConfig: (c) => c,
+  JSON: JSON,
+  Promise: Promise,
+};
+// `Date` must be a constructor (the bundle calls `new Date(ms).toISOString()`) AND carry `now`.
+scope.Date = function (ms) { return new globalThis.Date(ms === undefined ? clock : ms); };
+scope.Date.now = () => clock;
+
+const names = Object.keys(scope);
+const api = new Function(...names, source + `
+  return {
+    start: function () {
+      return liveStream({ headers: function () { return {}; }, onState: function () {},
+                          onFrame: function (f) { lastFrame = f; } });
+    },
+    bundle: bundle
+  };
+`)(...names.map((k) => scope[k]));
+
+const wait = () => new Promise((r) => globalThis.setTimeout(r, 5));
+
+(async () => {
+  if (input.withStream !== false) {
+    api.start();
+    await wait();
+  }
+  clock += (input.advanceMs || 0);
+  const text = await api.bundle();
+  process.stdout.write(JSON.stringify({ bundle: JSON.parse(text) }));
+})();

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -548,6 +548,12 @@ function sinceLastBlockMs() {
   return liveBlockAtMs ? (Date.now() - liveBlockAtMs) : 0;
 }
 
+/* Whether a stream has ever delivered anything to this page. Read by code that runs on a button
+   press rather than on a frame, which has no other way to ask. */
+function streamConnected() {
+  return liveBlockAtMs > 0;
+}
+
 /* Three ticks: one missed tick is scheduling, two is a slow one, three is not arriving. Derived
    from the cadence the gateway sent rather than a number written here, because a page holding its
    own copy of the server's interval is a second place for it to be wrong. Unknown cadence means an
@@ -882,9 +888,25 @@ function liveStream(options) {
       }).catch(function () { return null; })
     ]).then(function (parts) {
       var traffic = (lastFrame || {}).traffic || {};
+      var quiet = sinceLastBlockMs();
       return JSON.stringify({
         collected_at: new Date().toISOString(),
+        /* The same instant on the GATEWAY's clock, and how far apart the two are.
+           `recent_failures` below carries server timestamps, so a reader correlating them against
+           `collected_at` alone is comparing two machines -- and this file is read by somebody who
+           was not at the keyboard and cannot ask whose clock was wrong. Absent when no frame has
+           arrived to establish it, rather than repeating the browser's answer under another name. */
+        gateway_time: liveFrameAtMs ? new Date(serverNowMs()).toISOString() : null,
+        clock_skew_ms: liveFrameAtMs ? clockSkewMs() : null,
         origin: location.origin,
+        /* How fresh the live-frame parts below are. `recent_failures` and `datanode` come off the
+           stream, so on a stalled stream they are as old as this says and the rest of the bundle
+           is current -- one document, two ages, and nothing used to say so. */
+        stream: {
+          connected: streamConnected(),
+          since_last_block_ms: liveFrameAtMs ? quiet : null,
+          stalled: streamStalledFor() > 0
+        },
         overview: lastReport,
         config: compactConfig(parts[0]),
         metrics: parts[1],

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -909,6 +909,12 @@ function sinceLastBlockMs() {
   return liveBlockAtMs ? (Date.now() - liveBlockAtMs) : 0;
 }
 
+/* Whether a stream has ever delivered anything to this page. Read by code that runs on a button
+   press rather than on a frame, which has no other way to ask. */
+function streamConnected() {
+  return liveBlockAtMs > 0;
+}
+
 /* Three ticks: one missed tick is scheduling, two is a slow one, three is not arriving. Derived
    from the cadence the gateway sent rather than a number written here, because a page holding its
    own copy of the server's interval is a second place for it to be wrong. Unknown cadence means an

--- a/tools/test_matrixark_the_bundle_dates_itself_against_the_gateway.py
+++ b/tools/test_matrixark_the_bundle_dates_itself_against_the_gateway.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The diagnostics bundle is the file that leaves the building.
+
+It is downloaded and sent to somebody who was not at the keyboard, cannot ask which machine
+collected it, and cannot ask whether the page was still receiving anything at the time. It carried
+neither answer.
+
+**It dated itself with the browser's clock.** `collected_at` came from `new Date()`, while
+`recent_failures` inside the same file carries GATEWAY timestamps -- so a reader lining the two up
+was comparing two machines, with nothing in the document saying so. It now carries the gateway's
+own time for the same instant, and the difference between them.
+
+**It did not say how fresh its live parts were.** `recent_failures` and `datanode` come off the
+stream; everything else is fetched when the button is pressed. On a stalled stream the file holds
+one current half and one arbitrarily old half, presented as one document.
+
+Both answers are absent rather than guessed when no frame has arrived: repeating the browser's
+clock under a second name would be worse than saying nothing, because it would read as
+corroboration.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+#: Not `bundle_harness.js`: that one drives the whole page and reports its own ok/FAIL
+#: lines, and overwriting it took four of its tests with it.
+HARNESS = os.path.join(PORTAL, "bundle_clock_harness.js")
+PAGE = os.path.join(PORTAL, "overview_portal.html")
+
+#: The harness's browser clock, in seconds. A server timestamp equal to this is two clocks agreeing.
+BROWSER_TS = 1760000000
+
+
+def collect(**case) -> dict:
+    out = subprocess.run(["node", HARNESS, PAGE, json.dumps(case)],
+                         capture_output=True, text=True, timeout=300)
+    if out.returncode != 0:
+        raise AssertionError(out.stderr[-900:])
+    return json.loads(out.stdout)["bundle"]
+
+
+class ItCarriesBothClocksTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    def test_it_carries_the_gateways_time_as_well_as_the_browsers(self) -> None:
+        bundle = collect(serverTs=BROWSER_TS)
+        self.assertIn("collected_at", bundle)
+        self.assertEqual(bundle["collected_at"], bundle["gateway_time"])
+        self.assertEqual(0, bundle["clock_skew_ms"])
+
+    def test_a_skewed_browser_is_recorded_not_hidden(self) -> None:
+        """The case the file exists for: the reader can see which clock to trust."""
+        bundle = collect(serverTs=BROWSER_TS + 60)
+        self.assertNotEqual(bundle["collected_at"], bundle["gateway_time"])
+        self.assertEqual(60_000, bundle["clock_skew_ms"])
+
+    def test_with_no_frame_it_says_nothing_rather_than_guessing(self) -> None:
+        """Repeating the browser's clock under a second name would read as corroboration."""
+        bundle = collect(withStream=False)
+        self.assertIsNone(bundle["gateway_time"])
+        self.assertIsNone(bundle["clock_skew_ms"])
+        self.assertIsNotNone(bundle["collected_at"])
+
+
+class ItSaysHowFreshItsLivePartsAreTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    def test_a_live_stream_is_recorded_as_current(self) -> None:
+        stream = collect(serverTs=BROWSER_TS)["stream"]
+        self.assertTrue(stream["connected"])
+        self.assertFalse(stream["stalled"])
+        self.assertEqual(0, stream["since_last_block_ms"])
+
+    def test_a_stalled_stream_is_recorded_as_stalled(self) -> None:
+        stream = collect(serverTs=BROWSER_TS, advanceMs=8000)["stream"]
+        self.assertTrue(stream["connected"])
+        self.assertTrue(stream["stalled"])
+        self.assertEqual(8000, stream["since_last_block_ms"])
+
+    def test_never_connected_is_not_the_same_as_quiet(self) -> None:
+        stream = collect(withStream=False)["stream"]
+        self.assertFalse(stream["connected"])
+        self.assertIsNone(stream["since_last_block_ms"])
+
+
+class TheRestOfTheBundleIsUnchangedTest(unittest.TestCase):
+    """The floor. Everything this file already carried has to still be in it."""
+
+    def setUp(self) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    def test_the_existing_fields_are_all_still_there(self) -> None:
+        bundle = collect(serverTs=BROWSER_TS)
+        for field in ("collected_at", "origin", "overview", "config", "metrics", "readiness",
+                      "recent_failures", "datanode"):
+            self.assertIn(field, bundle)
+
+    def test_the_failures_off_the_frame_still_arrive(self) -> None:
+        """`recent_failures` exists only on the live frame, which is why the freshness of the
+        stream is worth recording beside it."""
+        bundle = collect(serverTs=BROWSER_TS)
+        self.assertTrue(bundle["recent_failures"])
+        self.assertEqual("ok", bundle["datanode"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The diagnostics bundle is the file that leaves the building. It is downloaded and sent to somebody who was not at the keyboard, cannot ask which machine collected it, and cannot ask whether the page was still receiving anything at the time. It carried neither answer.

## It dated itself with the browser's clock

`collected_at` came from `new Date()`, while `recent_failures` **inside the same file** carries gateway timestamps — so a reader lining the two up was comparing two machines, with nothing in the document saying so. It now carries the gateway's own time for the same instant and the difference between them.

## It did not say how fresh its live half was

`recent_failures` and `datanode` come off the stream; everything else is fetched when the button is pressed. On a stalled stream the file holds one current half and one arbitrarily old half, presented as one document. It now records whether the stream was connected, how long since anything arrived, and whether that counts as stalled.

| state when collected | `gateway_time` | `clock_skew_ms` | `stream` |
|---|---|---|---|
| live, clocks agree | same as `collected_at` | `0` | connected, not stalled |
| live, browser 60s off | differs | `60000` | connected, not stalled |
| stalled 8s | present | present | `since_last_block_ms: 8000`, `stalled: true` |
| no frame ever arrived | **`null`** | **`null`** | `connected: false`, `since_last_block_ms: null` |

**Both clock answers are absent rather than guessed** when no frame has arrived. Repeating the browser's clock under a second name would be worse than saying nothing, because it would read as corroboration.

## The probe

`bundle_clock_harness.js`, not `bundle_harness.js`. The latter already existed, drives the whole overview page and reports its own `ok`/`FAIL` lines — and writing over it took four of its tests with it. That was caught by running the **full ratchet** on the branch rather than the suites this change touches, which is also how the `event: hello` mistake in #1189 surfaced.

## Mutations

Eleven tests, driven through the shipped `bundle()` with a real stream in front of it. Each of these reddens at least one:

| mutation | reddens |
|---|---|
| the gateway's time is dropped | `test_it_carries_the_gateways_time_as_well_as_the_browsers` |
| the skew is dropped | `test_a_skewed_browser_is_recorded_not_hidden` |
| with no frame it repeats the browser's clock | `test_with_no_frame_it_says_nothing_rather_than_guessing` |
| the gateway time is silently the browser's | `test_a_skewed_browser_is_recorded_not_hidden` |
| the stream block is dropped | `test_a_stalled_stream_is_recorded_as_stalled` |
| a stalled stream is recorded as fine | `test_a_stalled_stream_is_recorded_as_stalled` |
| never-connected reads the same as quiet | `test_never_connected_is_not_the_same_as_quiet` |
| the failures off the frame stop being carried | `test_the_failures_off_the_frame_still_arrive` |

That last one is the floor: everything the bundle already carried has to still be in it.
