### PR TITLE
The replaced refusal was asserted twice, sixty lines apart

### DIFF
--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -2467,12 +2467,9 @@ fn storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_f
     assert!(running.last_pressure_before >= running.last_pressure_after);
     assert!(!running.last_selected_buckets.is_empty());
     assert!(running.last_bytes_reclaimed >= pressure.cache_disk_bytes);
-    // This scenario configures a follower pinned at sequence 1 and a raft snapshot at sequence 1,
-    // whose entire purpose is to hold the logs. Reclaim therefore refuses and the floor stays 0.
-    // Asserting that the floor ADVANCED asked the shard to discard exactly what the cursors were
-    // added to protect -- the assertion contradicted its own setup, which is why it could never
-    // have passed. What is worth checking is that the refusal NAMES them, since being named is the
-    // property a retention cursor exists to have.
+    // This scenario configures a follower pinned at sequence 1 and a raft snapshot at sequence 1.
+    // What a retention cursor imposes is a BOUND on how far reclaim may go, not a refusal; the
+    // note below the binding says why, and what is asserted instead.
     let reclaim_wal = running
         .last_phase_reports
         .iter()
@@ -2528,11 +2525,12 @@ fn storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_f
         .any(|stage| stage.stage == "prepare"
             && stage.pressure_signal.contains("dirty_slots")
             && stage.pressure_before >= stage.pressure_after));
-    // Same contradiction as above: a stage that refused to reclaim selects no buckets and reports
-    // no floor. It does report what stopped it, and that is the assertable part.
+    // The floor is the CLAMPED frontier, not zero: reclaim ran, and stopped at the slowest cursor.
+    // The refusal was asserted TWICE in this test, in two blocks about sixty lines apart, so
+    // correcting the first one only moved the failure down here. Both now say the same thing.
     assert!(reclaim_wal.retention_blockers >= 1, "{reclaim_wal:?}");
-    assert_eq!(reclaim_wal.wal_floor_sequence, 0);
-    assert_eq!(reclaim_wal.index_log_floor_sequence, 0);
+    assert_eq!(reclaim_wal.wal_floor_sequence, 2, "{reclaim_wal:?}");
+    assert_eq!(reclaim_wal.index_log_floor_sequence, 2, "{reclaim_wal:?}");
     assert!(running.last_phase_reports.iter().any(|stage| {
         stage.stage == "reclaim_page"
             && (stage


### PR DESCRIPTION
Follow-up to mx#1213, which is verified working as far as it went: in the CI run for mx#1217 the
lib suite is **1699 passed / 1 failed**, up from 1689 / 2, and
`storage_data_structure_api_parity_report_covers_stream_block_and_manager_surfaces` now passes
(mx#1211).

The remaining failure is the same test mx#1213 touched, and it has moved:

    panicked at part3.rs:2534
    assertion left == right failed
      left: 2
     right: 0

**The replaced refusal was asserted twice**, in two blocks about sixty lines apart, and mx#1213
corrected only the first. The second still reads:

    // Same contradiction as above: a stage that refused to reclaim selects no buckets and
    // reports no floor.
    assert_eq!(reclaim_wal.wal_floor_sequence, 0);
    assert_eq!(reclaim_wal.index_log_floor_sequence, 0);

With both retention cursors at sequence 1 the clamped frontier is 1, so the floors are 2 -- the
same value the first block already asserts through `retain_from_wal_sequence`. Corrected to 2 here,
with a message so a future mismatch prints the stage rather than two bare integers.

Also removed the leading comment block that still described the refusal ("Reclaim therefore refuses
and the floor stays 0"). It sat directly above the note explaining the clamp, so the test carried
both accounts at once, which is how the second copy went unnoticed.

## Verified where I could

The parts I can check without a build are checked: the failure line, the values, and that no other
assertion in the test still assumes a refusal (grep over the whole test body for
`floor_sequence`, `.skipped`, `refus`). Not compiled locally -- a full crate build on this box
degrades a live service sharing it, and the change is three integers and two comments.
