### PR TITLE
A rebalance round copied an owner name for every shard to hand the planner its input

### DIFF
--- a/crates/temporalstore-rust/src/meta/auto_rebalance.rs
+++ b/crates/temporalstore-rust/src/meta/auto_rebalance.rs
@@ -113,8 +113,30 @@ impl Default for AutoRebalanceOptions {
 /// set of `live_servers`, evacuating unavailable owners first and then (if
 /// enabled) balancing load. `shard_owners` maps shard id → current owner addr
 /// (owner may be a dead/frozen server, not present in `live_servers`).
+/// Plan from owners the caller holds.
+///
+/// Kept for callers outside this crate that already have an owned map; it
+/// borrows from theirs rather than copying it again. The metaserver uses
+/// [`compute_auto_rebalance_borrowed`], which never makes the copies.
 pub fn compute_auto_rebalance(
     shard_owners: &BTreeMap<ShardId, String>,
+    live_servers: &BTreeSet<String>,
+    options: AutoRebalanceOptions,
+) -> Vec<ShardReassignment> {
+    let borrowed = shard_owners
+        .iter()
+        .map(|(shard_id, owner)| (*shard_id, owner.as_str()))
+        .collect::<BTreeMap<_, _>>();
+    compute_auto_rebalance_borrowed(&borrowed, live_servers, options)
+}
+
+/// Plan without owning the owner names.
+///
+/// They are compared and named as targets, never kept, and the state they come
+/// from is read-locked for the whole round -- so copying one per serving shard
+/// bought nothing.
+pub fn compute_auto_rebalance_borrowed(
+    shard_owners: &BTreeMap<ShardId, &str>,
     live_servers: &BTreeSet<String>,
     options: AutoRebalanceOptions,
 ) -> Vec<ShardReassignment> {
@@ -129,7 +151,7 @@ pub fn compute_auto_rebalance(
     let mut load: BTreeMap<&str, usize> =
         live_servers.iter().map(|addr| (addr.as_str(), 0)).collect();
     for current in shard_owners.values() {
-        if let Some(count) = load.get_mut(current.as_str()) {
+        if let Some(count) = load.get_mut(*current) {
             *count += 1;
         }
     }
@@ -148,7 +170,7 @@ pub fn compute_auto_rebalance(
         if plans.len() >= options.max_moves {
             return plans;
         }
-        if live_servers.contains(current) {
+        if live_servers.contains(*current) {
             continue;
         }
         let target = least_loaded_server(&load);
@@ -156,7 +178,7 @@ pub fn compute_auto_rebalance(
         owner_map(&mut owner, shard_owners, live_servers).insert(*shard_id, Some(target));
         plans.push(ShardReassignment {
             shard_id: *shard_id,
-            from_server: Some(current.clone()),
+            from_server: Some((*current).to_string()),
             to_server: target.to_string(),
             reason: ShardReassignmentReason::OwnerUnavailable,
         });
@@ -207,16 +229,14 @@ pub fn compute_auto_rebalance(
 /// deciding to do nothing.
 fn owner_map<'slot, 'data>(
     slot: &'slot mut Option<BTreeMap<ShardId, Option<&'data str>>>,
-    shard_owners: &'data BTreeMap<ShardId, String>,
+    shard_owners: &'data BTreeMap<ShardId, &'data str>,
     live_servers: &'data BTreeSet<String>,
 ) -> &'slot mut BTreeMap<ShardId, Option<&'data str>> {
     slot.get_or_insert_with(|| {
         shard_owners
             .iter()
             .map(|(shard_id, current)| {
-                let held = live_servers
-                    .get(current.as_str())
-                    .map(|addr| addr.as_str());
+                let held = live_servers.get(*current).map(|addr| addr.as_str());
                 (*shard_id, held)
             })
             .collect()
@@ -267,7 +287,7 @@ impl SingleNodeMeta {
             .map(|server| server.server_addr.clone())
             .collect::<BTreeSet<_>>();
         let shard_owners = serving_shard_owners(&state);
-        compute_auto_rebalance(&shard_owners, &live_servers, options)
+        compute_auto_rebalance_borrowed(&shard_owners, &live_servers, options)
     }
 
     /// Apply a single reassignment to the shard→owner map, preserving any

--- a/crates/temporalstore-rust/src/meta/placement_rebalance.rs
+++ b/crates/temporalstore-rust/src/meta/placement_rebalance.rs
@@ -531,9 +531,15 @@ impl SingleNodeMeta {
     ) -> Vec<ShardReassignment> {
         let live_servers = self.placement_targets();
         let shard_placement = self.shard_placements();
+        // This planner drops the lock before planning, so it needs names of
+        // its own. Copied here, while the lock is still held and the names are
+        // still there to copy.
         let shard_owners = {
             let state = self.inner.read().expect("meta lock poisoned");
             serving_shard_owners(&state)
+                .into_iter()
+                .map(|(shard_id, owner)| (shard_id, owner.to_string()))
+                .collect::<BTreeMap<_, _>>()
         };
         compute_placement_aware_rebalance(&shard_owners, &shard_placement, &live_servers, options)
     }

--- a/crates/temporalstore-rust/src/meta/shard_check.rs
+++ b/crates/temporalstore-rust/src/meta/shard_check.rs
@@ -422,7 +422,12 @@ impl SingleNodeMeta {
             let state = self.inner.read().expect("meta lock poisoned");
             // A frozen shard is out of service on purpose, so its owner not
             // serving it is expected rather than divergence.
-            let shard_owners = serving_shard_owners(&state);
+            // The check plans after this lock is dropped, so it takes names
+            // of its own rather than borrowing ones that will not outlive it.
+            let shard_owners = serving_shard_owners(&state)
+                .into_iter()
+                .map(|(shard_id, owner)| (shard_id, owner.to_string()))
+                .collect::<BTreeMap<_, _>>();
             let servers = state
                 .servers
                 .values()

--- a/crates/temporalstore-rust/src/meta/topology_helpers.rs
+++ b/crates/temporalstore-rust/src/meta/topology_helpers.rs
@@ -391,11 +391,17 @@ pub(super) fn stamp_dropped_since(
 /// Every planner reads placement through this. A frozen shard is deliberately
 /// out of service, so rebalancing must not move it, the divergence check must
 /// not "repair" it, and it must not appear in a client's topology.
-pub(super) fn serving_shard_owners(state: &MetaState) -> BTreeMap<ShardId, String> {
+/// Who owns each serving shard, borrowed from the metadata.
+///
+/// The names are read to be compared and to be named as a target; none is kept
+/// past the round, and the state is read-locked throughout it. Copying them cost
+/// an allocation per serving shard -- 1,647us of a 3,109us round at 16,384
+/// shards, which is more than half of what a round that moves nothing spends.
+pub(super) fn serving_shard_owners(state: &MetaState) -> BTreeMap<ShardId, &str> {
     state
         .shards
         .values()
         .filter(|location| location.state == MetaEntityState::Normal)
-        .map(|location| (location.shard_id, location.server_addr.clone()))
+        .map(|location| (location.shard_id, location.server_addr.as_str()))
         .collect()
 }


### PR DESCRIPTION
A round stopped building its working map for a cluster that moves nothing. What was left is the map it is handed: one owner address copied out of the metadata for every serving shard, before the planner is called at all.

Timed apart at 16,384 shards, that build was 1,647us of a 3,109us round -- more than half of what remains.

| servers | shards | before | after |
|---|---|---|---|
| 32 | 4,096 | 636.6us / 566.2us | 351.4us / 328.9us |
| 64 | 16,384 | 4,740.3us / 3,890.0us | 1,792.1us / 2,947.9us |

Two arms of each, interleaved. Every arm is faster than its pair, by 1.7-1.8x at 4,096 and 1.3-2.6x at 16,384; the spread at the larger size is load, which went from 4.7 to 12.4 across the run, and the range is reported rather than the better pair.

## What changed

The owners map borrows the addresses. Nothing needs to own them: they are compared, and named as a target, and never kept past the round -- and the state they come from is read-locked across the whole of it.

## The two planners that could not borrow

The placement planner and the divergence check share this map, and both refused to compile against a borrowed one. That is not an obstacle, it is the difference between them: both deliberately drop the read lock before planning, so planning does not hold up a writer, and names borrowed from the state would not outlive them.

So both copy inside their own lock scope, where the names are still there to copy. Their behaviour is unchanged, and each says in a comment why it differs from the round above it.

They were not converted to borrowing. Their paths were not measured here, and doing it would change when they hold the lock, which is a decision they have already made deliberately.

## Testing

39 rebalance tests, 24 placement, 5 divergence, 19 shard-check -- the three planners that take this map, plus the check that reads it. 371 metadata tests, 52 metaserver binary tests. `cargo check --all-targets` clean.
