### PR TITLE
The strip notices a quiet stream too

### DIFF
--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -1274,6 +1274,22 @@
   if (window.__matrixarkLive) { return; }
   window.__matrixarkLive = "strip";
 
+  /* Nothing arrives to announce that nothing is arriving, so noticing needs a timer. Three ticks
+     of the gateway's OWN cadence: one missed tick is scheduling, two is a slow one, three is not
+     arriving. The number is not written here -- it is whatever the gateway last said. */
+  function watchQuiet() {
+    if (!tickMs || !blockAt || !controller) { return; }
+    var quiet = Date.now() - blockAt;
+    if (quiet > tickMs * 3 && dot.className.indexOf("stale") < 0) {
+      dot.className = "live-dot stale";
+      dot.title = "no update for " + Math.round(quiet / 1000) + "s";
+    }
+  }
+  quietTimer = setInterval(watchQuiet, 1000);
+  window.addEventListener("pagehide", function () {
+    if (quietTimer) { clearInterval(quietTimer); quietTimer = null; }
+  });
+
   function key() {
     var el = document.getElementById("key");
     if (el && el.value.trim()) { return el.value.trim(); }
@@ -1281,6 +1297,13 @@
   }
 
   var controller = null, backoff = 1000, buffer = "";
+  /* When anything last arrived, and the gateway's own cadence off its frames.
+     The strip is the one element on every page, and it said "live" whenever the socket was open --
+     so a gateway that stopped producing frames left every page green. The page-side client learned
+     this in mx#1189; the strip runs its own client, because five of the seven pages never load the
+     other one, so it has to learn it too. `test_both_stream_clients_agree_when_a_stream_is_quiet`
+     is what stops the two rules drifting apart. */
+  var blockAt = 0, tickMs = 0, quietTimer = null;
   /* Set when the gateway says it is closing on purpose, cleared by the reopen it
      causes. A planned recycle and a gateway that stopped answering look identical
      from here without it, and only one of them is      one of them is worth telling anybody about. */
@@ -1333,6 +1356,14 @@
           var parts = buffer.split("\n\n");
           buffer = parts.pop();
           parts.forEach(function (block) {
+            /* Every block, keepalives included: when nothing has changed the gateway sends a
+               keepalive instead of a frame, so silence on an idle deployment is HEALTHY and only
+               nothing-at-all is not. */
+            blockAt = Date.now();
+            if (dot.className.indexOf("stale") >= 0) {
+              dot.className = "live-dot";
+              dot.title = "live";
+            }
             /* Read the label. A goodbye carries a data line of its own, and rendering it as a
                frame empties every segment of the strip -- on all five pages that read the stream
                through here, every ten minutes. */
@@ -1343,7 +1374,15 @@
             });
             if (name === "bye") { planned = true; return; }
             if (name !== "status" || !payload) { return; }
-            try { render(JSON.parse(payload)); } catch (err) { /* ignore */ }
+            try {
+              var frame = JSON.parse(payload);
+              /* The gateway states its cadence on every frame. Without one -- an older gateway --
+                 nothing is claimed about a quiet stream. */
+              if (typeof frame.tick_s === "number" && frame.tick_s > 0) {
+                tickMs = frame.tick_s * 1000;
+              }
+              render(frame);
+            } catch (err) { /* ignore */ }
           });
           return pump();
         });

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -984,6 +984,22 @@
   if (window.__matrixarkLive) { return; }
   window.__matrixarkLive = "strip";
 
+  /* Nothing arrives to announce that nothing is arriving, so noticing needs a timer. Three ticks
+     of the gateway's OWN cadence: one missed tick is scheduling, two is a slow one, three is not
+     arriving. The number is not written here -- it is whatever the gateway last said. */
+  function watchQuiet() {
+    if (!tickMs || !blockAt || !controller) { return; }
+    var quiet = Date.now() - blockAt;
+    if (quiet > tickMs * 3 && dot.className.indexOf("stale") < 0) {
+      dot.className = "live-dot stale";
+      dot.title = "no update for " + Math.round(quiet / 1000) + "s";
+    }
+  }
+  quietTimer = setInterval(watchQuiet, 1000);
+  window.addEventListener("pagehide", function () {
+    if (quietTimer) { clearInterval(quietTimer); quietTimer = null; }
+  });
+
   function key() {
     var el = document.getElementById("key");
     if (el && el.value.trim()) { return el.value.trim(); }
@@ -991,6 +1007,13 @@
   }
 
   var controller = null, backoff = 1000, buffer = "";
+  /* When anything last arrived, and the gateway's own cadence off its frames.
+     The strip is the one element on every page, and it said "live" whenever the socket was open --
+     so a gateway that stopped producing frames left every page green. The page-side client learned
+     this in mx#1189; the strip runs its own client, because five of the seven pages never load the
+     other one, so it has to learn it too. `test_both_stream_clients_agree_when_a_stream_is_quiet`
+     is what stops the two rules drifting apart. */
+  var blockAt = 0, tickMs = 0, quietTimer = null;
   /* Set when the gateway says it is closing on purpose, cleared by the reopen it
      causes. A planned recycle and a gateway that stopped answering look identical
      from here without it, and only one of them is      one of them is worth telling anybody about. */
