### PR TITLE
The unserialized-map rebuild covers one map of three

### DIFF
--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -954,9 +954,42 @@ pub(super) fn promote_model_maps_to_bucket_index_authority(
     true
 }
 
-/// Rebuild ONLY the model maps that are `skip_serializing` -- today just `hashes` -- from the
-/// durable bucket index. A freshly deserialized index never carries them, so anything deriving
-/// state from the model maps would see a shard with no hash objects at all.
+/// Rebuild ONLY the model maps that are `skip_serializing`, from the durable bucket index. A
+/// freshly deserialized index never carries them, so anything deriving state from the model maps
+/// would see a shard with no objects of those kinds at all.
+///
+/// THIS COVERS ONE OF THREE, and the sentence here used to say there was only one. Checked field
+/// by field against `collect_model_live_page_entries`, which is what the manifest cross-check
+/// reads: of the twelve maps it walks, three are `skip_serializing` --
+///
+///   * `hashes`            rebuilt below
+///   * `context_events`    NOT rebuilt
+///   * `context_indexes`   NOT rebuilt
+///
+/// so a slot dump whose buckets hold context-event or context-index pages decodes with those maps
+/// empty, the model-map derivation misses every one of those pages, the bucket-index derivation
+/// does not, and `install_bucket_dump_manifest` rejects a perfectly good manifest with
+/// `slot_dump_object_lifecycle_mismatch`. That is the live failure of
+/// `rust_executes_temporalstore_corpus` and
+/// `rust_storage_replays_migration_corpus_across_lifecycle_paths`, both on case
+/// `native_logical_storage_models_packed_timestamped_pages` -- timestamped being the shape of
+/// exactly these two maps, which are keyed by `u64`.
+///
+/// NOT fixed here, because the two obvious repairs are not equivalent and the choice is not a
+/// detail:
+///
+///   1. Rebuild them too. But these maps are keyed by TIMESTAMP and the bucket-index entries for
+///      them carry `component: None` (see the `context_event` arm of
+///      `collect_model_live_page_entries`), so the keys are not recoverable from the index.
+///      Synthesising keys would make the cross-check agree while putting invented timestamps into
+///      a time-keyed map, which is worse than the failure it cures.
+///   2. Have the cross-check compare only the maps that SURVIVE serialization. A map the manifest
+///      does not carry cannot disagree with the manifest, so it is outside what the check is for
+///      -- its stated purpose is a manifest whose serialized model maps contradict its bucket
+///      index. On this reading the `hashes` rebuild below is also unnecessary for the check.
+///
+/// The second looks right, but it narrows a durability check, so it wants the owner of the dump
+/// format rather than an inference from a failing test.
 ///
 /// Deliberately narrow: the serialized maps are left exactly as decoded. Rebuilding those from
 /// the bucket index too would overwrite whatever the index actually said, which is precisely


### PR DESCRIPTION
`rust_executes_temporalstore_corpus` and
`rust_storage_replays_migration_corpus_across_lifecycle_paths` both fail on the same case,
`native_logical_storage_models_packed_timestamped_pages`, with:

    slot dump install failed: Status { ok: false, code: "slot_dump_object_lifecycle_mismatch",
      message: "slot dump object lifecycle metadata does not match restored index" }

`install_bucket_dump_manifest` derives the object-lifecycle report twice -- once from the bucket
index, once from the serialized model maps -- and rejects the manifest if they disagree. That
cross-check is deliberate: it catches a manifest whose model maps contradict its own index.

A restored index carries no `skip_serializing` map, which would make the model-map derivation see
nothing, so `rebuild_unserialized_model_maps_from_bucket_index` exists to put them back. Its
comment says it covers "today just `hashes`".

**Checked field by field, it is one of three.** Of the twelve maps
`collect_model_live_page_entries` walks:

| map | serde | rebuilt |
|---|---|---|
| `hashes` | `skip_serializing` | yes |
| `context_events` | `skip_serializing` | **no** |
| `context_indexes` | `skip_serializing` | **no** |
| the other nine | serialized | not needed |

So a dump whose buckets hold context-event or context-index pages decodes with those maps empty,
the model-map derivation misses every such page, the bucket-index derivation does not, and a good
manifest is rejected. Both maps are keyed by `u64` -- which is what "packed timestamped pages"
names in the failing case.

## Why this PR does not fix it

The two obvious repairs are not equivalent:

1. **Rebuild them too.** But the bucket-index entries for these kinds carry `component: None`
   (the `context_event` arm of `collect_model_live_page_entries`), so their TIMESTAMP keys are not
   recoverable from the index. Synthesising keys would make the cross-check agree while writing
   invented timestamps into a time-keyed map -- worse than the failure it cures.
2. **Compare only the maps that survive serialization.** A map the manifest does not carry cannot
   contradict the manifest, so it is outside what the check is for. On this reading the `hashes`
   rebuild is also unnecessary for the check.

The second looks right to me, but it narrows a durability check on the dump-install path, so it
wants whoever owns the dump format rather than an inference drawn from a failing test.

What this PR does is record the mechanism where the next person will look -- on the function whose
comment currently says the scope is one map -- so the failure stops reading as a mystery. Comment
only; no behaviour change.
