### PR TITLE
The scan decodes every record twice, and what it costs to stop

### DIFF
--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -6189,6 +6189,60 @@ mod tests {
         std::env::remove_var("TS_WAL_COMPRESS_RECORDS");
     }
 
+    /// What the scan's read-time check costs, against the check that catches corruption.
+    ///
+    /// `scan_bounded` calls `decode_wal_line` on every record and throws the record away; the
+    /// caller then decodes the same bytes again. `decode_wal_line` starts by calling
+    /// `log_framing::decode_line`, which verifies the declared length and the checksum -- so
+    /// corruption, meaning bytes that changed on disk, is already caught there. What the rest of
+    /// the decode adds is a payload that checksums correctly and still will not parse.
+    ///
+    /// This prices the difference, because it is paid once per record on every recovery.
+    #[test]
+    #[ignore]
+    fn what_the_scan_time_check_costs() {
+        let record = WriteAheadLogRecord {
+            shard_id: 1,
+            sequence: 7,
+            command: Some(Command::StringSet {
+                key: "tenant/7/object/000000123".to_string(),
+                value: (0..4096u32).map(|index| (index % 7) as u8).collect(),
+            }),
+            metadata: None,
+            staged_pages: Vec::new(),
+            outcomes: Vec::new(),
+        };
+        let line = encode_wal_line_for_test(&record).expect("record frames");
+
+        let rounds = 200usize;
+        let mut full_best = f64::MAX;
+        let mut framed_best = f64::MAX;
+        for _ in 0..7 {
+            let start = std::time::Instant::now();
+            for _ in 0..rounds {
+                std::hint::black_box(decode_wal_line(std::hint::black_box(&line)).unwrap());
+            }
+            full_best = full_best.min(start.elapsed().as_secs_f64());
+
+            let start = std::time::Instant::now();
+            for _ in 0..rounds {
+                std::hint::black_box(
+                    crate::log_framing::decode_line(std::hint::black_box(&line)).unwrap(),
+                );
+            }
+            framed_best = framed_best.min(start.elapsed().as_secs_f64());
+        }
+
+        let us = |t: f64| t / rounds as f64 * 1e6;
+        println!(
+            "  SCANCHECK line {} B | full decode {:>7.3} us | length+checksum only {:>7.3} us | {:>5.1}x",
+            line.len(),
+            us(full_best),
+            us(framed_best),
+            full_best / framed_best,
+        );
+    }
+
     #[test]
     fn what_a_record_actually_costs_on_disk() {
         for value_len in [64usize, 1024, 4096] {


### PR DESCRIPTION
`scan_bounded` calls `decode_wal_line` on every record in the window and throws the record away. It
then pushes the same bytes into the result and the caller decodes them. Every record in a scan is
decoded twice, once for nothing, on recovery, on replay, and on every read from a watermark.

The check exists for a stated reason: refuse a corrupt record where it is being read. What notices
corruption is `log_framing::decode_line`, which verifies the declared length and the checksum, and
which `decode_wal_line` already calls first before doing anything else. So the corruption half of
the check is the cheap half. Measured in release on one compressed record:

    full decode                7.261 us
    length and checksum only   0.063 us     115.5x

This change adds that measurement and nothing else. Replacing the call was tried and is NOT included,
because it does not survive its own suite:

  * `wal::` was run four times with the narrowed check and four times without.
    `one_reclaim_pass_unlinks_at_most_its_bound` failed 4 of 4 with it and 2 of 4 without, and 3 of 3
    in an earlier round with it. In isolation it passes 5 of 5 either way.
  * The in-suite failure arrives as a JSON parse error reaching an `unwrap`, not as a returned error.
    That contradicts the reason narrowing looked safe -- that a record which checksums correctly and
    will not parse would simply fail one step later in the caller, with the same error. At least one
    caller does not propagate it.

Whether the mechanism is that consequence or the ordering this suite is sensitive to -- the tests
share a thread and inherit each other's thread-local overrides, as the comment on
`finding_the_tail_reads_a_block_not_the_log` says -- the change makes a test that failed half the
time fail every time. That is not shippable, and it is more useful written down than repeated.

So what lands is the number, and `what_the_scan_time_check_costs` to re-run it. Anyone removing the
second decode should start from the two findings above rather than from the assumption I started
from.