### PR TITLE
The durable log is served from memory between writes

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -7477,13 +7477,32 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         raw: list[Json] = []
         if not self._local_jsonl_enabled:
             return raw
+        # Served from memory while the shards are unchanged.
+        #
+        # Every call re-read and re-parsed every line of every retained shard, then expanded the
+        # interned metadata over the result -- two full passes over the durable log to answer, for
+        # instance, one memory's history. Measured at 761 ms against a 150-message store, which is
+        # the whole of that call. The compacted view beside this one has been cached on the shard
+        # signature all along; the raw view had no cache at all.
+        #
+        # The log is append-only, so (total size, newest mtime) is the same validity key
+        # `_read_all_compacted` already trusts for itself: any write moves it, and a write is the
+        # only thing that changes what this returns.
         with self._event_log_lock:
-            for path in self._retained_jsonl_paths():
+            paths = self._retained_jsonl_paths()
+            signature = self._jsonl_cache_signature_detail(paths)
+            key = (int(signature.get("total_size", -1)), int(signature.get("max_mtime_ns", -1)))
+            cached = getattr(self, "_raw_records_cache", None)
+            if cached is not None and cached[0] == key:
+                return cached[1]
+            for path in paths:
                 for line in _iter_shard_lines(path):
                     line = line.strip()
                     if line:
                         raw.append(loads_with_interned_keys(line))
-        return expand_interned_records(raw)
+            expanded = expand_interned_records(raw)
+            self._raw_records_cache = (key, expanded)
+        return expanded
 
     def _count_raw_tombstones(self) -> int:
         return sum(

--- a/tools/test_raw_records_served_from_memory.py
+++ b/tools/test_raw_records_served_from_memory.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The raw durable log is served from memory, and a write is still visible immediately.
+
+`_read_raw_records` re-read and re-parsed every line of every retained shard on every call, then
+expanded interned metadata over the result. `history` measured 761 ms against a 150-message store
+and 960 ms at 600; served from memory it is 5 ms.
+
+The risk a cache introduces here is staleness on a durable path: a record written after a read must
+appear in the next one, and a tombstone must be seen by the code that counts them.
+"""
+from __future__ import annotations
+import tempfile, unittest
+from pathlib import Path
+import matrixark_mcp_server as mcp
+
+ANCHOR_MS = 1_780_000_000_000
+
+def _scope(user: str = "alice") -> dict:
+    return {"account_id": "acct_local", "tenant_id": "tenant_raw", "user_id": user,
+            "session_id": "s1", "agent_name": "t"}
+
+class RawRecordsMemoryCase(unittest.TestCase):
+    def test_a_write_is_visible_to_the_next_raw_read(self) -> None:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+            adapter = mcp.MatrixArkLocalAdapter(Path(tmp) / "events.jsonl")
+            server = mcp.MatrixArkMcpServer(adapter, access_mode="dev")
+            self.addCleanup(server.close, timeout_s=1.0)
+            for i in range(4):
+                server.call_tool("matrixark_ingest", {
+                    "messages": [{"role": "user", "content": f"FACT{i}"}],
+                    "scope": _scope(), "ingestion_time_ms": ANCHOR_MS + i * 1000,
+                })
+            first = adapter._read_raw_records()
+            self.assertTrue(first, "the fill must produce raw records")
+            again = adapter._read_raw_records()
+            self.assertEqual(len(first), len(again), "a second read with no write sees the same log")
+
+            # a write must invalidate: the new row has to be in the next raw read
+            server.call_tool("matrixark_ingest", {
+                "messages": [{"role": "user", "content": "AFTERWARDS"}],
+                "scope": _scope(), "ingestion_time_ms": ANCHOR_MS + 90_000,
+            })
+            after = adapter._read_raw_records()
+            self.assertGreater(len(after), len(first),
+                               "a record written after a raw read must appear in the next one")
+            self.assertIn("AFTERWARDS", str(after),
+                          "the raw log went stale: a durable write is missing from it")
+
+    def test_a_delete_is_visible_to_the_raw_reader(self) -> None:
+        """Tombstones live in the raw log, and code counts them there."""
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+            adapter = mcp.MatrixArkLocalAdapter(Path(tmp) / "events.jsonl")
+            server = mcp.MatrixArkMcpServer(adapter, access_mode="dev")
+            self.addCleanup(server.close, timeout_s=1.0)
+            for i in range(3):
+                server.call_tool("matrixark_ingest", {
+                    "messages": [{"role": "user", "content": f"FACT{i}"}],
+                    "scope": _scope(), "ingestion_time_ms": ANCHOR_MS + i * 1000,
+                })
+            adapter._read_raw_records()                     # prime the cache
+            before = adapter._count_raw_tombstones()
+            listed = server.call_tool("matrixark_get_all", {"scope": _scope(), "limit": 1})
+            memory_id = str(listed["memories"][0]["id"])
+            server.call_tool("matrixark_delete", {"scope": _scope(), "memory_id": memory_id})
+            after = adapter._count_raw_tombstones()
+            self.assertGreater(after, before,
+                               "a tombstone written after a raw read must be counted")
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
`_read_raw_records` re-read and re-parsed every line of every retained shard, on every call, and
then walked the result again to expand interned metadata. Nothing cached it, while the compacted
view beside it has been cached on the shard signature all along.

Sixteen call sites pay it, including `history`, the raw tombstone count that gates auto-purge, and
the surviving-source-id scan.

| api, 600 messages | before | after |
|---|---|---|
| `history` | 960.7 ms | **5.2 ms** |
| `retrieve` | 204.5 ms | **44.7 ms** |
| `get_memory` | 3.31 ms | 2.06 ms |
| `list_users` | 5.25 ms | 4.38 ms |

`history` is a lookup by memory id; it was reading and parsing the whole durable log to answer, at
761 ms against a store of only 150 messages.

It is now served from memory while the shards are unchanged, keyed on `(total size, newest mtime)`
across the retained shards -- the same validity key `_read_all_compacted` already trusts for itself.
The log is append-only, so a write is the only thing that changes what this returns, and a write
always moves the signature.

## Test

Two cases, both about staleness on a durable path rather than speed:

* a record written after a raw read must appear in the next one;
* a tombstone written after a raw read must be counted -- a stale count feeds the auto-purge
  decision.

Both verified to FAIL with the invalidation removed: "41 not greater than 41: a record written
after a raw read must appear in the next one" and "0 not greater than 0: a tombstone written after
a raw read must be counted".

The suites that exercise the raw log pass: TTL (8), mem0 completion (27), delete/forget (21),
delete-membership index (14), native read path (11), and interned metadata.
