### PR TITLE
A degraded batch read said what it cost, not what caused it

### DIFF
--- a/tools/matrixark_temporal_direct_retrieve.py
+++ b/tools/matrixark_temporal_direct_retrieve.py
@@ -44,15 +44,32 @@ except ImportError:
 BATCH_HGET_CHUNK = 1000
 
 
-def _batch_hget_degraded_log(chunks: int, chunk_size: int) -> None:
-    """Report that a batched read fell back to per-record reads, and roughly what it cost."""
+def _batch_hget_degraded_log(chunks: int, chunk_size: int, reasons=()) -> None:
+    """Report that a batched read fell back to per-record reads, what it cost, and WHY.
+
+    The count says a degradation happened. It does not say which value caused it -- and the
+    exception that would have said is in hand at the call site, where it was being dropped. The
+    live debug log carries sixty of these, every one of them 1 chunk of 1000, so every one cost a
+    thousand round trips, and not one names the payload that raised.
+
+    That is the same half-measure the comment at the call site warns about: the whole-store
+    fallback used to be silent, and saying it out loud without saying why leaves the operator
+    knowing a chunk is poisoned but not which one.
+    """
     try:  # package path
         from tools.matrixark_mcp_core import _mcp_debug_log
     except ImportError:  # Direct script execution from tools/.
         from matrixark_mcp_core import _mcp_debug_log
+    detail = ""
+    if reasons:
+        unique = sorted(set(reasons))
+        detail = " causes: " + "; ".join(unique[:3])
+        if len(unique) > 3:
+            detail += " (and %d more)" % (len(unique) - 3)
     _mcp_debug_log(
         f"matrixark batch_hget degraded to per-record reads for {chunks} "
         f"chunk(s) of {chunk_size}: about {chunks * chunk_size} records read one at a time"
+        f"{detail}"
     )
 
 
@@ -415,6 +432,7 @@ class _TemporalDirectRetrieveMixin:
                 record_key, record_id = self._record_location(sequence)
                 entries.append({"key": record_key, "field": record_id})
             degraded_chunks = 0
+            degraded_reasons = []
             for start in range(0, len(entries), BATCH_HGET_CHUNK):
                 block = entries[start:start + BATCH_HGET_CHUNK]
                 try:
@@ -428,6 +446,12 @@ class _TemporalDirectRetrieveMixin:
                     # indistinguishable from an empty store -- so every record was refetched one at
                     # a time, twice per retrieve.
                     degraded_chunks += 1
+                    # Keep WHICH failure, not just that there was one. Truncated because this is a
+                    # debug line, deduplicated by the logger because one poisoned value raises the
+                    # same way on every retrieve.
+                    degraded_reasons.append(
+                        "%s: %s" % (type(exc).__name__, str(exc)[:120])
+                    )
                     read_records = []
                     for entry in block:
                         try:
@@ -454,7 +478,7 @@ class _TemporalDirectRetrieveMixin:
             if degraded_chunks:
                 # Said out loud: the old whole-store fallback was silent, which is why a 20x
                 # slowdown ran unnoticed for as long as one bad value sat in the store.
-                _batch_hget_degraded_log(degraded_chunks, BATCH_HGET_CHUNK)
+                _batch_hget_degraded_log(degraded_chunks, BATCH_HGET_CHUNK, degraded_reasons)
             if records or count == 0:
                 return records
         for sequence in range(count):

--- a/tools/test_the_degraded_batch_read_says_why.py
+++ b/tools/test_the_degraded_batch_read_says_why.py
@@ -27,19 +27,37 @@ import matrixark_mcp_core as core  # noqa: E402
 import matrixark_mcp_temporal_adapters  # noqa: E402,F401  (the retrieve mixin imports circularly)
 import matrixark_temporal_direct_retrieve as retrieve  # noqa: E402
 
+# The same file is importable TWICE -- as `matrixark_mcp_core` from tools/, and as
+# `tools.matrixark_mcp_core` from the repo root -- and the two are different module objects with
+# different attributes. `_batch_hget_degraded_log` resolves the logger at call time and tries the
+# PACKAGE path first, so patching only the script-path module leaves the real logger in place and
+# this file captures nothing. It then passes or fails according to which path the runner used
+# rather than according to the code, which is what happened: green from tools/, three failures
+# under the suite.
+_CORE_MODULES = [core]
+try:  # available whenever the repo root is importable, which is how the suite runs
+    from tools import matrixark_mcp_core as _core_package  # noqa: E402
+except ImportError:
+    pass
+else:
+    if _core_package is not core:
+        _CORE_MODULES.append(_core_package)
+
 
 class _Captured:
     def __init__(self) -> None:
         self.lines: list[str] = []
-        self._original = None
+        self._original = []
 
     def __enter__(self) -> "_Captured":
-        self._original = core._mcp_debug_log
-        core._mcp_debug_log = self.lines.append
+        self._original = [(module, module._mcp_debug_log) for module in _CORE_MODULES]
+        for module in _CORE_MODULES:
+            module._mcp_debug_log = self.lines.append
         return self
 
     def __exit__(self, *exc) -> None:
-        core._mcp_debug_log = self._original
+        for module, original in self._original:
+            module._mcp_debug_log = original
 
 
 class TheDegradedBatchReadSaysWhyTest(unittest.TestCase):

