### PR TITLE
The rebalancer that runs by default moved shards an operator had pinned

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -8782,6 +8782,110 @@ fn counting_resources_agrees_with_listing_them_and_counting_those() {
     }
 
     #[test]
+    fn balancing_leaves_a_pinned_shard_alone_but_never_strands_one() {
+        fn cluster() -> SingleNodeMeta {
+            let meta = SingleNodeMeta::default();
+            for n in 0..2u64 {
+                assert!(meta
+                    .register_server(RegisterServerRequest {
+                        numa_nodes: Vec::new(),
+                        server_addr: format!("node-{n}"),
+                        node_id: n + 1,
+                        location: format!("rack-{n}"),
+                        binary_version: "v1".to_string(),
+                        registered_at_ms: 0,
+                    })
+                    .status
+                    .ok);
+            }
+            assert!(meta
+                .add_table(AddTableRequest {
+                    namespace: "ns".to_string(),
+                    table_name: "t".to_string(),
+                    first_shard_id: 1,
+                    shard_count: 6,
+                    replica_count: 1,
+                    partition_version: 1,
+                    serving_options: Default::default(),
+                })
+                .status
+                .ok);
+            // Every shard on one node, so a round has real work to do.
+            for shard_id in 1..=6u64 {
+                assert!(meta
+                    .register(RegisterShardRequest {
+                        shard_id,
+                        server_addr: "node-0".to_string(),
+                        registered_at_ms: 0,
+                    })
+                    .status
+                    .ok);
+            }
+            meta
+        }
+
+        // Unpinned, the balancer has work and does it. Without this the rest of
+        // the test could pass because nothing was ever going to move.
+        let plain = cluster();
+        let moves = plain.plan_auto_rebalance();
+        assert!(
+            !moves.is_empty(),
+            "the cluster is not unbalanced enough to test anything"
+        );
+
+        // Pinned where they sit, the balancer leaves them.
+        let pinned = cluster();
+        for shard_id in 1..=6u64 {
+            assert!(pinned
+                .pin_shard(ShardPinRequest {
+                    shard_id,
+                    location: "rack-0".to_string(),
+                })
+                .status
+                .ok);
+        }
+        let plans = pinned.plan_auto_rebalance();
+        assert!(
+            plans.is_empty(),
+            "balancing moved shards an operator pinned: {plans:?}"
+        );
+
+        // But a pin is a preference, not a cage. With the owner gone, the shard
+        // still moves -- a preference must never take a shard out of service,
+        // which is the rule a table preference already follows.
+        let stranded = cluster();
+        for shard_id in 1..=6u64 {
+            assert!(stranded
+                .pin_shard(ShardPinRequest {
+                    shard_id,
+                    location: "rack-0".to_string(),
+                })
+                .status
+                .ok);
+        }
+        assert!(stranded
+            .freeze_server(StateChangeRequest {
+                endpoint: "node-0".to_string(),
+                freeze_cooldown_ms: 0,
+                reason: FreezeReason::Unresponsive,
+            })
+            .status
+            .ok);
+        let rescue = stranded.plan_auto_rebalance();
+        assert_eq!(
+            rescue.len(),
+            6,
+            "a pinned shard was left on an owner that is gone"
+        );
+        for plan in &rescue {
+            assert_eq!(
+                plan.to_server, "node-1",
+                "the only live server is where they must go"
+            );
+        }
+    }
+
+    #[test]
     fn metaserver_safe_mode_cooldown_blocks_rejoin_and_round_trips() {
         let dir = tempfile::tempdir().unwrap();
         let log_path = dir.path().join("safe-mode-mutations.jsonl");

--- a/crates/temporalstore-rust/src/meta/auto_rebalance.rs
+++ b/crates/temporalstore-rust/src/meta/auto_rebalance.rs
@@ -127,7 +127,9 @@ pub fn compute_auto_rebalance(
         .iter()
         .map(|(shard_id, owner)| (*shard_id, owner.as_str()))
         .collect::<BTreeMap<_, _>>();
-    compute_auto_rebalance_borrowed(&borrowed, live_servers, options)
+    // A caller holding its own owner map has no pins to give; the metaserver's
+    // own path reads them from the metadata and passes them.
+    compute_auto_rebalance_borrowed(&borrowed, live_servers, &BTreeSet::new(), options)
 }
 
 /// Plan without owning the owner names.
@@ -138,6 +140,7 @@ pub fn compute_auto_rebalance(
 pub fn compute_auto_rebalance_borrowed(
     shard_owners: &BTreeMap<ShardId, &str>,
     live_servers: &BTreeSet<String>,
+    pinned: &BTreeSet<ShardId>,
     options: AutoRebalanceOptions,
 ) -> Vec<ShardReassignment> {
     let mut plans = Vec::new();
@@ -199,9 +202,15 @@ pub fn compute_auto_rebalance_borrowed(
             }
             // Pick a shard currently on the busy server (highest id, for
             // determinism) to move to the idle server.
+            // A pinned shard is where an operator put it, so balancing does
+            // not take it away. Pass 1 above does not consult this: a pin is a
+            // preference, and a preference must never leave a shard stranded on
+            // an owner that is gone.
             let Some(shard_id) = owner_map(&mut owner, shard_owners, live_servers)
                 .iter()
-                .filter(|(_, owner_addr)| **owner_addr == Some(busy_addr))
+                .filter(|(shard_id, owner_addr)| {
+                    **owner_addr == Some(busy_addr) && !pinned.contains(shard_id)
+                })
                 .map(|(shard_id, _)| *shard_id)
                 .max()
             else {
@@ -287,7 +296,16 @@ impl SingleNodeMeta {
             .map(|server| server.server_addr.clone())
             .collect::<BTreeSet<_>>();
         let shard_owners = serving_shard_owners(&state);
-        compute_auto_rebalance_borrowed(&shard_owners, &live_servers, options)
+        // Which shards an operator has placed by hand. Read here rather than
+        // inside the planner so the planner stays a function of what it is
+        // given.
+        let pinned = state
+            .shards
+            .values()
+            .filter(|location| !location.preferred_location.is_empty())
+            .map(|location| location.shard_id)
+            .collect::<BTreeSet<_>>();
+        compute_auto_rebalance_borrowed(&shard_owners, &live_servers, &pinned, options)
     }
 
     /// Apply a single reassignment to the shard→owner map, preserving any


### PR DESCRIPTION
Two planners can run a rebalance round. The placement-aware one reads a shard's pin. The other does not, and it is the one a deployment runs unless it asks otherwise -- `TS_META_PLACEMENT_AWARE_REBALANCE` is off by default.

On one unbalanced cluster with every shard pinned where it sits, the two disagree completely: the placement-aware planner moves nothing, and the default one moves three of the six, onto a node in a location none of them is pinned to.

## The rule

A pin is a preference, not a cage. That is already settled for a table's preferred location, and a per-shard pin inherits it: a preference must never take a shard out of service.

So this constrains balancing, not evacuation.

- A pinned shard on a live owner is left where the operator put it.
- A pinned shard whose owner is gone still moves, because leaving it would strand it.

Only the load-balancing pass consults the pins. The evacuation pass is untouched, and says so where it would otherwise be tempting to add the same check.

## Testing

The test builds one unbalanced cluster three ways.

Unpinned, it asserts the balancer *does* plan moves -- without that, "nothing moved" would pass on a cluster that was never unbalanced enough to move anything, which is the failure mode where a test is green and proves nothing.

Pinned, it asserts nothing moves. Run against the tree before this change it fails, naming the three shards it moved and where it sent them.

Pinned with the owner frozen, it asserts all six move anyway, and that every one of them goes to the only live server. That is the half that keeps a pin from becoming a cage.

## Related but separate

A move used to erase the pin outright, which was a dropped field in a struct literal rather than a planning decision. That is fixed separately; this is about a planner that reads the pin and one that never did.
