### PR TITLE
One MatrixArkError, not two

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -881,18 +881,10 @@ def build_segment_prompt(messages: list[Json]) -> str:
     )
 
 
-def parse_first_json_object(text: str) -> Json:
-    decoder = json.JSONDecoder()
-    for index, char in enumerate(text):
-        if char != "{":
-            continue
-        try:
-            value, _end = decoder.raw_decode(text[index:])
-        except json.JSONDecodeError:
-            continue
-        if isinstance(value, dict):
-            return value
-    raise MatrixArkError("model response did not contain a JSON object")
+try:  # the implementation lives in matrixark_mcp_extraction_provider; this module re-exports it
+    from .matrixark_mcp_extraction_provider import parse_first_json_object
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_extraction_provider import parse_first_json_object
 
 
 def oss_model_memory_segments(messages: list[Json], *, model: str, model_path: str = "", max_new_tokens: int = 512, local_only: bool = False) -> Json:

--- a/tools/matrixark_mcp_core_extraction.py
+++ b/tools/matrixark_mcp_core_extraction.py
@@ -84,36 +84,10 @@ except ImportError:  # top-level path (matrixark_mcp_core)
 __all__ = ['openai_compatible_json_call', 'anthropic_json_call', 'normalize_entity_operator', 'normalize_extracted_entities', 'normalize_extracted_segments', 'normalize_extracted_facts', 'openai_compatible_one_pass_memory_extraction', 'anthropic_one_pass_memory_extraction', 'openai_compatible_resource_facts', 'compact_internal_extraction', 'ONE_PASS_MEMORY_SCHEMA']
 
 
-def openai_compatible_json_call(*, system: str, user: str, model: str | None = None, max_tokens: int | None = None) -> Json:
-    payload = {
-        "model": model or EXTRACTION_LLM_MODEL,
-        "messages": [
-            {"role": "system", "content": system},
-            {"role": "user", "content": user},
-        ],
-        "temperature": 0,
-        "max_tokens": max_tokens or EXTRACTION_LLM_MAX_TOKENS,
-        "response_format": {"type": "json_object"},
-    }
-    headers = {"Content-Type": "application/json"}
-    api_key = os.environ.get(EXTRACTION_LLM_API_KEY_ENV, "")
-    if api_key:
-        headers["Authorization"] = f"Bearer {api_key}"
-    request = urllib.request.Request(
-        f"{EXTRACTION_LLM_BASE_URL}/chat/completions",
-        data=json.dumps(payload).encode("utf-8"),
-        headers=headers,
-        method="POST",
-    )
-    try:
-        with urllib.request.urlopen(request, timeout=EXTRACTION_LLM_TIMEOUT_SEC) as response:
-            data = json.loads(response.read().decode("utf-8"))
-        content = str(data.get("choices", [{}])[0].get("message", {}).get("content", "")).strip()
-        if not content:
-            raise MatrixArkError("OpenAI-compatible extraction provider returned empty content")
-        return parse_first_json_object(content)
-    except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError, MatrixArkError) as exc:
-        raise MatrixArkError(f"OpenAI-compatible extraction provider failed: {exc}") from exc
+try:  # the implementation lives in matrixark_mcp_extraction_provider; this module re-exports it
+    from .matrixark_mcp_extraction_provider import openai_compatible_json_call
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_extraction_provider import openai_compatible_json_call
 
 
 def anthropic_json_call(*, system: str, user: str, model: str | None = None, max_tokens: int | None = None) -> Json:

--- a/tools/matrixark_mcp_core_identity.py
+++ b/tools/matrixark_mcp_core_identity.py
@@ -81,8 +81,14 @@ def json_text(value: Json) -> Json:
     }
 
 
-class MatrixArkError(ValueError):
-    pass
+# One class, not two. This was written out here as well as in matrixark_mcp_errors, and two
+# classes of the same name are not interchangeable: `except` compares by identity, so a handler
+# bound to one silently misses an exception raised through the other. matrixark_mcp_errors owns
+# it -- more modules import from there, and it is a leaf, so nothing can cycle through it.
+try:  # the implementation lives in matrixark_mcp_errors; this module re-exports it
+    from .matrixark_mcp_errors import MatrixArkError
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_errors import MatrixArkError
 
 
 class MatrixArkInvalidRequestError(MatrixArkError):