@@ -1043,6 +1066,14 @@
           var parts = buffer.split("\n\n");
           buffer = parts.pop();
           parts.forEach(function (block) {
+            /* Every block, keepalives included: when nothing has changed the gateway sends a
+               keepalive instead of a frame, so silence on an idle deployment is HEALTHY and only
+               nothing-at-all is not. */
+            blockAt = Date.now();
+            if (dot.className.indexOf("stale") >= 0) {
+              dot.className = "live-dot";
+              dot.title = "live";
+            }
             /* Read the label. A goodbye carries a data line of its own, and rendering it as a
                frame empties every segment of the strip -- on all five pages that read the stream
                through here, every ten minutes. */
@@ -1053,7 +1084,15 @@
             });
             if (name === "bye") { planned = true; return; }
             if (name !== "status" || !payload) { return; }
-            try { render(JSON.parse(payload)); } catch (err) { /* ignore */ }
+            try {
+              var frame = JSON.parse(payload);
+              /* The gateway states its cadence on every frame. Without one -- an older gateway --
+                 nothing is claimed about a quiet stream. */
+              if (typeof frame.tick_s === "number" && frame.tick_s > 0) {
+                tickMs = frame.tick_s * 1000;
+              }
+              render(frame);
+            } catch (err) { /* ignore */ }
           });
           return pump();
         });

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -519,6 +519,22 @@ NAV_JS = r'''<script>
   if (window.__matrixarkLive) { return; }
   window.__matrixarkLive = "strip";
 
+  /* Nothing arrives to announce that nothing is arriving, so noticing needs a timer. Three ticks
+     of the gateway's OWN cadence: one missed tick is scheduling, two is a slow one, three is not
+     arriving. The number is not written here -- it is whatever the gateway last said. */
+  function watchQuiet() {
+    if (!tickMs || !blockAt || !controller) { return; }
+    var quiet = Date.now() - blockAt;
+    if (quiet > tickMs * 3 && dot.className.indexOf("stale") < 0) {
+      dot.className = "live-dot stale";
+      dot.title = "no update for " + Math.round(quiet / 1000) + "s";
+    }
+  }
+  quietTimer = setInterval(watchQuiet, 1000);
+  window.addEventListener("pagehide", function () {
+    if (quietTimer) { clearInterval(quietTimer); quietTimer = null; }
+  });
+
   function key() {
     var el = document.getElementById("key");
     if (el && el.value.trim()) { return el.value.trim(); }
@@ -526,6 +542,13 @@ NAV_JS = r'''<script>
   }
 
   var controller = null, backoff = 1000, buffer = "";
+  /* When anything last arrived, and the gateway's own cadence off its frames.
+     The strip is the one element on every page, and it said "live" whenever the socket was open --
+     so a gateway that stopped producing frames left every page green. The page-side client learned
+     this in mx#1189; the strip runs its own client, because five of the seven pages never load the
+     other one, so it has to learn it too. `test_both_stream_clients_agree_when_a_stream_is_quiet`
+     is what stops the two rules drifting apart. */
+  var blockAt = 0, tickMs = 0, quietTimer = null;
   /* Set when the gateway says it is closing on purpose, cleared by the reopen it
      causes. A planned recycle and a gateway that stopped answering look identical
      from here without it, and only one of them is      one of them is worth telling anybody about. */
@@ -578,6 +601,14 @@ NAV_JS = r'''<script>
           var parts = buffer.split("\n\n");
           buffer = parts.pop();
           parts.forEach(function (block) {
+            /* Every block, keepalives included: when nothing has changed the gateway sends a
+               keepalive instead of a frame, so silence on an idle deployment is HEALTHY and only
+               nothing-at-all is not. */
+            blockAt = Date.now();
+            if (dot.className.indexOf("stale") >= 0) {
+              dot.className = "live-dot";
+              dot.title = "live";
+            }
             /* Read the label. A goodbye carries a data line of its own, and rendering it as a
                frame empties every segment of the strip -- on all five pages that read the stream
                through here, every ten minutes. */
@@ -588,7 +619,15 @@ NAV_JS = r'''<script>
             });
             if (name === "bye") { planned = true; return; }
             if (name !== "status" || !payload) { return; }
-            try { render(JSON.parse(payload)); } catch (err) { /* ignore */ }
+            try {
+              var frame = JSON.parse(payload);
+              /* The gateway states its cadence on every frame. Without one -- an older gateway --
+                 nothing is claimed about a quiet stream. */
+              if (typeof frame.tick_s === "number" && frame.tick_s > 0) {
+                tickMs = frame.tick_s * 1000;
+              }
+              render(frame);
+            } catch (err) { /* ignore */ }
           });
           return pump();
         });

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -1125,6 +1125,22 @@
   if (window.__matrixarkLive) { return; }
   window.__matrixarkLive = "strip";
 
