### PR TITLE
Ten thousand hook closes timed out and none said which stage

### DIFF
--- a/tools/matrixark_codex_hook.py
+++ b/tools/matrixark_codex_hook.py
@@ -2248,7 +2248,15 @@ def close_server_best_effort(server: Any, *, timeout_ms: int = HOOK_CLOSE_TIMEOU
     close_timeout_s = max(0.001, timeout_ms / 1000.0)
     result = _run_best_effort_with_timeout("close", timeout_ms, close, timeout_s=close_timeout_s)
     if result.get("status") != "ok":
-        _mcp_debug_log(f"matrixark hook close skipped after {timeout_ms}ms: {result}")
+        # Say HOW FAR it got. This line has been written 10,105 times in the live debug log, all
+        # of them at 750ms, and every one of them said only that the budget ran out -- never
+        # which stage was holding it. The close spends its budget in order (thread joins, adapter
+        # close, audit drain), so the stage reached is the difference between a poller that will
+        # not stop and a flush that never ran.
+        progress = getattr(server, "_close_progress", None)
+        _mcp_debug_log(
+            f"matrixark hook close skipped after {timeout_ms}ms: {result} reached={progress}"
+        )
 
 
 def is_resource_event(event: str) -> bool:

--- a/tools/matrixark_mcp_shutdown.py
+++ b/tools/matrixark_mcp_shutdown.py
@@ -43,13 +43,33 @@ def close_server_within_budget(server: Any, timeout_s: float) -> None:
     Total, not per step: each stage asks what is LEFT rather than helping itself to the whole budget
     again. A caller that waits `timeout_s` gets a close that tried to finish in `timeout_s`.
     """
-    deadline = time.monotonic() + max(0.0, timeout_s)
+    started = time.monotonic()
+    deadline = started + max(0.0, timeout_s)
 
     def remaining() -> float:
         return max(0.0, deadline - time.monotonic())
 
+    # Which stage the close reached, and when. A caller that abandons this on a timeout cannot
+    # see where the budget went -- the thread is left running and its return value never arrives
+    # -- so the progress is recorded ON THE SERVER as each stage completes, and whatever is there
+    # when the caller gives up is what actually got done.
+    #
+    # Worth having because the budget is spent IN ORDER and the last stage is the audit drain:
+    # joins, then the adapter close, then the drain. The joins are capped at
+    # CLOSE_JOIN_BUDGET_SHARE for exactly this reason, but the adapter close is handed
+    # `remaining()` uncapped, so it can still leave the drain with nothing. Whether that is what
+    # happens is a question about a running deployment, and this is what lets the log answer it.
+    def reached(stage: str) -> None:
+        server._close_progress = {
+            "stage": stage,
+            "elapsed_ms": round((time.monotonic() - started) * 1000.0, 1),
+            "budget_ms": round(max(0.0, timeout_s) * 1000.0, 1),
+        }
+
+    reached("start")
     server._summary_stop.set()
     server._stream_materialize_stop.set()
+    reached("stop_flags_set")
 
     # The joins share a slice; whatever they leave goes to the flushes below.
     join_deadline = time.monotonic() + remaining() * CLOSE_JOIN_BUDGET_SHARE
@@ -57,8 +77,11 @@ def close_server_within_budget(server: Any, timeout_s: float) -> None:
         if thread is None:
             continue
         thread.join(timeout=max(0.0, join_deadline - time.monotonic()))
+    reached("threads_joined")
 
     adapter_close = getattr(server.adapter, "close", None)
     if callable(adapter_close):
         adapter_close(timeout_s=remaining())
+    reached("adapter_closed")
     server._audit_queue.drain(remaining())
+    reached("audit_drained")

--- a/tools/test_the_close_says_which_stage_it_reached.py
+++ b/tools/test_the_close_says_which_stage_it_reached.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A close that runs out of budget has to say how far it got.
+
+`close_server_best_effort` abandons the close thread when the budget runs out, so its return value
+never arrives and the caller can only report that the budget ran out. That line has been written
+10,105 times in the live debug log, every one of them at 750ms, and not one of them said which
+stage was holding it.
+
+It matters because the budget is spent IN ORDER -- thread joins, then the adapter close, then the
+audit drain -- and the drain is last. `CLOSE_JOIN_BUDGET_SHARE` caps the joins for exactly that
+reason: "stops a poller that will not stop from consuming everything and leaving the flushes with
+nothing". The stage after it is handed `remaining()` uncapped.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_mcp_shutdown as shutdown  # noqa: E402
+
+
+class _Queue:
+    def __init__(self) -> None:
+        self.drained_with: float | None = None
+
+    def drain(self, budget_s: float) -> None:
+        self.drained_with = budget_s
+
+
+class _Adapter:
+    def __init__(self, blocks_for: float) -> None:
+        self.blocks_for = blocks_for
+        self.closed_with: float | None = None
+
+    def close(self, timeout_s: float | None = None) -> None:
+        self.closed_with = timeout_s
+        time.sleep(self.blocks_for)
+
+
+class _Server:
+    """The attributes close_server_within_budget touches, and nothing else."""
+
+    def __init__(self, adapter_blocks_for: float = 0.0) -> None:
+        self._summary_stop = threading.Event()
+        self._stream_materialize_stop = threading.Event()
+        self._summary_thread = None
+        self._stream_materialize_thread = None
+        self.adapter = _Adapter(adapter_blocks_for)
+        self._audit_queue = _Queue()
+
+
+class TheCloseSaysWhichStageItReachedTest(unittest.TestCase):
+
+    def test_a_close_that_finishes_records_the_last_stage(self) -> None:
+        server = _Server()
+        shutdown.close_server_within_budget(server, 0.75)
+        progress = getattr(server, "_close_progress", None)
+        self.assertIsNotNone(progress, "the close recorded no progress at all")
+        self.assertEqual(
+            "audit_drained", progress["stage"],
+            "a close with nothing to wait for must reach the last stage: %r" % (progress,))
+        self.assertEqual(750.0, progress["budget_ms"])
+
+    def test_the_stage_is_recorded_as_it_goes_not_at_the_end(self) -> None:
+        """The point of the record is to survive a caller that gives up, so it cannot be written
+        once at the end -- that is exactly the case where it never gets written."""
+        seen = []
+        server = _Server()
+
+        # Observed from inside the LAST stage: the drain runs after everything else, so if the
+        # progress were written once at the end, the stage visible here would still be missing.
+        def record(budget_s: float) -> None:
+            seen.append(getattr(server, "_close_progress", {}).get("stage"))
+
+        server._audit_queue.drain = record
+        shutdown.close_server_within_budget(server, 0.75)
+        self.assertEqual(
+            ["adapter_closed"], seen,
+            "at the drain the close should already have recorded reaching adapter_closed: %r"
+            % (seen,))
+
+    def test_an_overrunning_adapter_leaves_the_audit_drain_nothing(self) -> None:
+        """CHARACTERISATION, not an endorsement.
+
+        The joins are capped so they cannot starve what follows. The adapter close is not: it is
+        handed `remaining()`, so one that overruns leaves the drain with zero budget -- the same
+        starvation, one stage further down. This pins the behaviour so a fix is visible rather
+        than silent.
+
+        If this assertion starts failing because the drain now gets a floor, that is the fix
+        landing: update this test, do not restore the zero.
+        """
+        server = _Server(adapter_blocks_for=0.30)
+        shutdown.close_server_within_budget(server, 0.20)
+        self.assertEqual(
+            0.0, server._audit_queue.drained_with,
+            "an adapter that outruns the whole budget currently leaves the drain nothing")
+        self.assertGreater(
+            server._close_progress["elapsed_ms"], server._close_progress["budget_ms"],
+            "the close overran its own budget, which is what the caller reports as a timeout")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The live debug log has this line **10,105 times**, and every one of them says the same thing:

    matrixark hook close skipped after 750ms: {status: timeout, timeout_ms: 750}

10,105 of 10,157 closes, all at exactly 750ms. Not one says which stage was holding the budget,
and the caller cannot know: `close_server_best_effort` abandons the close thread on timeout, so
its return value never arrives.

That matters because the budget is spent **in order** -- thread joins, then the adapter close,
then the audit drain -- and the drain is last. `CLOSE_JOIN_BUDGET_SHARE` caps the joins for
exactly this reason:

    Capping it is what stops a poller that will not stop from consuming everything and leaving
    the flushes with nothing.

The stage after it is handed `remaining()` **uncapped**.

## Demonstrated, not hypothesised

Driving `close_server_within_budget` against a stub whose adapter close overruns:

    fast close   -> stage=audit_drained  elapsed=0.0ms     drain budget=0.750s
    slow adapter -> stage=audit_drained  elapsed=1001.1ms  drain budget=0.000s

An adapter that outruns the budget leaves the audit drain **zero** -- the same starvation the cap
was written to prevent, one stage further down.

## What changed

Instrumentation, no behaviour change. `close_server_within_budget` records the stage it has
reached ON THE SERVER as each one completes -- start, stop_flags_set, threads_joined,
adapter_closed, audit_drained -- with elapsed and budget. Recorded as it goes rather than
returned, because the case that needs it is precisely the one where the caller has stopped
listening. The hook line now prints `reached={...}`, so the next occurrence in the live log says
where the 750ms went.

## Why not just fix it here

Capping the adapter close the way the joins are capped is the obvious next step, and it may well
be right. But in the reproduction above the stub ignores the `timeout_s` it is handed, and whether
the real adapter honours it is a question about a running deployment -- if it does not, capping
the request changes nothing and the reserve is imaginary. The log will answer that within a day of
this landing, and the fix can then be aimed rather than guessed.

## Coverage

`test_the_close_says_which_stage_it_reached.py`, three tests: the last stage is recorded, the
record is written AS IT GOES (observed from inside the drain, so a write-once-at-the-end
implementation fails), and the starvation is pinned as an explicit characterisation whose comment
says that a failure here means the fix landed and the test should be updated rather than the zero
restored. Deleting the recorder turns all three red (2 failures, 1 error).
