### PR TITLE
A portal timestamp says which clock it is

### DIFF
--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -1096,6 +1096,27 @@
 
      `detail` still wins where there is one: it names the setting and the reason. The scope is
      appended to that rather than replacing it. */
+  /* One way to render an absolute time, and it names the clock.
+   *
+   * Four places showed a timestamp with toLocaleString() and none said which zone it was in, while
+   * the records they describe -- a configuration write, an audit entry, a stored memory -- carry
+   * the GATEWAY's time. Correlating a portal timestamp with a server log was guesswork, and on a
+   * browser whose clock is off (which the setup page can now measure and say) it was wrong as well
+   * as ambiguous.
+   *
+   * `timeZoneName: "short"` rather than the IANA name: "GMT+1" beside the time reads at a glance
+   * where "Europe/London" pushes the useful part off the end of a table cell. Falls back to the
+   * bare local string on a runtime without it, which is no worse than what was there before. */
+  window.__matrixarkWhen = function (ms) {
+    /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
+       `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
+    if (!ms) { return "—"; }
+    var at = new Date(Number(ms));
+    if (isNaN(at.getTime())) { return "—"; }
+    try { return at.toLocaleString(undefined, { timeZoneName: "short" }); }
+    catch (e) { return at.toLocaleString(); }
+  };
+
   window.__matrixarkWhy = function (body, fallback) {
     body = body || {};
     var text = body.detail || body.error || fallback;

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -806,6 +806,27 @@
 
      `detail` still wins where there is one: it names the setting and the reason. The scope is
      appended to that rather than replacing it. */
+  /* One way to render an absolute time, and it names the clock.
+   *
+   * Four places showed a timestamp with toLocaleString() and none said which zone it was in, while
+   * the records they describe -- a configuration write, an audit entry, a stored memory -- carry
+   * the GATEWAY's time. Correlating a portal timestamp with a server log was guesswork, and on a
+   * browser whose clock is off (which the setup page can now measure and say) it was wrong as well
+   * as ambiguous.
+   *
+   * `timeZoneName: "short"` rather than the IANA name: "GMT+1" beside the time reads at a glance
+   * where "Europe/London" pushes the useful part off the end of a table cell. Falls back to the
+   * bare local string on a runtime without it, which is no worse than what was there before. */
+  window.__matrixarkWhen = function (ms) {
+    /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
+       `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
+    if (!ms) { return "—"; }
+    var at = new Date(Number(ms));
+    if (isNaN(at.getTime())) { return "—"; }
+    try { return at.toLocaleString(undefined, { timeZoneName: "short" }); }
+    catch (e) { return at.toLocaleString(); }
+  };
+
   window.__matrixarkWhy = function (body, fallback) {
     body = body || {};
     var text = body.detail || body.error || fallback;

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -341,6 +341,27 @@ NAV_JS = r'''<script>
 
      `detail` still wins where there is one: it names the setting and the reason. The scope is
      appended to that rather than replacing it. */
+  /* One way to render an absolute time, and it names the clock.
+   *
+   * Four places showed a timestamp with toLocaleString() and none said which zone it was in, while
+   * the records they describe -- a configuration write, an audit entry, a stored memory -- carry
+   * the GATEWAY's time. Correlating a portal timestamp with a server log was guesswork, and on a
+   * browser whose clock is off (which the setup page can now measure and say) it was wrong as well
+   * as ambiguous.
+   *
+   * `timeZoneName: "short"` rather than the IANA name: "GMT+1" beside the time reads at a glance
+   * where "Europe/London" pushes the useful part off the end of a table cell. Falls back to the
+   * bare local string on a runtime without it, which is no worse than what was there before. */
+  window.__matrixarkWhen = function (ms) {
+    /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
+       `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
+    if (!ms) { return "—"; }
+    var at = new Date(Number(ms));
+    if (isNaN(at.getTime())) { return "—"; }
+    try { return at.toLocaleString(undefined, { timeZoneName: "short" }); }
+    catch (e) { return at.toLocaleString(); }
+  };
+
   window.__matrixarkWhy = function (body, fallback) {
     body = body || {};
     var text = body.detail || body.error || fallback;
@@ -1659,7 +1680,7 @@ SETUP_JS = r"""
     renderAwaiting((settings || {}).pending_restart);
     $("cfgTime").textContent = settings && settings.updated_at
       ? "Stored in " + (settings.config_file || "the runtime config") + " · last saved " +
-        new Date(settings.updated_at * 1000).toLocaleString()
+        window.__matrixarkWhen(settings.updated_at * 1000)
       : "Stored in " + ((settings || {}).config_file || "the runtime config") +
         " · nothing saved from the portal yet";
     applyFilter();
@@ -1685,7 +1706,7 @@ SETUP_JS = r"""
         var restart = (e.restart_required || []).length
           ? '<div class="hint" style="margin:4px 0 0">needed a restart: ' +
             esc(e.restart_required.join(", ")) + "</div>" : "";
-        return "<tr><td>" + esc(new Date(e.at * 1000).toLocaleString()) + "</td><td>" +
+        return "<tr><td>" + esc(window.__matrixarkWhen(e.at * 1000)) + "</td><td>" +
           esc(e.by) + "</td><td>" + what + restart + "</td></tr>";
       }).join("") + "</tbody></table>";
   }
@@ -3419,7 +3440,7 @@ CATALOG_JS = r"""
     $("dot").className = "dot " + state;
     $("conn").textContent = text;
   }
-  function when(ms) { return ms ? new Date(ms).toLocaleString() : "—"; }
+  function when(ms) { return window.__matrixarkWhen(ms); }
 
   function query() {
     var parts = [];
@@ -4556,7 +4577,7 @@ EXPLORE_JS = r"""
             return '<tr class="rowlink" data-id="' + esc(id) + '"><td>' +
               esc(String(m.memory || m.text || m.content || "").slice(0, 160)) + "</td><td>" +
               esc(m.record_type || m.kind || "—") + "</td><td>" +
-              esc(when ? new Date(when).toLocaleString() : "—") + "</td></tr>";
+              esc(window.__matrixarkWhen(when)) + "</td></tr>";
           }).join("") + "</tbody></table>";
       })
       .catch(function (e) {

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -647,7 +647,7 @@
     $("dot").className = "dot " + state;
     $("conn").textContent = text;
   }
-  function when(ms) { return ms ? new Date(ms).toLocaleString() : "—"; }
+  function when(ms) { return window.__matrixarkWhen(ms); }
 
   function query() {
     var parts = [];
@@ -947,6 +947,27 @@
 
      `detail` still wins where there is one: it names the setting and the reason. The scope is
      appended to that rather than replacing it. */
+  /* One way to render an absolute time, and it names the clock.
+   *
+   * Four places showed a timestamp with toLocaleString() and none said which zone it was in, while
+   * the records they describe -- a configuration write, an audit entry, a stored memory -- carry
+   * the GATEWAY's time. Correlating a portal timestamp with a server log was guesswork, and on a
+   * browser whose clock is off (which the setup page can now measure and say) it was wrong as well
+   * as ambiguous.
+   *
+   * `timeZoneName: "short"` rather than the IANA name: "GMT+1" beside the time reads at a glance
+   * where "Europe/London" pushes the useful part off the end of a table cell. Falls back to the
+   * bare local string on a runtime without it, which is no worse than what was there before. */
+  window.__matrixarkWhen = function (ms) {
+    /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
+       `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
+    if (!ms) { return "—"; }
+    var at = new Date(Number(ms));
+    if (isNaN(at.getTime())) { return "—"; }
+    try { return at.toLocaleString(undefined, { timeZoneName: "short" }); }
+    catch (e) { return at.toLocaleString(); }
+  };
+
   window.__matrixarkWhy = function (body, fallback) {
     body = body || {};
     var text = body.detail || body.error || fallback;

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -970,7 +970,7 @@
             return '<tr class="rowlink" data-id="' + esc(id) + '"><td>' +
               esc(String(m.memory || m.text || m.content || "").slice(0, 160)) + "</td><td>" +
               esc(m.record_type || m.kind || "—") + "</td><td>" +
-              esc(when ? new Date(when).toLocaleString() : "—") + "</td></tr>";
+              esc(window.__matrixarkWhen(when)) + "</td></tr>";
           }).join("") + "</tbody></table>";
       })
       .catch(function (e) {
@@ -1892,6 +1892,27 @@
 
      `detail` still wins where there is one: it names the setting and the reason. The scope is
      appended to that rather than replacing it. */
+  /* One way to render an absolute time, and it names the clock.
+   *
+   * Four places showed a timestamp with toLocaleString() and none said which zone it was in, while
+   * the records they describe -- a configuration write, an audit entry, a stored memory -- carry
+   * the GATEWAY's time. Correlating a portal timestamp with a server log was guesswork, and on a
+   * browser whose clock is off (which the setup page can now measure and say) it was wrong as well
+   * as ambiguous.
+   *
+   * `timeZoneName: "short"` rather than the IANA name: "GMT+1" beside the time reads at a glance
+   * where "Europe/London" pushes the useful part off the end of a table cell. Falls back to the
+   * bare local string on a runtime without it, which is no worse than what was there before. */
+  window.__matrixarkWhen = function (ms) {
+    /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
+       `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
+    if (!ms) { return "—"; }
+    var at = new Date(Number(ms));
+    if (isNaN(at.getTime())) { return "—"; }
+    try { return at.toLocaleString(undefined, { timeZoneName: "short" }); }
+    catch (e) { return at.toLocaleString(); }
+  };
+
   window.__matrixarkWhy = function (body, fallback) {
     body = body || {};
     var text = body.detail || body.error || fallback;

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -815,6 +815,27 @@
 
      `detail` still wins where there is one: it names the setting and the reason. The scope is
      appended to that rather than replacing it. */
+  /* One way to render an absolute time, and it names the clock.
+   *
+   * Four places showed a timestamp with toLocaleString() and none said which zone it was in, while
+   * the records they describe -- a configuration write, an audit entry, a stored memory -- carry
+   * the GATEWAY's time. Correlating a portal timestamp with a server log was guesswork, and on a
+   * browser whose clock is off (which the setup page can now measure and say) it was wrong as well
+   * as ambiguous.
+   *
+   * `timeZoneName: "short"` rather than the IANA name: "GMT+1" beside the time reads at a glance
+   * where "Europe/London" pushes the useful part off the end of a table cell. Falls back to the
+   * bare local string on a runtime without it, which is no worse than what was there before. */
+  window.__matrixarkWhen = function (ms) {
+    /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
+       `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
+    if (!ms) { return "—"; }
+    var at = new Date(Number(ms));
+    if (isNaN(at.getTime())) { return "—"; }
+    try { return at.toLocaleString(undefined, { timeZoneName: "short" }); }
+    catch (e) { return at.toLocaleString(); }
+  };
+
   window.__matrixarkWhy = function (body, fallback) {
     body = body || {};
     var text = body.detail || body.error || fallback;

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -1072,6 +1072,27 @@ function liveStream(options) {
 
      `detail` still wins where there is one: it names the setting and the reason. The scope is
      appended to that rather than replacing it. */
+  /* One way to render an absolute time, and it names the clock.
+   *
+   * Four places showed a timestamp with toLocaleString() and none said which zone it was in, while
+   * the records they describe -- a configuration write, an audit entry, a stored memory -- carry
+   * the GATEWAY's time. Correlating a portal timestamp with a server log was guesswork, and on a
+   * browser whose clock is off (which the setup page can now measure and say) it was wrong as well
+   * as ambiguous.
+   *
+   * `timeZoneName: "short"` rather than the IANA name: "GMT+1" beside the time reads at a glance
+   * where "Europe/London" pushes the useful part off the end of a table cell. Falls back to the
+   * bare local string on a runtime without it, which is no worse than what was there before. */
+  window.__matrixarkWhen = function (ms) {
+    /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
+       `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
+    if (!ms) { return "—"; }
+    var at = new Date(Number(ms));
+    if (isNaN(at.getTime())) { return "—"; }
+    try { return at.toLocaleString(undefined, { timeZoneName: "short" }); }
+    catch (e) { return at.toLocaleString(); }
+  };
+
   window.__matrixarkWhy = function (body, fallback) {
     body = body || {};
     var text = body.detail || body.error || fallback;

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -1380,7 +1380,7 @@ function liveStream(options) {
     renderAwaiting((settings || {}).pending_restart);
     $("cfgTime").textContent = settings && settings.updated_at
       ? "Stored in " + (settings.config_file || "the runtime config") + " · last saved " +
-        new Date(settings.updated_at * 1000).toLocaleString()
+        window.__matrixarkWhen(settings.updated_at * 1000)
       : "Stored in " + ((settings || {}).config_file || "the runtime config") +
         " · nothing saved from the portal yet";
     applyFilter();
@@ -1406,7 +1406,7 @@ function liveStream(options) {
         var restart = (e.restart_required || []).length
           ? '<div class="hint" style="margin:4px 0 0">needed a restart: ' +
             esc(e.restart_required.join(", ")) + "</div>" : "";
-        return "<tr><td>" + esc(new Date(e.at * 1000).toLocaleString()) + "</td><td>" +
+        return "<tr><td>" + esc(window.__matrixarkWhen(e.at * 1000)) + "</td><td>" +
           esc(e.by) + "</td><td>" + what + restart + "</td></tr>";
       }).join("") + "</tbody></table>";
   }
@@ -3045,6 +3045,27 @@ function liveStream(options) {
 
      `detail` still wins where there is one: it names the setting and the reason. The scope is
      appended to that rather than replacing it. */
+  /* One way to render an absolute time, and it names the clock.
+   *
+   * Four places showed a timestamp with toLocaleString() and none said which zone it was in, while
+   * the records they describe -- a configuration write, an audit entry, a stored memory -- carry
+   * the GATEWAY's time. Correlating a portal timestamp with a server log was guesswork, and on a
+   * browser whose clock is off (which the setup page can now measure and say) it was wrong as well
+   * as ambiguous.
+   *
+   * `timeZoneName: "short"` rather than the IANA name: "GMT+1" beside the time reads at a glance
+   * where "Europe/London" pushes the useful part off the end of a table cell. Falls back to the
+   * bare local string on a runtime without it, which is no worse than what was there before. */
+  window.__matrixarkWhen = function (ms) {
+    /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
+       `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
+    if (!ms) { return "—"; }
+    var at = new Date(Number(ms));
+    if (isNaN(at.getTime())) { return "—"; }
+    try { return at.toLocaleString(undefined, { timeZoneName: "short" }); }
+    catch (e) { return at.toLocaleString(); }
+  };
+
   window.__matrixarkWhy = function (body, fallback) {
     body = body || {};
     var text = body.detail || body.error || fallback;

--- a/tools/portal/when_harness.js
+++ b/tools/portal/when_harness.js
@@ -1,0 +1,17 @@
+// Runs the SHIPPED __matrixarkWhen from a generated page. Reading the source would not catch a
+// formatter that returns "Invalid Date", which is what the old sites did for a missing timestamp.
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const start = page.indexOf("window.__matrixarkWhen = function (ms)");
+if (start < 0) throw new Error("__matrixarkWhen not found on this page");
+let depth = 0, end = -1;
+for (let i = page.indexOf("{", start); i < page.length; i++) {
+  if (page[i] === "{") depth++;
+  else if (page[i] === "}") { depth--; if (depth === 0) { end = i + 1; break; } }
+}
+const body = page.slice(start, end).replace("window.__matrixarkWhen = ", "var when = ");
+const when = new Function("Date", "isNaN", "Number", body + "; return when;")(Date, isNaN, Number);
+
+const inputs = JSON.parse(process.argv[3]);
+process.stdout.write(JSON.stringify(inputs.map((v) => when(v))));

--- a/tools/test_matrixark_a_portal_timestamp_says_which_clock.py
+++ b/tools/test_matrixark_a_portal_timestamp_says_which_clock.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A timestamp on the portal did not say which clock it came from.
+
+Four places showed one -- when the configuration was last written, each entry in its history, the
+catalog's updated column, and a stored memory's time -- all with `toLocaleString()`, and **none of
+them named the zone**. The records they describe carry the GATEWAY's time: a configuration write,
+an audit entry, a stored memory. So correlating a portal timestamp with a server log was guesswork,
+and on a browser whose clock is off -- which the setup page can now measure and say, since
+mx#1181 -- it was wrong as well as ambiguous.
+
+The four now go through one helper that names the zone. Not a sweep of every `toLocaleString()` in
+the tree: most of those are `Number(...).toLocaleString()` putting separators in a count, and a
+first pass at this counted twenty-four sites when there are four.
+
+It also fixes something the old sites got wrong on the way: a missing timestamp rendered as
+`Invalid Date` wherever the call was not already guarded, and two of the four were not.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+HARNESS = os.path.join(PORTAL, "when_harness.js")
+
+#: Every page, including the two that are hand-maintained and only have the nav injected.
+PAGES = ("setup_portal.html", "overview_portal.html", "catalog_portal.html",
+         "explore_portal.html", "api_portal.html", "ingestion_portal.html",
+         "api_key_portal.html")
+
+AN_INSTANT = 1760000000000
+
+
+def rendered(values: list, page: str = "setup_portal.html", timezone: str = "UTC") -> list:
+    """What the shipped helper returns, with the zone pinned so this reads the same anywhere."""
+    environ = dict(os.environ)
+    environ["TZ"] = timezone
+    out = subprocess.run(["node", HARNESS, os.path.join(PORTAL, page), json.dumps(values)],
+                         capture_output=True, text=True, timeout=300, env=environ)
+    if out.returncode != 0:
+        raise AssertionError(out.stderr[-800:])
+    return json.loads(out.stdout)
+
+
+def source(name: str) -> str:
+    with io.open(os.path.join(PORTAL, name), encoding="utf-8") as handle:
+        return handle.read()
+
+
+class ItNamesTheZoneTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    def test_a_rendered_time_carries_its_zone(self) -> None:
+        text = rendered([AN_INSTANT])[0]
+        self.assertIn("UTC", text, "the zone is still not named: %r" % text)
+
+    def test_the_zone_is_the_browsers_own(self) -> None:
+        """The floor: if it printed a constant, the test above would pass on a lie."""
+        self.assertIn("UTC", rendered([AN_INSTANT], timezone="UTC")[0])
+        self.assertNotIn("UTC", rendered([AN_INSTANT], timezone="Asia/Tokyo")[0])
+
+    def test_it_still_shows_the_time(self) -> None:
+        text = rendered([AN_INSTANT])[0]
+        self.assertIn("2025", text)
+
+
+class AMissingTimeIsADashNotAnInvalidDateTest(unittest.TestCase):
+    """Two of the four sites had no guard, so an absent timestamp read `Invalid Date`."""
+
+    def setUp(self) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    def test_nothing_renders_as_a_dash(self) -> None:
+        for value in (None, "", 0):
+            with self.subTest(value=value):
+                self.assertEqual("—", rendered([value])[0])
+
+    def test_garbage_renders_as_a_dash(self) -> None:
+        self.assertEqual("—", rendered(["not a time"])[0])
+
+    def test_nothing_ever_reads_invalid_date(self) -> None:
+        for value in (None, "", 0, "not a time", []):
+            with self.subTest(value=value):
+                self.assertNotIn("Invalid", rendered([value])[0])
+
+
+class EveryPageHasItTest(unittest.TestCase):
+    """It lives in the shared nav, so the two hand-maintained pages get it too."""
+
+    def test_every_page_carries_the_helper(self) -> None:
+        for page in PAGES:
+            with self.subTest(page=page):
+                self.assertIn("window.__matrixarkWhen = function", source(page))
+
+    def test_the_four_sites_go_through_it(self) -> None:
+        builder = source("build_portal_pages.py")
+        for site in ("window.__matrixarkWhen(settings.updated_at * 1000)",
+                     "esc(window.__matrixarkWhen(e.at * 1000))",
+                     "function when(ms) { return window.__matrixarkWhen(ms); }",
+                     "esc(window.__matrixarkWhen(when))"):
+            with self.subTest(site=site[:40]):
+                self.assertIn(site, builder)
+
+    def test_no_timestamp_site_formats_its_own(self) -> None:
+        """The point of one helper. A `new Date(x).toLocaleString()` anywhere is a fifth site that
+        does not name its zone -- number formatting, which is the same method on a Number, is not
+        matched by this."""
+        builder = source("build_portal_pages.py")
+        offenders = [line.strip() for line in builder.splitlines()
+                     if "toLocaleString()" in line and "new Date(" in line]
+        self.assertEqual([], offenders, offenders)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A timestamp on the portal did not say which clock it came from.

Four places showed one — when the configuration was last written, each entry in its history, the catalog's *updated* column, and a stored memory's time — all through `toLocaleString()`, and **none named the zone**. The records they describe carry the *gateway's* time: a configuration write, an audit entry, a stored memory. So correlating a portal timestamp with a server log was guesswork, and on a browser whose clock is off — which the setup page can now measure and say, since #1181 — it was wrong as well as ambiguous.

The four now go through one helper in the shared nav, which every page has, including the two that are hand-maintained and only get the nav injected.

```
1760000000000  ->  10/9/2025, 1:53:20 AM PDT
```

## Scope, and a count I got wrong

This is **not** a sweep of every `toLocaleString()` in the tree. A first pass counted twenty-four sites; listing them showed most are `Number(...).toLocaleString()` putting separators in a count. There are four timestamps.

## Two things it fixes on the way

- **A missing time read `Invalid Date`.** Two of the four sites had no guard. It is now an em-dash.
- **`0` still means "no timestamp", not 1970.** The catalog site this replaces read `ms ? … : dash`, and my first version rendered the epoch — caught by its own test before it went anywhere.

## Mutations

Thirteen tests, run against the shipped helper with `TZ` pinned so they read the same on any machine. Each of these reddens at least one:

| mutation | reddens |
|---|---|
| the zone is dropped again | `test_a_rendered_time_carries_its_zone` |
| a missing time is the epoch again | `test_nothing_renders_as_a_dash` |
| garbage renders as `Invalid Date` | `test_nothing_ever_reads_invalid_date` |
| the catalog formats its own again | `test_no_timestamp_site_formats_its_own` |
| the config history formats its own again | `test_the_four_sites_go_through_it` |
| the helper is not defined at all | `test_every_page_carries_the_helper` |

`test_the_zone_is_the_browsers_own` is the floor: it renders the same instant under two zones and requires them to differ, so a helper printing a constant would fail rather than pass.