+  /* Nothing arrives to announce that nothing is arriving, so noticing needs a timer. Three ticks
+     of the gateway's OWN cadence: one missed tick is scheduling, two is a slow one, three is not
+     arriving. The number is not written here -- it is whatever the gateway last said. */
+  function watchQuiet() {
+    if (!tickMs || !blockAt || !controller) { return; }
+    var quiet = Date.now() - blockAt;
+    if (quiet > tickMs * 3 && dot.className.indexOf("stale") < 0) {
+      dot.className = "live-dot stale";
+      dot.title = "no update for " + Math.round(quiet / 1000) + "s";
+    }
+  }
+  quietTimer = setInterval(watchQuiet, 1000);
+  window.addEventListener("pagehide", function () {
+    if (quietTimer) { clearInterval(quietTimer); quietTimer = null; }
+  });
+
   function key() {
     var el = document.getElementById("key");
     if (el && el.value.trim()) { return el.value.trim(); }
@@ -1132,6 +1148,13 @@
   }
 
   var controller = null, backoff = 1000, buffer = "";
+  /* When anything last arrived, and the gateway's own cadence off its frames.
+     The strip is the one element on every page, and it said "live" whenever the socket was open --
+     so a gateway that stopped producing frames left every page green. The page-side client learned
+     this in mx#1189; the strip runs its own client, because five of the seven pages never load the
+     other one, so it has to learn it too. `test_both_stream_clients_agree_when_a_stream_is_quiet`
+     is what stops the two rules drifting apart. */
+  var blockAt = 0, tickMs = 0, quietTimer = null;
   /* Set when the gateway says it is closing on purpose, cleared by the reopen it
      causes. A planned recycle and a gateway that stopped answering look identical
      from here without it, and only one of them is      one of them is worth telling anybody about. */
@@ -1184,6 +1207,14 @@
           var parts = buffer.split("\n\n");
           buffer = parts.pop();
           parts.forEach(function (block) {
+            /* Every block, keepalives included: when nothing has changed the gateway sends a
+               keepalive instead of a frame, so silence on an idle deployment is HEALTHY and only
+               nothing-at-all is not. */
+            blockAt = Date.now();
+            if (dot.className.indexOf("stale") >= 0) {
+              dot.className = "live-dot";
+              dot.title = "live";
+            }
             /* Read the label. A goodbye carries a data line of its own, and rendering it as a
                frame empties every segment of the strip -- on all five pages that read the stream
                through here, every ten minutes. */
@@ -1194,7 +1225,15 @@
             });
             if (name === "bye") { planned = true; return; }
             if (name !== "status" || !payload) { return; }
-            try { render(JSON.parse(payload)); } catch (err) { /* ignore */ }
+            try {
+              var frame = JSON.parse(payload);
+              /* The gateway states its cadence on every frame. Without one -- an older gateway --
+                 nothing is claimed about a quiet stream. */
+              if (typeof frame.tick_s === "number" && frame.tick_s > 0) {
+                tickMs = frame.tick_s * 1000;
+              }
+              render(frame);
+            } catch (err) { /* ignore */ }
           });
           return pump();
         });

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -2070,6 +2070,22 @@
   if (window.__matrixarkLive) { return; }
   window.__matrixarkLive = "strip";
 
+  /* Nothing arrives to announce that nothing is arriving, so noticing needs a timer. Three ticks
+     of the gateway's OWN cadence: one missed tick is scheduling, two is a slow one, three is not
+     arriving. The number is not written here -- it is whatever the gateway last said. */
+  function watchQuiet() {
+    if (!tickMs || !blockAt || !controller) { return; }
+    var quiet = Date.now() - blockAt;
+    if (quiet > tickMs * 3 && dot.className.indexOf("stale") < 0) {
+      dot.className = "live-dot stale";
+      dot.title = "no update for " + Math.round(quiet / 1000) + "s";
+    }
+  }
+  quietTimer = setInterval(watchQuiet, 1000);
+  window.addEventListener("pagehide", function () {
+    if (quietTimer) { clearInterval(quietTimer); quietTimer = null; }
+  });
+
   function key() {
     var el = document.getElementById("key");
     if (el && el.value.trim()) { return el.value.trim(); }
@@ -2077,6 +2093,13 @@
   }
 
   var controller = null, backoff = 1000, buffer = "";
+  /* When anything last arrived, and the gateway's own cadence off its frames.
+     The strip is the one element on every page, and it said "live" whenever the socket was open --
+     so a gateway that stopped producing frames left every page green. The page-side client learned
+     this in mx#1189; the strip runs its own client, because five of the seven pages never load the
+     other one, so it has to learn it too. `test_both_stream_clients_agree_when_a_stream_is_quiet`
+     is what stops the two rules drifting apart. */
+  var blockAt = 0, tickMs = 0, quietTimer = null;
   /* Set when the gateway says it is closing on purpose, cleared by the reopen it
      causes. A planned recycle and a gateway that stopped answering look identical
      from here without it, and only one of them is      one of them is worth telling anybody about. */
