### PR TITLE
A third copy of the reclaim refusal, in the corpus suite

### DIFF
--- a/crates/temporalstore-rust/tests/unified_temporalstore_corpus.rs
+++ b/crates/temporalstore-rust/tests/unified_temporalstore_corpus.rs
@@ -3703,7 +3703,12 @@ fn verify_storage_wal_index_gc_generation_retention(shard_id: u64) {
         vec![lagging_cursor.clone()],
         vec![lagging_snapshot.clone()],
     );
-    assert!(!blocked.safe_to_reclaim, "{blocked:?}");
+    // Both cursors sit at the parent manifest, so the frontier CLAMPS down to the parent instead
+    // of refusing at the child. They are still counted and named as retaining the logs above them.
+    // Refusing outright let one lagging follower pin the whole log for as long as it lagged. This
+    // is a third copy of the contract corrected in mx#1213 and mx#1220; the engine-side test for
+    // the same scenario, engine/tests/part4.rs, already asserts it this way.
+    assert!(blocked.safe_to_reclaim, "{blocked:?}");
     assert_eq!(blocked.follower_cursor_block_count, 1);
     assert_eq!(blocked.raft_snapshot_block_count, 1);
     assert_eq!(
@@ -3714,8 +3719,16 @@ fn verify_storage_wal_index_gc_generation_retention(shard_id: u64) {
         blocked.durable_bucket_generation_frontier_index_log_sequence,
         child.index_log_sequence
     );
-    assert_eq!(blocked.retain_from_wal_sequence, 0);
-    assert_eq!(blocked.retain_from_index_log_sequence, 0);
+    assert_eq!(
+        blocked.retain_from_wal_sequence,
+        parent.wal_sequence.saturating_add(1),
+        "clamped to the slowest cursor, not refused at the frontier: {blocked:?}"
+    );
+    assert_eq!(
+        blocked.retain_from_index_log_sequence,
+        parent.index_log_sequence.saturating_add(1),
+        "{blocked:?}"
+    );
     assert!(blocked
         .blocker_reasons
         .contains(&"follower_cursor_retains_logs:unified-lagging-follower".to_string()));
@@ -3734,13 +3747,31 @@ fn verify_storage_wal_index_gc_generation_retention(shard_id: u64) {
         ..StorageManagerCycleRequest::default()
     });
     let blocked_wal = blocked_cycle.wal_reclaim_report.as_ref().unwrap();
-    assert!(!blocked_wal.applied, "{blocked_wal:?}");
-    assert_eq!(blocked_wal.wal_records_removed, 0);
-    let blocked_index_gc = blocked_cycle.index_gc_report.as_ref().unwrap();
-    assert!(!blocked_index_gc.applied, "{blocked_index_gc:?}");
+    // The cycle carries the same clamp: it reclaims the span the cursors have already consumed
+    // and keeps everything above them. Asserting that nothing was reclaimed was asserting the
+    // refusal itself.
+    assert!(blocked_wal.applied, "{blocked_wal:?}");
+    assert!(
+        blocked_wal.wal_records_removed > 0,
+        "the span below the slowest cursor should go: {blocked_wal:?}"
+    );
     assert_eq!(
-        blocked_index_gc.skipped_reason,
-        "durable WAL/index frontier not safe"
+        blocked_wal.plan.retain_from_wal_sequence,
+        parent.wal_sequence.saturating_add(1),
+        "and nothing above it: {blocked_wal:?}"
+    );
+    assert_eq!(
+        blocked_wal.plan.retain_from_index_log_sequence,
+        parent.index_log_sequence.saturating_add(1),
+        "{blocked_wal:?}"
+    );
+    // Index GC follows the same frontier, so its verdict must agree with the plan rather than be
+    // asserted independently -- the two disagreeing is the defect worth catching here.
+    let blocked_index_gc = blocked_cycle.index_gc_report.as_ref().unwrap();
+    assert_eq!(
+        blocked_index_gc.applied,
+        blocked_wal.plan.safe_to_reclaim,
+        "index GC and WAL reclaim must reach the same verdict on one frontier: {blocked_index_gc:?}"
     );
 
     let released_anchor = engine


### PR DESCRIPTION
`rust_executes_storage_raft_gc_cases` fails on the same replaced contract as mx#1213 and mx#1220 --
a third copy, in a different file:

    assert!(!blocked.safe_to_reclaim, "{blocked:?}");   // unified_temporalstore_corpus.rs:3706

The dump in the failure says what happened instead:

    StorageWalReclaimPlan { safe_to_reclaim: true, retain_from_wal_sequence: 2,
      follower_cursor_block_count: 1, raft_snapshot_block_count: 1,
      blocker_reasons: ["follower_cursor_retains_logs:unified-lagging-follower",
                        "raft_snapshot_retains_logs:unified-raft-snapshot-lagging"] }

A retention cursor no longer refuses, it CLAMPS: the span at or below the slowest cursor is behind
every reader and goes, nothing above it does. Refusing outright let one lagging follower pin the
whole log for as long as it lagged.

## Copied from the sibling, not invented

The engine-side test for the identical scenario, `engine/tests/part4.rs`, was already corrected and
says exactly what to assert. This mirrors it rather than approximating it:

| | asserted |
|---|---|
| plan | `safe_to_reclaim` true, block counts still 1 and 1, `retain_from_* == parent.*.saturating_add(1)` |
| cycle | `applied` true, `wal_records_removed > 0`, plan retain-from at the same bound |
| index GC | `applied == plan.safe_to_reclaim` -- the two must reach the same verdict on one frontier, rather than being asserted independently |

That last one matters here: index GC skips when `!wal_plan.safe_to_reclaim`
(`storage_lifecycle_methods.rs:960`), so under the clamp its old assertion -- skipped, reason
"durable WAL/index frontier not safe" -- cannot hold either. The panic was at the FIRST assertion,
so none of the later ones had reported yet; tying index GC to the plan is what the sibling does and
avoids guessing at the fixture.

The exact `parent + 1` is deliberate: a `>=` would pass with the clamp deleted and reclaim running
to the durable frontier, which is the regression worth catching.

## Not this PR

`rust_executes_temporalstore_corpus` also fails in this file, on
`slot_dump_object_lifecycle_mismatch` for case
`native_logical_storage_models_packed_timestamped_pages`. Different cause, not touched here.

Not compiled locally -- a full crate build on this box degrades a live service sharing it. Every
value asserted is copied from the already-corrected engine-side test for the same scenario.
