### PR TITLE
Nine more functions written out twice, now written once

### DIFF
--- a/tools/matrixark_mcp_entity_ops.py
+++ b/tools/matrixark_mcp_entity_ops.py
@@ -34,87 +34,19 @@ except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_core import edit_distance
 
 
-def best_span_by_edit_distance(text: str, search: str) -> tuple[int, int, float]:
-    if not text or not search:
-        return -1, -1, 1.0
-    lower_text = text.lower()
-    lower_search = search.lower()
-    exact = lower_text.find(lower_search)
-    if exact >= 0:
-        return exact, exact + len(search), 0.0
-    search_len = len(search)
-    best = (-1, -1, 1.0)
-    min_len = max(1, int(search_len * 0.7))
-    max_len = min(len(text), max(search_len + 8, int(search_len * 1.3)))
-    step = max(1, search_len // 8)
-    for start in range(0, len(text), step):
-        for span_len in range(min_len, max_len + 1, step):
-            end = min(len(text), start + span_len)
-            if end <= start:
-                continue
-            candidate = text[start:end]
-            distance = edit_distance(candidate.lower(), lower_search)
-            ratio = distance / max(len(candidate), len(search), 1)
-            if ratio < best[2]:
-                best = (start, end, ratio)
-    return best
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import best_span_by_edit_distance
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import best_span_by_edit_distance
 
 
-def apply_entity_patch(old_value: str, patch_text: str, *, max_distance_ratio: float = 0.45) -> Json:
-    parsed = parse_entity_patch(patch_text)
-    if not parsed:
-        return {
-            "updated": old_value,
-            "applied": False,
-            "reason": "invalid_patch",
-            "distance_ratio": 1.0,
-        }
-    search, replace = parsed
-    if not old_value:
-        return {
-            "updated": replace,
-            "applied": True,
-            "reason": "empty_old_value",
-            "distance_ratio": 0.0,
-        }
-    start, end, ratio = best_span_by_edit_distance(old_value, search)
-    if start < 0 or ratio > max_distance_ratio:
-        return {
-            "updated": replace,
-            "applied": False,
-            "reason": "no_close_span",
-            "distance_ratio": round(ratio, 6),
-        }
-    return {
-        "updated": old_value[:start] + replace + old_value[end:],
-        "applied": True,
-        "reason": "approximate_patch",
-        "distance_ratio": round(ratio, 6),
-        "span": [start, end],
-    }
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import apply_entity_patch
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import apply_entity_patch
 
 
-def apply_entity_patches(old_entity: Json | None, extracted_entity: Json) -> Json:
-    state = str((old_entity or {}).get("state", ""))
-    patches = extracted_entity.get("field_patches", [])
-    patch_results = []
-    updated_state = state or str(extracted_entity.get("state", ""))
-    for patch in patches:
-        if not isinstance(patch, dict) or patch.get("field", "state") != "state":
-            continue
-        result = apply_entity_patch(updated_state, str(patch.get("patch", "")))
-        updated_state = str(result.get("updated", updated_state))
-        patch_results.append(result)
-    if not patches and not state:
-        updated_state = str(extracted_entity.get("state", ""))
-    elif not patches and state:
-        new_state = str(extracted_entity.get("state", ""))
-        if new_state and new_state.lower() not in state.lower():
-            updated_state = summarize_text(state + " " + new_state, limit=320)
-    return {
-        **extracted_entity,
-        "state": summarize_text(updated_state, limit=320),
-        "previous_state": state,
-        "patch_results": patch_results,
-        "update_mode": "deterministic_eua" if patches else "merge_without_patch",
-    }
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import apply_entity_patches
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import apply_entity_patches

--- a/tools/matrixark_mcp_extraction_normalization.py
+++ b/tools/matrixark_mcp_extraction_normalization.py
@@ -740,8 +740,10 @@ def infer_entity_field_patches(entity_type: str, value: str, text: str) -> list[
     return patches[:3]
 
 
-def clean_patch_value(value: str) -> str:
-    return summarize_text(" ".join(value.split()).strip(" ,;:-"), limit=180)
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import clean_patch_value
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import clean_patch_value
 
 
 try:  # the implementation lives in matrixark_mcp_core; this module re-exports it

--- a/tools/matrixark_mcp_resources.py
+++ b/tools/matrixark_mcp_resources.py
@@ -89,16 +89,10 @@ DEBUG_RESOURCE_METADATA_FIELDS = {
 }
 
 
-def sanitize_resource_metadata(metadata: Json) -> Json:
-    sanitized = {
-        key: value
-        for key, value in metadata.items()
-        if key not in RAW_BYTE_METADATA_FIELDS
-    }
-    sanitized["parse_warnings"] = normalize_parse_warnings(sanitized)
-    sanitized["raw_storage_policy"] = str(sanitized.get("raw_storage_policy") or "raw_uri_only")
-    sanitized["raw_bytes_stored"] = False
-    return sanitized
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import sanitize_resource_metadata
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import sanitize_resource_metadata
 
 
 def serving_resource_metadata(metadata: Json) -> Json:
@@ -232,14 +226,10 @@ except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_core_resource_io import is_s3_uri
 
 
-def parse_s3_uri(uri: str) -> tuple[str, str]:
-    if not is_s3_uri(uri):
-        raise MatrixArkError(f"not an s3 uri: {uri}")
-    rest = uri[len("s3://") :]
-    bucket, sep, key = rest.partition("/")
-    if not bucket or not sep or not key:
-        raise MatrixArkError(f"invalid s3 uri: {uri}")
-    return bucket, key
+try:  # the implementation lives in matrixark_mcp_core_resource_io; this module re-exports it
+    from .matrixark_mcp_core_resource_io import parse_s3_uri
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_resource_io import parse_s3_uri
 
 
 def _cloud_resource_bucket(args: Json, envelope: Json) -> str:
@@ -335,21 +325,10 @@ def download_s3_to_file(uri: str, target: Path) -> Path:
     return target
 
 
-def _resource_object_key(prefix: str, raw_uri: str, source_path: Path | None, resource_type: str) -> str:
-    suffix = Path(raw_uri).name if raw_uri and raw_uri != "inline-resource" else ""
-    if source_path is not None:
-        suffix = source_path.name
-    suffix = safe_identifier(suffix or f"resource.{resource_type or 'txt'}", default="resource")
-    digest = hashlib.sha256()
-    digest.update(raw_uri.encode("utf-8", errors="ignore"))
-    if source_path is not None and source_path.exists() and source_path.is_file():
-        try:
-            with source_path.open("rb") as fh:
-                for block in iter(lambda: fh.read(1024 * 1024), b""):
-                    digest.update(block)
-        except OSError:
-            pass
-    return f"{prefix}/{digest.hexdigest()[:16]}-{suffix}"
+try:  # the implementation lives in matrixark_mcp_core_resource_io; this module re-exports it
+    from .matrixark_mcp_core_resource_io import _resource_object_key
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_resource_io import _resource_object_key
 
 
 try:  # the implementation lives in matrixark_mcp_core_resource_io; this module re-exports it

--- a/tools/matrixark_mcp_session_runtime.py
+++ b/tools/matrixark_mcp_session_runtime.py
@@ -45,11 +45,10 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
     )
 
 
-def attach_memory_layer(record: Json) -> Json:
-    layer = candidate_memory_layer_name(record)
-    if not layer or layer == "unknown":
-        return record
-    return {**record, "memory_layer": layer}
+try:  # the implementation lives in matrixark_codex_hook; this module re-exports it
+    from .matrixark_codex_hook import attach_memory_layer
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_codex_hook import attach_memory_layer
 
 
 def add_codex_selection_policies(bucket: Json, selection: Json, add_count_fn: object) -> None:

--- a/tools/matrixark_mcp_summaries.py
+++ b/tools/matrixark_mcp_summaries.py
@@ -57,21 +57,10 @@ except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_core import summarize_text
 
 
-def deterministic_time_compression_summary(
-    *,
-    node_path: list[str],
-    source_start_ms: int,
-    source_end_ms: int,
-    event_texts: list[str],
-    max_raw_events_per_node: int,
-) -> str:
-    snippets = [summarize_text(text, limit=180) for text in event_texts[:5]]
-    return (
-        f"Temporal compression window [{source_start_ms}, {source_end_ms}] under "
-        f"{' / '.join(node_path)} contains {len(event_texts)} source events. "
-        f"Normal retrieval should score this synthesis plus the newest {max_raw_events_per_node} raw events. "
-        + " | ".join(snippets)
-    )
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import deterministic_time_compression_summary
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import deterministic_time_compression_summary
 
 
 try:  # the implementation lives in matrixark_mcp_core; this module re-exports it


### PR DESCRIPTION
Nine more functions that existed as two byte-identical copies are now one, and the interesting part
is which rule had been stopping them.

## The owner was being chosen by filename

Several remaining pairs are one live copy and one sitting in a module production cannot reach —
`apply_entity_patch` in `matrixark_mcp_core`, and again in the unreachable
`matrixark_mcp_entity_ops`. Neither copy is imported across modules, so their weights tie, and the
tie broke on filename, which picked the unreachable module as the owner. A separate rule then
correctly refused the whole group for owning a body production cannot reach.

Two rules fighting, and the only visible symptom was "refused", which reads as a real constraint
rather than a bad tie-break. Reachability now leads the ordering, so the live copy owns the body
and the island imports it — adding no edge, since the island already reaches core.

That released a chain across three passes: `best_span_by_edit_distance`, then `apply_entity_patch`,
then `apply_entity_patches`, each unblocked by the one before it.

## Functions that read an environment flag are left alone

`test_flag_readers_agree` holds a floor on how many flags are read from more than one production
site, and checks that the readers of each agree. Collapsing two readers into one drops that count:

```
found 13 flags read from more than one production site, expected at least 14
-- if the read shape changed, this file is looking for something that no longer exists
   and the assertion below passes on an empty set
```

The floor exists so the agreement assertion cannot pass on an empty set, so lowering it to match
would defeat the guard rather than satisfy it. Flag readers are now refused, derived from the body
— `getenv`, `environ`, `env_bool`, `live_int` — rather than from a list of names.

## Verification

By object identity: `owner.f is importer.f` for all 105 consolidations in the tree, every module's
`__all__` still resolving, and every file still parsing.

The whole `tools/` suite ran before and after with the control pinned to this exact commit:
**393 of 393 files on both sides, 357 pass / 36 fail on each, zero tests failing only after.** All
36 remaining failures fail identically on both trees.
