### PR TITLE
Three flag guards scanned one line at a time, so a split read escaped them

### DIFF
--- a/tools/test_an_addressed_flag_is_offered.py
+++ b/tools/test_an_addressed_flag_is_offered.py
@@ -92,11 +92,12 @@ def _reads() -> Dict[str, Tuple[str, int, str]]:
     for rel in _tracked("*.py"):
         if os.path.basename(rel).startswith("test_"):
             continue
-        lines = _text(rel).splitlines()
-        for number, line in enumerate(lines, 1):
-            match = _READ.search(line)
-            if not match:
-                continue
+        text = _text(rel)
+        lines = text.splitlines()
+        # Whole file, not line by line: a read split across lines was invisible, and the flag it
+        # names was exempt from the rule below without anything saying so. 442 flags, not 419.
+        for match in _READ.finditer(text):
+            number = text.count("\n", 0, match.start()) + 1
             name = match.group(1) or match.group(2)
             if name in found:
                 continue

--- a/tools/test_config_says_when_it_overrides_a_python_reader.py
+++ b/tools/test_config_says_when_it_overrides_a_python_reader.py
@@ -108,13 +108,14 @@ def _readers() -> Dict[str, list]:
             continue
         try:
             with open(os.path.join(REPO, path), encoding="utf-8", errors="replace") as handle:
-                lines = handle.read().splitlines()
+                text = handle.read()
         except OSError:
             continue
-        for number, line in enumerate(lines, 1):
-            for match in _READ.finditer(line):
-                found[match.group("var")].append(
-                    (path, number, _unquote(match.group("default"))))
+        # Whole file, not line by line -- see the note in test_an_addressed_flag_is_offered.
+        for match in _READ.finditer(text):
+            number = text.count("\n", 0, match.start()) + 1
+            found[match.group("var")].append(
+                (path, number, _unquote(match.group("default"))))
     return found
 
 

--- a/tools/test_python_flag_switches.py
+++ b/tools/test_python_flag_switches.py
@@ -75,20 +75,22 @@ def _default_on_switches() -> Dict[str, str]:
     for path in _production_sources():
         try:
             with open(os.path.join(REPO, path), encoding="utf-8") as handle:
-                lines = handle.read().splitlines()
+                text = handle.read()
         except OSError:
             continue
-        for number, line in enumerate(lines, 1):
-            for match in _READ.finditer(line):
-                name, default = match.group(1), match.group(2)
-                if name in found or not _ON_DEFAULT.match(default.strip()):
-                    continue
-                window = " ".join(lines[number - 1:number + 2])
-                if _NUMERIC.search(window):
-                    continue
-                if not (_TRUTH_SET.search(window) or _EQ.search(window)):
-                    continue
-                found[name] = "%s:%d" % (path, number)
+        lines = text.splitlines()
+        # Whole file, not line by line -- see the note in test_an_addressed_flag_is_offered.
+        for match in _READ.finditer(text):
+            number = text.count("\n", 0, match.start()) + 1
+            name, default = match.group(1), match.group(2)
+            if name in found or not _ON_DEFAULT.match(default.strip()):
+                continue
+            window = " ".join(lines[number - 1:number + 2])
+            if _NUMERIC.search(window):
+                continue
+            if not (_TRUTH_SET.search(window) or _EQ.search(window)):
+                continue
+            found[name] = "%s:%d" % (path, number)
     return found
 
 


### PR DESCRIPTION
Companion to mx#1217, which found the same shape in `test_string_defaults_agree`. Three more flag
guards collect their reads with a regex applied to **one line at a time**:

    for number, line in enumerate(lines, 1):
        for match in _READ.finditer(line):

So a read split across lines is invisible to them, and a long default or a nested fallback is
exactly what splits one:

    _KNOB = os.environ.get(
        "MATRIXARK_INDEX_POSTING_LISTS",
        "1",
    )

A flag written that way was silently outside each rule. In `test_an_addressed_flag_is_offered` --
whose rule is that a flag whose comment TELLS AN OPERATOR to set it must be reachable somewhere an
operator can reach -- the scan covered **406 flags; it now covers 431**. The 25 it could not see
include `MATRIXARK_INDEX_POSTING_LISTS`, `MATRIXARK_LOCAL_JSONL_BLOCK_LOG`,
`MATRIXARK_LOCAL_JSONL_COMPRESS_SEALED`, `MATRIXARK_INTERN_BACKEND_METADATA` and
`MATRIXARK_RUST_PROXY_DEDICATED_CLIENTS`.

`test_python_flag_switches` and `test_config_says_when_it_overrides_a_python_reader` carry the
identical loop and are converted the same way.

## Honest about what it found

**None of the 25 is an actual violation today** -- none carries operator-addressed prose while
being unoffered, which is the only thing that guard fails on. So this fixes the blind spot, not a
live defect. It is worth doing anyway because the coverage depended on formatting: whether a flag
was governed came down to whether its read fitted on one line.

## Proof it discriminates

A probe module with a multi-line read, an operator-addressed comment, and a flag offered nowhere:

    # Set MATRIXARK_ZZ_PROBE_KNOB=1 in production to turn this on.
    _KNOB = os.environ.get(
        "MATRIXARK_ZZ_PROBE_KNOB",
        "0",
    )

now fails the guard, naming it:

    these flags are described to an operator who has no way to reach them ...
    [MATRIXARK_ZZ_PROBE_KNOB (tools/matrixark_zz_probe.py:5, says "turn this on")]

Before this change the same probe passed, because the read spans lines. The probe was removed; it
is quoted here as evidence, not committed. All four tests in each of the three files pass.

Each conversion keeps the same pattern, the same filters and the same return shape -- only the
text it is searched against changes, plus the line number now derived from the match offset.