@@ -2129,6 +2152,14 @@
           var parts = buffer.split("\n\n");
           buffer = parts.pop();
           parts.forEach(function (block) {
+            /* Every block, keepalives included: when nothing has changed the gateway sends a
+               keepalive instead of a frame, so silence on an idle deployment is HEALTHY and only
+               nothing-at-all is not. */
+            blockAt = Date.now();
+            if (dot.className.indexOf("stale") >= 0) {
+              dot.className = "live-dot";
+              dot.title = "live";
+            }
             /* Read the label. A goodbye carries a data line of its own, and rendering it as a
                frame empties every segment of the strip -- on all five pages that read the stream
                through here, every ten minutes. */
@@ -2139,7 +2170,15 @@
             });
             if (name === "bye") { planned = true; return; }
             if (name !== "status" || !payload) { return; }
-            try { render(JSON.parse(payload)); } catch (err) { /* ignore */ }
+            try {
+              var frame = JSON.parse(payload);
+              /* The gateway states its cadence on every frame. Without one -- an older gateway --
+                 nothing is claimed about a quiet stream. */
+              if (typeof frame.tick_s === "number" && frame.tick_s > 0) {
+                tickMs = frame.tick_s * 1000;
+              }
+              render(frame);
+            } catch (err) { /* ignore */ }
           });
           return pump();
         });

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -993,6 +993,22 @@
   if (window.__matrixarkLive) { return; }
   window.__matrixarkLive = "strip";
 
+  /* Nothing arrives to announce that nothing is arriving, so noticing needs a timer. Three ticks
+     of the gateway's OWN cadence: one missed tick is scheduling, two is a slow one, three is not
+     arriving. The number is not written here -- it is whatever the gateway last said. */
+  function watchQuiet() {
+    if (!tickMs || !blockAt || !controller) { return; }
+    var quiet = Date.now() - blockAt;
+    if (quiet > tickMs * 3 && dot.className.indexOf("stale") < 0) {
+      dot.className = "live-dot stale";
+      dot.title = "no update for " + Math.round(quiet / 1000) + "s";
+    }
+  }
+  quietTimer = setInterval(watchQuiet, 1000);
+  window.addEventListener("pagehide", function () {
+    if (quietTimer) { clearInterval(quietTimer); quietTimer = null; }
+  });
+
   function key() {
     var el = document.getElementById("key");
     if (el && el.value.trim()) { return el.value.trim(); }
@@ -1000,6 +1016,13 @@
   }
 
   var controller = null, backoff = 1000, buffer = "";
+  /* When anything last arrived, and the gateway's own cadence off its frames.
+     The strip is the one element on every page, and it said "live" whenever the socket was open --
+     so a gateway that stopped producing frames left every page green. The page-side client learned
+     this in mx#1189; the strip runs its own client, because five of the seven pages never load the
+     other one, so it has to learn it too. `test_both_stream_clients_agree_when_a_stream_is_quiet`
+     is what stops the two rules drifting apart. */
+  var blockAt = 0, tickMs = 0, quietTimer = null;
   /* Set when the gateway says it is closing on purpose, cleared by the reopen it
      causes. A planned recycle and a gateway that stopped answering look identical
      from here without it, and only one of them is      one of them is worth telling anybody about. */
@@ -1052,6 +1075,14 @@
           var parts = buffer.split("\n\n");
           buffer = parts.pop();
           parts.forEach(function (block) {
+            /* Every block, keepalives included: when nothing has changed the gateway sends a
+               keepalive instead of a frame, so silence on an idle deployment is HEALTHY and only
+               nothing-at-all is not. */
+            blockAt = Date.now();
+            if (dot.className.indexOf("stale") >= 0) {
+              dot.className = "live-dot";
+              dot.title = "live";
+            }
             /* Read the label. A goodbye carries a data line of its own, and rendering it as a
                frame empties every segment of the strip -- on all five pages that read the stream
                through here, every ten minutes. */
@@ -1062,7 +1093,15 @@
             });
             if (name === "bye") { planned = true; return; }
             if (name !== "status" || !payload) { return; }
