### PR TITLE
A proxy that came back stopped belonging to the group an operator put it in

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -9022,6 +9022,97 @@ fn counting_resources_agrees_with_listing_them_and_counting_those() {
     }
 
     #[test]
+    fn a_proxy_that_comes_back_still_belongs_to_its_group() {
+        let meta = SingleNodeMeta::default();
+        assert!(meta
+            .put_proxy_group(PutProxyGroupRequest {
+                group: "g-1".to_string(),
+                namespace: "served".to_string(),
+                location: String::new(),
+                instance_num: 1,
+                drop_percent: 0,
+            })
+            .status
+            .ok);
+        // The proxy declares a different namespace for itself, so what it ends
+        // up serving shows which of the two is in force.
+        let register = || RegisterProxyRequest {
+            proxy_addr: "proxy-a".to_string(),
+            namespace: "declared".to_string(),
+            location: "rack-0".to_string(),
+            binary_version: "v1".to_string(),
+            config_version: 0,
+            registered_at_ms: 0,
+        };
+        assert!(meta.register_proxy(register()).status.ok);
+        assert!(meta
+            .set_proxy_group(ProxyAttachment {
+                proxy_addr: "proxy-a".to_string(),
+                group: "g-1".to_string(),
+            })
+            .status
+            .ok);
+
+        let group_of = |meta: &SingleNodeMeta| {
+            meta.list_proxies()
+                .proxies
+                .into_iter()
+                .find(|proxy| proxy.proxy_addr == "proxy-a")
+                .map(|proxy| proxy.group)
+                .unwrap_or_default()
+        };
+        assert_eq!(group_of(&meta), "g-1", "the operator's attachment did not take");
+
+        // It restarts and registers again.
+        assert!(meta.register_proxy(register()).status.ok);
+        assert_eq!(
+            group_of(&meta),
+            "g-1",
+            "registering again threw away the group an operator put it in"
+        );
+
+        // And it is really in force, not merely recorded: the group decides the
+        // namespace, so the heartbeat answers with the group's, not the one the
+        // proxy declared for itself.
+        let beat = meta.proxy_heartbeat(ProxyHeartbeatRequest {
+            proxy_addr: "proxy-a".to_string(),
+            namespace: "declared".to_string(),
+            config_version: 0,
+            boot_time_ms: 1,
+            binary_version: "v1".to_string(),
+        });
+        assert!(beat.status.ok);
+        assert_eq!(
+            beat.namespace, "served",
+            "the proxy came back serving what it declared instead of what its group says"
+        );
+
+        // A proxy nobody attached still comes back unattached, so keeping the
+        // group cannot be confused with inventing one.
+        assert!(meta
+            .register_proxy(RegisterProxyRequest {
+                proxy_addr: "proxy-b".to_string(),
+                namespace: "declared".to_string(),
+                location: "rack-0".to_string(),
+                binary_version: "v1".to_string(),
+                config_version: 0,
+                registered_at_ms: 0,
+            })
+            .status
+            .ok);
+        assert!(
+            meta.list_proxies()
+                .proxies
+                .into_iter()
+                .find(|proxy| proxy.proxy_addr == "proxy-b")
+                .map(|proxy| proxy.group)
+                .unwrap_or_default()
+                .is_empty(),
+            "a proxy nobody attached came back in a group"
+        );
+    }
+
+    #[test]
     fn metaserver_safe_mode_cooldown_blocks_rejoin_and_round_trips() {
         let dir = tempfile::tempdir().unwrap();
         let log_path = dir.path().join("safe-mode-mutations.jsonl");

--- a/crates/temporalstore-rust/src/meta/registration.rs
+++ b/crates/temporalstore-rust/src/meta/registration.rs
@@ -308,6 +308,17 @@ impl SingleNodeMeta {
             .map(|proxy| proxy.registered_at_ms)
             .filter(|first| *first != 0)
             .unwrap_or(request.registered_at_ms);
+        // Which group this proxy belongs to, kept for the reason the join time
+        // above is kept: registering again is a proxy saying it is here, not an
+        // operator saying to forget where it belongs. The group decides which
+        // namespace it serves, and the loop that could reassign it is off
+        // unless asked for -- so clearing it here left a restarted proxy
+        // unattached with nothing to put it back.
+        let group = state
+            .proxies
+            .get(&request.proxy_addr)
+            .map(|proxy| proxy.group.clone())
+            .unwrap_or_default();
         if let Some(existing) = state.proxies.get(&request.proxy_addr) {
             let now = now_ms();
             if existing.state == MetaEntityState::Frozen && existing.freeze_cooldown_until_ms > now
@@ -336,7 +347,7 @@ impl SingleNodeMeta {
             ProxyMetaInfo {
                 heartbeats_total: 0,
                 freeze_reason: FreezeReason::Unspecified,
-                group: String::new(),
+                group,
                 proxy_addr: request.proxy_addr,
                 namespace: request.namespace,
                 location: request.location,


### PR DESCRIPTION
A proxy's group decides which namespace it serves. An operator sets it, and the loop that could set it again is off unless asked for -- `TS_META_PROXY_CALIBRATION` defaults false, deliberately, because reassigning what a proxy serves is intrusive.

Registering again rebuilt the proxy's record and wrote the group away. So a proxy that restarted came back unattached, and nothing put it back.

## Why it did not look broken

The heartbeat still answers. An unattached proxy falls back to the namespace it declared for itself, so it keeps serving something and reports no change -- while the group an operator put it in has quietly stopped being the thing in force.

That is why the test checks what the proxy is told to serve, not just what the record says. The group's namespace and the proxy's own are deliberately different in it, so a proxy serving its own namespace fails even if the field looks right.

## What changed

The group is kept across a re-registration, for the reason the join time beside it is already kept: a proxy saying it is here again is not an operator saying to forget where it belongs.

## Testing

An operator attaches a proxy to a group whose namespace differs from the one the proxy declares. The proxy registers again, and the test asks both what the record says and what the next heartbeat tells the proxy to serve.

Against the tree before this change it fails, saying registering again threw away the group an operator put it in.

A proxy nobody attached still comes back unattached, so keeping a group cannot be confused with inventing one.

## Where this came from

The same shape has now been found five times: a record rebuilt by a struct literal, dropping a field added to it later. Reassigning a shard, registering one, and finishing a load onto one all threw away its pin; this is the proxy's version.

`register_server` is the one that does it right, and shows what the difference looks like: it re-declares the node's hardware and clears its reboot verdict on purpose, and says so in a comment at each. The sites that lost a field had no comment -- nothing was decided there, the field was simply written away.
