### PR TITLE
Every append copies its outcome payload before the encoder copies it again

### DIFF
--- a/crates/temporalstore-rust/src/wal_proto.rs
+++ b/crates/temporalstore-rust/src/wal_proto.rs
@@ -816,6 +816,15 @@ mod tests {
                 .map(metadata_to_proto)
                 .transpose()
                 .unwrap(),
+            // `items` is still filled the ordinary way, and it has the shape `staged_blocks`
+            // below was taken out of this struct for: every outcome carries an owned
+            // `value: Option<Vec<u8>>`, and `item_to_proto` copies it here before the encoder
+            // copies it again into the frame. Measured by `does_the_outcome_value_get_copied`, the
+            // bytes allocated per append track the outcome value one for one -- 4,489 B for a
+            // 4,096 B value and 16,777 B for a 16,384 B one, a fixed 393 B either side of a whole
+            // extra copy. Fixing it means what fixing `staged_blocks` meant: a hand-written encoder
+            // and a hand-written length for this field, which is a larger job here because an item
+            // has ten fields and a nested message rather than two scalars.
             items: record.outcomes.iter().map(item_to_proto).collect(),
             staged_blocks: record
                 .staged_pages
@@ -974,6 +983,59 @@ mod tests {
 
         std::env::remove_var("TS_WAL_COMPRESS_RECORDS");
         std::env::remove_var("TS_WAL_BINARY_RECORDS");
+    }
+
+    /// Whether building the proto tail copies each outcome value before the encoder copies it.
+    ///
+    /// `staged_blocks` was taken out of the proto struct for exactly this reason -- the comment in
+    /// `record_parts` says filling it copied every page before the encoder copied them again. The
+    /// `items` field is still filled the ordinary way, and every outcome carries an owned value.
+    /// If that value is copied, the bytes allocated per append rise with it, one for one.
+    #[test]
+    #[ignore]
+    #[cfg(feature = "alloc-probe")]
+    fn does_the_outcome_value_get_copied() {
+        for value_len in [512usize, 4096, 16384] {
+            let mut record = record_with(Some(Command::StringSet {
+                key: "k".to_string(),
+                value: vec![1u8; 16],
+            }));
+            record.outcomes = vec![crate::wal::WalOutcomeItem {
+                kind: "page".to_string(),
+                object_key: "tenant/1/object/9".to_string(),
+                component: Some("body".to_string()),
+                object_id: 9,
+                routing_bucket: 8539,
+                address: None,
+                value: Some(vec![7u8; value_len]),
+                ttl: Some(60_000),
+                deleted: false,
+                meta: false,
+            }];
+
+            let mut out = Vec::with_capacity(1024 * 1024);
+            let prepared = prepare(&record).unwrap();
+            out.clear();
+            prepared.put(&record, &mut out).unwrap();
+            let payload_len = out.len();
+
+            let runs = 32usize;
+            let probe = crate::alloc_probe::Probe::start();
+            for _ in 0..runs {
+                let prepared = prepare(std::hint::black_box(&record)).unwrap();
+                out.clear();
+                prepared.put(&record, &mut out).unwrap();
+                std::hint::black_box(out.len());
+            }
+            let counts = probe.stop();
+
+            println!(
+                "  ITEMS outcome value {value_len:>6} B | payload {payload_len:>6} B | {:>5.1} allocs {:>8.0} B per append",
+                counts.allocs as f64 / runs as f64,
+                counts.alloc_bytes as f64 / runs as f64,
+            );
+        }
+        println!("  (if the bytes rise with the value, the outcome payload is being copied)");
     }
 
     #[test]


### PR DESCRIPTION
`record_parts` builds the proto tail with `items: record.outcomes.iter().map(item_to_proto).collect()`.
Each outcome carries an owned `value: Option<Vec<u8>>`, and `item_to_proto` copies it into the proto
message. The encoder then copies it again, into the frame buffer that goes to disk.

That is the shape `staged_blocks` was taken out of this same struct for. The comment two lines below
still records why: filling it "copied every one of them before the encoder copied them again".

Measured with the allocation probe, driving the borrowing writer the way the append path does:

    outcome value      allocated per append      overhead
        4,096 B                4,489 B              393 B
       16,384 B               16,777 B              393 B

The rows differ by 12,288 bytes, which is exactly the difference in value size. So the copy is one
for one: a fixed 393 bytes of conversion, plus a whole second copy of whatever the outcome carries.
On a page write that is the page.

This change does not fix it. Fixing it means what fixing `staged_blocks` meant -- a hand-written
encoder and a hand-written length for the field, checked byte for byte against the ordinary path by
`the_borrowing_encoder_writes_the_same_bytes`. That was tractable for a staged block, which is two
scalars. An outcome item has ten fields and a nested message, and proto3 default omission has to be
reproduced exactly or records already on disk stop decoding. It deserves its own change rather than
being tacked onto a measurement.

What lands here is the measurement and a note at the field, so the next person finds a number
instead of rediscovering it: `does_the_outcome_value_get_copied`, behind the `alloc-probe` feature.