@@ -188,13 +194,10 @@ def require_messages(data: Json) -> list[Json]:
     return normalized_messages
 
 
-def optional_object(data: Json, field: str) -> Json:
-    value = data.get(field, {})
-    if value is None:
-        return {}
-    if not isinstance(value, dict):
-        raise MatrixArkError(f"{field} must be an object")
-    return value
+try:  # the implementation lives in matrixark_mcp_validation; this module re-exports it
+    from .matrixark_mcp_validation import optional_object
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_validation import optional_object
 
 
 def optional_string(data: Json, field: str, default: str = "") -> str:

--- a/tools/matrixark_mcp_core_scoring.py
+++ b/tools/matrixark_mcp_core_scoring.py
@@ -190,25 +190,16 @@ def final_recall_score(origin_score: float, time_score: float, business_score: f
     )
 
 
-def integer_arg(data: Json, field: str, default: int, *, minimum: int = 0) -> int:
-    value = data.get(field, default)
-    if not isinstance(value, int):
-        raise MatrixArkError(f"{field} must be an integer")
-    if value < minimum:
-        raise MatrixArkError(f"{field} must be >= {minimum}")
-    return value
+try:  # the implementation lives in matrixark_mcp_validation; this module re-exports it
+    from .matrixark_mcp_validation import integer_arg
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_validation import integer_arg
 
 
-def float_arg(data: Json, field: str, default: float, *, minimum: float = 0.0, maximum: float | None = None) -> float:
-    value = data.get(field, default)
-    if not isinstance(value, (int, float)):
-        raise MatrixArkError(f"{field} must be a number")
-    result = float(value)
-    if result < minimum:
-        raise MatrixArkError(f"{field} must be >= {minimum}")
-    if maximum is not None and result > maximum:
-        raise MatrixArkError(f"{field} must be <= {maximum}")
-    return result
+try:  # the implementation lives in matrixark_mcp_validation; this module re-exports it
+    from .matrixark_mcp_validation import float_arg
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_validation import float_arg
 
 
 def _tenant_profile_max_candidates(args: Json, fallback: int) -> int:


### PR DESCRIPTION
`class MatrixArkError(ValueError): pass` is written out twice — in `matrixark_mcp_errors` and
again in `matrixark_mcp_core_identity`. The bodies are identical, but they are two different
classes, and `except` compares by identity: a handler bound to one does not catch an exception
raised through the other.

That split is reachable rather than merely untidy. Both sides have raise sites AND except sites:

| class in use | modules | raise sites | except sites |
|---|---|---|---|
| via `matrixark_mcp_core` → `core_identity` | 31 | 107 | 7 |
| `matrixark_mcp_errors` | 16 | 55 | 6 |
| `core_identity` directly | 2 | 8 | 0 |

Nothing prevents an except site in one group from receiving a raise from the other; it just
depends on which call path runs. The failure mode is not hypothetical either — moving a validation
helper between these two modules produced exactly it, and a test that expects a payload to be
rejected instead reported an unhandled error, because the rejection arrived as the other class.

`matrixark_mcp_errors` owns it. It has the most importers, and it is a leaf — it imports only
`__future__` and `typing`, so nothing can cycle through it. `core_identity` already reaches it, so
this adds no edge to the module graph. The two subclasses defined there,
`MatrixArkInvalidRequestError` and `MatrixArkNotFoundError`, rebase onto the unified class, which
is the point.

Unifying only ever makes an `except` catch more, never less: both classes derive from `ValueError`
and both bodies are `pass`. No test depends on the two being distinct — checked for the shapes that
would (comparing identity, or importing the name from both sources).

## The rest of the change

With one class, several duplicated functions that read `MatrixArkError` as a free name became
consolidatable — their bodies were byte-identical but resolved that name to different classes
depending on which module held them, which is a behaviour difference rather than duplication. Five
of those are now one shared object each.

## Verification

By object identity: the class is one object through every path that reaches it
(`core is errors`, `validation is errors`), where before `core is validation` was false. All 78
function consolidations in the tree resolve to one shared object, every module's `__all__` still
resolves, and every file still parses.

The whole `tools/` suite (381 files) ran before and after with the control pinned to this exact
commit.
