### PR TITLE
Moving a shard threw away the location it was pinned to

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -8698,6 +8698,90 @@ fn counting_resources_agrees_with_listing_them_and_counting_those() {
     }
 
     #[test]
+    fn moving_a_shard_keeps_its_pin_and_the_time_it_joined() {
+        let meta = SingleNodeMeta::default();
+        for n in 0..2u64 {
+            assert!(meta
+                .register_server(RegisterServerRequest {
+                    numa_nodes: Vec::new(),
+                    server_addr: format!("node-{n}"),
+                    node_id: n + 1,
+                    location: format!("rack-{n}"),
+                    binary_version: "v1".to_string(),
+                    registered_at_ms: 0,
+                })
+                .status
+                .ok);
+        }
+        assert!(meta
+            .add_table(AddTableRequest {
+                namespace: "ns".to_string(),
+                table_name: "t".to_string(),
+                first_shard_id: 1,
+                shard_count: 1,
+                replica_count: 1,
+                partition_version: 1,
+                serving_options: Default::default(),
+            })
+            .status
+            .ok);
+        assert!(meta
+            .register(RegisterShardRequest {
+                shard_id: 1,
+                server_addr: "node-0".to_string(),
+                registered_at_ms: 0,
+            })
+            .status
+            .ok);
+        assert!(meta
+            .pin_shard(ShardPinRequest {
+                shard_id: 1,
+                location: "rack-9".to_string(),
+            })
+            .status
+            .ok);
+
+        let before = meta.get(1).location.expect("registered");
+        assert_eq!(before.preferred_location, "rack-9");
+        assert!(before.registered_at_ms > 0, "the join time was never stamped");
+
+        // A rebalance round moves it, or an operator does.
+        assert!(meta.reassign_shard(1, "node-1").status.ok);
+
+        let after = meta.get(1).location.expect("still registered");
+        assert_eq!(after.server_addr, "node-1", "the move did not happen");
+        // The pin exists to say where this shard should live. A move is exactly
+        // when that matters, so losing it here loses it when it counts.
+        assert_eq!(
+            after.preferred_location, "rack-9",
+            "moving the shard threw away the location it was pinned to"
+        );
+        // And it has not newly joined the cluster by changing owner.
+        assert_eq!(
+            after.registered_at_ms, before.registered_at_ms,
+            "moving the shard reset the time it joined"
+        );
+
+        // The snapshot is still carried too, which it already was -- kept here
+        // so a later rewrite of this record cannot drop one and keep the others.
+        assert_eq!(after.latest_snapshot, before.latest_snapshot);
+
+        // And the listing agrees, since that is where an operator would look.
+        let listed = meta.list_shards(ListShardsRequest {
+            server_addr: String::new(),
+            after_shard_id: 0,
+            limit: 0,
+        });
+        let entry = listed
+            .shards
+            .iter()
+            .find(|entry| entry.shard_id == 1)
+            .expect("listed");
+        assert_eq!(entry.preferred_location, "rack-9");
+        assert_eq!(entry.registered_at_ms, before.registered_at_ms);
+    }
+
+    #[test]
     fn metaserver_safe_mode_cooldown_blocks_rejoin_and_round_trips() {
         let dir = tempfile::tempdir().unwrap();
         let log_path = dir.path().join("safe-mode-mutations.jsonl");

--- a/crates/temporalstore-rust/src/meta/auto_rebalance.rs
+++ b/crates/temporalstore-rust/src/meta/auto_rebalance.rs
@@ -318,15 +318,27 @@ impl SingleNodeMeta {
             server_addr: to_server.to_string(),
         }));
         let mut state = self.inner.write().expect("meta lock poisoned");
-        let latest_snapshot = state
+        // What the shard knows about itself does not change because it changed
+        // owner: it still prefers the location it was pinned to, and it has not
+        // newly joined the cluster. Rebuilding the record around the new owner
+        // used to write both away -- so a pin did not survive the move it
+        // exists to constrain, and a moved shard reported that it never joined.
+        let (latest_snapshot, preferred_location, registered_at_ms) = state
             .shards
             .get(&shard_id)
-            .and_then(|location| location.latest_snapshot.clone());
+            .map(|location| {
+                (
+                    location.latest_snapshot.clone(),
+                    location.preferred_location.clone(),
+                    location.registered_at_ms,
+                )
+            })
+            .unwrap_or_default();
         state.shards.insert(
             shard_id,
             ShardLocation {
-                registered_at_ms: 0,
-                preferred_location: String::new(),
+                registered_at_ms,
+                preferred_location,
                 state: MetaEntityState::Normal,
                 shard_id,
                 server_addr: to_server.to_string(),


### PR DESCRIPTION
Reassigning a shard rebuilds its record around the new owner. It kept the snapshot on purpose, and wrote the two newer fields as empty and zero -- which is what a struct literal does to fields added to a record after it was written.

So moving a shard threw away the location it was pinned to, and reset the time it joined.

The pin is the part that matters. A pin says where this shard should live; a move is exactly the moment that applies. Losing it there means the pin survives right up until the operation it exists to constrain, and then goes, with nothing said.

The join time reset is quieter but reads wrong in the same way: a shard that changed owner has not newly joined the cluster. That is the reading the field already takes for a server that restarts in place, and now it is visible wherever shards are listed.

## What changed

Both are carried across the move, the way the snapshot already was.

## Testing

The test moves a pinned shard and asks for it back. Run against the tree before this change it fails, saying the move threw away the location it was pinned to.

It also holds the snapshot to the same standard, so a later rewrite of this record cannot drop one of the three and keep the others -- which is how these two came to be lost while the snapshot survived.

And it checks the listing as well as the record, because the listing is where an operator would look for a pin.

## Not in this change

The rebalancer that runs by default does not read per-shard pins at all: only the placement-aware planner does, and it is off unless asked for. That is a behavioural question rather than a dropped field, and it wants its own measurement and its own change.
