### PR TITLE
One default for MATRIXARK_TEST_RUST_PROXY, not two that disagree three ways

### DIFF
--- a/tools/test_matrixark_popular_agent_hooks.py
+++ b/tools/test_matrixark_popular_agent_hooks.py
@@ -33,7 +33,9 @@ def require_rust_proxy() -> str:
     them against a proxy kept elsewhere.
     """
     path = os.environ.get("MATRIXARK_TEST_RUST_PROXY", DEFAULT_RUST_PROXY)
-    if not os.path.exists(path):
+    # Executable, not merely present: a file that exists and cannot be run turns a clean skip into
+    # a failure further in, where the message is about the hook rather than about the binary.
+    if not os.access(path, os.X_OK):
         raise unittest.SkipTest(
             "no native proxy at %s, so an end-to-end agent hook cannot be driven; set "
             "MATRIXARK_TEST_RUST_PROXY to point at one" % path)
@@ -242,12 +244,10 @@ class MatrixArkPopularAgentHooksTest(unittest.TestCase):
         The shared pipeline writes to MATRIXARK_TEMPORALSTORE_RUST_ROOT; the offline
         engine uses a different root, so that store's creation proves auto->shared."""
         repo = Path(__file__).resolve().parents[1]
-        proxy = os.environ.get(
-            "MATRIXARK_TEST_RUST_PROXY",
-            str(repo / "target" / "debug" / "matrixark_rust_proxy"),
-        )
-        if not os.access(proxy, os.X_OK):
-            self.skipTest("shared rust proxy not built")
+        # Was a second, different default for the same variable -- <repo>/target/debug against the
+        # helper's /opt/.../target/release -- so the two disagreed about where the proxy lives and
+        # which profile it was built with, and a machine with a normal build satisfied neither.
+        proxy = require_rust_proxy()
         hook = repo / "tools" / "matrixark_claude_hook.sh"
         with tempfile.TemporaryDirectory() as tmp_dir:
             shared_root = Path(tmp_dir) / "shared-store"


### PR DESCRIPTION
`require_rust_proxy()` and `test_claude_hook_default_auto_routes_through_shared_pipeline` both
resolve `MATRIXARK_TEST_RUST_PROXY`, and disagreed about **every part** of the answer:

| | path | profile | check |
|---|---|---|---|
| helper | `/opt/github-services/TemporalStore/target/…` | **release** | `os.path.exists` |
| that test | `<repo>/target/…` | **debug** | `os.access(X_OK)` |

Different directory, different build profile, different existence check. Whichever a reader looks at
first tells them something the other contradicts — and a machine that has built the proxy in the
normal place satisfies **neither**.

## Consolidated onto the helper, keeping the better half of each

Not the first one found:

- **The executable check**, from the test. `os.path.exists` passes for a file that cannot be run,
  which turns a clean skip into a failure further in whose message is about the hook rather than
  about the binary.
- **The message that names the variable**, from the helper. "shared rust proxy not built" does not
  tell a reader how to run these.

## The default path is deliberately NOT made more findable

These tests set a temp `MATRIXARK_TEMPORALSTORE_RUST_ROOT` but never `MATRIXARK_RUST_PROXY_SOCKET`.
`matrixark_claude_hook.sh` defaults that to the shared live socket, so when a proxy is serving they
drive the **live store** under the live storage prefix — probe strings from earlier runs of this
suite are in the live WAL, in sealed pieces written at 18:13 and 18:26.

Making them easier to discover would spread that rather than fix it. **One default first, then
isolation, then findability.** Isolation is not a one-line change: pinning the socket per test drops
the run from 67 s to 5.7 s and turns 1 failure into 5, because the ingest/retrieve tests depend on a
proxy already running rather than starting their own.

## Verified

- with the variable set, the helper returns that path
- with it pointing at nothing, the skip message names the variable
- a present but **non-executable** file now skips, where `os.path.exists` accepted it
- without a proxy: 24 tests, 7 skipped, no errors
