### PR TITLE
Two raft metric assertions passed by substring and a third named nothing

### DIFF
--- a/crates/temporalstore-rust/src/bin/raft_node.rs
+++ b/crates/temporalstore-rust/src/bin/raft_node.rs
@@ -997,9 +997,39 @@ mod tests {
             .any(|peer| peer.pipeline_state.peer_id == peer.status.node_id));
 
         let metrics = String::from_utf8(route(&runtime, "GET", "/metrics", Vec::new())).unwrap();
-        assert!(metrics.contains("matrixraft_ready"));
-        assert!(metrics.contains("matrixraft_capability_ready"));
-        assert!(metrics.contains("matrixraft_capability_field_present"));
+        // All three named something no emitter produces under that name. The first two passed
+        // anyway: temporalstore_raft_matrixraft_ready and
+        // temporalstore_raft_matrixraft_capability_ready CONTAIN those substrings, so they would
+        // have passed with no matrixraft-prefixed metric in the tree at all. The third is emitted
+        // by nothing in either repository -- MatrixRaft at the pinned rev spells its own
+        // rustraft_baseline_raft_capability_field_present, and this crate reports WHICH field was
+        // the evidence as a label on the capability gauge rather than as a metric of its own.
+        //
+        // So each now names what is actually emitted, including the label carrying the
+        // field-present information. This does not decide whether a capability_field_present
+        // metric OUGHT to exist; if it should, that is a product change, not an assertion.
+        assert!(
+            metrics.contains("temporalstore_raft_matrixraft_ready"),
+            "the cluster metrics carry no matrixraft readiness gauge"
+        );
+        assert!(
+            metrics.contains("temporalstore_raft_matrixraft_capability_ready"),
+            "the cluster metrics carry no matrixraft capability gauge"
+        );
+        // Per sample, not over the whole dump: the evidence_field label is only emitted inside
+        // the capability loop, so requiring it outright would assert that the matrix is populated
+        // in this fixture -- a different claim, and one not verified here. This says the thing the
+        // deleted assertion was reaching for: a capability that IS reported names the field that
+        // evidenced it.
+        for sample in metrics
+            .lines()
+            .filter(|line| line.contains("temporalstore_raft_matrixraft_capability_ready{"))
+        {
+            assert!(
+                sample.contains("evidence_field="),
+                "a capability sample must name the field that evidenced it: {sample}"
+            );
+        }
         assert!(metrics.contains("temporalstore_raft_matrixraft_ready"));
         assert!(metrics.contains("temporalstore_raft_matrixraft_capability_ready"));
         assert!(metrics.contains("capability=\"wal_segment_lifecycle\""));

--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -3516,9 +3516,39 @@ mod tests {
             .any(|peer| peer.pipeline_state.peer_id == peer.status.node_id));
 
         let metrics = state.runtime.cluster().prometheus_metrics();
-        assert!(metrics.contains("matrixraft_ready"));
-        assert!(metrics.contains("matrixraft_capability_ready"));
-        assert!(metrics.contains("matrixraft_capability_field_present"));
+        // All three named something no emitter produces under that name. The first two passed
+        // anyway: temporalstore_raft_matrixraft_ready and
+        // temporalstore_raft_matrixraft_capability_ready CONTAIN those substrings, so they would
+        // have passed with no matrixraft-prefixed metric in the tree at all. The third is emitted
+        // by nothing in either repository -- MatrixRaft at the pinned rev spells its own
+        // rustraft_baseline_raft_capability_field_present, and this crate reports WHICH field was
+        // the evidence as a label on the capability gauge rather than as a metric of its own.
+        //
+        // So each now names what is actually emitted, including the label carrying the
+        // field-present information. This does not decide whether a capability_field_present
+        // metric OUGHT to exist; if it should, that is a product change, not an assertion.
+        assert!(
+            metrics.contains("temporalstore_raft_matrixraft_ready"),
+            "the cluster metrics carry no matrixraft readiness gauge"
+        );
+        assert!(
+            metrics.contains("temporalstore_raft_matrixraft_capability_ready"),
+            "the cluster metrics carry no matrixraft capability gauge"
+        );
+        // Per sample, not over the whole dump: the evidence_field label is only emitted inside
+        // the capability loop, so requiring it outright would assert that the matrix is populated
+        // in this fixture -- a different claim, and one not verified here. This says the thing the
+        // deleted assertion was reaching for: a capability that IS reported names the field that
+        // evidenced it.
+        for sample in metrics
+            .lines()
+            .filter(|line| line.contains("temporalstore_raft_matrixraft_capability_ready{"))
+        {
+            assert!(
+                sample.contains("evidence_field="),
+                "a capability sample must name the field that evidenced it: {sample}"
+            );
+        }
         assert!(metrics.contains("temporalstore_raft_matrixraft_ready"));
         assert!(metrics.contains("temporalstore_raft_matrixraft_capability_ready"));
         assert!(metrics.contains("capability=\"wal_segment_lifecycle\""));


### PR DESCRIPTION
Two tests fail on an assertion for a metric **nothing emits**, and the two assertions above it pass
for a reason that is not evidence:

    assert!(metrics.contains("matrixraft_ready"));
    assert!(metrics.contains("matrixraft_capability_ready"));
    assert!(metrics.contains("matrixraft_capability_field_present"));   // fails

Identical blocks in `bin/server.rs` (`server_exposes_matrixraft_runtime_admin_route`) and
`bin/raft_node.rs` (`raft_control_exposes_matrixraft_runtime_admin_report`).

**The first two are satisfied by substring.** The emitter produces
`temporalstore_raft_matrixraft_ready` and `temporalstore_raft_matrixraft_capability_ready`, which
CONTAIN `matrixraft_ready` and `matrixraft_capability_ready` -- so both would pass with no
matrixraft-prefixed metric in the tree at all.

**The third names nothing.** MatrixRaft at the pinned rev spells its own
`rustraft_baseline_raft_capability_field_present` -- `rustraft_`, not `matrixraft_` -- and this
crate does not model field-presence as a metric. It reports WHICH field evidenced a capability as
an `evidence_field` LABEL on the capability gauge (`raft.rs:6353`).

## What each asserts now

Exact emitted names for the first two, and for the third the thing the deleted line was reaching
for -- a reported capability names its evidence:

    for sample in metrics.lines().filter(|l| l.contains("temporalstore_raft_matrixraft_capability_ready{")) {
        assert!(sample.contains("evidence_field="), ..);
    }

Per sample rather than over the whole dump on purpose. The label is only emitted inside the
capability loop, so requiring it outright would additionally assert that the matrix is populated
in this fixture -- a different claim, and not one verified here. The two gauges themselves are
asserted unconditionally, and both HELP lines are pushed unconditionally by the emitter, so those
hold whatever the matrix contains.

## What this does not decide

Whether a `capability_field_present` METRIC ought to exist. If raft readiness should publish one,
that is a product change and this assertion should be restored against it. What is not defensible
is the current state: one assertion that cannot pass, guarding a name from another repository, and
two that pass whatever happens.

Not compiled locally -- a full crate build on this box degrades a live service sharing it. The
emitted names and the sample format (`name{key="value"} value`, `push_raft_metric`) were read from
the emitter rather than assumed.
