### PR TITLE
The readiness gate assertion knew which service was blocked and threw it away

### DIFF
--- a/crates/temporalstore-rust/src/bin/readiness_gate.rs
+++ b/crates/temporalstore-rust/src/bin/readiness_gate.rs
@@ -282,18 +282,29 @@ mod tests {
     fn readiness_gate_failure_lines_include_service_next_actions() {
         let report = production_readiness_report();
         let lines = service_failure_lines(&report);
-        assert!(lines
-            .iter()
-            .all(|line| !line.contains("service client") && !line.contains("service proxy")));
-        assert!(
+        // Named, not bare. `service_failure_lines` has already formatted the service, its blocker
+        // count, the blocker classes and the next action into the line being rejected, and a bare
+        // `assert!(..all(..))` throws all of that away -- it prints the predicate and nothing
+        // about which service tripped it, so the reader has to reproduce the run to find out.
+        let blocked_by = |needles: &[&str]| -> Vec<String> {
             lines
                 .iter()
-                .all(|line| !line.contains("service ingestion")
-                    && !line.contains("service data_node"))
-        );
-        assert!(lines
-            .iter()
-            .all(|line| !line.contains("service metaserver")));
+                .filter(|line| needles.iter().any(|needle| line.contains(needle)))
+                .cloned()
+                .collect()
+        };
+        for needles in [
+            &["service client", "service proxy"][..],
+            &["service ingestion", "service data_node"][..],
+            &["service metaserver"][..],
+        ] {
+            let blocked = blocked_by(needles);
+            assert!(
+                blocked.is_empty(),
+                "these services report blockers, so the readiness gate would refuse:\n  {}",
+                blocked.join("\n  ")
+            );
+        }
     }
 
     // shared-corpus: ops_scale_readiness_slo_gate


### PR DESCRIPTION
Three bare `assert!(lines.iter().all(|line| !line.contains(..)))` calls. One is failing — visible for the first time since #1198 made bin tests run at all — and all it prints is:

```
assertion failed: lines.iter().all(|line| ...)
```

which names neither the service nor its blocker. `service_failure_lines` has already formatted the service, its blocker count, the blocker classes and its `next_action` into the very line the predicate rejects.

The assertions now report those lines. **Same predicate**: `all(!contains(a) && !contains(b))` is the same condition as `filter(any contains).is_empty()`, and the three checks keep their original groupings.

## What this deliberately does NOT do

Weaken the test. Its name says failure lines *include* next actions, while every assertion says certain services have no failure lines *at all* — so name and body disagree, and it would be easy to convert it into a formatting check that always passes.

If ingestion or data_node genuinely has a blocker, that is a product regression and this test should keep failing. Making it legible is the useful half; deciding what to do about the blocker needs whoever owns that service.

## Not compiled locally

A full crate build on this box degrades a live service sharing it. The constructs are ordinary — a closure returning `Vec<String>`, a slice-of-slices loop, `assert!` with a format argument — and CI pins Rust 1.88.0.
