### PR TITLE
Install a typed removal on replay instead of refusing the load

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -3346,10 +3346,26 @@ fn mark_bucket_index_page_deleted(
     key: &str,
     component: Option<&str>,
 ) -> bool {
+    mark_bucket_index_page_deleted_with(shard, shard_id, model_id, key, component, true)
+}
+
+/// The same, with a say over whether an outcome is staged for the record.
+///
+/// Replay INSTALLS a removal that was already recorded; staging another from inside the install
+/// would record the recovery as a write of its own. Same shape as
+/// `upsert_bucket_index_page_with`, and the same reason.
+fn mark_bucket_index_page_deleted_with(
+    shard: &mut ShardState,
+    shard_id: ShardId,
+    model_id: &str,
+    key: &str,
+    component: Option<&str>,
+    stage: bool,
+) -> bool {
     // Removing a member IS an outcome, and it is the one a command log states worst: replay has
     // to re-run the removal and hope the state it removes from matches. Saying "this component
     // is gone" needs no such hope. Recorded here because every typed removal comes through.
-    {
+    if stage {
         block_in_wal::stage_outcome(crate::wal::WalOutcomeItem {
             kind: model_id.to_string(),
             object_key: key.to_string(),

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -813,6 +813,77 @@ impl TemporalEngine {
             return false;
         };
         match item.kind.as_str() {
+            // A TYPED REMOVAL. `mark_bucket_index_page_deleted` records one with no address --
+            // nothing was written, so there is none to name -- and `stage_meta_outcome` does the
+            // same for a string delete. Every arm below opens by demanding an address, so before
+            // this branch existed a removal could not be installed, `apply_outcome_item` answered
+            // false, and the caller refused the whole shard load over a member that is meant to be
+            // gone. `list_recovery` and `zset_recovery` fail on main for exactly that, and the
+            // string, hash and set equivalents were untested.
+            //
+            // `meta` is what says this is not a page upsert. It is written on every such outcome
+            // and it round-trips as `meta_log`; nothing read it until now.
+            //
+            // Each removal mirrors the write path it undoes: the same component decoding as the
+            // insert arm below, and the bucket index cleared through the same helper, asked not
+            // to stage -- replay installs a removal that was already recorded, and staging another
+            // would record the recovery as a write of its own.
+            "string" | "hash" | "set" | "list" | "zset" if item.deleted => {
+                let component = item.component.clone();
+                match (item.kind.as_str(), component.as_deref()) {
+                    ("string", _) => {
+                        super::mark_bucket_index_object_deleted(shard, &item.object_key);
+                        shard.strings.remove(&item.object_key);
+                    }
+                    ("hash", Some(field)) => {
+                        if let Some(fields) = shard.hashes.get_mut(&item.object_key) {
+                            fields.remove(field);
+                        }
+                    }
+                    ("set", Some(encoded)) => {
+                        let Ok(member) = hex::decode(encoded) else {
+                            return false;
+                        };
+                        if let Some(members) = shard.sets.get_mut(&item.object_key) {
+                            members.remove(&member);
+                        }
+                    }
+                    ("list", Some(encoded)) => {
+                        let Ok(biased) = u64::from_str_radix(encoded, 16) else {
+                            return false;
+                        };
+                        let sequence = biased.wrapping_add(i64::MIN as u64) as i64;
+                        if let Some(elements) = shard.lists.get_mut(&item.object_key) {
+                            elements.remove(&sequence);
+                        }
+                    }
+                    ("zset", Some(encoded)) => {
+                        if encoded.len() < 16 {
+                            return false;
+                        }
+                        let (_score_hex, member_hex) = encoded.split_at(16);
+                        let Ok(member) = hex::decode(member_hex) else {
+                            return false;
+                        };
+                        if let Some(members) = shard.zsets.get_mut(&item.object_key) {
+                            members.remove(&member);
+                        }
+                    }
+                    // A component-keyed kind with no component names nothing to remove.
+                    _ => return false,
+                }
+                if item.kind != "string" {
+                    super::mark_bucket_index_page_deleted_with(
+                        shard,
+                        shard_id,
+                        &item.kind,
+                        &item.object_key,
+                        component.as_deref(),
+                        false,
+                    );
+                }
+                true
+            }
             // The object is gone, everywhere it appeared.
             "object" if item.deleted => {
                 super::delete_record(shard, &item.object_key);

--- a/crates/temporalstore-rust/tests/hash_set_delete_recovery.rs
+++ b/crates/temporalstore-rust/tests/hash_set_delete_recovery.rs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Do a deleted hash field and a deleted set member survive a restart?
+//!
+//! `hash` and `set` are two of the five kinds whose typed removal goes through
+//! `mark_bucket_index_page_deleted`, which stages `address: None, deleted: true`, while their arms
+//! in `apply_outcome_item` open by demanding an address. `list`, `zset` and `string` are confirmed
+//! to refuse the load because of it; these two share the arm shape and had no coverage at all.
+//!
+//! **Both fail**, which completes the set at five:
+//!
+//!     hash outcome at sequence 3 ... (address UNRESOLVED, component present, 5 chars)
+//!     set  outcome at sequence 3 ... (address UNRESOLVED, component present, 10 chars)
+//!
+//! -- the hash field `alpha`, and the same member hex-encoded for the set. So EVERY typed removal
+//! refuses the load: a deleted hash field, a removed set member, a popped list element, a rescored
+//! zset member, a deleted string.
+//!
+//! They pass with the deleted-branch this change adds, and fail without it.//!
+//! Dropped, NOT unloaded. `unload_shard` flushes the index, so the reopened engine reads a base
+//! that already has the delete and never replays the tail -- a test written that way passes
+//! without touching the path it is about, which is how the string case was briefly and wrongly
+//! declared healthy.
+
+use std::path::PathBuf;
+
+use temporalstore_rust::{Command, CommandResponse, ExecuteRequest, LoadShardRequest, TemporalEngine};
+
+const SHARD_ID: u64 = 1;
+const CACHE_BYTES: usize = 4096;
+
+fn unique_root(name: &str) -> PathBuf {
+    let mut root = std::env::temp_dir();
+    root.push(format!("ts-hash-set-delete-recovery-{name}-{}", std::process::id()));
+    root
+}
+
+fn new_engine(root: &PathBuf) -> TemporalEngine {
+    for sub in ["cache", "pages", "indexes"] {
+        std::fs::create_dir_all(root.join(sub)).expect("create engine dir");
+    }
+    let engine = TemporalEngine::with_local_dirs(
+        CACHE_BYTES,
+        root.join("cache"),
+        root.join("pages"),
+        root.join("indexes"),
+    );
+    let loaded = engine.load_shard_with(LoadShardRequest {
+        shard_id: SHARD_ID,
+        load_version: 0,
+        local_node_id: None,
+        shard_uri: String::new(),
+        start_routing_bucket: 0,
+        end_routing_bucket: u32::MAX,
+        readonly: false,
+        table_name: String::new(),
+    });
+    assert!(loaded.status.ok, "the shard did not load: {:?}", loaded.status);
+    engine
+}
+
+fn run(engine: &TemporalEngine, command: Command) -> CommandResponse {
+    let response = engine.execute(ExecuteRequest { shard_id: SHARD_ID, command });
+    assert!(response.status.ok, "command failed: {:?}", response.status);
+    response.response
+}
+
+fn get(engine: &TemporalEngine, key: &str) -> Option<Vec<u8>> {
+    match run(engine, Command::StringGet { key: key.to_string() }) {
+        CommandResponse::Bytes { value } => value,
+        other => panic!("unexpected response: {other:?}"),
+    }
+}
+
+fn hget(engine: &TemporalEngine, key: &str, field: &str) -> Option<Vec<u8>> {
+    match run(engine, Command::HashGet { key: key.to_string(), field: field.to_string() }) {
+        CommandResponse::Bytes { value } => value,
+        other => panic!("unexpected response: {other:?}"),
+    }
+}
+
+#[test]
+fn a_deleted_hash_field_stays_deleted_across_a_restart() {
+    let root = unique_root("hash");
+    let _ = std::fs::remove_dir_all(&root);
+    {
+        let engine = new_engine(&root);
+        run(&engine, Command::HashSet {
+            key: "h".to_string(), field: "alpha".to_string(), value: b"v1".to_vec() });
+        run(&engine, Command::HashSet {
+            key: "h".to_string(), field: "bravo".to_string(), value: b"v2".to_vec() });
+        run(&engine, Command::HashDelete { key: "h".to_string(), field: "alpha".to_string() });
+        assert_eq!(None, hget(&engine, "h", "alpha"));
+    }
+    let engine = new_engine(&root);
+    assert_eq!(None, hget(&engine, "h", "alpha"), "the delete did not survive the restart");
+    assert_eq!(Some(b"v2".to_vec()), hget(&engine, "h", "bravo"), "the sibling field was lost");
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn a_removed_set_member_stays_removed_across_a_restart() {
+    let root = unique_root("set");
+    let _ = std::fs::remove_dir_all(&root);
+    {
+        let engine = new_engine(&root);
+        run(&engine, Command::SetAdd { key: "s".to_string(), member: b"alpha".to_vec() });
+        run(&engine, Command::SetAdd { key: "s".to_string(), member: b"bravo".to_vec() });
+        run(&engine, Command::SetRemove { key: "s".to_string(), member: b"alpha".to_vec() });
+    }
+    let engine = new_engine(&root);
+    match run(&engine, Command::SetMembers { key: "s".to_string() }) {
+        CommandResponse::Members { members } => {
+            assert!(!members.iter().any(|v| v.as_slice() == b"alpha"), "the removal did not survive");
+            assert!(members.iter().any(|v| v.as_slice() == b"bravo"), "the sibling member was lost");
+        }
+        other => panic!("unexpected response: {other:?}"),
+    }
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/crates/temporalstore-rust/tests/string_delete_recovery.rs
+++ b/crates/temporalstore-rust/tests/string_delete_recovery.rs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Does a deleted string survive a restart?
+//!
+//! `StringDelete` stages `stage_meta_outcome(.., "string", .., deleted: true)`, which carries no
+//! address, and the `"string"` arm of `apply_outcome_item` opens by demanding one:
+//!
+//!     "string" => { let Some(address) = item.resolved_address() else { return false }; ..
+//!
+//! That is the same shape as the four kinds behind `wal_replay_outcome_refused` -- `hash`,
+//! `list`, `set` and `zset` -- where a typed removal cannot be installed and the whole shard load
+//! is refused. Nothing exercised it for strings: `StringDelete` appears only in lib tests, and no
+//! test both deletes a string and reloads.
+//!
+//! **It fails**, and `StringDelete` is a fifth kind:
+//!
+//!     wal_replay_outcome_refused: WAL replay could not install a recorded string outcome at
+//!     sequence 3 ... (address UNRESOLVED, component missing)
+//!
+//! A FIRST VERSION OF THIS TEST PASSED, and it was wrong. It called `unload_shard` before
+//! reopening, which flushes the index, so the reopened engine read a base that already had the
+//! delete and never replayed the tail -- the test passed without touching the path it is about.
+//! `list_recovery` and `zset_recovery` drop the engine instead, which is why they reach it. That
+//! one line was the difference between "the string path is fine" and "a string delete makes a
+//! shard refuse to load".
+
+use std::path::PathBuf;
+
+use temporalstore_rust::{Command, CommandResponse, ExecuteRequest, LoadShardRequest, TemporalEngine};
+
+const SHARD_ID: u64 = 1;
+const CACHE_BYTES: usize = 4096;
+
+fn unique_root(name: &str) -> PathBuf {
+    let mut root = std::env::temp_dir();
+    root.push(format!("ts-string-delete-recovery-{name}-{}", std::process::id()));
+    root
+}
+
+fn new_engine(root: &PathBuf) -> TemporalEngine {
+    for sub in ["cache", "pages", "indexes"] {
+        std::fs::create_dir_all(root.join(sub)).expect("create engine dir");
+    }
+    let engine = TemporalEngine::with_local_dirs(
+        CACHE_BYTES,
+        root.join("cache"),
+        root.join("pages"),
+        root.join("indexes"),
+    );
+    let loaded = engine.load_shard_with(LoadShardRequest {
+        shard_id: SHARD_ID,
+        load_version: 0,
+        local_node_id: None,
+        shard_uri: String::new(),
+        start_routing_bucket: 0,
+        end_routing_bucket: u32::MAX,
+        readonly: false,
+        table_name: String::new(),
+    });
+    assert!(loaded.status.ok, "the shard did not load: {:?}", loaded.status);
+    engine
+}
+
+fn run(engine: &TemporalEngine, command: Command) -> CommandResponse {
+    let response = engine.execute(ExecuteRequest { shard_id: SHARD_ID, command });
+    assert!(response.status.ok, "command failed: {:?}", response.status);
+    response.response
+}
+
+fn get(engine: &TemporalEngine, key: &str) -> Option<Vec<u8>> {
+    match run(engine, Command::StringGet { key: key.to_string() }) {
+        CommandResponse::Bytes { value } => value,
+        other => panic!("unexpected response: {other:?}"),
+    }
+}
+
+#[test]
+fn a_deleted_string_stays_deleted_across_a_restart() {
+    let root = unique_root("basic");
+    let _ = std::fs::remove_dir_all(&root);
+    {
+        let engine = new_engine(&root);
+        run(&engine, Command::StringSet { key: "alpha".to_string(), value: b"v1".to_vec() });
+        run(&engine, Command::StringSet { key: "bravo".to_string(), value: b"v2".to_vec() });
+        run(&engine, Command::StringDelete { key: "alpha".to_string() });
+        assert_eq!(None, get(&engine, "alpha"));
+        assert_eq!(Some(b"v2".to_vec()), get(&engine, "bravo"));
+        // Dropped, NOT unloaded -- exactly as list_recovery and zset_recovery do it. `unload_shard`
+        // flushes the index, so the reopened engine reads a base that already has the delete and
+        // never replays the tail: the test then passes without touching the path it is about.
+    }
+
+    // The load is where this fails if the removal outcome cannot be installed: `new_engine`
+    // asserts the load status, so a refusal shows up here and not two steps later.
+    let engine = new_engine(&root);
+    assert_eq!(None, get(&engine, "alpha"), "the delete did not survive the restart");
+    assert_eq!(
+        Some(b"v2".to_vec()),
+        get(&engine, "bravo"),
+        "the untouched key did not survive the restart",
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
Fixes the defect diagnosed in mx#1244, and supersedes mx#1245 and mx#1246, whose tests are
included here passing rather than ignored.

## What was wrong

`mark_bucket_index_page_deleted` records every typed removal with `address: None, deleted: true,
meta: true` -- nothing was written, so there is no address to name -- and `stage_meta_outcome`
does the same for a string delete. Every arm of `apply_outcome_item` opened by demanding an
address, `item.deleted` was read by two other arms and `item.meta` by none, so a removal answered
false and the caller **refused the whole shard load** over a member that is meant to be gone.

Five kinds, all ordinary operations:

| kind | operation |
|---|---|
| `list` | a pop |
| `zset` | a rescore |
| `string` | a delete |
| `hash` | deleting a field |
| `set` | removing a member |

## The change

One branch, ahead of the arms that demand an address. Each removal mirrors the write path it
undoes -- the same component decoding as the matching insert arm -- and clears the bucket index
through the same helper, asked **not to stage**: replay installs a removal that was already
recorded, and staging another would record the recovery as a write of its own. That is why
`mark_bucket_index_page_deleted` gains a `_with(stage)` variant, exactly as
`upsert_bucket_index_page_with` has one, with the original delegating and the write path
unchanged.

`meta` is what says an outcome is not a page upsert. It was written on every one, round-tripped as
`meta_log`, and read by nothing.

## Verification

Run locally against a release build.

    list_order_survives_restart_and_pops_stay_popped        ok   (red on main)
    scores_and_order_survive_restart_including_a_rescore    ok   (red on main)
    a_deleted_string_stays_deleted_across_a_restart         ok   (new)
    a_deleted_hash_field_stays_deleted_across_a_restart     ok   (new)
    a_removed_set_member_stays_removed_across_a_restart     ok   (new)

Full suite, `--lib --tests --no-fail-fast`: **no new failures.** Every remaining failure is from
the known baseline -- three raft, four `single_barrier` plus `wal_is_self_sufficient`, two corpus,
one raft-gc. The lib reports 1703 passed with one failure,
`storage_manager_runtime_supports_..._phase_flags`, which **fails identically on clean main when
run filtered** -- checked by stashing this change and re-running -- so it is an isolation artifact
of running it alone, not a regression here.

The three new tests drop the engine rather than calling `unload_shard`. That distinction is the
whole test: `unload_shard` flushes the index, so the reopened engine reads a base that already has
the removal and never replays the tail. A version of the string test written that way passed while
the defect was live.

## This is not a new convention, it is an existing one the typed kinds never got

The arm directly below the five already does exactly this. For `feature`, `context_index`,
`context_audit`, `context_child`, `context_summary` and `context_compression`:

    if !item.deleted && item.address.is_none() {
        return false;                       // refuses only a NON-deletion with no address
    }
    ...
    match item.resolved_address() {
        Some(address) if !item.deleted => { entries.insert(stored_key, address); }
        _ => { entries.remove(&stored_key); }
    }

A removal with no address is expected there and handled, both for a whole series
(`component.is_none()`) and for a single point. Their removals are staged by
`stage_timestamped_removal`, with `address: None, deleted: true`, exactly like the five.

So the timestamped kinds were made to work and the typed kinds were not, in the same match, and
the difference has been sitting there. That also answers the question mx#1245 raised when a broken
test briefly suggested the string path was healthy -- there IS an arm doing the right thing, just
not the one the failing tests reach.

Checked for completeness while writing this: the three places that stage a removal are
`mark_bucket_index_page_deleted` (hash, list, set, zset), `stage_meta_outcome` (string, and the
object/bucket/seen kinds that have their own arms), and `stage_timestamped_removal` (the six
above, already correct). No kind is left demanding an address for a removal after this change.