-            try { render(JSON.parse(payload)); } catch (err) { /* ignore */ }
+            try {
+              var frame = JSON.parse(payload);
+              /* The gateway states its cadence on every frame. Without one -- an older gateway --
+                 nothing is claimed about a quiet stream. */
+              if (typeof frame.tick_s === "number" && frame.tick_s > 0) {
+                tickMs = frame.tick_s * 1000;
+              }
+              render(frame);
+            } catch (err) { /* ignore */ }
           });
           return pump();
         });

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -1250,6 +1250,22 @@ function liveStream(options) {
   if (window.__matrixarkLive) { return; }
   window.__matrixarkLive = "strip";
 
+  /* Nothing arrives to announce that nothing is arriving, so noticing needs a timer. Three ticks
+     of the gateway's OWN cadence: one missed tick is scheduling, two is a slow one, three is not
+     arriving. The number is not written here -- it is whatever the gateway last said. */
+  function watchQuiet() {
+    if (!tickMs || !blockAt || !controller) { return; }
+    var quiet = Date.now() - blockAt;
+    if (quiet > tickMs * 3 && dot.className.indexOf("stale") < 0) {
+      dot.className = "live-dot stale";
+      dot.title = "no update for " + Math.round(quiet / 1000) + "s";
+    }
+  }
+  quietTimer = setInterval(watchQuiet, 1000);
+  window.addEventListener("pagehide", function () {
+    if (quietTimer) { clearInterval(quietTimer); quietTimer = null; }
+  });
+
   function key() {
     var el = document.getElementById("key");
     if (el && el.value.trim()) { return el.value.trim(); }
@@ -1257,6 +1273,13 @@ function liveStream(options) {
   }
 
   var controller = null, backoff = 1000, buffer = "";
+  /* When anything last arrived, and the gateway's own cadence off its frames.
+     The strip is the one element on every page, and it said "live" whenever the socket was open --
+     so a gateway that stopped producing frames left every page green. The page-side client learned
+     this in mx#1189; the strip runs its own client, because five of the seven pages never load the
+     other one, so it has to learn it too. `test_both_stream_clients_agree_when_a_stream_is_quiet`
+     is what stops the two rules drifting apart. */
+  var blockAt = 0, tickMs = 0, quietTimer = null;
   /* Set when the gateway says it is closing on purpose, cleared by the reopen it
      causes. A planned recycle and a gateway that stopped answering look identical
      from here without it, and only one of them is      one of them is worth telling anybody about. */
@@ -1309,6 +1332,14 @@ function liveStream(options) {
           var parts = buffer.split("\n\n");
           buffer = parts.pop();
           parts.forEach(function (block) {
+            /* Every block, keepalives included: when nothing has changed the gateway sends a
+               keepalive instead of a frame, so silence on an idle deployment is HEALTHY and only
+               nothing-at-all is not. */
+            blockAt = Date.now();
+            if (dot.className.indexOf("stale") >= 0) {
+              dot.className = "live-dot";
+              dot.title = "live";
+            }
             /* Read the label. A goodbye carries a data line of its own, and rendering it as a
                frame empties every segment of the strip -- on all five pages that read the stream
                through here, every ten minutes. */
@@ -1319,7 +1350,15 @@ function liveStream(options) {
             });
             if (name === "bye") { planned = true; return; }
             if (name !== "status" || !payload) { return; }
-            try { render(JSON.parse(payload)); } catch (err) { /* ignore */ }
+            try {
+              var frame = JSON.parse(payload);
+              /* The gateway states its cadence on every frame. Without one -- an older gateway --
+                 nothing is claimed about a quiet stream. */
+              if (typeof frame.tick_s === "number" && frame.tick_s > 0) {
+                tickMs = frame.tick_s * 1000;
+              }
+              render(frame);
+            } catch (err) { /* ignore */ }
           });
           return pump();
         });

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -3223,6 +3223,22 @@ function liveStream(options) {
   if (window.__matrixarkLive) { return; }
   window.__matrixarkLive = "strip";
 
+  /* Nothing arrives to announce that nothing is arriving, so noticing needs a timer. Three ticks
+     of the gateway's OWN cadence: one missed tick is scheduling, two is a slow one, three is not
+     arriving. The number is not written here -- it is whatever the gateway last said. */
+  function watchQuiet() {
+    if (!tickMs || !blockAt || !controller) { return; }
+    var quiet = Date.now() - blockAt;
+    if (quiet > tickMs * 3 && dot.className.indexOf("stale") < 0) {
+      dot.className = "live-dot stale";
+      dot.title = "no update for " + Math.round(quiet / 1000) + "s";
+    }
+  }
+  quietTimer = setInterval(watchQuiet, 1000);
+  window.addEventListener("pagehide", function () {
+    if (quietTimer) { clearInterval(quietTimer); quietTimer = null; }
+  });
+
   function key() {
     var el = document.getElementById("key");
     if (el && el.value.trim()) { return el.value.trim(); }
@@ -3230,6 +3246,13 @@ function liveStream(options) {
   }
 
   var controller = null, backoff = 1000, buffer = "";
+  /* When anything last arrived, and the gateway's own cadence off its frames.
+     The strip is the one element on every page, and it said "live" whenever the socket was open --
+     so a gateway that stopped producing frames left every page green. The page-side client learned
+     this in mx#1189; the strip runs its own client, because five of the seven pages never load the
+     other one, so it has to learn it too. `test_both_stream_clients_agree_when_a_stream_is_quiet`
+     is what stops the two rules drifting apart. */
+  var blockAt = 0, tickMs = 0, quietTimer = null;
   /* Set when the gateway says it is closing on purpose, cleared by the reopen it
      causes. A planned recycle and a gateway that stopped answering look identical
      from here without it, and only one of them is      one of them is worth telling anybody about. */
@@ -3282,6 +3305,14 @@ function liveStream(options) {
           var parts = buffer.split("\n\n");
           buffer = parts.pop();
           parts.forEach(function (block) {
+            /* Every block, keepalives included: when nothing has changed the gateway sends a
+               keepalive instead of a frame, so silence on an idle deployment is HEALTHY and only
+               nothing-at-all is not. */
+            blockAt = Date.now();
+            if (dot.className.indexOf("stale") >= 0) {
+              dot.className = "live-dot";
+              dot.title = "live";
+            }
             /* Read the label. A goodbye carries a data line of its own, and rendering it as a
                frame empties every segment of the strip -- on all five pages that read the stream
                through here, every ten minutes. */
@@ -3292,7 +3323,15 @@ function liveStream(options) {
             });
             if (name === "bye") { planned = true; return; }
             if (name !== "status" || !payload) { return; }
-            try { render(JSON.parse(payload)); } catch (err) { /* ignore */ }
+            try {
+              var frame = JSON.parse(payload);
+              /* The gateway states its cadence on every frame. Without one -- an older gateway --
+                 nothing is claimed about a quiet stream. */
+              if (typeof frame.tick_s === "number" && frame.tick_s > 0) {
+                tickMs = frame.tick_s * 1000;
+              }
+              render(frame);
+            } catch (err) { /* ignore */ }
           });
           return pump();
         });

