### PR TITLE
A record cache limit that limited nothing

### DIFF
--- a/tools/matrixark_mcp_direct_cache.py
+++ b/tools/matrixark_mcp_direct_cache.py
@@ -101,8 +101,51 @@ def get_direct_record_cache(target: Any, count: int) -> list[Json] | None:
         return list(records)
 
 
+#: Reported once per process. The point is to tell an operator the ceiling is now binding, not to
+#: print a line on every read once the store has outgrown it.
+_RECORD_CACHE_DECLINE_REPORTED = False
+
+
+def _log_record_cache_declined(record_count: int, limit: int) -> None:
+    global _RECORD_CACHE_DECLINE_REPORTED
+    if _RECORD_CACHE_DECLINE_REPORTED:
+        return
+    _RECORD_CACHE_DECLINE_REPORTED = True
+    try:  # package path
+        from tools.matrixark_mcp_core import _mcp_debug_log
+    except ImportError:  # Direct script execution from tools/.
+        from matrixark_mcp_core import _mcp_debug_log
+    _mcp_debug_log(
+        f"matrixark record cache disabled: {record_count} records exceeds "
+        f"MATRIXARK_DIRECT_RECORD_HOT_CACHE_MAX_RECORDS={limit}; reads will reload the store "
+        f"each time until the limit is raised"
+    )
+
+
+def direct_record_cache_max_records() -> int:
+    """The documented ceiling on how many records one cache entry may hold.
+
+    Read at call time, not captured at import, so raising the limit does not require restarting
+    every hook process to take effect. 0 or a negative value means no ceiling.
+    """
+    try:
+        return int(os.environ.get("MATRIXARK_DIRECT_RECORD_HOT_CACHE_MAX_RECORDS", "20000"))
+    except (TypeError, ValueError):
+        return 20000
+
+
 def put_direct_record_cache(target: Any, count: int, records: list[Json]) -> None:
     if not target.python_hot_cache_enabled():
+        return
+    # Honour the limit the portal offers. It was carried through config and presented as a live
+    # setting while nothing read it, so a deployment that set it to bound memory got no bound and
+    # the entry held the whole decoded store however large it grew.
+    limit = direct_record_cache_max_records()
+    if limit > 0 and len(records) > limit:
+        # Said out loud. A cache that stops serving looks exactly like one that is working, only
+        # slower, and that is how a 20x read regression hides.
+        _log_record_cache_declined(len(records), limit)
+        drop_direct_record_cache(target)
         return
     with _DIRECT_RECORD_CACHE_LOCK:
         if len(_DIRECT_RECORD_CACHE) >= _DIRECT_RECORD_CACHE_MAX_PREFIXES and direct_cache_scope(target) not in _DIRECT_RECORD_CACHE:

