### PR TITLE
The codec matrix compared two encoders and never decoded

### DIFF
--- a/crates/temporalstore-rust/src/wal_proto.rs
+++ b/crates/temporalstore-rust/src/wal_proto.rs
@@ -1227,10 +1227,20 @@ mod tests {
         ];
 
         let mut checked = 0usize;
-        for kind in ["page", "feature", "context_index", "an_unmapped_kind_name"] {
+        // `list` and `zset` were missing, and kind drives both `kind_code` and
+        // `numeric_component`, so the matrix skipped exactly the two kinds whose outcomes replay
+        // refuses in list_recovery and zset_recovery.
+        for kind in [
+            "page", "feature", "context_index", "an_unmapped_kind_name", "list", "zset",
+        ] {
             for object_key in ["", "tenant/1/object/9"] {
                 for object_id in [0u64, 9] {
-                    for component in [None, Some(""), Some("body"), Some("1788748713578")] {
+                    // The last is the shape a list outcome actually carries: sixteen hex
+                    // digits of the biased sequence.
+                    for component in [
+                        None, Some(""), Some("body"), Some("1788748713578"),
+                        Some("8000000000000005"),
+                    ] {
                         for value in [None, Some(Vec::new()), Some(vec![7u8; 5])] {
                             for ttl in [None, Some(0u64), Some(60_000)] {
                                 for (deleted, meta) in
@@ -1277,6 +1287,22 @@ mod tests {
                                             theirs.extend_from_slice(&expected_body);
 
                                             assert_eq!(mine, theirs, "bytes differ for {item:?}");
+
+                                            // The two assertions above compare ENCODERS. Neither
+                                            // decodes, so a field the decoder drops is invisible
+                                            // to both -- and an outcome whose address comes back
+                                            // absent is exactly what `wal_replay_outcome_refused`
+                                            // reports, with the component intact beside it.
+                                            let decoded = item_from_proto(item_to_proto(&item));
+                                            assert_eq!(
+                                                decoded.address.is_some(),
+                                                item.address.is_some(),
+                                                "the address vanished in the round trip: {item:?}",
+                                            );
+                                            assert_eq!(
+                                                decoded.kind, item.kind,
+                                                "kind changed in the round trip for {item:?}",
+                                            );
                                             checked += 1;
                                         }
                                     }


### PR DESCRIPTION
mx#1238 made the replay refusal name its precondition, and the answer arrived in its own CI run:

    list outcome at sequence 5 ... (address UNRESOLVED, component present, 16 chars)
    zset outcome at sequence 4 ... (address UNRESOLVED, component present, 26 chars)

The component is intact. **The address arrives as `None`**, and that is why the load is refused.

`the_hand_written_item_is_the_same_item` is the exhaustive matrix over outcome shapes -- thousands
of combinations -- and it cannot see this, for two reasons.

**It never decodes.** Both assertions compare ENCODERS: the hand-written `put_wal_item` against
prost encoding `item_to_proto`. Agreeing on bytes says nothing about whether reading them back
returns the item, so a field the decoder drops is invisible to the whole matrix.

**Its kinds omit the two that fail.** The list was `page`, `feature`, `context_index`,
`an_unmapped_kind_name` -- no `list`, no `zset`. Kind is not incidental here: it drives
`kind_code`, and it drives `numeric_component`, which decides whether a component travels as a
string or as `timestamp_ms`. The matrix skipped exactly the kinds whose outcomes replay refuses.

## What changed

Three things, all inside that test:

* `list` and `zset` join the kinds;
* a sixteen-hex-digit component joins the components -- the shape a list outcome actually carries,
  the biased sequence from `format!("{:016x}", ..)`;
* a decode round trip: `item_from_proto(item_to_proto(&item))` must still have an address if the
  original did, and must keep its kind.

The address is asserted by PRESENCE rather than equality on purpose. `item_to_proto` drops the
address object_id when it repeats the item, and `address_to_proto` leaves the routing bucket to
`resolved_address`, so a decoded address is legitimately not byte-identical to the one encoded.
Presence is the property the replay path actually needs, and it is the one that is failing.

## This answers either way

If it passes, the codec is exonerated and the loss is upstream of the record -- which narrows the
remaining search to what happens between `take_outcomes()` and the record being written. If it
fails, it is the codec and the matrix simply never asked.

Five hypotheses about this defect have been wrong and one measurement was decisive, so this is a
probe rather than a fix, and it is written to be informative in both directions.

The positive control (`assert!(checked > 3_000)`) is a lower bound, so a larger matrix keeps
passing it. Not compiled locally -- a full crate build degrades a live service sharing this box.