--- a/tools/test_the_degraded_batch_read_says_why.py
+++ b/tools/test_the_degraded_batch_read_says_why.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A batched read that degrades has to say WHICH value poisoned it.
+
+`batch_hget` covers a chunk of 1000 record locations. One value it cannot decode makes the whole
+call raise, and the chunk falls back to reading its thousand records one at a time. The live debug
+log carries sixty of these, every one of them 1 chunk of 1000, so every one cost a thousand round
+trips -- and the line named the cost and not the cause, while the exception sat in hand at the
+call site.
+
+The call site comment already knows why that matters: the whole-store fallback used to be silent,
+and a 20x slowdown ran unnoticed for as long as one bad value sat in the store. Saying it out loud
+without saying why leaves the reader knowing a chunk is poisoned but not which one.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_mcp_core as core  # noqa: E402
+import matrixark_mcp_temporal_adapters  # noqa: E402,F401  (the retrieve mixin imports circularly)
+import matrixark_temporal_direct_retrieve as retrieve  # noqa: E402
+
+
+class _Captured:
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+        self._original = None
+
+    def __enter__(self) -> "_Captured":
+        self._original = core._mcp_debug_log
+        core._mcp_debug_log = self.lines.append
+        return self
+
+    def __exit__(self, *exc) -> None:
+        core._mcp_debug_log = self._original
+
+
+class TheDegradedBatchReadSaysWhyTest(unittest.TestCase):
+
+    def test_the_cause_reaches_the_log(self) -> None:
+        with _Captured() as cap:
+            retrieve._batch_hget_degraded_log(
+                1, 1000, ["UnicodeDecodeError: invalid start byte at 7"])
+        self.assertEqual(1, len(cap.lines))
+        self.assertIn("1000 records read one at a time", cap.lines[0])
+        self.assertIn("UnicodeDecodeError: invalid start byte at 7", cap.lines[0],
+                      "the exception is what identifies the poisoned chunk: %s" % cap.lines[0])
+
+    def test_the_line_is_unchanged_when_there_is_no_cause_to_give(self) -> None:
+        """Callers that have nothing to add must not start emitting an empty causes clause."""
+        with _Captured() as cap:
+            retrieve._batch_hget_degraded_log(2, 1000)
+        self.assertNotIn("causes", cap.lines[0])
+        self.assertTrue(cap.lines[0].endswith("read one at a time"), cap.lines[0])
+
+    def test_repeated_causes_collapse_and_the_rest_are_counted(self) -> None:
+        """One poisoned value raises the same way on every chunk, so the line must not repeat it
+        a thousand times -- and it must still say that more kinds were seen."""
+        with _Captured() as cap:
+            retrieve._batch_hget_degraded_log(
+                4, 1000, ["A: x", "A: x", "B: y", "C: z", "D: w"])
+        line = cap.lines[0]
+        self.assertEqual(1, line.count("A: x"), line)
+        self.assertIn("and 1 more", line)
+
+
+    def test_the_call_site_actually_passes_the_reasons(self) -> None:
+        """The helper can format a cause it is never handed.
+
+        Found by mutation: deleting the third argument at the call site left every other test in
+        this file passing while the live log went back to naming the cost and not the cause. So the
+        WIRING is asserted here, structurally, rather than assumed from the helper being correct.
+        """
+        source = pathlib.Path(retrieve.__file__).read_text(encoding="utf-8")
+        calls = [
+            node for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Call)
+            and getattr(node.func, "id", getattr(node.func, "attr", "")) == "_batch_hget_degraded_log"
+        ]
+        self.assertTrue(calls, "the degradation is no longer reported at all")
+        for call in calls:
+            self.assertGreaterEqual(
+                len(call.args), 3,
+                "the call at line %d drops the collected causes, so the log says how much it cost "
+                "and not which value did it" % call.lineno)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`batch_hget` reads a chunk of 1000 record locations. One value it cannot decode makes the whole
call raise, and the chunk falls back to reading its thousand records **one at a time**. The live
debug log carries that fallback **60 times**, every one of them identical:

    matrixark batch_hget degraded to per-record reads for 1 chunk(s) of 1000:
    about 1000 records read one at a time

A thousand round trips each, and the line names the cost and not the cause -- while the exception
that would name it sits in hand at the call site and is dropped:

    except Exception as exc:
        if is_retryable_temporalstore_error(exc):
            raise
        degraded_chunks += 1          # exc goes no further

The call site comment already argues the point: the whole-store fallback used to be silent, and a
20x slowdown ran unnoticed for as long as one bad value sat in the store. Saying it out loud
without saying why leaves the reader knowing a chunk is poisoned but not which one -- and the fix
is to find the value.

## What changed

The degrade branch keeps `type(exc).__name__` and the first 120 characters of the message; the log
appends them:

    ... about 1000 records read one at a time causes: UnicodeDecodeError: invalid start byte at 7

Deduplicated, because one poisoned value raises the same way on every chunk, and capped at three
kinds with `(and N more)`. A call with nothing to add emits exactly the line it emitted before.

## Coverage, and what mutation testing exposed

Four tests. Three cover the helper: the cause reaches the log, the line is unchanged when there is
no cause, repeated causes collapse while the remainder is counted.

The fourth exists because mutation testing found the first three insufficient. **Deleting the third
argument at the CALL SITE left all of them passing** while the live log went back to naming only
the cost -- the helper can format a cause it is never handed. So the wiring is now asserted
structurally, over the parsed source, and both mutations fail:

| mutation | result |
|---|---|
| drop the causes clause in the helper | 2 failures |
| drop the argument at the call site | 1 failure |
