### PR TITLE
The replay refusal did not say which precondition was unmet

### DIFF
--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -1596,11 +1596,28 @@ impl TemporalEngine {
             if !record.outcomes.is_empty() {
                 for item in &record.outcomes {
                     if !self.apply_outcome_item(shard_id, item) {
+                        // Say which precondition was unmet. `apply_outcome_item` answers with a
+                        // bool from eighteen different places, so the caller was reporting that
+                        // an outcome would not install and never which part of it was missing --
+                        // and this refusal FAILS THE LOAD, so it is the last thing anyone sees.
+                        // Nearly every arm needs a resolved address and, for the keyed kinds, a
+                        // component; those two are what the caller can check for itself.
+                        //
+                        // The component VALUE is deliberately not printed: for a zset it is the
+                        // member, which is caller data. Present-or-missing and its length localise
+                        // the failure without putting a record key into an error string.
+                        let component = match item.component.as_deref() {
+                            None => "missing".to_string(),
+                            Some(value) => format!("present, {} chars", value.len()),
+                        };
                         return Err(Status::error(
                             "wal_replay_outcome_refused",
                             format!(
-                                "WAL replay could not install a recorded {} outcome at sequence {}; refusing load rather than serving a shard missing it",
-                                item.kind, record.sequence
+                                "WAL replay could not install a recorded {} outcome at sequence {}; refusing load rather than serving a shard missing it (address {}, component {})",
+                                item.kind,
+                                record.sequence,
+                                if item.resolved_address().is_some() { "resolved" } else { "UNRESOLVED" },
+                                component
                             ),
                         ));
                     }


### PR DESCRIPTION
Follow-on from mx#1227, which made two restart-recovery tests report why the shard would not load.
They now do, and the answer was not what the shape suggested:

    the shard did not load: Status { ok: false, code: "wal_replay_outcome_refused",
      message: "WAL replay could not install a recorded list outcome at sequence 5;
                refusing load rather than serving a shard missing it" }

`scores_and_order_survive_restart_including_a_rescore` gives the identical code for a `zset`
outcome at sequence 4. So `list_recovery` and `zset_recovery` are one defect, not two.

**And it is NOT the single-barrier story.** Those tests do a clean `unload_shard` then `load_shard`
in a fresh engine -- no crash, no lost page -- so the pages are durable and the outcome should
install. Something inside the arm refuses.

## What is missing from the message

`apply_outcome_item` answers with a bool, from **eighteen** separate `return false` sites. The
`list` arm alone has three:

    let (Some(address), Some(component)) = (item.resolved_address(), item.component.clone())
        else { return false; };
    let Ok(biased) = u64::from_str_radix(&component, 16) else { return false; };

The caller reports the kind and the sequence and none of that -- and this refusal **fails the
load**, so it is the last thing anyone sees.

## What changed

The caller now names the two preconditions it can check for itself, from the item it already holds:

    ... (address resolved, component present, 16 chars)
    ... (address UNRESOLVED, component missing)

The component VALUE is deliberately not printed: for a zset it is the member, which is caller data.
Present-or-missing plus a length localises the failure without putting a record key into an error
string.

The signature is left alone on purpose. Turning the bool into a reason-carrying result touches
eighteen returns and four call sites, and I cannot build this crate locally -- a full crate build
degrades a live service sharing the box. This is two extra arguments to an existing `format!`, and
it is enough to say which of the three list preconditions is the one failing.

## Why not fix the defect here

Because which precondition fails is exactly what is not yet known -- that is the point of the
change. The next run says it, and the fix can then be aimed. Same order as mx#1207, which made a
readiness assertion name its blocked service and turned into mx#1222 once it did.
