### PR TITLE
A flag read through a helper was invisible to the offered rule

### DIFF
--- a/tools/test_an_addressed_flag_is_offered.py
+++ b/tools/test_an_addressed_flag_is_offered.py
@@ -42,7 +42,16 @@ REPO = os.path.dirname(TOOLS)
 
 _READ = re.compile(
     r'os\.(?:environ\.get|getenv)\(\s*["\']((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)["\']'
-    r'|os\.environ\[\s*["\']((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)["\']')
+    r'|os\.environ\[\s*["\']((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)["\']'
+    r'|\b\w*[Ee][Nn][Vv]\w*\(\s*["\']((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)["\']')
+
+# The third alternative is any call whose NAME contains env, taking a flag name as its first
+# argument -- env_bool, _env_int, positive_int_env, _matrixark_env_truthy and eight more. Those
+# reads were invisible here: the scan knew two spellings of a read, and a flag reached through a
+# helper was outside the rule below without anything saying so. 82 flags, among them
+# MATRIXARK_HOOK_CLOSE_TIMEOUT_MS, the budget every hook close in the live log runs out of.
+# None of the 82 gives advice it cannot honour, so this changes no verdict -- it stops the
+# verdict depending on which idiom a read happens to use.
 
 _NAME = re.compile(r"(?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+")
 
@@ -98,7 +107,7 @@ def _reads() -> Dict[str, Tuple[str, int, str]]:
         # names was exempt from the rule below without anything saying so. 442 flags, not 419.
         for match in _READ.finditer(text):
             number = text.count("\n", 0, match.start()) + 1
-            name = match.group(1) or match.group(2)
+            name = match.group(1) or match.group(2) or match.group(3)
             if name in found:
                 continue
             block = []


### PR DESCRIPTION
`test_an_addressed_flag_is_offered` enforces a real rule: a flag whose comment TELLS AN OPERATOR to
set it must be reachable somewhere an operator can reach. It found flag reads with:

    os.environ.get("NAME", ..)      os.getenv("NAME", ..)      os.environ["NAME"]

Those are two spellings of a read. This tree has twelve more, all wrappers:

    env_bool  _env_int  _env_bool  _env  positive_int_env  bool_env
    _matrixark_env_truthy  _env_flag  _env_seconds_from_ms  _truthy_env  _bool_env

**82 flags are read only that way, and the guard could not see any of them.** Among them
`MATRIXARK_HOOK_CLOSE_TIMEOUT_MS` -- the budget every hook close in the live debug log runs out of,
10,105 times out of 10,157 -- which the guard reported as not read at all.

## What changed

A third alternative in the pattern: any call whose NAME contains `env`, taking a flag name as its
first argument. Coverage goes from **431 flags to 517**.

## It changes no verdict, and that was checked first

Of the 82, **none** carries operator-addressed prose while being unoffered, so nothing new fails.
That was measured before touching the pattern, because widening a guard that then goes red is a
different change and wants a different PR. What this fixes is that whether a flag was governed
depended on which idiom its read happened to use.

## Proof it discriminates

A probe module reading through a helper, with an operator-addressed comment and offered nowhere:

    # Set MATRIXARK_ZZ_HELPER_KNOB=1 in production to turn this on.
    _KNOB = _env_int("MATRIXARK_ZZ_HELPER_KNOB", 0)

now fails, naming it:

    these flags are described to an operator who has no way to reach them ...
    [MATRIXARK_ZZ_HELPER_KNOB (tools/matrixark_zz_helper_probe.py:10, says "turn this on")]

Before this change the same probe passed. The probe was removed; it is quoted as evidence, not
committed. All four tests pass.

Third in the family with mx#1217 and mx#1218: a guard whose reach is decided by the shape of the
code rather than by what it is asserting.
