### PR TITLE
A boolean the engine names by a const had no default to compare

### DIFF
--- a/tools/test_config_says_when_it_overrides.py
+++ b/tools/test_config_says_when_it_overrides.py
@@ -227,6 +227,38 @@ def _annotated_boolean_keys():
 
 class TheShippedConfigSaysWhenItOverridesTest(unittest.TestCase):
 
+    def test_the_const_pairing_agrees_with_the_published_inventory(self) -> None:
+        """This file DERIVES a default the inventory also derives. Pin the two together.
+
+        `_builder` execs only the inventory prelude -- everything before `sources = {}` -- so its
+        computed entries are not reachable from here and the defaults have to be worked out again.
+        That is a second implementation of one question, which is exactly the shape that drifts:
+        the inventory pairs `TS_X` with `DEFAULT_X` at its own line and this file now does the
+        same, and nothing would notice if one learned an idiom the other did not.
+
+        The published document is the inventory answer, and it is itself checked against the
+        generator by `test_matrixark_engine_flag_inventory`. So every default this pairing produces
+        must be the one the document states. If they disagree, one of the two extractors moved.
+        """
+        ns = _builder()
+        source_root = os.path.join(REPO, "crates", "temporalstore-rust", "src")
+        paired = _boolean_defaults_named_by_a_const(ns, source_root)
+        self.assertTrue(paired, "the const pairing found nothing; the storage_config idiom moved")
+        with open(os.path.join(REPO, "docs", "ops", "temporalstore-engine-flags.md"),
+                  encoding="utf-8") as handle:
+            document = handle.read()
+        published = dict(re.findall(
+            r"\|\s*`((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)`\s*\|\s*([^|]*?)\s*\|",
+            document))
+        disagreeing = sorted(
+            "%s: here=%s document=%s" % (flag, value, published.get(flag, "<absent>"))
+            for flag, value in paired.items()
+            if published.get(flag, "").strip() != value)
+        self.assertEqual(
+            [], disagreeing,
+            "this file and the shipped inventory disagree about a default they both derive: %s"
+            % disagreeing)
+
     def test_the_config_still_annotates_its_keys(self) -> None:
         with open(CONFIG, encoding="utf-8") as handle:
             annotated = sum(1 for line in handle if _LINE.match(line))

--- a/tools/test_config_says_when_it_overrides.py
+++ b/tools/test_config_says_when_it_overrides.py
@@ -35,6 +35,14 @@ KNOWN_OVERRIDES: Dict[str, str] = {
         "the engine defaults ON; the shipped config, three binaries and the one-box all turn it "
         "off, because warming every record on load pays the whole cache cost before the first "
         "read is served",
+    "cold_scan_no_cache_fill":
+        "RECORDED, NOT BLESSED. The engine defaults ON -- DEFAULT_COLD_SCAN_NO_CACHE_FILL = true "
+        "in storage_config.rs -- so a cold scan bypasses cache fill and does not evict what the "
+        "serving path put there. The shipped config turns that bypass off, letting a cold scan "
+        "populate the cache, and no reason is written anywhere: not beside the line, not here. It "
+        "surfaced only when the extractor learned to read a default named by a const. Whether a "
+        "cold scan should fill the cache belongs to whoever owns the cache budget; this entry "
+        "makes the disagreement visible rather than settling it",
 }
 
 # The same, for keys whose value is a number. Empty today: all EIGHT comparable numeric keys
@@ -97,7 +105,43 @@ def _engine_defaults() -> Dict[str, str]:
                         value = default_of(body, 1)
                 if value:
                     defaults[flag] = value
+    defaults.update(_boolean_defaults_named_by_a_const(ns, source_root))
     return defaults
+
+
+def _boolean_defaults_named_by_a_const(ns, source_root) -> Dict[str, str]:
+    """flag -> on/off for a boolean the engine reads through a CONST, not a string literal.
+
+    The storage_config family reads `get(TS_COLD_SCAN_NO_CACHE_FILL)`; no scan of string literals
+    sees that, so the extractor above finds no default and this guard cannot compare the shipped
+    config against one. The numeric extractor below already pairs `TS_X` with `DEFAULT_X` for that
+    exact reason -- and then drops the pair when its value is a boolean:
+
+        if paired and paired not in ("on", "off"):
+
+    which says those pairs exist and belong here. They were reaching nowhere. One flag is affected
+    today, `TS_COLD_SCAN_NO_CACHE_FILL`, and the shipped config contradicts it -- so the single
+    thing this file exists to catch was invisible to it for that flag.
+    """
+    strip, literal_consts = ns["strip_test_modules"], ns["literal_consts"]
+    sources: Dict[str, str] = {}
+    for directory, _, names in os.walk(source_root):
+        if os.sep + "tests" in directory:
+            continue
+        for name in sorted(names):
+            if not name.endswith(".rs") or name.startswith("test"):
+                continue
+            path = os.path.join(directory, name)
+            with open(path, encoding="utf-8", errors="replace") as handle:
+                sources[path] = strip(handle.read())
+    consts = literal_consts(sources)
+    found: Dict[str, str] = {}
+    for source in sources.values():
+        for ident, env in _NAME_CONST.findall(source):
+            paired = consts.get("DEFAULT_" + ident[len("TS_"):])
+            if paired in ("on", "off"):
+                found.setdefault(env, paired)
+    return found
 
 
 _NAME_CONST = re.compile(r'pub const (TS_[A-Z0-9_]+)\s*:\s*&str\s*=\s*"([A-Z0-9_]+)"\s*;')


