### PR TITLE
A discarded load status hides why the shard is absent

### DIFF
--- a/crates/temporalstore-rust/tests/list_recovery.rs
+++ b/crates/temporalstore-rust/tests/list_recovery.rs
@@ -11,7 +11,9 @@
 
 use std::path::PathBuf;
 
-use temporalstore_rust::{Command, CommandResponse, ExecuteRequest, TemporalEngine};
+use temporalstore_rust::{
+    Command, CommandResponse, ExecuteRequest, LoadShardRequest, TemporalEngine,
+};
 
 const SHARD_ID: u64 = 1;
 const CACHE_BYTES: usize = 4096;
@@ -33,7 +35,24 @@ fn new_engine(root: &PathBuf) -> TemporalEngine {
         root.join("pages"),
         root.join("indexes"),
     );
-    engine.load_shard(SHARD_ID);
+    // `load_shard` builds this request and then drops the answer on the floor:
+    //
+    //     let _ = self.load_shard_with(request);
+    //
+    // So a load that fails is invisible until the first command comes back shard_not_loaded, and
+    // that status says only that the shard is absent, never why. Both of these tests fail exactly
+    // that way on main. Asking through load_shard_with makes the load report for itself.
+    let loaded = engine.load_shard_with(LoadShardRequest {
+        shard_id: SHARD_ID,
+        load_version: 0,
+        local_node_id: None,
+        shard_uri: String::new(),
+        start_routing_bucket: 0,
+        end_routing_bucket: u32::MAX,
+        readonly: false,
+        table_name: String::new(),
+    });
+    assert!(loaded.status.ok, "the shard did not load: {:?}", loaded.status);
     engine
 }
 

--- a/crates/temporalstore-rust/tests/zset_recovery.rs
+++ b/crates/temporalstore-rust/tests/zset_recovery.rs
@@ -11,7 +11,9 @@
 
 use std::path::PathBuf;
 
-use temporalstore_rust::{Command, CommandResponse, ExecuteRequest, TemporalEngine};
+use temporalstore_rust::{
+    Command, CommandResponse, ExecuteRequest, LoadShardRequest, TemporalEngine,
+};
 
 const SHARD_ID: u64 = 1;
 const CACHE_BYTES: usize = 4096;
@@ -33,7 +35,24 @@ fn new_engine(root: &PathBuf) -> TemporalEngine {
         root.join("pages"),
         root.join("indexes"),
     );
-    engine.load_shard(SHARD_ID);
+    // `load_shard` builds this request and then drops the answer on the floor:
+    //
+    //     let _ = self.load_shard_with(request);
+    //
+    // So a load that fails is invisible until the first command comes back shard_not_loaded, and
+    // that status says only that the shard is absent, never why. Both of these tests fail exactly
+    // that way on main. Asking through load_shard_with makes the load report for itself.
+    let loaded = engine.load_shard_with(LoadShardRequest {
+        shard_id: SHARD_ID,
+        load_version: 0,
+        local_node_id: None,
+        shard_uri: String::new(),
+        start_routing_bucket: 0,
+        end_routing_bucket: u32::MAX,
+        readonly: false,
+        table_name: String::new(),
+    });
+    assert!(loaded.status.ok, "the shard did not load: {:?}", loaded.status);
     engine
 }
 


### PR DESCRIPTION
`list_order_survives_restart_and_pops_stay_popped` and
`scores_and_order_survive_restart_including_a_rescore` both fail at line 45 of their files with:

    command failed: Status { ok: false, code: "shard_not_loaded",
                             message: "shard is not loaded on this server" }

That is the first command in each test, and the message says the shard is absent without saying
why. The reason it cannot say more is upstream:

    pub fn load_shard(&self, shard_id: ShardId) {
        let request = LoadShardRequest { .. };
        let _ = self.load_shard_with(request);
    }

**The load answers, and the answer is dropped on the floor.** A load that fails is then invisible
until some later command reports the shard missing, which is where both of these land.

## What changed

Only the two tests. Each asks through `load_shard_with` -- building the identical request
`load_shard` builds, field for field -- and asserts the response:

    assert!(loaded.status.ok, "the shard did not load: {:?}", loaded.status);

So the next run prints why the load failed instead of reporting the consequence two steps later.
Same shape as mx#1207, where a readiness assertion had the blocked service in hand and printed a
bare predicate; that one, once legible, named its cause immediately and became mx#1222.

## What this does not do

It does not fix the load, because what is wrong is not yet known -- that is the point of the
change. It also does not touch `load_shard` itself: dropping the status there is worth revisiting,
but the signature has 604 call sites in this crate and some may sit in expression position, so
widening the return type is not a change to make blind.

Not compiled locally -- a full crate build on this box degrades a live service sharing it.
`LoadShardRequest` is exported from the crate root and all eight fields are public, checked in
`control.rs`, and the request is copied from `load_shard` rather than rewritten.
