### PR TITLE
The released phase has nothing left to remove, because the clamp already did

### DIFF
--- a/crates/temporalstore-rust/tests/unified_temporalstore_corpus.rs
+++ b/crates/temporalstore-rust/tests/unified_temporalstore_corpus.rs
@@ -3804,7 +3804,18 @@ fn verify_storage_wal_index_gc_generation_retention(shard_id: u64) {
     let released_wal = released_cycle.wal_reclaim_report.as_ref().unwrap();
     assert!(released_wal.plan.safe_to_reclaim, "{released_wal:?}");
     assert!(released_wal.applied, "{released_wal:?}");
-    assert!(released_wal.wal_records_removed > 0, "{released_wal:?}");
+    // There may be nothing left to remove, because the clamped cycle above already released the
+    // span both cursors had consumed. That is the point of clamping: the work happens as the
+    // cursor advances rather than all at once when it finally reaches the frontier. What must
+    // hold is that the frontier itself has moved up to the final anchor.
+    //
+    // Copied from engine/tests/part4.rs, which covers this scenario and was corrected for the
+    // clamp already. mx#1228 fixed the blocked phase in this file and the failure moved here.
+    assert_eq!(
+        released_wal.plan.retain_from_wal_sequence,
+        released_anchor.wal_sequence.saturating_add(1),
+        "{released_wal:?}"
+    );
     let released_index_gc = released_cycle.index_gc_report.as_ref().unwrap();
     assert!(released_index_gc.safe_to_truncate, "{released_index_gc:?}");
     assert!(released_index_gc.applied, "{released_index_gc:?}");


### PR DESCRIPTION
mx#1228 corrected the blocked phase of `rust_executes_storage_raft_gc_cases` for the reclaim
clamp, and the failure moved down the same test -- the third time this contract has been asserted
in more than one place, after mx#1213 and mx#1220.

    unified_temporalstore_corpus.rs:3807
    assert!(released_wal.wal_records_removed > 0, "{released_wal:?}");

The released phase, with both cursors caught up, expects records to be removed. There are none
left: **the clamped phase above already removed them.** That is what clamping does -- the work
happens as the cursor advances rather than all at once when it finally reaches the frontier -- so
an assertion that the final phase does the removing is asserting the refusal that clamping
replaced, one step further along.

## Copied, not invented

`engine/tests/part4.rs` covers this scenario and was corrected for the clamp already, comment
included:

    // There may be nothing left to remove, because the clamped cycle above already released the
    // span both cursors had consumed. ... What must hold is that the frontier itself has moved
    // up to the final anchor.
    assert_eq!(released_wal.plan.retain_from_wal_sequence,
               final_anchor.wal_sequence.saturating_add(1), ..);

Same assertion here, against this test own `released_anchor`.

## Verified

Run locally against a release build:

    rust_client_executes_temporalstore_corpus  ok
    rust_executes_storage_eviction_cases       ok
    rust_executes_storage_raft_gc_cases        ok   (red on main)
    rust_executes_temporalstore_corpus         FAILED -- unrelated

That last one is `slot_dump_object_lifecycle_mismatch`, the separate defect diagnosed in mx#1231
(the unserialized-map rebuild covers one map of three). It is untouched by this change and fails
identically before it.