--- a/tools/portal/strip_quiet_harness.js
+++ b/tools/portal/strip_quiet_harness.js
@@ -1,0 +1,109 @@
+// Drives the SHIPPED strip client from a generated page: opens, speaks, then goes quiet.
+// The strip is an IIFE inside the shared nav script, so it is located by its content
+// (`__matrixarkLive = "strip"`) rather than by a name, and evaluated with the globals it uses.
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const input = JSON.parse(process.argv[3]);
+
+// Find the IIFE whose body claims the strip.
+function stripIife(text) {
+  const marker = text.indexOf('__matrixarkLive = "strip"');
+  if (marker < 0) throw new Error("strip client not found");
+  let start = text.lastIndexOf("(function () {", marker);
+  if (start < 0) throw new Error("no enclosing IIFE");
+  let depth = 0;
+  for (let i = text.indexOf("{", start); i < text.length; i++) {
+    if (text[i] === "{") depth++;
+    // The slice starts at the IIFE's opening paren, so close it: the body's brace alone
+    // leaves  unbalanced.
+    else if (text[i] === "}") { depth--; if (depth === 0) return text.slice(start, i + 1) + ")();"; }
+  }
+  throw new Error("unclosed IIFE");
+}
+
+const ORIGIN = 1_760_000_000_000;
+let clock = ORIGIN;
+let ticker = null;
+
+const dot = { className: "live-dot", title: "live" };
+const states = [];
+
+// The strip looks up `liveStrip` first and RETURNS if it is missing, so every id has to answer.
+const elements = { liveDot: dot };
+function element(id) {
+  if (!elements[id]) {
+    elements[id] = {
+      id: id, className: "", textContent: "", innerHTML: "", hidden: false,
+      // The key lookup calls .value.trim(), so every element needs one.
+      value: "",
+      style: {}, dataset: {}, title: "",
+      setAttribute() {}, getAttribute() { return null; },
+      appendChild() {}, addEventListener() {},
+      classList: { add() {}, remove() {}, toggle() {} },
+    };
+  }
+  return elements[id];
+}
+
+const blocks = ["retry: 3000\n\n"];
+const frame = { ts: 1760000000, traffic: {}, datanode: "ok" };
+if (input.tickS) { frame.tick_s = input.tickS; }
+blocks.push("event: status\ndata: " + JSON.stringify(frame) + "\n\n");
+
+let releaseSecond = null;
+
+const scope = {
+  document: {
+    hidden: false,
+    getElementById: (id) => element(id),
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    addEventListener: () => {},
+  },
+  window: { addEventListener: () => {}, location: { pathname: "/v1/admin/explore" } },
+  sessionStorage: { getItem: () => "k-admin", setItem: () => {} },
+  fetch: () => Promise.resolve({
+    ok: true,
+    status: 200,
+    body: {
+      getReader: () => {
+        let sent = false;
+        return {
+          read: () => sent ? new Promise((r) => { releaseSecond = r; })
+                           : ((sent = true), Promise.resolve({ done: false, value: blocks.join("") })),
+        };
+      },
+    },
+  }),
+  TextDecoder: function () { this.decode = (v) => (v === undefined ? "" : String(v)); },
+  AbortController: function () { this.abort = () => {}; this.signal = null; },
+  Date: Object.assign(function () {}, { now: () => clock }),
+  setTimeout: () => 0,
+  setInterval: (fn) => { ticker = fn; return 1; },
+  clearInterval: () => { ticker = null; },
+  console: { log: () => {}, warn: () => {}, error: () => {} },
+};
+
+const names = Object.keys(scope);
+// The IIFE also assigns onto `window`; give it the same object it reads.
+new Function(...names, stripIife(page))(...names.map((k) => scope[k]));
+
+const wait = () => new Promise((r) => globalThis.setTimeout(r, 5));
+
+(async () => {
+  await wait();
+  states.push({ at: 0, className: dot.className, title: dot.title });
+  for (const step of (input.advanceMs || [])) {
+    clock += step;
+    if (ticker) { ticker(); }
+    states.push({ at: clock - ORIGIN, className: dot.className, title: dot.title });
+  }
+  if (input.thenAKeepalive) {
+    clock += input.thenAKeepalive;
+    if (releaseSecond) { releaseSecond({ done: false, value: ": keepalive\n\n" }); await wait(); }
+    if (ticker) { ticker(); }
+    states.push({ at: clock - ORIGIN, className: dot.className, title: dot.title });
+  }
+  process.stdout.write(JSON.stringify({ states, tickerRegistered: ticker !== null }));
+})();

