### PR TITLE
A string delete makes the shard refuse to load, and nothing checked it

### DIFF
--- a/crates/temporalstore-rust/tests/string_delete_recovery.rs
+++ b/crates/temporalstore-rust/tests/string_delete_recovery.rs
@@ -13,14 +13,20 @@
 //! is refused. Nothing exercised it for strings: `StringDelete` appears only in lib tests, and no
 //! test both deletes a string and reloads.
 //!
-//! **It passes.** Reading the arms predicted a fifth failing kind and the prediction was wrong,
-//! which is why this file exists as a test rather than as a sentence in a report. Whatever saves
-//! the string path does not save `list` and `zset`, whose equivalents fail on main today, and the
-//! difference is worth knowing to whoever fixes those: something here already does the right
-//! thing.
+//! **It fails**, and `StringDelete` is a fifth kind:
 //!
-//! Kept because the coverage was genuinely missing, not to prove a point. A string that is
-//! deleted and then reloaded is an ordinary thing to want, and nothing checked it.
+//!     wal_replay_outcome_refused: WAL replay could not install a recorded string outcome at
+//!     sequence 3 ... (address UNRESOLVED, component missing)
+//!
+//! `#[ignore]` only because a failing test trips the ratchet on every later pull request. Remove
+//! the attribute when the deleted-branch lands; this is the verification for it.
+//!
+//! A FIRST VERSION OF THIS TEST PASSED, and it was wrong. It called `unload_shard` before
+//! reopening, which flushes the index, so the reopened engine read a base that already had the
+//! delete and never replayed the tail -- the test passed without touching the path it is about.
+//! `list_recovery` and `zset_recovery` drop the engine instead, which is why they reach it. That
+//! one line was the difference between "the string path is fine" and "a string delete makes a
+//! shard refuse to load".
 
 use std::path::PathBuf;
 
@@ -73,6 +79,7 @@ fn get(engine: &TemporalEngine, key: &str) -> Option<Vec<u8>> {
 }
 
 #[test]
