### PR TITLE
One unreadable record made every read fetch the whole store a row at a time

### DIFF
--- a/tools/matrixark_temporal_direct_retrieve.py
+++ b/tools/matrixark_temporal_direct_retrieve.py
@@ -33,6 +33,29 @@ except ImportError:
 )
 
 
+#: How many record locations to ask for in one `batch_hget`.
+#:
+#: Measured against the live 16,717-record store: 100/1000/4000 complete in under a second; 8000
+#: came back with 5,146 of 8,000 and no error; the whole store raised. 1000 sits an order of
+#: magnitude under where truncation began.
+#:
+#: Deliberately a constant and not an environment variable. The failure this guards against is a
+#: silent one, and a knob with a second default is its own silent failure.
+BATCH_HGET_CHUNK = 1000
+
+
+def _batch_hget_degraded_log(chunks: int, chunk_size: int) -> None:
+    """Report that a batched read fell back to per-record reads, and roughly what it cost."""
+    try:  # package path
+        from tools.matrixark_mcp_core import _mcp_debug_log
+    except ImportError:  # Direct script execution from tools/.
+        from matrixark_mcp_core import _mcp_debug_log
+    _mcp_debug_log(
+        f"matrixark batch_hget degraded to per-record reads for {chunks} "
+        f"chunk(s) of {chunk_size}: about {chunks * chunk_size} records read one at a time"
+    )
+
+
 class _TemporalDirectRetrieveMixin:
     def retrieve(self, args: Json) -> Json:
         self._ensure_backend_metric_fields()
@@ -391,23 +414,47 @@ class _TemporalDirectRetrieveMixin:
             for sequence in range(count):
                 record_key, record_id = self._record_location(sequence)
                 entries.append({"key": record_key, "field": record_id})
-            try:
-                read_records = batch_hget(entries)
-            except Exception as exc:
-                if is_retryable_temporalstore_error(exc):
-                    raise
-                read_records = []
-            for item in read_records:
-                if not isinstance(item, dict):
-                    continue
-                payload = item.get("value", "")
-                if not payload:
-                    continue
-                decoded = json.loads(str(payload))
-                if isinstance(decoded, dict) and isinstance(decoded.get("record_bundle"), list):
-                    records.extend(item for item in decoded["record_bundle"] if isinstance(item, dict))
-                elif isinstance(decoded, dict):
-                    records.append(decoded)
+            degraded_chunks = 0
+            for start in range(0, len(entries), BATCH_HGET_CHUNK):
+                block = entries[start:start + BATCH_HGET_CHUNK]
+                try:
+                    read_records = batch_hget(block)
+                except Exception as exc:
+                    if is_retryable_temporalstore_error(exc):
+                        raise
+                    # Degrade THIS chunk, not the store. One unreadable value used to cost every
+                    # record: the batch covered all of them, so a single non-UTF-8 payload made the
+                    # call raise, the raise became an empty list, and an empty list is
+                    # indistinguishable from an empty store -- so every record was refetched one at
+                    # a time, twice per retrieve.
+                    degraded_chunks += 1
+                    read_records = []
+                    for entry in block:
+                        try:
+                            value = self._client.hget(entry["key"], entry["field"])
+                        except Exception as inner_exc:
+                            if is_retryable_temporalstore_error(inner_exc):
+                                raise
+                            continue
+                        if value:
+                            read_records.append(
+                                {"key": entry["key"], "field": entry["field"], "value": value}
+                            )
+                for item in read_records:
+                    if not isinstance(item, dict):
+                        continue
+                    payload = item.get("value", "")
+                    if not payload:
+                        continue
+                    decoded = json.loads(str(payload))
+                    if isinstance(decoded, dict) and isinstance(decoded.get("record_bundle"), list):
+                        records.extend(item for item in decoded["record_bundle"] if isinstance(item, dict))
+                    elif isinstance(decoded, dict):
+                        records.append(decoded)
+            if degraded_chunks:
+                # Said out loud: the old whole-store fallback was silent, which is why a 20x
+                # slowdown ran unnoticed for as long as one bad value sat in the store.
+                _batch_hget_degraded_log(degraded_chunks, BATCH_HGET_CHUNK)
             if records or count == 0:
                 return records
         for sequence in range(count):

