### PR TITLE
A perf fix switched off the one field a readiness check required

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -22,6 +22,8 @@ mod gc;
 mod slab_ids;
 mod record;
 
+pub(crate) use record::block_index_checksums_enabled;
+
 use paths::{
     delayed_destroy_dir, delayed_destroy_path, band_manifest_path, file_created_unix_ms,
     file_modified_unix_ms, legacy_zone_manifest_path, now_unix_ms, slab_path, sync_dir,

--- a/crates/temporalstore-rust/src/block_store/record.rs
+++ b/crates/temporalstore-rust/src/block_store/record.rs
@@ -828,9 +828,16 @@ pub(super) fn max_page_id_in_slab_file(
 /// Default OFF. `inspect_slab` runs at every engine open, and this hashes each payload a second
 /// time -- `decode_page_record` has already verified the stored checksum -- then allocates a
 /// 64-character String for it. Measured on a live-store copy, slab verification ran at 13.5 MB/s
-/// against hundreds of MB/s for sha256 alone. Nothing in the crate reads the field; it is kept for
-/// hand-inspecting a slab.
-fn block_index_checksums_enabled() -> bool {
+/// against hundreds of MB/s for sha256 alone.
+///
+/// ONE caller reads the field: `block_address_api_ready` in
+/// `StorageDataStructureApiParityReport`, which required `checksum.is_some()` on a block index
+/// entry. An earlier version of this
+/// comment claimed nothing read it -- wrong by exactly one -- and switching the hashing off left
+/// that report permanently `ready: false` behind a `block_address_metadata_incomplete` blocker on
+/// every default deployment. The report now asks for the checksum only when this is enabled, so
+/// the two agree in both positions of the flag.
+pub(crate) fn block_index_checksums_enabled() -> bool {
     std::env::var("TS_BLOCK_INDEX_CHECKSUMS")
         .map(|value| {
             let value = value.trim().to_ascii_lowercase();

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -1680,6 +1680,13 @@ impl TemporalEngine {
             .iter()
             .map(|slab| slab.block_index_count)
             .sum::<u64>();
+        // The checksum is asked for only when checksum recording is on. It is an opt-in
+        // diagnostic (TS_BLOCK_INDEX_CHECKSUMS, default off, because recomputing it at every
+        // engine open dominated slab verification), and the integrity it would attest to is
+        // already verified by decode_page_record on the way in. Requiring it unconditionally
+        // made this report ready: false on every default deployment. The addressing fields are
+        // what a complete block address API means; the digest is a hand-inspection aid.
+        let checksums_recorded = crate::block_store::block_index_checksums_enabled();
         let block_address_api_ready = slab_reports.iter().any(|slab| {
             slab.block_index_entries.iter().any(|entry| {
                 entry.compact_slab_address.is_some()
@@ -1688,7 +1695,7 @@ impl TemporalEngine {
                     && entry.block_id.is_some()
                     && entry.object_id.is_some()
                     && entry.routing_bucket.is_some()
-                    && entry.checksum.is_some()
+                    && (!checksums_recorded || entry.checksum.is_some())
             })
         });
         let band_report = self.page_store.stream_backed_band_runtime_report().ok();
@@ -1810,7 +1817,7 @@ impl TemporalEngine {
             evidence: vec![
                 "slot/object/page authority is reported from the first-class slot index"
                     .to_string(),
-                "block addresses expose segment, offset, length, block id, object id, routing slot, band id, and checksum"
+                "block addresses expose segment, offset, length, block id, object id, routing slot and band id, plus a payload checksum when checksum recording is enabled"
                     .to_string(),
                 "stream-backed storage exposes active/sealed/delayed-destroy/purged band lifecycle while accepting legacy zone aliases"
                     .to_string(),


### PR DESCRIPTION
mx#1166 stopped recomputing a sha256 per page record at every engine open -- a real win, slab
verification ran at 13.5 MB/s against hundreds of MB/s for the hash alone -- and put it behind
`TS_BLOCK_INDEX_CHECKSUMS`, default off. Its doc comment says:

    Nothing in the crate reads the field; it is kept for hand-inspecting a slab.

Wrong by exactly one. `engine.rs:1691` reads it:

    let block_address_api_ready = slab_reports.iter().any(|slab| {
        slab.block_index_entries.iter().any(|entry| {
            ... && entry.checksum.is_some()
        })
    });

`entry.checksum` has exactly one non-test reader in the crate and this predicate is it. With the
flag off the field is `None`, so `block_address_api_ready` is false, so
`StorageDataStructureApiParityReport` carries a `block_address_metadata_incomplete` blocker and
reports `ready: false` -- on every default deployment. Every other sub-check in that report is
true. `engine::tests::part1::storage_data_structure_api_parity_report_covers_stream_block_and_manager_surfaces`
has been red on main for this reason, and its entire output is the report dump, which names the
blocker.

## The fix keeps the perf win

The default stays off. The checksum is an opt-in diagnostic, and the integrity it would attest to
is already verified by `decode_page_record` on the way in, so the report asks for it only when
checksum recording is on:

    && (!checksums_recorded || entry.checksum.is_some())

The addressing fields -- segment, offset, length, block id, object id, routing slot, band id --
are what a complete block address API means, and every one of them is still required
unconditionally. The evidence string now says the digest is conditional instead of listing it
flatly, and mx#1166 comment is corrected rather than left to mislead the next reader.

## Coverage

The existing test IS the regression test: it goes red to green here, and red again if anyone
re-tightens the predicate. The checksums-on branch is not separately tested because setting the
variable mid-suite races the ~180 other `std::env::set_var` sites in this crate.

Not compiled locally -- a full crate build on this box degrades a live service sharing it. The
change is one bool, one re-export and a visibility widening; CI pins 1.88.0.
