### PR TITLE
A context pack that finished late was deleted instead of served

### DIFF
--- a/tools/matrixark_agent_hook.py
+++ b/tools/matrixark_agent_hook.py
@@ -545,8 +545,7 @@ def retrieval_session_identity_from_retrieve(pack: Json | None, *, session_id_so
 def retrieval_quality_warnings_from_retrieve(pack: Json | None) -> list[Any]:
     if not isinstance(pack, dict):
         return []
-    warnings = pack.get("quality_warnings")
-    return warnings if isinstance(warnings, list) else []
+    return _pack_cache.retrieval_warnings(pack)
 
 
 HOOK_MESSAGE_ROLE_ALIASES = {

--- a/tools/matrixark_codex_hook.py
+++ b/tools/matrixark_codex_hook.py
@@ -1770,7 +1770,7 @@ def additional_context_from_retrieve(
         return ""
     refs = [ref for ref in _selected_refs_from_retrieve(pack) if not _ref_is_codex_hook_heartbeat(ref)]
     context_text = sanitized_rendered_context_from_retrieve(pack)
-    quality_warnings = pack.get("quality_warnings")
+    quality_warnings = _pack_cache.retrieval_warnings(pack)
     retrieval_metrics = pack.get("retrieval_metrics")
     budget = retrieval_budget_summary_from_retrieve(pack)
     budget_pressure = retrieval_budget_pressure_from_retrieve(pack)

--- a/tools/matrixark_hook_pack_cache.py
+++ b/tools/matrixark_hook_pack_cache.py
@@ -150,6 +150,28 @@ def store_answered(retrieve: object) -> bool:
                ("pack_id", "context_pack_id", "context", "refs", "selected_refs"))
 
 
+def retrieval_warnings(pack: object) -> list:
+    """The retrieval warnings on a pack, under either name it can arrive under.
+
+    `compact_context_pack_for_serving` renames `quality_warnings` to `warnings`, and what reaches a
+    hook is the COMPACT pack -- so a reader that knows only `quality_warnings` reports an empty
+    list on every live turn. That is how a `retrieval_deadline_exceeded` warning went unseen while
+    both agents served empty context: the signal was produced, compacted under another name, and
+    read for by nobody.
+
+    Both spellings are accepted rather than the compact one alone, because the full pack is what
+    comes back with `include_retrieval_debug`, and a diagnostic that only works in production is
+    the same trap in the other direction.
+    """
+    if not isinstance(pack, dict):
+        return []
+    for key in ("quality_warnings", "warnings"):
+        value = pack.get(key)
+        if isinstance(value, list) and value:
+            return list(value)
+    return []
+
+
 def label_previous_pack(previous: str, age_s: float) -> str:
     """Mark a served pack as prior context, in band, with its age.
 

--- a/tools/matrixark_mcp_dispatch.py
+++ b/tools/matrixark_mcp_dispatch.py
@@ -169,9 +169,18 @@ def dispatch_matrixark_tool(server: Any, name: str, args: Json, hook: Json | Non
         elapsed_ms = (time.perf_counter() - started_perf) * 1000.0
         timeout = request_deadline_ms > 0 and elapsed_ms >= request_deadline_ms
         if timeout and not (result.get("partial_context_pack") or result.get("partial")):
-            result = server._retrieve_timeout_fallback(args, deadline_ms=effective_retrieve_deadline_ms or request_deadline_ms, elapsed_ms=elapsed_ms, reason="request_deadline_after_retrieve")
+            # The retrieve COMPLETED -- the refs are computed and the full cost is already spent.
+            # A deadline bounds how long a caller WAITS, and that wait is over by the time we get
+            # here, so overrunning it makes the answer LATE, not wrong. Replacing it with
+            # `_retrieve_timeout_fallback` (which builds from `records = []` on a native backend)
+            # deletes every ref just computed and tells the agent it has no history: the silent
+            # recall collapse the deadline above this was raised to prevent, arriving instead by
+            # way of a store that outgrew the ceiling. Label it and serve it.
+            #
+            # The RAISING path above keeps the fallback: there, no pack exists to serve.
             result["quality_warnings"] = list(result.get("quality_warnings", [])) + ["request_deadline_after_retrieve"]
-            result["partial_context_pack"] = True
+            result["retrieval_deadline_exceeded"] = True
+            result["late_context_pack"] = True
         result["request_deadline_ms"] = request_deadline_ms
         result["request_elapsed_ms"] = round(elapsed_ms, 3)
         server.metrics.observe_operation("retrieve", "ok", elapsed_ms, timeout=timeout)

--- a/tools/test_a_late_context_pack_is_served_not_discarded.py
+++ b/tools/test_a_late_context_pack_is_served_not_discarded.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A retrieve that finishes LATE must still be served; only one that never finished may be dropped.
+
+Both agents on the live box served empty context for hours while retrieval was healthy. The
+retrieve completed and returned a full pack every time; the dispatcher then discarded that pack
+because it had taken longer than the request deadline and substituted an empty
+`deadline_fallback_pack`. On a native backend that replacement is built from `records = []`, so a
+complete answer became no answer, with no error raised and -- because the compact pack renames
+`quality_warnings` to `warnings`, which no hook read -- no warning surfaced either.
+
+The deadline bounds how long a caller WAITS. By the time the dispatcher inspects the result the
+wait is over and the work is paid for, so lateness is a property to LABEL, not grounds to delete
+the answer.
+
+These tests pin both halves, and the third pins the boundary: when `retrieve` RAISES there is no
+pack to serve and the fallback is still the only option. Without that case a "fix" that simply
+deleted the timeout branch would look correct.
+"""
+from __future__ import annotations
+
+import time
+import unittest
+
+try:  # package path
+    from tools import matrixark_hook_pack_cache as pack_cache
+    from tools import matrixark_mcp_dispatch as dispatch
+    from tools import matrixark_mcp_server as mcp
+    from tools.matrixark_mcp_core import MatrixArkError
+except ImportError:  # direct execution from tools/
+    import matrixark_hook_pack_cache as pack_cache  # type: ignore
+    import matrixark_mcp_dispatch as dispatch  # type: ignore
+    import matrixark_mcp_server as mcp  # type: ignore
+    from matrixark_mcp_core import MatrixArkError  # type: ignore
+
+
+REAL_PACK = {
+    "context_pack_id": "pack-that-finished",
+    "selected_refs": [{"text": "the fact the agent needed"}],
+    "selected_ref_counts": {"context_event": 1},
+}
+
+
+#: Long enough that the retrieve provably overruns DEADLINE_MS, short enough to stay a unit test.
+#: Without a real overrun the timeout branch never runs and every assertion below passes on
+#: unmodified code -- which is no coverage at all.
+SLOW_RETRIEVE_S = 0.05
+DEADLINE_MS = 1
+
+
+class _SlowButCompleteAdapter:
+    """Returns a real pack, having taken longer than any deadline the caller set."""
+
+    def __init__(self) -> None:
+        self.fallback_calls = 0
+
+    def _backend_label(self) -> str:
+        return "temporalstore-direct"
+
+    def retrieve(self, args):
+        time.sleep(SLOW_RETRIEVE_S)
+        return dict(REAL_PACK)
+
+    def read_all(self):
+        raise AssertionError("a completed pack must not be rebuilt from a full scan")
+
+    def deadline_fallback_pack(self, **kwargs):
+        self.fallback_calls += 1
+        return {"context_pack_id": "deadline-fallback", "selected_refs": []}
+
+
+class _RaisingAdapter(_SlowButCompleteAdapter):
+    """Never produces a pack at all."""
+
+    def retrieve(self, args):
+        raise MatrixArkError("temporalstore request timed out")
+
+
+def _dispatch(adapter, *, request_deadline_ms):
+    server = mcp.MatrixArkMcpServer(adapter)
+    args = {"query": "what did we change", "scope": {"account_id": "acct"}, "_matrixark_auth": {}}
+    return server, dispatch.dispatch_matrixark_tool(
+        server, "matrixark_retrieve", args, None, {}, request_deadline_ms,
+    )
+
+
+def _refs(response):
+    for key in ("selected_refs", "refs"):
+        value = response.get(key)
+        if isinstance(value, list):
+            return value
+    groups = response.get("groups")
+    if isinstance(groups, list):
+        return [item for group in groups for item in (group.get("items") or [])]
+    return []
+
+
+class LateContextPackTest(unittest.TestCase):
+    def test_a_pack_that_finished_late_is_still_served(self) -> None:
+        # deadline of 1ms: any real call overruns it, so this is the late-but-complete case.
+        adapter = _SlowButCompleteAdapter()
+        _, response = _dispatch(adapter, request_deadline_ms=DEADLINE_MS)
+
+        self.assertEqual(
+            0, adapter.fallback_calls,
+            "a completed pack was replaced by the empty deadline fallback",
+        )
+        self.assertTrue(
+            _refs(response),
+            f"the refs the retrieve computed were dropped: {response!r}",
+        )
+
+    def test_lateness_is_reported_rather_than_hidden(self) -> None:
+        _, response = _dispatch(_SlowButCompleteAdapter(), request_deadline_ms=DEADLINE_MS)
+        warnings = [str(w) for w in pack_cache.retrieval_warnings(response)]
+        self.assertTrue(
+            any("request_deadline_after_retrieve" in w for w in warnings),
+            f"a late pack must say so; warnings were {warnings!r}",
+        )
+
+    def test_a_retrieve_that_never_finished_still_falls_back(self) -> None:
+        # The boundary: no pack exists here, so the fallback is the only thing to serve. A fix that
+        # merely removed the timeout branch would break this.
+        adapter = _RaisingAdapter()
+        try:
+            _, response = _dispatch(adapter, request_deadline_ms=DEADLINE_MS)
+        except MatrixArkError:
+            self.fail("a timed-out retrieve must degrade to the fallback pack, not propagate")
+        self.assertEqual(1, adapter.fallback_calls)
+        self.assertEqual("deadline-fallback", response.get("context_pack_id"))
+
+
+class CompactWarningNameTest(unittest.TestCase):
+    """The hooks receive the COMPACT pack, which spells the field `warnings`."""
+
+    def test_warnings_are_read_under_the_compact_name(self) -> None:
+        compact = {"context_pack_id": "p", "warnings": ["retrieval_deadline_exceeded:x"]}
+        self.assertEqual(["retrieval_deadline_exceeded:x"], pack_cache.retrieval_warnings(compact))
+
+    def test_warnings_are_still_read_under_the_full_name(self) -> None:
+        full = {"context_pack_id": "p", "quality_warnings": ["retrieval_deadline_exceeded:x"]}
+        self.assertEqual(["retrieval_deadline_exceeded:x"], pack_cache.retrieval_warnings(full))
+
+    def test_a_pack_with_no_warnings_reads_empty(self) -> None:
+        self.assertEqual([], pack_cache.retrieval_warnings({"context_pack_id": "p"}))
+        self.assertEqual([], pack_cache.retrieval_warnings(None))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A retrieve that completed was thrown away because it was slow, and the agent was told it had no
history.

`dispatch_matrixark_tool` runs the retrieve, gets a full ContextPack back, and then — if the call
took longer than the request deadline — discards that pack and substitutes
`_retrieve_timeout_fallback`:

```python
result = server.adapter.retrieve(args)          # completes; refs computed
timeout = request_deadline_ms > 0 and elapsed_ms >= request_deadline_ms
if timeout and not (result.get("partial_context_pack") or result.get("partial")):
    result = server._retrieve_timeout_fallback(...)   # replaces it
```

On a native backend that replacement builds its pack from `records = []`, so a complete answer
becomes an empty one. Nothing raises, and the empty pack carries a `context_pack_id` like any
other, so every downstream check reads it as a legitimate answer.

A deadline bounds how long a caller **waits**. By the time this branch runs the wait is already
over and the full cost is already paid, so overrunning it makes the answer *late* — not wrong, and
certainly not worth deleting. This keeps the pack, marks it late, and lets it through.

The comment above the deadline constant describes this same failure happening once before, at the
old 5000 ms ceiling: *"made the server discard the real ContextPack for an empty
deadline_fallback_pack (silent recall collapse: refs computed but dropped)"*. It was fixed by
raising the ceiling to 30000 ms, on the stated assumption that *"actual warm/cold retrieve latency
stays well under this ceiling"*. That assumption expires as a store grows. Measured on a 16,717-record
store at four secondary-index budgets:

| tenant / scope budget | retrieve | outcome |
|---|---|---|
| 1024 / 128 (default) | 32.1 s | over deadline, pack discarded |
| 4096 / 512 | 57.3 s | over deadline, pack discarded |
| 8192 / 1024 | 75.7 s | over deadline, pack discarded |
| 32768 / 4096 | 72.3 s | over deadline, pack discarded |

Every setting overruns the 30 s deadline, including the default — so no tuning of that budget could
avoid it, and raising the ceiling again would only postpone the same collapse behind a larger
number. The behaviour is what needed fixing.

### Why it stayed silent

`compact_context_pack_for_serving` renames `quality_warnings` to `warnings`, and what reaches a hook
is the compact pack — but both hooks read only `quality_warnings`. Every retrieval warning therefore
read as an empty list on every live turn: the deadline warning, the embedding-model-conflict warning,
and the underfill warning alike. The signal was produced, compacted under another name, and read for
by nobody.

`retrieval_warnings()` now accepts either spelling, and both hooks use it. Both spellings rather than
just the compact one, because the full pack is what comes back with `include_retrieval_debug`, and a
diagnostic that only works in production is the same trap facing the other way.

### Scope

The raising path is deliberately untouched: when `adapter.retrieve` raises there is no pack, and the
fallback is the only thing available to serve. `test_a_retrieve_that_never_finished_still_falls_back`
pins that boundary and passes both with and without this change, so a "fix" that merely deleted the
timeout branch would not get past it.

### Verified on a live box

One agent turn against the 16,717-record store, before and after:

| | context served | refs | warnings surfaced |
|---|---|---|---|
| before | 3 bytes | 0 | `[]` |
| after | 7,886 bytes | 24 | `["request_deadline_after_retrieve"]` |

`context_pack_source` is unset on the served turn, so this is a freshly retrieved pack rather than
the previous-pack fallback covering for it. The warning string had been produced on every turn for
hours and read as an empty list the whole time.

### Tests

`tools/test_a_late_context_pack_is_served_not_discarded.py`. Against unmodified code the central
test fails with `a completed pack was replaced by the empty deadline fallback`; the boundary test
passes on both arms. The stub adapter sleeps past the deadline on purpose — with an instant adapter
the timeout branch never runs and all of these pass against unmodified code, which is no coverage at
all.

Suites touching the changed files were run on both arms and are unchanged:
`test_codex_pipeline_part4`, `test_python_module_boundaries_part3` and `test_matrixark_codex_hook_pipeline`
carry identical pre-existing failure counts before and after; `test_a_setting_declares_the_default_the_code_applies`,
`test_a_retrieve_that_raises_is_recorded_not_fatal` and `test_the_callers_deadline_reaches_the_socket`
pass.
