### PR TITLE
The metrics contract checked six files the metrics had moved out of

### DIFF
--- a/crates/temporalstore-rust/src/bin/ops_scale_readiness_harness.rs
+++ b/crates/temporalstore-rust/src/bin/ops_scale_readiness_harness.rs
@@ -446,23 +446,44 @@ fn grafana_metrics_coverage_ready(root: &Path) -> bool {
 }
 
 fn rust_sources_contain(root: &Path, snippets: &[&str]) -> bool {
-    let relative_paths = [
-        "crates/temporalstore-rust/src/engine.rs",
-        "crates/temporalstore-rust/src/raft.rs",
-        "crates/temporalstore-rust/src/proxy.rs",
-        "crates/temporalstore-rust/src/ingestion.rs",
-        "crates/temporalstore-rust/src/bin/server.rs",
-        "crates/temporalstore-rust/src/bin/metaserver.rs",
-    ];
+    // Walked, not listed. This was six hardcoded paths, and it broke the moment `engine.rs` was
+    // split into submodules and `server.rs` into `server/metrics.rs`: six of the eleven metrics
+    // moved into `engine/prometheus_metrics.rs` and `bin/server/metrics.rs`, the list still named
+    // the old files, and the contract asserted that files contain metrics they no longer hold. It
+    // failed for a refactor that should not have concerned it, and said only `false`.
     let mut text = String::new();
-    for relative in relative_paths {
-        let Ok(part) = fs::read_to_string(root.join(relative)) else {
-            return false;
-        };
-        text.push_str(&part);
-        text.push('\n');
-    }
+    collect_rust_sources(&root.join("crates/temporalstore-rust/src"), &mut text);
     snippets.iter().all(|snippet| text.contains(snippet))
+}
+
+/// Every `.rs` under `dir`, minus two exclusions that are the whole point of the check.
+fn collect_rust_sources(dir: &Path, out: &mut String) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            // A `tests` directory ASSERTS on these names; it does not emit them. Counting a test
+            // as an emitter would let this pass for a metric nothing produces, which is the one
+            // thing the contract is for.
+            if path.file_name().is_some_and(|name| name == "tests") {
+                continue;
+            }
+            collect_rust_sources(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            // This harness carries the token list itself, so reading it makes the check vacuous.
+            if path
+                .file_name()
+                .is_some_and(|name| name == "ops_scale_readiness_harness.rs")
+            {
+                continue;
+            }
+            if let Ok(text) = fs::read_to_string(&path) {
+                out.push_str(&text);
+            }
+        }
+    }
 }
 
 fn push_missing(missing: &mut Vec<String>, ready: bool, capability: &str) {


### PR DESCRIPTION
The bare assertion is `assert!(grafana_metrics_coverage_ready(&root))` over four checks ANDed together, so it reported false and named neither the file nor the token. It has been failing invisibly until #1198 made bin and integration tests run at all.

Running the same four checks by hand: **all three documents are complete** — 15, 11 and 7 tokens, none missing. The failure is `rust_sources_contain`, where six of eleven metric names are absent from the six paths it reads.

**Every one of the eleven is still emitted.** `engine.rs` was split into submodules and `server.rs` into `server/metrics.rs`, so those six now live in `engine/prometheus_metrics.rs` and `bin/server/metrics.rs` — neither of which the list names. The contract was asserting that files contain metrics they no longer hold, and broke on a refactor that should not have concerned it.

## Walked, not listed

A written list of paths goes stale on exactly the change that should not matter to it. Two exclusions, both load-bearing:

- a `tests` **directory** — `engine/tests/part3.rs` *asserts* on these names. Counting a test as an emitter would let the contract pass for a metric nothing emits, which is the one thing it exists to catch.
- **the harness itself**, which carries the token list being checked, so reading it would make the check vacuous.

Verified by simulating the new logic over the crate with those exact exclusions: **11 tokens, 0 missing**, so the contract returns true.

## Not compiled locally

A full crate build on this box degrades a live service sharing it. The constructs used are already idiomatic here — `is_some_and` appears 52 times in the crate, let-else in this same file — and CI pins Rust 1.88.0. The fast `cargo check` is the compile gate.
