### PR TITLE
The dump cross-check did not say which derivation disagreed

### DIFF
--- a/crates/temporalstore-rust/src/engine/bucket_dump_manifest_methods.rs
+++ b/crates/temporalstore-rust/src/engine/bucket_dump_manifest_methods.rs
@@ -679,9 +679,28 @@ impl TemporalEngine {
             if manifest.object_lifecycle != expected_object_lifecycle
                 || manifest.object_lifecycle != model_object_lifecycle
             {
+                // Say WHICH of the two derivations disagrees, and how. There are two comparisons
+                // here and the message named neither, so a refusal said only that a dump would
+                // not install -- and the two have different causes: the index-derived report
+                // disagreeing means the manifest metadata is stale or wrong, while the model-map
+                // one disagreeing means a map the manifest does not carry was compared against a
+                // populated index.
+                let which = if manifest.object_lifecycle != expected_object_lifecycle {
+                    "bucket-index derivation"
+                } else {
+                    "model-map derivation"
+                };
+                let other = if manifest.object_lifecycle != expected_object_lifecycle {
+                    &expected_object_lifecycle
+                } else {
+                    &model_object_lifecycle
+                };
                 return Err(Status::error(
                     "slot_dump_object_lifecycle_mismatch",
-                    "slot dump object lifecycle metadata does not match restored index",
+                    format!(
+                        "slot dump object lifecycle metadata does not match restored index; the {which} disagrees. manifest={:?} derived={:?}",
+                        manifest.object_lifecycle, other
+                    ),
                 ));
             }
         }


### PR DESCRIPTION
`install_bucket_dump_manifest` refuses a dump when the object-lifecycle metadata does not match,
and it makes TWO comparisons:

    if manifest.object_lifecycle != expected_object_lifecycle      // from the bucket index
        || manifest.object_lifecycle != model_object_lifecycle     // from the model maps

The refusal named neither, and the two have different causes. The index-derived one disagreeing
means the manifest metadata is stale or wrong. The model-map one disagreeing means a map the
manifest does not carry was compared against a populated index -- a different problem with a
different owner.

Now it says which, and shows both reports.

## What it says today

    the model-map derivation disagrees.
    manifest=StorageObjectLifecycleReport { live_object_ids: 12, live_page_refs: 12, .. }
    derived=StorageObjectLifecycleReport { live_object_ids: 10, live_page_refs: 10, .. }

Two pages, present in the manifest and in the bucket index, absent from the restored model maps.
That is `slot_dump_object_lifecycle_mismatch` on
`rust_executes_temporalstore_corpus` and
`rust_storage_replays_migration_corpus_across_lifecycle_paths`, and it puts a number on the
diagnosis in mx#1231.

## Why this is only the message

I tried the narrowing mx#1231 suggested -- deriving the model-map report without
`context_event` and `context_index`, the two `skip_serializing` maps that
`rebuild_unserialized_model_maps_from_bucket_index` cannot rebuild -- and **measured it as a
no-op**: the derived count is 10 either way, because those entries are already absent from the
restored maps rather than present and wrong.

The manifest value was computed at dump time from a LIVE shard, where those maps are populated,
so it counts 12. A restored shard can only ever reach 10. Making the two comparable means changing
what the manifest stores, which is a dump-format decision and belongs to whoever owns it -- the
same conclusion mx#1231 reached, now with the numbers behind it.

So this pull request is the message and nothing else. No behaviour change: the same dumps are
accepted and refused.
