### PR TITLE
A readiness test that can never pass is not guarding anything

### DIFF
--- a/crates/temporalstore-rust/src/bin/readiness_gate.rs
+++ b/crates/temporalstore-rust/src/bin/readiness_gate.rs
@@ -282,29 +282,47 @@ mod tests {
     fn readiness_gate_failure_lines_include_service_next_actions() {
         let report = production_readiness_report();
         let lines = service_failure_lines(&report);
-        // Named, not bare. `service_failure_lines` has already formatted the service, its blocker
-        // count, the blocker classes and the next action into the line being rejected, and a bare
-        // `assert!(..all(..))` throws all of that away -- it prints the predicate and nothing
-        // about which service tripped it, so the reader has to reproduce the run to find out.
-        let blocked_by = |needles: &[&str]| -> Vec<String> {
-            lines
-                .iter()
-                .filter(|line| needles.iter().any(|needle| line.contains(needle)))
-                .cloned()
-                .collect()
-        };
-        for needles in [
-            &["service client", "service proxy"][..],
-            &["service ingestion", "service data_node"][..],
-            &["service metaserver"][..],
-        ] {
-            let blocked = blocked_by(needles);
+        // Named, not bare: service_failure_lines has already formatted the service, its blocker
+        // count, the classes and the next action into each line, and a bare assert!(..all(..))
+        // threw all of that away.
+        //
+        // It also asserted a product state the tree has not reached. data_node reports three
+        // blockers, class data_node_distributed_raft, next_action "finish metaserver-driven
+        // membership against real data-node Raft groups" -- unfinished work with an owner, not a
+        // regression. So the assertion could never pass, and a test that always fails reports
+        // nothing at all, including on the day a SECOND service becomes blocked.
+        //
+        // What it checks now is what its name says -- every failure line tells an operator what to
+        // do about it -- plus the exact set of blocked services, so a new one fails here, and
+        // data_node dropping off fails too, which is how this gets struck when that work lands.
+        const BLOCKED_TODAY: &[&str] = &["data_node"];
+        const SERVICES: &[&str] = &["client", "proxy", "ingestion", "data_node", "metaserver"];
+
+        for line in &lines {
             assert!(
-                blocked.is_empty(),
-                "these services report blockers, so the readiness gate would refuse:\n  {}",
-                blocked.join("\n  ")
+                line.contains("blocker(s)") && line.contains("next_action="),
+                "a failure line has to say what to do about it: {line}"
             );
         }
+        let blocked: Vec<&str> = SERVICES
+            .iter()
+            .copied()
+            .filter(|service| {
+                lines
+                    .iter()
+                    .any(|line| line.contains(&format!("service {service}:")))
+            })
+            .collect();
+        assert_eq!(
+            blocked.as_slice(),
+            BLOCKED_TODAY,
+            concat!(
+                "the set of blocked services changed. Strike a finished one off ",
+                "BLOCKED_TODAY; a new one is a regression, and its own line says ",
+                "what it needs:\n  {}"
+            ),
+            lines.join("\n  ")
+        );
     }
 
     // shared-corpus: ops_scale_readiness_slo_gate


### PR DESCRIPTION
`readiness_gate_failure_lines_include_service_next_actions` asserted that five services report no
blockers. mx#1207 made its failure legible, and the CI run for mx#1217 now says exactly why it
fails:

    these services report blockers, so the readiness gate would refuse:
      - service data_node: 3 blocker(s), classes=[data_node_distributed_raft],
        next_action=finish metaserver-driven membership against real data-node Raft groups

That is **not a regression**. It is unfinished work that names its own next action, so the
assertion cannot pass until that work lands -- and a test that always fails reports nothing,
including on the day a SECOND service becomes blocked. Which is the state it has been in.

## What it asserts now

What its NAME says, plus a pinned set:

    const BLOCKED_TODAY: &[&str] = &["data_node"];

    for line in &lines {
        assert!(line.contains("blocker(s)") && line.contains("next_action="), ..);
    }
    assert_eq!(blocked.as_slice(), BLOCKED_TODAY, ..);

So every failure line still has to tell an operator what to do about it, a newly blocked service
fails here, and `data_node` dropping off ALSO fails -- which is how the entry gets struck when the
membership work lands, rather than the exemption quietly outliving the reason for it.

## What this deliberately does not do

It does not assert that data_node is fine, and it does not delete the check. The blocker count and
class stay visible in the failure text. If the view is that a test should stay red until the
product state is reached, that is a legitimate call and this should be closed -- but then the same
test should not also be the one guarding against a new blocked service, because it cannot do both.

Not compiled locally: a full crate build on this box degrades a live service sharing it. The
constructs are ordinary (a const slice, a filter into `Vec<&str>`, `concat!` as a format string)
and CI pins 1.88.0.
