### PR TITLE
Assert the reclaim clamp, not the refusal it replaced

### DIFF
--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -2478,25 +2478,45 @@ fn storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_f
         .iter()
         .find(|stage| stage.stage == "reclaim_wal")
         .expect("the cycle ran a reclaim_wal stage");
-    assert!(reclaim_wal.skipped, "{reclaim_wal:?}");
-    assert!(
-        reclaim_wal
-            .reason
-            .contains("follower_cursor_retains_logs:follower-lagging-runtime"),
-        "the refusal must name the follower holding the logs: {reclaim_wal:?}"
-    );
-    assert!(
-        reclaim_wal
-            .reason
-            .contains("raft_snapshot_retains_logs:raft-snapshot-runtime"),
-        "the refusal must name the snapshot holding the logs: {reclaim_wal:?}"
+    // The refusal this asserted was deliberately replaced by a CLAMP. A cursor at sequence 1
+    // means everything at or below 1 is behind every reader, so reclaim may take exactly that
+    // span and no more; refusing outright let one lagging follower pin the whole log for as long
+    // as it lagged, and the log grew without bound underneath it (storage_lifecycle_methods.rs).
+    // So the property worth asserting is the BOUND, not a refusal message -- and the bound is the
+    // one a retention cursor exists to impose.
+    //
+    // Both cursors sit at sequence 1, and the wait above already required a retention blocker,
+    // which needs 1 < durable_frontier. The floor over the cursors is therefore 1 and the plan
+    // must retain from exactly 2. The exact value is the point: >= would also pass if the clamp
+    // were dropped and reclaim ran all the way to the durable frontier, which is the regression
+    // being guarded here.
+    assert!(!reclaim_wal.skipped, "{reclaim_wal:?}");
+    assert_eq!(
+        reclaim_wal.retain_from_wal_sequence, 2,
+        "reclaim must not advance past the slowest cursor: {reclaim_wal:?}"
     );
     assert_eq!(
-        running.last_wal_floor_sequence, 0,
-        "logs held by a cursor have no floor to report: {:?}",
+        reclaim_wal.retain_from_index_log_sequence, 2,
+        "reclaim must not advance past the slowest cursor: {reclaim_wal:?}"
+    );
+    // Clamping instead of refusing did not stop the cursors being counted, nor the pressure
+    // signal naming what is holding the logs.
+    assert_eq!(reclaim_wal.retention_blockers, 2, "{reclaim_wal:?}");
+    assert!(
+        reclaim_wal
+            .pressure_signal
+            .contains("follower_snapshot_retention"),
+        "{reclaim_wal:?}"
+    );
+    assert_eq!(
+        running.last_wal_floor_sequence, reclaim_wal.wal_floor_sequence,
+        "the manager must report the floor the stage computed: {:?}",
         running.last_skipped_reasons
     );
-    assert_eq!(running.last_index_log_floor_sequence, 0);
+    assert_eq!(
+        running.last_index_log_floor_sequence,
+        reclaim_wal.index_log_floor_sequence
+    );
     assert!(running.last_retention_blockers >= 1);
     assert!(running
         .last_phase_blockers


### PR DESCRIPTION
`data_node::tests::part3::storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_flags`
is red on main. It asserts that WAL reclaim REFUSES while a follower cursor and a raft snapshot
ref both sit at sequence 1:

    assert!(reclaim_wal.skipped, "{reclaim_wal:?}");
    assert!(reclaim_wal.reason.contains("follower_cursor_retains_logs:follower-lagging-runtime"), ..);
    assert_eq!(running.last_wal_floor_sequence, 0, ..);

That contract was deliberately replaced. `storage_lifecycle_methods.rs` now CLAMPS instead of
refusing, and says why:

    Refusing at the cursor instead of clamping to it meant one lagging follower pinned the
    entire log for as long as it lagged, and the log grew without bound underneath it.

So the engine is right and the test is stale. With both cursors at sequence 1 the floor over them
is 1, `effective_wal_frontier = min(durable, 1) = 1`, and the plan retains from 2 -- it drops only
sequences at or below 1, which every reader has already consumed. The run confirms it:
`skipped: false, retain_from_wal_sequence: 2, wal_floor_sequence: 2, retention_blockers: 2`.

## What it asserts now

The BOUND, which is the property a retention cursor exists to impose:

    assert_eq!(reclaim_wal.retain_from_wal_sequence, 2, ..);
    assert_eq!(reclaim_wal.retain_from_index_log_sequence, 2, ..);

The exact value is deliberate. `>=` would pass just as well if the clamp were deleted and reclaim
ran to the durable frontier -- which is the one regression worth catching here, and it is caught:
drop the `.min(floor)` and the frontier is at least 2, so `retain_from` is at least 3 and this
fails. The wait above already required a retention blocker, which needs `1 < durable_frontier`, so
the value is deterministic rather than timing-dependent.

Being NAMED was the other half of the old assertion and it is kept, against the fields that
actually carry it now: `retention_blockers == 2` (one follower, one snapshot) and a
`pressure_signal` containing `follower_snapshot_retention`. The floor assertions now check that
the manager reports the floor the stage computed, rather than hardcoding the zero that only the
refusal produced.

## What this does not do

It does not weaken the test into one that passes either way, and it does not touch the engine.
Worth a second opinion: on the clamped path the blocker REASONS -- which name the specific
follower and snapshot -- are computed but do not reach `reason`, so the operator-visible string
no longer names who is holding the logs. That is an observability question for whoever owns
reclaim, not something to infer from a test, so it is flagged rather than changed.

Not compiled locally -- a full crate build on this box degrades a live service sharing it.