--- a/tools/test_matrixark_the_strip_notices_a_quiet_stream_too.py
+++ b/tools/test_matrixark_the_strip_notices_a_quiet_stream_too.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The strip is on every page and said "live" whenever the socket was open.
+
+mx#1189 taught the page-side stream client that a connection which has stopped delivering is not a
+live one. **The strip runs its own client** -- five of the seven pages never load the other one --
+so on those five the dot stayed green however long the gateway had been silent.
+
+Silence alone is still not the signal: when nothing has changed the gateway sends `: keepalive`
+instead of a frame, so a quiet stream on an idle deployment is healthy. What is not normal is
+nothing at all, for three ticks of the gateway's own cadence, which every frame carries.
+
+Two clients now apply one rule, which is a thing that can drift.
+`TheTwoClientsAgreeTest` is the answer to that: both must read `tick_s` off the frame, both must
+stamp on EVERY block rather than on frames, and neither may write the interval down.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import re
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+HARNESS = os.path.join(PORTAL, "strip_quiet_harness.js")
+PAGE = os.path.join(PORTAL, "explore_portal.html")   # a page that runs the STRIP's own client
+
+
+def drive(**case) -> list:
+    out = subprocess.run(["node", HARNESS, PAGE, json.dumps(case)],
+                         capture_output=True, text=True, timeout=300)
+    if out.returncode != 0:
+        raise AssertionError(out.stderr[-900:])
+    return json.loads(out.stdout)["states"]
+
+
+def final(states: list) -> tuple:
+    return states[-1]["className"], states[-1]["title"]
+
+
+class TheDotNoticesSilenceTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    def test_two_ticks_of_quiet_leaves_it_alone(self) -> None:
+        """The floor: an idle deployment sends keepalives and is perfectly healthy."""
+        self.assertEqual(("live-dot", "live"), final(drive(tickS=2, advanceMs=[2000, 2000])))
+
+    def test_four_ticks_of_quiet_turns_it(self) -> None:
+        css, title = final(drive(tickS=2, advanceMs=[2000, 2000, 2000, 2000]))
+        self.assertIn("stale", css)
+        self.assertEqual("no update for 8s", title)
+
+    def test_anything_arriving_turns_it_back(self) -> None:
+        """A keepalive carries no frame and no data and is exactly the evidence of life."""
+        states = drive(tickS=2, advanceMs=[2000, 2000, 2000, 2000], thenAKeepalive=100)
+        self.assertIn("stale", states[-2]["className"])
+        self.assertEqual(("live-dot", "live"), final(states))
+
+    def test_a_slower_gateway_gets_a_longer_leash(self) -> None:
+        """Eight seconds is a stall at a two-second cadence and not at a ten-second one."""
+        self.assertEqual(("live-dot", "live"),
+                         final(drive(tickS=10, advanceMs=[2000, 2000, 2000, 2000])))
+
+    def test_a_gateway_that_states_no_cadence_is_not_second_guessed(self) -> None:
+        self.assertEqual(("live-dot", "live"),
+                         final(drive(advanceMs=[2000, 2000, 2000, 2000, 60000])))
+
+
+class TheTwoClientsAgreeTest(unittest.TestCase):
+    """One rule, written twice, is a rule that drifts. These are the parts of it that matter.
+
+    Both regions are cut by matching braces from a named anchor rather than by taking a fixed
+    number of characters -- the first version of this test took 6,000 either side and checked
+    neither the code it meant to.
+    """
+
+    @staticmethod
+    def _builder() -> str:
+        with io.open(os.path.join(PORTAL, "build_portal_pages.py"), encoding="utf-8") as handle:
+            return handle.read()
+
+    @staticmethod
+    def _braced(text: str, anchor: str) -> str:
+        start = text.index(anchor)
+        depth = 0
+        for index in range(text.index("{", start), len(text)):
+            if text[index] == "{":
+                depth += 1
+            elif text[index] == "}":
+                depth -= 1
+                if depth == 0:
+                    return text[start:index + 1]
+        raise AssertionError("unclosed block at %r" % anchor)
+
+    def _rules(self) -> dict:
+        """The staleness decision in each client, as source."""
+        text = self._builder()
+        strip_marker = text.index('__matrixarkLive = "strip"')
+        return {
+            "shared": self._braced(text, "function streamStalledFor()"),
+            "strip": self._braced(text[strip_marker:], "function watchQuiet()"),
+        }
+
+    def test_each_client_has_one(self) -> None:
+        """The floor: an empty string satisfies every assertion below."""
+        for name, rule in self._rules().items():
+            with self.subTest(client=name):
+                self.assertGreater(len(rule), 80, rule)
+
+    def test_both_wait_three_ticks(self) -> None:
+        for name, rule in self._rules().items():
+            with self.subTest(client=name):
+                self.assertTrue(re.search(r"\*\s*3\b", rule),
+                                "this client no longer waits three ticks: %s" % rule)
+
+    def test_both_take_the_interval_from_the_gateway(self) -> None:
+        """The whole reason the gateway states it. A literal here is a second place to be wrong."""
+        for name, rule in self._rules().items():
+            with self.subTest(client=name):
+                comparison = [line for line in rule.splitlines() if "* 3" in line]
+                self.assertTrue(comparison, "no three-tick comparison in: %s" % rule)
+                for line in comparison:
+                    # The thing multiplied by three must be the cadence, not a number. Checking the
+                    # comparison rather than banning digits: `Math.round(quiet / 1000)` is a
+                    # milliseconds-to-seconds divisor and caught a cruder rule.
+                    self.assertTrue(re.search(r"\b(tickMs|liveTickMs)\s*\*\s*3\b", line),
+                                    "three ticks of WHAT? %s" % line.strip())
+
+    def _bodies(self) -> dict:
+        """Each client's whole body. Both `tick_s` reads are inside them -- the shared one in
+        `handle`, the strip's in its pump -- so anything narrower misses the code it checks."""
+        text = self._builder()
+        strip_marker = text.index('__matrixarkLive = "strip"')
+        return {
+            "shared": self._braced(text, "function liveStream(options)"),
+            "strip": self._braced(text[strip_marker:], "function open()"),
+        }
+
+    def test_both_read_the_cadence_off_a_frame(self) -> None:
+        for name, body in self._bodies().items():
+            with self.subTest(client=name):
+                self.assertIn("tick_s", body)
+
+    def test_both_bodies_are_really_the_clients(self) -> None:
+        """The floor for the test above: a region that happened to be empty would pass nothing."""
+        for name, body in self._bodies().items():
+            with self.subTest(client=name):
+                self.assertIn("getReader", body, "this is not a stream client: %s" % body[:120])
+
+    def test_the_strip_stamps_on_every_block_not_every_frame(self) -> None:
+        """A frame arrives only when something changed; a keepalive is what says an idle stream is
+        alive. Stamping on frames would call every idle deployment stale."""
+        text = self._builder()
+        region = text[text.index('__matrixarkLive = "strip"'):]
+        stamp = region.index("blockAt = Date.now();")
+        status_check = region.index('if (name !== "status"')
+        self.assertLess(stamp, status_check,
+                        "the stamp happens after the status check, so keepalives do not count")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#1189 taught the page-side stream client that a connection which has stopped delivering is not a live one. **The strip runs its own client** — five of the seven portal pages never load the other one — so on those five the dot stayed green however long the gateway had been silent.

