### PR TITLE
Two config keys named a variable the loader never mapped

### DIFF
--- a/tools/matrixark_load_config.py
+++ b/tools/matrixark_load_config.py
@@ -90,6 +90,9 @@ ENV_MAP: Dict[str, str] = {
     "storage.page_store_compression_level": "TS_PAGE_STORE_COMPRESSION_LEVEL",
     "storage.page_store_compression_min_bytes": "TS_PAGE_STORE_COMPRESSION_MIN_BYTES",
     "storage.cross_shard_reclaim_guard": "TS_CROSS_SHARD_RECLAIM_GUARD",
+    # Offered by the config file, commented out, and mapped by nothing -- so uncommenting the line
+    # would have set nothing. The flag is live: default ON, read in eight places.
+    "storage.index_catalog_fold": "TS_INDEX_CATALOG_FOLD",
     # The engine reads TS_INDEX_DUMP_WAL_GAP_BYTES first and falls back to
     # TS_INDEX_DUMP_OPLOG_GAP_BYTES only when it is unset, so exporting the older name put
     # every value from this file behind anything that set the current one -- including a
@@ -99,6 +102,12 @@ ENV_MAP: Dict[str, str] = {
     # TS_BLOCK_SLAB_TARGET_BYTES.)
     "storage.index_dump_oplog_gap_bytes": "TS_INDEX_DUMP_WAL_GAP_BYTES",
     # ---- [wal] --------------------------------------------------------------
+    # The engine documents the config key as the way to set this -- the doc comment on
+    # group_commit_delay reads "`TS_WAL_COMMIT_DELAY_US` (config `[wal] commit_delay_us`)" -- and
+    # the config file offers it with a paragraph explaining what widening the batch window does.
+    # It was mapped by nothing, so an operator following that documentation set a value which
+    # never reached the engine, while both of its neighbours below worked.
+    "wal.commit_delay_us": "TS_WAL_COMMIT_DELAY_US",
     "wal.wal_legacy_recovery": "TS_WAL_LEGACY_RECOVERY",
     "wal.wal_compress_records": "TS_WAL_COMPRESS_RECORDS",
     "wal.raft_wal_dir": "TS_RAFT_WAL_DIR",

--- a/tools/test_the_loader_maps_every_config_key.py
+++ b/tools/test_the_loader_maps_every_config_key.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A config key that names a variable has to actually set it.
+
+`config/temporalstore.toml` is written as `key = value  # TS_SOMETHING  what it does`, and
+`matrixark_load_config.ENV_MAP` turns `SECTION.key` into that variable in `os.environ`. A key with
+no entry in the map sets nothing: the file documents a knob, an operator turns it, and the engine
+never hears about it.
+
+Two were in that state and neither was visible:
+
+  * `[wal] commit_delay_us`, ACTIVE, naming `TS_WAL_COMMIT_DELAY_US` -- while the ENGINE
+    documents the config key as the way to set it (`group_commit_delay`, whose doc comment reads
+    "`TS_WAL_COMMIT_DELAY_US` (config `[wal] commit_delay_us`)"), and both of its neighbours in
+    the same section were mapped.
+  * `[storage] index_catalog_fold`, commented out, naming a flag that defaults ON and is read in
+    eight places -- so uncommenting it would have done nothing.
+
+Commented keys count. A commented line is an offer, and the only reason to write one is that
+somebody may uncomment it.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(TOOLS)
+sys.path.insert(0, TOOLS)
+
+import matrixark_load_config  # noqa: E402
+
+CONFIG = os.path.join(REPO, "config", "temporalstore.toml")
+
+_SECTION = re.compile(r"^\s*\[([a-z0-9_.]+)\]")
+_LINE = re.compile(
+    r"^\s*(#?)\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+?)\s+#\s*"
+    r"((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)")
+
+#: A scan that finds nothing passes every assertion below, so it is floored. The file names well
+#: over a hundred keys; this is far under that and only catches the shape changing.
+EXPECTED_KEY_FLOOR = 60
+
+
+def _declared():
+    """(SECTION.key, variable named in the comment, line number, active?) for the config file."""
+    section = ""
+    with open(CONFIG, encoding="utf-8") as handle:
+        for number, raw in enumerate(handle, 1):
+            found = _SECTION.match(raw)
+            if found:
+                section = found.group(1)
+                continue
+            match = _LINE.match(raw)
+            if match:
+                yield ("%s.%s" % (section, match.group(2)), match.group(4), number,
+                       not match.group(1))
+
+
+class TheLoaderMapsEveryConfigKeyTest(unittest.TestCase):
+
+    def test_the_scan_still_finds_the_config_keys(self) -> None:
+        keys = list(_declared())
+        self.assertGreaterEqual(
+            len(keys), EXPECTED_KEY_FLOOR,
+            "found %d keys naming a variable, expected at least %d -- if the line shape changed, "
+            "the assertions below run on an empty set" % (len(keys), EXPECTED_KEY_FLOOR))
+
+    def test_every_key_that_names_a_variable_is_mapped(self) -> None:
+        unmapped = [
+            "%s -> %s (%s, line %d)"
+            % (key, variable, "active" if active else "commented", number)
+            for key, variable, number, active in _declared()
+            if key not in matrixark_load_config.ENV_MAP
+        ]
+        self.assertEqual(
+            [], unmapped,
+            "these config keys name a variable the loader does not map, so setting them does "
+            "nothing: %s" % unmapped)
+
+    def test_the_map_does_not_carry_keys_the_config_stopped_offering(self) -> None:
+        """The other direction: an entry for a key no longer in the file is dead weight, and it
+        makes the map look like it covers more of the file than it does."""
+        declared = {key for key, _, _, _ in _declared()}
+        # Keys the loader accepts from a deployment file rather than from the shipped one are not
+        # in the tree to be found; only complain about a SECTION the shipped file still has.
+        sections = {key.split(".", 1)[0] for key in declared}
+        orphaned = sorted(
+            key for key in matrixark_load_config.ENV_MAP
+            if key.split(".", 1)[0] in sections and key not in declared)
+        self.assertEqual(
+            [], orphaned,
+            "the loader maps keys the shipped config no longer offers: %s" % orphaned)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`config/temporalstore.toml` is written as `key = value  # TS_SOMETHING  what it does`, and
`matrixark_load_config.ENV_MAP` turns `SECTION.key` into that variable in `os.environ`. A key with
no entry in the map sets nothing: the file documents a knob, an operator turns it, and the engine
never hears about it.

Two were in that state.

**`[wal] commit_delay_us`** -- active, naming `TS_WAL_COMMIT_DELAY_US`, and the ENGINE names the
config key as the way to set it:

    /// `TS_WAL_COMMIT_DELAY_US` (config `[wal] commit_delay_us`): optional deliberate widening
    /// of the group-commit batch window under extreme load.

The config offers it with a paragraph on what widening the batch window does. Both of its
neighbours in the same section -- `wal_legacy_recovery`, `wal_compress_records` -- were mapped. So
an operator following the engine documentation set a value that never arrived, and nothing said
so.

**`[storage] index_catalog_fold`** -- commented out, naming a flag that defaults ON and is read in
eight places. Uncommenting it would have done nothing.

## Safe today, working tomorrow

Neither mapping changes current behaviour: `commit_delay_us` is set to `0` in the file and the
engine defaults to `0` (`unwrap_or(0)` in `group_commit_delay`), and `index_catalog_fold` is
commented out so nothing is set. What changes is that turning either knob now reaches the engine.

## The guard

`test_the_loader_maps_every_config_key.py`, derived rather than listed:

* every key naming a variable has a map entry -- **commented keys count**, because a commented
  line is an offer and the only reason to write one is that somebody may uncomment it;
* the map carries no key the shipped config stopped offering, in a section the file still has;
* a floor, so a scan that stops matching the line shape fails instead of passing on an empty set.

Mutations both fail: removing the wal mapping names it back with its line number and whether it
was active, and adding a map entry for a key the file does not offer names that. Verified under
both import paths -- `tools.test_x` and from `tools/` -- after mx#1235 showed a test can pass on
one and fail on the other. The five neighbouring config suites pass unchanged.

## The inventory reported a setter that did not function

Worth stating, because it explains how this survived. The shipped flag inventory row is:

    | `TS_WAL_COMMIT_DELAY_US` | 0 | config | 1 | — |

Its only listed setter is **config**, and the portal does not offer it either. So the knob was
reachable by nothing: the document named the one route, and that route was inert.

The inventory is not wrong to say so -- its who-sets-it column is deliberately literal about WHERE
a name appears, and the config file does name this variable. But a config key only sets anything
if the loader also maps it, and nothing checked that second half. That is the gap this guard
closes, and it is why the guard belongs next to the loader rather than in the inventory: the
inventory reads text, and this needs the map.
