### PR TITLE
A back-compat constant froze the environment at import

### DIFF
--- a/tools/matrixark_skill_parser.py
+++ b/tools/matrixark_skill_parser.py
@@ -61,12 +61,7 @@ MAX_BUNDLE_FILES = 200
 # Env is read at call time (via ``resolve_max_skill_bytes``) so an override set by the
 # host process takes effect without re-importing.
 DEFAULT_MAX_SKILL_BYTES = DEFAULT_MAX_INLINE_TEXT_CHARS  # skills share the resource cap
-# Back-compat module constant (import-time snapshot). Prefer resolve_max_skill_bytes().
-DEFAULT_MAX_SKILL_TEXT_CHARS = int(
-    os.environ.get("MATRIXARK_MAX_SKILL_BYTES")
-    or os.environ.get("MATRIXARK_SKILL_MAX_TEXT_CHARS")
-    or DEFAULT_MAX_SKILL_BYTES
-)
+# `DEFAULT_MAX_SKILL_TEXT_CHARS` is resolved on access; see __getattr__ at the end of this file.
 
 
 def resolve_max_skill_bytes(override: int | None = None) -> int:
@@ -409,3 +404,21 @@ def _first_paragraph(text: str) -> str:
         if part:
             return part[:240]
     return ""
+
+
+def __getattr__(name: str) -> int:
+    """Back-compat for `DEFAULT_MAX_SKILL_TEXT_CHARS`, resolved WHEN READ.
+
+    It used to be a module-level assignment, and so an import-time snapshot of the environment --
+    which contradicts the note beside it: env is read at call time so an override set by the host
+    process takes effect without re-importing. A snapshot does the opposite. Whoever imported the
+    constant got whatever the environment held at import, and an override applied afterwards was
+    invisible to them alone, because both live readers go through `resolve_max_skill_bytes`.
+
+    Nothing in this repository referenced it -- one occurrence, its own assignment -- so the name is
+    kept for an outside importer rather than for a caller here. Resolving on access keeps that name
+    working and makes it agree with the documented precedence instead of freezing one arm of it.
+    """
+    if name == "DEFAULT_MAX_SKILL_TEXT_CHARS":
+        return resolve_max_skill_bytes()
+    raise AttributeError("module %r has no attribute %r" % (__name__, name))

--- a/tools/test_skill_content_cap.py
+++ b/tools/test_skill_content_cap.py
@@ -190,6 +190,31 @@ class SkillAndResourceGateIdenticallyTest(unittest.TestCase):
             self.assertTrue(self._skill_ok(under))
             self.assertTrue(self._resource_ok(under))
 
+    def test_the_backcompat_constant_is_resolved_when_read_not_at_import(self):
+        """DEFAULT_MAX_SKILL_TEXT_CHARS used to be a module-level assignment.
+
+        That froze the environment as it stood at IMPORT, which is the opposite of what the note
+        beside it says is intended: env is read at call time so an override set by the host process
+        takes effect without re-importing. Nothing in this repository referenced the constant -- one
+        occurrence, its own assignment -- so the staleness was invisible here, and would have been
+        carried only by an outside importer, who would then disagree with both live readers.
+        """
+        with _defaults_cleared():
+            self.assertEqual(
+                DEFAULT_MAX_SKILL_BYTES, skill_parser.DEFAULT_MAX_SKILL_TEXT_CHARS)
+            with _EnvGuard(MATRIXARK_MAX_SKILL_BYTES=str(_TWO_MIB)):
+                self.assertEqual(
+                    _TWO_MIB, skill_parser.DEFAULT_MAX_SKILL_TEXT_CHARS,
+                    "an override applied after import must be visible through the constant")
+                self.assertEqual(
+                    resolve_max_skill_bytes(), skill_parser.DEFAULT_MAX_SKILL_TEXT_CHARS,
+                    "the back-compat name must agree with the resolver it stands in for")
+
+    def test_an_unknown_module_attribute_still_raises(self):
+        """The back-compat hook answers one name. A typo must not come back as a cap."""
+        with self.assertRaises(AttributeError):
+            getattr(skill_parser, "NO_SUCH_SETTING")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Sweeping the Python config surface for constants assigned from an env read that nothing reads back
turned up 280 such constants and exactly **one** with no reader anywhere in the tree:

    # Back-compat module constant (import-time snapshot). Prefer resolve_max_skill_bytes().
    DEFAULT_MAX_SKILL_TEXT_CHARS = int(
        os.environ.get("MATRIXARK_MAX_SKILL_BYTES")
        or os.environ.get("MATRIXARK_SKILL_MAX_TEXT_CHARS")
        or DEFAULT_MAX_SKILL_BYTES
    )

One occurrence repo-wide: its own assignment. Not in a test, not in a doc, not imported.

**It is not merely unused, it disagrees with the design six lines above it:**

    Env is read at call time (via resolve_max_skill_bytes) so an override set by the
    host process takes effect without re-importing.

A module-level assignment does exactly the opposite -- it freezes the environment as it stood at
import. Whoever imported this name got a value the two live readers would never use, and an
override applied afterwards was invisible to them alone. Unreferenced here, so nothing surfaced it.

## What changed

The assignment is gone and the name is answered by a module `__getattr__` that calls
`resolve_max_skill_bytes()`. The name keeps working for an outside importer -- which is what
back-compat was for -- and now agrees with the documented precedence instead of freezing one arm
of it.

Deleting it outright was the other option. It is kept because "back-compat" says it exists for
someone outside this repository, and resolving on access costs nothing while removing the name
might cost them.

## Coverage

Two tests in `test_skill_content_cap.py`, reusing its `_EnvGuard`: an override applied AFTER import
is visible through the constant and agrees with the resolver, and an unknown module attribute still
raises `AttributeError` -- a back-compat hook that answers one name must not turn a typo into a cap.

Restoring the import-time assignment fails the first (15 tests, 1 failure). The three existing
skill suites -- `test_skill_content_cap`, `test_matrixark_skill_discovery`,
`test_matrixark_skill_sections_stored_once` -- pass unchanged.
