### PR TITLE
Replay cannot install a deletion outcome, and the load refuses

### DIFF
--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -812,6 +812,31 @@ impl TemporalEngine {
         let Some(shard) = shards.get_mut(&shard_id) else {
             return false;
         };
+        // ROOT CAUSE of `wal_replay_outcome_refused`, traced 2026-09-07 and NOT fixed here.
+        //
+        // This matches on KIND alone. `item.deleted` is read by exactly two arms below (`object`
+        // and, partly, `feature`) and `item.meta` by none at all -- yet
+        // `mark_bucket_index_page_deleted` stages every typed removal as
+        //
+        //     kind: "hash" | "list" | "set" | "zset",  component: Some(..),
+        //     address: None,  deleted: true,  meta: true
+        //
+        // and the `hash`, `list`, `set` and `zset` arms all open by demanding
+        // `resolved_address()`. A removal therefore returns false, the caller refuses the load,
+        // and the whole shard is lost over a member that is supposed to be gone. That is
+        // `list_order_survives_restart_and_pops_stay_popped` (a pop) and
+        // `scores_and_order_survive_restart_including_a_rescore` (a rescore removes the old score
+        // entry); mx#1238 printed the shape -- "address UNRESOLVED, component present, 16 chars".
+        //
+        // `TS_WAL_DATA_ONLY` is what makes it fatal rather than a miss: with results recorded the
+        // command is dropped, so there is nothing left to re-run the removal.
+        //
+        // The fix is a deleted-branch per arm, removing the component from the model map and the
+        // bucket index instead of demanding an address -- mirroring the write side. It is not
+        // done here because each arm decodes its component differently (a hash field, a set
+        // member, sixteen hex digits of a biased list sequence, a zset score plus member), and a
+        // removal that takes the wrong entry corrupts a recovered shard SILENTLY, which is worse
+        // than the loud refusal happening now. It wants someone who can run the recovery suite.
         match item.kind.as_str() {
             // The object is gone, everywhere it appeared.
             "object" if item.deleted => {

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -831,6 +831,16 @@ impl TemporalEngine {
         // `TS_WAL_DATA_ONLY` is what makes it fatal rather than a miss: with results recorded the
         // command is dropped, so there is nothing left to re-run the removal.
         //
+        // MITIGATION, for anyone hitting this before the fix lands: `TS_WAL_OUTCOME_ITEMS=0`.
+        // `stage_outcome` returns early when it is off, so nothing is staged, `record_command`
+        // keeps the command because `outcomes.is_empty()`, and replay re-runs the removal --
+        // which works. `TS_WAL_DATA_ONLY=0` does NOT help: it keeps the command too, but the
+        // branch below is `if !record.outcomes.is_empty()`, so a present-and-uninstallable
+        // outcome still refuses and the command beside it is never reached.
+        //
+        // It prevents NEW occurrences only. A record already on disk carrying an uninstallable
+        // outcome still refuses, so this stops the bleeding and does not repair a store.
+        //
         // The discriminator already exists and already survives replay: `meta` is false for a
         // page upsert and true for both `stage_meta_outcome` and every typed removal, and it
         // round-trips as `meta_log`. Its only readers in the crate are the three proto encoder

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -831,6 +831,12 @@ impl TemporalEngine {
         // `TS_WAL_DATA_ONLY` is what makes it fatal rather than a miss: with results recorded the
         // command is dropped, so there is nothing left to re-run the removal.
         //
+        // The discriminator already exists and already survives replay: `meta` is false for a
+        // page upsert and true for both `stage_meta_outcome` and every typed removal, and it
+        // round-trips as `meta_log`. Its only readers in the crate are the three proto encoder
+        // sites that write it, plus one test assertion -- nothing branches on it. So the field
+        // saying "do not go looking for an address" is in the log, correct, and unread.
+        //
         // The fix is a deleted-branch per arm, removing the component from the model map and the
         // bucket index instead of demanding an address -- mirroring the write side. It is not
         // done here because each arm decodes its component differently (a hash field, a set


### PR DESCRIPTION
Traced through mx#1227 (report the load status), mx#1238 (name the failing precondition) and
mx#1241 (exonerate the codec). This is where it ends.

## The chain

    mark_bucket_index_page_deleted  stages every typed removal as
        kind: "hash" | "list" | "set" | "zset",  component: Some(..),
        address: None,  deleted: true,  meta: true

    apply_outcome_item              matches on KIND alone
        "hash" | "set" | "list" | "zset"  =>  let Some(address) = item.resolved_address()
                                              else { return false };

`item.deleted` is read by two arms in that match -- `object`, and partly `feature`. **`item.meta`
is read by none.** So a removal returns false, the caller refuses the load, and an entire shard is
lost over a member that is supposed to be gone.

That is exactly what the two restart tests do: `list_order_survives_restart_and_pops_stay_popped`
POPS, and `scores_and_order_survive_restart_including_a_rescore` rescores, which removes the old
score entry. mx#1238 printed the shape -- `address UNRESOLVED, component present, 16 chars` for
list, `26 chars` for zset -- and mx#1241 proved the codec carries an address fine for both kinds,
so it was never lost in transit. It was never there.

**`TS_WAL_DATA_ONLY` decides whether this is fatal.** Default ON: once results are recorded the
command is dropped, so nothing is left to re-run the removal. With it off the record keeps its
command and replay recovers.

Scope is wider than the two failing tests: `mark_bucket_index_page_deleted` is called with `hash`,
`list`, `set` and `zset`, and all four arms have the same shape. Only list and zset have
restart-recovery tests, which is why only they fail.

## Why this documents rather than fixes

The fix is a deleted-branch per arm: remove the component from the model map and the bucket index
instead of demanding an address, mirroring the write side.

I am not writing it blind. Each arm decodes its component differently -- a hash field, a set
member, sixteen hex digits of a biased list sequence, a zset score followed by its member -- and a
removal that takes the wrong entry corrupts a recovered shard **silently**. Today the failure is
loud: the load refuses and says so. Trading a loud failure for a quiet one, in recovery code I
cannot compile or exercise here, is the wrong direction.

So the diagnosis goes where the next person looks -- on the `match` itself -- with the shape of the
fix and the reason each arm needs its own.

Comment only. No behaviour change.

## The record already carries the discriminator

Worth adding, because it makes the fix cheaper to reason about than "decode four component
shapes" suggests. `WalOutcomeItem.meta` is written on every outcome and marks exactly the
distinction that is missing here:

| staged by | meta |
|---|---|
| `upsert_bucket_index_page_with` -- a page upsert | `false` |
| `stage_component_outcome` -- a component with a value or an address | `false` |
| `stage_meta_outcome` -- bucket-level state, no page | `true` |
| `mark_bucket_index_page_deleted` -- a typed removal | `true` |

It survives the round trip intact: `meta_log: item.meta` on the way out, `meta: item.meta_log` on
the way back.

And it is read by **nothing that decides anything**. Its only readers in the crate are the three
proto encoder sites that write it and one test assertion; `apply_outcome_item` never looks at it.

So the field that says "this is not a page upsert, do not go looking for an address" is already in
the log, already correct, and already surviving replay. What is missing is the arm that reads it.

That does not change my reason for not writing the fix here -- the removal itself still has to
take the right entry out of the right model map, per kind, in code I cannot exercise. But whoever
takes it starts with the discriminator in hand rather than having to invent one, and does not need
to add a field to a durable format to do it.

## A mitigation, and one that looks like it but is not

`TS_WAL_OUTCOME_ITEMS=0` stops new occurrences. `stage_outcome` returns early when it is off, so
nothing is staged; `record_command` then keeps the command, because its first condition is
`outcomes.is_empty()`; and replay re-runs the removal, which works.

`TS_WAL_DATA_ONLY=0` does **not** help, though it is the flag the analysis points at. It keeps the
command as well, but the replay branch is:

    if !record.outcomes.is_empty() {
        for item in &record.outcomes {
            if !self.apply_outcome_item(shard_id, item) { return Err(..) }

An outcome that is present and uninstallable refuses, and the command sitting beside it is never
reached. The fallback the comment there describes -- "a record carrying no outcomes is replayed as
a command exactly as before" -- is conditioned on EMPTY, not on failure.

Both flags default ON, so the shipped configuration is the failing one.

**It prevents new occurrences only.** A record already on disk carrying an uninstallable outcome
still refuses on every load, so this stops the bleeding and does not repair a store that already
has one.

### The mitigation is not offered anywhere

    | `TS_WAL_OUTCOME_ITEMS` | on | launch, test | 1 | — |

Not offered by the portal, absent from `config/temporalstore.toml`, and not in
`matrixark_load_config.ENV_MAP`. The deploy profile does set it -- to `1`, which is the failing
value and also the engine default.

So the only way to stop this recurring is to set the raw environment variable, which means already
knowing its name. An operator meeting the symptom sees a shard that will not load and a status
line naming an outcome kind, and nothing anywhere connects that to a switch.

Not proposing the config key here: adding one is a product surface decision, and it belongs with
whoever decides the fix, since a fix removes the need for it. Recorded so the choice is made
knowingly rather than by omission.

### A FIFTH kind, confirmed by test (mx#1245)

`Command::StringDelete` stages through the other address-less path:

    stage_meta_outcome(shard_id, "string", &key, .., None, None, true)
    -> kind: "string", address: None, deleted: true, meta: true

and the `"string"` arm opens the same way as the four above. mx#1245 tests it -- set, delete,
drop, reload -- and it fails:

    wal_replay_outcome_refused: could not install a recorded string outcome at sequence 3
    (address UNRESOLVED, component missing)

**This is the worst of the five.** `list` and `zset` need a pop or a rescore; this needs a string
delete.

Two revisions of this description got that wrong before the test settled it. The first asserted it
from a code reading. The second struck it as measured-wrong -- on a test that called
`unload_shard` before reopening, which flushes the index so the reload never replays the tail.
Dropping the engine instead, as `list_recovery` does, reaches the path and fails. The reading was
right; the test had been wrong.

So: five kinds -- `hash`, `list`, `set`, `zset` via `mark_bucket_index_page_deleted`, and `string`
via `stage_meta_outcome`. Three are confirmed by tests today (`list`, `zset`, `string`); `hash`
and `set` share the arm shape and have no coverage.
