### PR TITLE
A retired flag was still cited as the mechanism

### DIFF
--- a/crates/temporalstore-rust/src/engine/block_in_wal.rs
+++ b/crates/temporalstore-rust/src/engine/block_in_wal.rs
@@ -62,6 +62,12 @@ pub(super) fn begin_write() {
 }
 
 /// Put a page aside for the record this write is about to append.
+///
+/// Unconditional. `TS_BLOCK_IN_WAL` used to gate it and is gone -- said the way
+/// `hot_page_spill` says the same thing about `TS_HOT_PAGE_SPILL`, because a retired flag that
+/// leaves no note behind gets cited later as though it still decided something. It was, in the
+/// durability analysis at the top of `tests/wal_single_barrier_recovery.rs`, which is the file
+/// somebody reads to decide what an ack promises.
 pub(super) fn stage(object_id: u64, bytes: &[u8]) {
     STAGED.with(|staged| {
         staged.borrow_mut().push(StagedPage {

--- a/crates/temporalstore-rust/tests/wal_single_barrier_recovery.rs
+++ b/crates/temporalstore-rust/tests/wal_single_barrier_recovery.rs
@@ -28,8 +28,12 @@
 //!
 //! An outcome states "this object's page is at this address". With the page write deferred and then
 //! lost, the address names nothing and the command that could have re-derived the value is gone.
-//! Staged pages (`TS_BLOCK_IN_WAL`) would carry the bytes, but staging happens on the ASYNC storage
-//! path; a synchronous write stages nothing.
+//! Staged pages would carry the bytes, but staging happens on the ASYNC storage path; a
+//! synchronous write stages nothing. (This said `TS_BLOCK_IN_WAL` gated it. That flag is gone --
+//! two mentions survive in the whole tree and neither is code, `block_in_wal::stage` is
+//! unconditional, and the inventory does not list it. Anyone deciding the question below by
+//! looking for that switch would find nothing and conclude the analysis was stale, when only the
+//! name was: the async/sync split IS the whole of it.)
 //!
 //! Measured on the store these tests leave behind, with `examples/wal_scan_probe.rs`:
 //!


### PR DESCRIPTION
`tests/wal_single_barrier_recovery.rs` carries the analysis of the open ack-semantics question --
the one that decides four failing durability tests. It names the mechanism that would have saved
the value:

    Staged pages (`TS_BLOCK_IN_WAL`) would carry the bytes, but staging happens on the ASYNC
    storage path; a synchronous write stages nothing.

**`TS_BLOCK_IN_WAL` does not exist.** Two mentions survive in the whole repository and neither is
code:

* this line;
* a comment in the flag inventory explaining a past extraction bug, which says the flag "say[s]
  restore the previous behaviour in [its] own doc" -- so it existed when that was written.

`block_in_wal::stage` is unconditional now, and the inventory does not list the flag at all.

## Why it matters here rather than generally

This is the file somebody opens to decide what an ack promises. Reading it, they go looking for a
switch, find nothing, and have to work out whether the analysis is stale or the flag was renamed.
The analysis is sound -- the async/sync split is real and is the whole of it -- and only the name
was wrong, which is the most expensive kind of wrong in a document written to be acted on.

## What changed

Comments only.

* The citation now states the mechanism without the dead name, and says outright that the flag is
  gone so the next reader does not repeat the search.
* `block_in_wal::stage` gains a retirement note, in the form the codebase already uses next door:
  `hot_page_spill` says "Always installed. `TS_HOT_PAGE_SPILL` used to be able to skip it".
  `TS_BLOCK_IN_WAL` left no such note, which is how it went on being cited as live.

No behaviour change, no default change, nothing added to the inventory.