The strip is the one element on *every* page. It is the thing somebody glances at to answer "is this deployment alive", and it was answering "the socket is open".

## The rule, and why silence alone is not it

When nothing has changed the gateway sends `: keepalive` instead of a frame, so a quiet stream on an idle deployment is **healthy**. What is not normal is nothing at all — no frame and no keepalive — for three ticks of the gateway's own cadence, which every frame carries since #1189.

| | dot | title |
|---|---|---|
| quiet 4s at a 2s cadence | `live-dot` | live |
| quiet 8s at a 2s cadence | `live-dot stale` | `no update for 8s` |
| then anything arrives | `live-dot` | live |
| quiet 8s at a **10s** cadence | `live-dot` | live |
| gateway states no cadence | `live-dot` | live — nothing claimed |

`stale` is already in the strip's vocabulary and already amber; it simply never reached it while connected.

## Two clients, one rule

The strip cannot use the shared client — it has to work on pages that never load it — so the rule is now written twice, which is a thing that drifts. `TheTwoClientsAgreeTest` is the answer: both must read `tick_s` off a frame, both must wait `tickMs * 3` with the interval **taken from the gateway rather than written down**, and the strip must stamp on *every block* rather than every frame, since a keepalive is what says an idle stream is alive.

## Mutations

Fifteen tests, driven through the shipped strip client with a held clock. Each of these reddens at least one:

| mutation | reddens |
|---|---|
| the strip never stamps a block | `test_four_ticks_of_quiet_turns_it` |
| it stamps only on status frames | `test_anything_arriving_turns_it_back` |
| the watchdog never starts | `test_four_ticks_of_quiet_turns_it` |
| the rule writes the interval down | `test_a_slower_gateway_gets_a_longer_leash` |
| one tick counts as a stall | `test_both_wait_three_ticks` |
| the strip stops reading the cadence | `test_both_read_the_cadence_off_a_frame` |
| the dot never comes back | `test_anything_arriving_turns_it_back` |

Three of the agreement tests were wrong before they were right — they sliced fixed character windows that missed the code they meant to check, and one banned four-digit literals and caught `Math.round(quiet / 1000)`. They now cut by matching braces from a named anchor, and `test_both_bodies_are_really_the_clients` is the floor that stops an empty region passing everything.