+#[ignore = "fails on main: a StringDelete outcome cannot be installed; see the module comment"]
 fn a_deleted_string_stays_deleted_across_a_restart() {
     let root = unique_root("basic");
     let _ = std::fs::remove_dir_all(&root);
@@ -83,7 +90,9 @@ fn a_deleted_string_stays_deleted_across_a_restart() {
         run(&engine, Command::StringDelete { key: "alpha".to_string() });
         assert_eq!(None, get(&engine, "alpha"));
         assert_eq!(Some(b"v2".to_vec()), get(&engine, "bravo"));
-        engine.unload_shard(SHARD_ID);
+        // Dropped, NOT unloaded -- exactly as list_recovery and zset_recovery do it. `unload_shard`
+        // flushes the index, so the reopened engine reads a base that already has the delete and
+        // never replays the tail: the test then passes without touching the path it is about.
     }
 
     // The load is where this fails if the removal outcome cannot be installed: `new_engine`

--- a/crates/temporalstore-rust/tests/string_delete_recovery.rs
+++ b/crates/temporalstore-rust/tests/string_delete_recovery.rs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Does a deleted string survive a restart?
+//!
+//! `StringDelete` stages `stage_meta_outcome(.., "string", .., deleted: true)`, which carries no
+//! address, and the `"string"` arm of `apply_outcome_item` opens by demanding one:
+//!
+//!     "string" => { let Some(address) = item.resolved_address() else { return false }; ..
+//!
+//! That is the same shape as the four kinds behind `wal_replay_outcome_refused` -- `hash`,
+//! `list`, `set` and `zset` -- where a typed removal cannot be installed and the whole shard load
+//! is refused. Nothing exercised it for strings: `StringDelete` appears only in lib tests, and no
+//! test both deletes a string and reloads.
+//!
+//! **It passes.** Reading the arms predicted a fifth failing kind and the prediction was wrong,
+//! which is why this file exists as a test rather than as a sentence in a report. Whatever saves
+//! the string path does not save `list` and `zset`, whose equivalents fail on main today, and the
+//! difference is worth knowing to whoever fixes those: something here already does the right
+//! thing.
+//!
+//! Kept because the coverage was genuinely missing, not to prove a point. A string that is
+//! deleted and then reloaded is an ordinary thing to want, and nothing checked it.
+
+use std::path::PathBuf;
+
+use temporalstore_rust::{Command, CommandResponse, ExecuteRequest, LoadShardRequest, TemporalEngine};
+
+const SHARD_ID: u64 = 1;
+const CACHE_BYTES: usize = 4096;
+
+fn unique_root(name: &str) -> PathBuf {
+    let mut root = std::env::temp_dir();
+    root.push(format!("ts-string-delete-recovery-{name}-{}", std::process::id()));
+    root
+}
+
+fn new_engine(root: &PathBuf) -> TemporalEngine {
+    for sub in ["cache", "pages", "indexes"] {
+        std::fs::create_dir_all(root.join(sub)).expect("create engine dir");
+    }
+    let engine = TemporalEngine::with_local_dirs(
+        CACHE_BYTES,
+        root.join("cache"),
+        root.join("pages"),
+        root.join("indexes"),
+    );
+    let loaded = engine.load_shard_with(LoadShardRequest {
+        shard_id: SHARD_ID,
+        load_version: 0,
+        local_node_id: None,
+        shard_uri: String::new(),
+        start_routing_bucket: 0,
+        end_routing_bucket: u32::MAX,
+        readonly: false,
+        table_name: String::new(),
+    });
+    assert!(loaded.status.ok, "the shard did not load: {:?}", loaded.status);
+    engine
+}
+
+fn run(engine: &TemporalEngine, command: Command) -> CommandResponse {
+    let response = engine.execute(ExecuteRequest { shard_id: SHARD_ID, command });
+    assert!(response.status.ok, "command failed: {:?}", response.status);
+    response.response
+}
+
+fn get(engine: &TemporalEngine, key: &str) -> Option<Vec<u8>> {
+    match run(engine, Command::StringGet { key: key.to_string() }) {
+        CommandResponse::Bytes { value } => value,
+        other => panic!("unexpected response: {other:?}"),
+    }
+}
+
+#[test]
+fn a_deleted_string_stays_deleted_across_a_restart() {
+    let root = unique_root("basic");
+    let _ = std::fs::remove_dir_all(&root);
+    {
+        let engine = new_engine(&root);
+        run(&engine, Command::StringSet { key: "alpha".to_string(), value: b"v1".to_vec() });
+        run(&engine, Command::StringSet { key: "bravo".to_string(), value: b"v2".to_vec() });
+        run(&engine, Command::StringDelete { key: "alpha".to_string() });
+        assert_eq!(None, get(&engine, "alpha"));
+        assert_eq!(Some(b"v2".to_vec()), get(&engine, "bravo"));
+        engine.unload_shard(SHARD_ID);
+    }
+
+    // The load is where this fails if the removal outcome cannot be installed: `new_engine`
+    // asserts the load status, so a refusal shows up here and not two steps later.
+    let engine = new_engine(&root);
+    assert_eq!(None, get(&engine, "alpha"), "the delete did not survive the restart");
+    assert_eq!(
+        Some(b"v2".to_vec()),
+        get(&engine, "bravo"),
+        "the untouched key did not survive the restart",
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
Nothing in the tree both deletes a string and reloads. `StringDelete` appears only in lib tests,
and no integration test covers the pair -- so the ordinary question "does a delete survive a
restart" had no answer.

It does not. **A string delete makes the shard refuse to load:**

    wal_replay_outcome_refused: WAL replay could not install a recorded string outcome at
    sequence 3; refusing load rather than serving a shard missing it
    (address UNRESOLVED, component missing)

`StringDelete` stages through the address-less path --
`stage_meta_outcome(shard_id, "string", &key, .., None, None, true)` -- and the `"string"` arm of
`apply_outcome_item` opens by demanding an address. That is the same defect as mx#1244, and this
makes it five kinds rather than four. It is also the worst of them: `list` and `zset` need a pop
or a rescore, and this needs a string delete.

## The first version of this test passed, and it was wrong

Worth writing down, because the difference is one line and the wrong answer was the comfortable
one.

The first version called `unload_shard` before reopening. That flushes the index, so the reopened
engine read a base that already had the delete and never replayed the tail -- the test passed
without touching the path it is about. `list_recovery` and `zset_recovery` DROP the engine
instead, which is why they reach it.

On the strength of that pass I had already struck the prediction from mx#1244 as measured-wrong.
It was the test that was wrong. The prediction was right.

## Ignored, not red

`#[ignore]`, because a failing test trips the ratchet on every later pull request. The attribute
carries its reason, and removing it is the verification for the fix:

    #[ignore = "fails on main: a StringDelete outcome cannot be installed; see the module comment"]

Run locally against a release build: fails without the attribute, `1 ignored` with it.