--- a/tools/test_the_record_cache_limit_must_limit.py
+++ b/tools/test_the_record_cache_limit_must_limit.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The record-cache size limit has to actually limit something.
+
+`MATRIXARK_DIRECT_RECORD_HOT_CACHE_MAX_RECORDS` (default 20,000) is defined in two modules, carried
+through `matrixark_load_config`, and offered in the portal — `test_matrixark_the_portal_offers_what
+_the_config_file_does` asserts it is presented as a live setting. Nothing read it. The only bound
+applied was `_DIRECT_RECORD_CACHE_MAX_PREFIXES`, which caps how many STORES are cached, not how many
+records an entry holds.
+
+An operator setting it to bound memory therefore got no bound, and the entry retained the whole
+decoded record list for a store of any size. Harmless while the cache was off for native backends;
+not harmless once it is on.
+
+These pin the limit from both sides, because only enforcing it is half a setting: under the limit
+the cache must still serve (or the fix is just a slower cache), and over it the cache must decline
+AND say so — a cache that stops serving looks exactly like one that is working, only slower.
+"""
+from __future__ import annotations
+
+import os
+import unittest
+
+try:  # package path
+    from tools import matrixark_mcp_direct_cache as cache
+except ImportError:  # run from tools/
+    import matrixark_mcp_direct_cache as cache  # type: ignore
+
+
+ENV = "MATRIXARK_DIRECT_RECORD_HOT_CACHE_MAX_RECORDS"
+
+
+class _Target:
+    """The handful of attributes the cache helpers touch."""
+
+    def __init__(self, namespace="ns1", table="t1", prefix="matrixark:mcp"):
+        import threading
+        self._namespace = namespace
+        self._table = table
+        self._storage_prefix = prefix
+        self._entry_count_cache = None
+        self._records_cache = None
+        self._index_cache = None
+        self._retrieval_candidate_cache = {}
+        self._retrieval_candidate_cache_lock = threading.RLock()
+
+    def python_hot_cache_enabled(self) -> bool:
+        return True
+
+
+def _records(n):
+    return [{"record_type": "context_event", "i": i} for i in range(n)]
+
+
+class RecordCacheLimitTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._previous = os.environ.get(ENV)
+        with cache._DIRECT_RECORD_CACHE_LOCK:
+            cache._DIRECT_RECORD_CACHE.clear()
+        cache._RECORD_CACHE_DECLINE_REPORTED = False
+
+    def tearDown(self) -> None:
+        if self._previous is None:
+            os.environ.pop(ENV, None)
+        else:
+            os.environ[ENV] = self._previous
+        with cache._DIRECT_RECORD_CACHE_LOCK:
+            cache._DIRECT_RECORD_CACHE.clear()
+        cache._RECORD_CACHE_DECLINE_REPORTED = False
+
+    def test_a_record_set_over_the_limit_is_not_cached(self) -> None:
+        os.environ[ENV] = "10"
+        target = _Target()
+        cache.put_direct_record_cache(target, 25, _records(25))
+        self.assertIsNone(
+            cache.get_direct_record_cache(target, 25),
+            "the documented record limit did not bound the cache",
+        )
+
+    def test_under_the_limit_the_cache_still_serves(self) -> None:
+        # Without this the "fix" could simply be a cache that never caches.
+        os.environ[ENV] = "10"
+        target = _Target()
+        cache.put_direct_record_cache(target, 5, _records(5))
+        self.assertEqual(_records(5), cache.get_direct_record_cache(target, 5))
+
+    def test_declining_is_reported(self) -> None:
+        os.environ[ENV] = "10"
+        seen = []
+        target = _Target()
+        original = cache._log_record_cache_declined
+        cache._log_record_cache_declined = lambda n, limit: seen.append((n, limit))
+        try:
+            cache.put_direct_record_cache(target, 25, _records(25))
+        finally:
+            cache._log_record_cache_declined = original
+        self.assertEqual([(25, 10)], seen, "the cache went quiet instead of saying it declined")
+
+    def test_zero_means_no_ceiling(self) -> None:
+        os.environ[ENV] = "0"
+        target = _Target()
+        cache.put_direct_record_cache(target, 50, _records(50))
+        self.assertEqual(50, len(cache.get_direct_record_cache(target, 50) or []))
+
+    def test_the_limit_is_read_at_call_time(self) -> None:
+        # Captured at import, a deployment raising the limit would have to restart every hook.
+        os.environ[ENV] = "10"
+        self.assertEqual(10, cache.direct_record_cache_max_records())
+        os.environ[ENV] = "40"
+        self.assertEqual(40, cache.direct_record_cache_max_records())
+
+    def test_an_unparseable_limit_falls_back_to_the_documented_default(self) -> None:
+        os.environ[ENV] = "not-a-number"
+        self.assertEqual(20000, cache.direct_record_cache_max_records())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`MATRIXARK_DIRECT_RECORD_HOT_CACHE_MAX_RECORDS` is defined in two modules, carried through
`matrixark_load_config`, and **offered in the portal** — `test_matrixark_the_portal_offers_what_the_config_file_does`
asserts it is presented as a live setting. Nothing read it.

The only bound `put_direct_record_cache` applied was `_DIRECT_RECORD_CACHE_MAX_PREFIXES`, which caps
how many *stores* are cached, not how many records an entry holds. So an operator who set this limit
to bound memory got no bound, and the entry retained the whole decoded record list for a store of any
size.

That was harmless while the record cache was off for native backends. It stops being harmless the
moment it is on: the cache then holds every decoded record in the process, and the setting that
claims to cap it does nothing.

### The change

`put_direct_record_cache` now honours the documented limit, and **says so when it declines**:

```
matrixark record cache disabled: 41000 records exceeds
MATRIXARK_DIRECT_RECORD_HOT_CACHE_MAX_RECORDS=20000; reads will reload the store each time
until the limit is raised
```

Reported once per process — enough to tell an operator the ceiling is now binding, without a line on
every read.

The message matters as much as the bound. A cache that stops serving looks exactly like one that is
working, only slower, and that is how two separate read regressions stayed invisible here: a
completed context pack discarded for missing its deadline, and one undecodable record turning a
batched read into 33,434 single fetches. Both were silent for the same reason.

The limit is read at call time rather than captured at import, so raising it does not require
restarting every hook process.

`0` means no ceiling, and an unparseable value falls back to the documented default rather than
disabling the cache — a typo in a limit should not quietly change behaviour.

### Tests

`tools/test_the_record_cache_limit_must_limit.py` pins it from both sides, because only enforcing the
limit is half a setting:

- over the limit, the entry is not cached — against unmodified code this fails with
  `the documented record limit did not bound the cache`, showing all 25 records cached against a
  limit of 10
- **under** the limit the cache still serves, so the change cannot be a cache that never caches
- declining is reported, not silent
- `0` means unlimited; an unparseable value falls back to 20000; the limit is re-read per call

`test_direct_record_cache`, `test_matrixark_the_portal_offers_what_the_config_file_does`,
`test_a_setting_declares_the_default_the_code_applies` and `test_a_module_only_tests_reach_is_not_live`
all pass on this branch.

### Note on behaviour

On a deployment already above the limit this makes the cache stop serving where it previously served
unbounded — visibly, with the log line above, and adjustable by raising the setting. That is the
setting doing what it says. A store under the limit is unaffected.