### PR DESCRIPTION
`test_config_says_when_it_overrides` exists to catch one thing: a shipped-config key that sets
something the engine would not have chosen, without saying so. It read **26** engine boolean
defaults. It now reads 27, and the one it could not see is a real disagreement.

    config/temporalstore.toml:70   cold_scan_no_cache_fill = 0
    storage_config.rs             pub const DEFAULT_COLD_SCAN_NO_CACHE_FILL: bool = true;

The engine bypasses cache fill on a cold scan; the shipped config turns that bypass off.

## Why it was invisible

The storage_config family reads its flags through a CONST, never a literal:

    pub const TS_COLD_SCAN_NO_CACHE_FILL: &str = "TS_COLD_SCAN_NO_CACHE_FILL";
    ...
    get(TS_COLD_SCAN_NO_CACHE_FILL)

so a scan of string literals finds no read and derives no default, and a flag with no default
cannot be compared against anything.

**The file already knew.** The numeric extractor pairs `TS_X` with `DEFAULT_X` for exactly this
reason -- its docstring says "the storage_config family, whose reads no scan of string literals can
see" -- and then drops the pair when the value is a boolean:

    if paired and paired not in ("on", "off"):

That filter says such pairs exist and belong to the boolean side. They were reaching nowhere. The
same pairing now runs for booleans, in `_boolean_defaults_named_by_a_const`.

## The disagreement is recorded, not blessed

`cold_scan_no_cache_fill` goes into `KNOWN_OVERRIDES` with what is actually known: the engine
default, what the config does instead, and that **no reason for it is written anywhere** -- not
beside the line, not in this file. Its neighbour `eager_cache_warm_on_load` carries a full
explanation two lines away in the same config; this one carries none.

Whether a cold scan should fill the cache belongs to whoever owns the cache budget. I have not
changed the config or the engine, and the entry says so in as many words, because a list of
deliberate overrides that quietly absorbs an undecided one stops meaning anything.

## Proof it discriminates

Deleting the new entry fails the guard, naming it:

    these shipped-config keys set something the engine would not have chosen, and say nothing
    about it: [cold_scan_no_cache_fill]

Nine tests pass with it. Exactly one flag is added to the comparison -- measured, not assumed:
one `TS_` name-const in the tree is paired with a boolean `DEFAULT_` const.

## The duplication this creates, and what pins it

`_builder` execs only the inventory prelude -- everything before `sources = {}` -- so the
inventory computed entries are not reachable from a test, and defaults have to be worked out
again here. `_engine_defaults` already did that for the literal case; the const pairing is a
second place doing what the inventory does at its own line.

Two implementations of one question is the shape that drifts, so they are pinned:
`test_the_const_pairing_agrees_with_the_published_inventory` asserts every default the pairing
produces is the one the shipped document states, and that document is itself checked against the
generator by `test_matrixark_engine_flag_inventory`. A wrong paired value fails it, naming the
disagreement; a pairing that finds nothing fails the floor.

## The override reaches the engine, checked end to end

Worth stating, because a config line that nothing loads would make this decorative:

| step | evidence |
|---|---|
| the config sets it | `config/temporalstore.toml:70` -- `cold_scan_no_cache_fill = 0` |
| the loader knows the key | `matrixark_load_config.py:88` -- `"storage.cold_scan_no_cache_fill": "TS_COLD_SCAN_NO_CACHE_FILL"` |
| the loader applies it | it resolves known keys into `os.environ`, so the config number is what a reader that defaults actually gets |
| the engine would have chosen otherwise | `DEFAULT_COLD_SCAN_NO_CACHE_FILL: bool = true` |

So a deployment using the shipped config runs with the bypass OFF, and until now nothing in the
tree could see that it did.

### Scope: it does not reach every deployment

Checked so the entry is not read as wider than it is. The one-box this was found on does **not**
apply the shipped config: `TS_COLD_SCAN_NO_CACHE_FILL` is absent from the serving proxy
environment, and nothing in its unit or its launch scripts invokes `with_config.sh`. So that box
runs the engine default, bypass ON.

The override reaches whoever loads the config -- which is what `deploy_config.sh` installs and what
`matrixark_load_config.py` resolves into the environment. That is the deployment the entry is
about.
