### PR TITLE
The served index has not been text since the container landed

### DIFF
--- a/crates/temporalstore-rust/tests/delta_served_index.rs
+++ b/crates/temporalstore-rust/tests/delta_served_index.rs
@@ -84,13 +84,24 @@ fn delta_path_defers_base_write_but_funnel_and_reload_see_current_state() {
     let served = engine
         .export_index_bytes(SHARD_ID)
         .expect("funnel serves the live index");
-    let served_text = String::from_utf8_lossy(&served);
-    for key in ["alpha", "bravo", "charlie"] {
-        assert!(
-            served_text.contains(key),
-            "served index must contain {key}: {served_text}"
-        );
-    }
+    // The served index is a CONTAINER -- magic, a codec byte, then a zstd payload (and, for the
+    // msgpack codec, a four-byte struct-version stamp before it). It has not been text since that
+    // landed: `encode_index_bytes_as_plain_json` is `cfg(test)` and its own comment says
+    // production has no way to produce the plain shape any more. So searching the raw bytes for
+    // key names asserted a format that cannot occur, and this test has failed on main ever since.
+    //
+    // WHAT THIS COSTS: the funnel-is-current claim. Recovering it needs either a public decoder or
+    // a crate-internal test that can reach `decode_index_bytes`, and duplicating the container
+    // format here -- in a test, alongside the real reader -- is the wrong way to buy it back.
+    // Checkable from an integration test is that the funnel produced a container at all, and that
+    // the stream read returns those same bytes, asserted just below. The keys are read back for
+    // real in (4).
+    assert!(
+        served.starts_with(b"TSIDX"),
+        "the funnel must serve a served-index container, got {} bytes starting {:?}",
+        served.len(),
+        &served[..served.len().min(8)]
+    );
     // read_stream(Index) is routed through the same funnel.
     let stream = engine.read_stream(StreamReadRequest {
         shard_id: SHARD_ID,
@@ -106,9 +117,10 @@ fn delta_path_defers_base_write_but_funnel_and_reload_see_current_state() {
     let manifest = engine
         .create_bucket_dump_manifest(SHARD_ID, Vec::new())
         .expect("dump manifest should persist");
+    // Same container, same reason: this searched the embedded index for a key name.
     assert!(
-        String::from_utf8_lossy(&manifest.index_bytes).contains("charlie"),
-        "dump manifest must embed the current served index"
+        manifest.index_bytes.starts_with(b"TSIDX"),
+        "dump manifest must embed a served-index container"
     );
 
     // (4) Durability across a cold reload: the deferred writes live in the WAL and are


### PR DESCRIPTION
`delta_path_defers_base_write_but_funnel_and_reload_see_current_state` fails on a substring search
over the served index:

    let served_text = String::from_utf8_lossy(&served);
    assert!(served_text.contains(key), "served index must contain {key}: {served_text}");

The failure prints the reason directly -- the dump begins `TSIDX` and continues in binary:

    served index must contain alpha: TSIDX^A^A(.../.@X}^T@^Feh `I.h.^V-.(.^RqQC...

**The assertion cannot pass.** The served index is a container: magic, a codec byte, then a zstd
payload, plus a four-byte struct-version stamp for the msgpack codec (`engine.rs:2127`,
`decode_index_bytes`). Both codecs compress. The plain form still exists only as
`encode_index_bytes_as_plain_json`, which is `cfg(test)` and says so itself:

    Production has no way to produce this any more, and that is the point.

There is no flag that turns the container off -- `TS_INDEX_CODEC` chooses the payload, and both
choices are compressed. So this is a test pinning a format that was deliberately replaced, in the
same family as the reclaim refusal in mx#1213 and mx#1220.

## What it asserts now, and what that costs

Both text searches -- part (2) on the funnel and part (3) on the dump manifest -- become container
checks, and the comment says plainly what is given up:

    assert!(served.starts_with(b"TSIDX"), ..);

**This loses the funnel-is-current claim.** Buying it back needs a public decoder, or a
crate-internal test that can reach `decode_index_bytes`; duplicating the container layout inside a
test, alongside the real reader, is the wrong way to do it, and `zstd` is not a dev-dependency so
the test cannot decompress either. That is a call for whoever owns the index format, and it is
worth making -- but not by leaving an assertion that no build can satisfy.

What survives unchanged: part (1) still asserts the base file is not rewritten per write, the
stream read is still asserted to return the same bytes as the funnel, and part (4) still reads
every key back after a cold reload, which is the durability property the test exists for.

Not compiled locally -- a full crate build on this box degrades a live service sharing it. The
container layout was read from `decode_index_bytes` rather than assumed, and the change removes a
variable rather than adding constructs.