--- a/tools/test_one_bad_record_costs_one_chunk_not_the_store.py
+++ b/tools/test_one_bad_record_costs_one_chunk_not_the_store.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""One unreadable record must cost one chunk, not the whole store.
+
+`_load_records_by_count` asked `batch_hget` for every record location in a single call. On the live
+16,717-record store exactly one value is not valid UTF-8 (record #13526), so that one call raised;
+the handler turned a non-retryable failure into an empty list, and an empty list is
+indistinguishable from an empty store -- so the method refetched every record one at a time, twice
+per retrieve. Measured: 33,434 `hget` calls, 33,633 socket connects, ~167s per read_all against
+3.5-10.3s for the same work in chunks.
+
+The fake client below reproduces exactly that shape: `batch_hget` raises for any block containing
+the poisoned field, `hget` works for everything else. What the tests pin:
+
+  * the poisoned record costs ONE chunk of per-record reads, not `count` of them
+  * every readable record is still returned, and in order -- the fix must change cost, not content
+  * a client with no failures never falls back at all
+  * a RETRYABLE failure still propagates, so this cannot mask a backend that is genuinely unwell
+
+The per-record count is asserted against `count` rather than a magic number, so the test states the
+defect ("not the whole store") rather than restating the constant.
+"""
+from __future__ import annotations
+
+import json
+import unittest
+
+# The adapters module is imported FIRST on purpose. `matrixark_temporal_direct_retrieve` and
+# `matrixark_mcp_temporal_adapters` import each other, so importing the retrieve module first leaves
+# it partially initialised and the cycle raises. Production enters through the adapters module, and
+# so does this.
+try:  # package path
+    from tools import matrixark_mcp_temporal_adapters as _adapters  # noqa: F401
+    from tools import matrixark_temporal_direct_retrieve as direct_retrieve
+    from tools.matrixark_mcp_core import MatrixArkError
+except ImportError:  # direct execution from tools/
+    import matrixark_mcp_temporal_adapters as _adapters  # type: ignore # noqa: F401
+    import matrixark_temporal_direct_retrieve as direct_retrieve  # type: ignore
+    from matrixark_mcp_core import MatrixArkError  # type: ignore
+
+
+POISONED_SEQUENCE = 1526
+
+
+class _FakeClient:
+    """A store with exactly one value that cannot be read, as the live box has."""
+
+    def __init__(self, count, *, poisoned=POISONED_SEQUENCE, retryable=False):
+        self.count = count
+        self.poisoned = f"{poisoned:020d}"
+        self.retryable = retryable
+        self.batch_calls = 0
+        self.hget_calls = 0
+
+    def _payload(self, field):
+        return json.dumps({"record_type": "context_event", "field": field})
+
+    def _fail(self):
+        if self.retryable:
+            raise MatrixArkError("temporalstore request timed out")
+        raise MatrixArkError(
+            "Rust TemporalStore batch_hget failed: stored value is not UTF-8: "
+            "invalid utf-8 sequence of 1 bytes from index 0"
+        )
+
+    def batch_hget(self, entries):
+        self.batch_calls += 1
+        if any(entry["field"] == self.poisoned for entry in entries):
+            self._fail()
+        return [
+            {"key": e["key"], "field": e["field"], "value": self._payload(e["field"])}
+            for e in entries
+        ]
+
+    def hget(self, key, field):
+        self.hget_calls += 1
+        if field == self.poisoned:
+            self._fail()
+        return self._payload(field)
+
+
+class _Loader(direct_retrieve._TemporalDirectRetrieveMixin):
+    def __init__(self, client):
+        self._client = client
+        self._last_read_all_native_shard_scan = False
+
+    def _record_location(self, sequence):
+        return (f"records:{sequence // 256:06d}", f"{sequence:020d}")
+
+    def _load_records_by_native_shard_scan(self, count):
+        return None  # the live box returns None here, so the batch path is what runs
+
+
+class ChunkedBatchReadTest(unittest.TestCase):
+    COUNT = 4000
+
+    def test_one_unreadable_record_costs_one_chunk_not_the_store(self) -> None:
+        client = _FakeClient(self.COUNT)
+        records = _Loader(client)._load_records_by_count(self.COUNT)
+
+        # The DEFECT first, stated without reference to the constant the fix introduces -- against
+        # unmodified code this must fail on behaviour, not error on a missing attribute.
+        self.assertLess(
+            client.hget_calls, self.COUNT,
+            "one bad value still cost a whole-store per-record refetch",
+        )
+        self.assertLessEqual(
+            client.hget_calls, getattr(direct_retrieve, "BATCH_HGET_CHUNK", self.COUNT),
+            "one bad value fell back to per-record reads beyond its own chunk",
+        )
+        self.assertEqual(self.COUNT - 1, len(records), "readable records were lost")
+
+    def test_readable_records_come_back_in_order(self) -> None:
+        client = _FakeClient(self.COUNT)
+        records = _Loader(client)._load_records_by_count(self.COUNT)
+        fields = [r["field"] for r in records]
+        self.assertEqual(sorted(fields), fields, "chunking reordered the store")
+        self.assertNotIn(client.poisoned, fields)
+
+    def test_a_healthy_store_never_falls_back(self) -> None:
+        client = _FakeClient(self.COUNT, poisoned=-1)
+        records = _Loader(client)._load_records_by_count(self.COUNT)
+        self.assertEqual(0, client.hget_calls, "a healthy store paid for per-record reads")
+        self.assertEqual(self.COUNT, len(records))
+
+    def test_a_retryable_failure_still_propagates(self) -> None:
+        # Degrading here would hide a backend that is genuinely unwell behind a slow success.
+        client = _FakeClient(self.COUNT, retryable=True)
+        with self.assertRaises(MatrixArkError):
+            _Loader(client)._load_records_by_count(self.COUNT)
+
+    def test_it_batches_rather_than_asking_for_everything_at_once(self) -> None:
+        client = _FakeClient(self.COUNT, poisoned=-1)
+        _Loader(client)._load_records_by_count(self.COUNT)
+        self.assertGreater(
+            client.batch_calls, 1,
+            "the whole store was still requested in a single batch_hget",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`_load_records_by_count` asks `batch_hget` for every record location in one call. One value in the
store cannot be decoded, so that single call raises — and the handler turns the failure into an
empty list, which the next line cannot tell apart from an empty store:

```python
except Exception as exc:
    if is_retryable_temporalstore_error(exc):
        raise
    read_records = []      # a non-retryable failure becomes "no records"
...
if records or count == 0:
    return records         # empty is falsy -> fall through to the per-record loop
```

So every record is refetched one at a time, and nothing says so.

### Measured on a 16,717-record store

| batch size | result |
|---|---|
| 100 / 1000 / 4000 | complete, ≤ 1.0 s |
| 8000 | 5,146 of 8,000 returned, **no error** |
| 16000 / whole store | **raises** `stored value is not UTF-8: invalid utf-8 sequence of 1 bytes from index 0` |

The store holds exactly one such value — record #13526, `...records:000052` field `...214` — and both
`batch_hget` and `hget` raise on it. Because the batch covers everything, that one value costs the
whole read. Profiling one live retrieve:

```
33,434 hget calls  == 2 x 16,717      (the record load runs twice per retrieve)
33,633 socket connects, 89,081 recv_into, 64.5 s in recv_into alone
~167 s per load, against 3.5-10.3 s for the same work in chunks
```

### The change

Read in chunks of 1,000, and degrade **only the chunk that failed** to per-record reads. The other
sixteen chunks keep the fast path, so an unreadable value costs its own chunk instead of the store.
The fallback now also logs, because a silent 20x slowdown is how this ran unnoticed for as long as
one bad value sat there.

A constant rather than a new environment variable: 1,000 is an order of magnitude below the 8,000
where truncation began, and this tree already carries variables with more than one default.

### End to end on a live box

| | before | after |
|---|---|---|
| hook turn | 214,867 ms | **82,527 ms** |
| context served | 7,886 bytes | 7,886 bytes |
| refs | 24 | 24 |

2.6x, and the pack is byte-identical — this changes cost, not content. `context_pack_source` is
unset, so it is a freshly retrieved pack rather than the previous-pack fallback covering for it.

Verified separately on the live store that `batch_hget` returns the same multiset as `hget`, in the
requested order (1000/1000 exact on a dense window), which is what licenses reading in chunks at all.

### Tests

`tools/test_one_bad_record_costs_one_chunk_not_the_store.py`. Against unmodified code two tests fail
on behaviour — `4000 not less than 4000: one bad value still cost a whole-store per-record refetch`
and `the whole store was still requested in a single batch_hget` — while three pass on both arms,
pinning behaviour the change must preserve: readable records still come back in order, a healthy
store never falls back at all, and a **retryable** failure still propagates rather than being
degraded into a slow success.

Suites touching the changed module were run on both arms and are unchanged:
`test_delete_membership_index`, `test_matrixark_context_backfill`, `test_matrixark_rust_serve_readiness`
and `test_mem0_native_read_path` pass; `test_matrixark_the_placement_head_keeps_the_long_form`,
`test_side_index_batch_read` and `test_side_index_merge` carry identical pre-existing failures before
and after.

### Left alone deliberately

The unreadable record itself. Repairing store contents is a separate decision from making a reader
survive them, and the reader should not depend on the data being clean.
