### PR TITLE
Two methods written out twice, now written once

### DIFF
--- a/tools/matrixark_context_backfill.py
+++ b/tools/matrixark_context_backfill.py
@@ -409,11 +409,13 @@ class LocalJsonKV:
         return dict(self.data['hashes'].get(key, {}))
 
 
-class MatrixKVRecordLog:
-    def __init__(self, kv: Any, *, prefix: str, shard_size: int = DIRECT_RECORD_LOG_SHARD_SIZE) -> None:
-        self.kv = kv
-        self.prefix = prefix.rstrip(':')
-        self.shard_size = shard_size
+class _RecordCountFromKV:
+    """The record count, read from the key both a log and a backfill target keep it under.
+
+    Written out once in each class before this. The two bodies were byte-identical, and both
+    classes set `kv` and `prefix`, so the read has only ever had one definition's worth of
+    meaning -- a second copy could only ever drift from the first.
+    """
 
     def count(self) -> int:
         raw = self.kv.get_string(f'{self.prefix}:record_count')
@@ -421,6 +423,14 @@ class MatrixKVRecordLog:
             return max(0, int(raw)) if raw else 0
         except ValueError:
             return 0
+
+
+class MatrixKVRecordLog(_RecordCountFromKV):
+    def __init__(self, kv: Any, *, prefix: str, shard_size: int = DIRECT_RECORD_LOG_SHARD_SIZE) -> None:
+        self.kv = kv
+        self.prefix = prefix.rstrip(':')
+        self.shard_size = shard_size
+
 
     def legacy_index(self) -> list[str]:
         raw = self.kv.get_string(f'{self.prefix}:record_index')
@@ -770,7 +780,7 @@ def run_read_raw_event(args: argparse.Namespace) -> Json:
     return event
 
 
-class MatrixKVBackfillTarget:
+class MatrixKVBackfillTarget(_RecordCountFromKV):
     def __init__(
         self,
         kv: Any,
@@ -785,12 +795,6 @@ class MatrixKVBackfillTarget:
         self.shard_size = shard_size
         self._next_sequence: int | None = None
 
-    def count(self) -> int:
-        raw = self.kv.get_string(f'{self.prefix}:record_count')
-        try:
-            return max(0, int(raw)) if raw else 0
-        except ValueError:
-            return 0
 
     def _idempotency_key(self, record: Json) -> str:
         key = str(record.get('idempotency_key') or '')

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -3078,7 +3078,31 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
 
 
 
-class MatrixArkRustCdylibClient:
+class _AppendRecordsViaBatch:
+    """`matrixark_append_records` as the batch call it has always delegated to.
+
+    Both clients wrote this out identically: it forwards every argument to
+    `matrixark_batch_append_records` and adds nothing. Keeping one copy means the single-record
+    entry point cannot come to disagree with the batch one about what it forwards.
+    """
+
+    def matrixark_append_records(
+        self,
+        entries: list[Json],
+        *,
+        count_key: str | None = None,
+        count_value: str | None = None,
+        append_options: Json | None = None,
+    ) -> None:
+        self.matrixark_batch_append_records(
+            entries,
+            count_key=count_key,
+            count_value=count_value,
+            append_options=append_options,
+        )
+
+
+class MatrixArkRustCdylibClient(_AppendRecordsViaBatch):
     """In-process Rust direct SDK binding loaded through the Rust cdylib C ABI."""
 
     def __init__(
@@ -3261,20 +3285,6 @@ class MatrixArkRustCdylibClient:
             self._check(code, error)
         self._call("matrixark_batch_append_records", call, records_written=len(values) + (1 if count_key else 0))
 
-    def matrixark_append_records(
-        self,
-        entries: list[Json],
-        *,
-        count_key: str | None = None,
-        count_value: str | None = None,
-        append_options: Json | None = None,
-    ) -> None:
-        self.matrixark_batch_append_records(
-            entries,
-            count_key=count_key,
-            count_value=count_value,
-            append_options=append_options,
-        )
 
     def matrixark_scan_candidates(self, *, count_key: str, record_hash_key: str, shard_size: int, scope: Json, record_types: list[str], secondary_index_groups: list[list[str]], selected_node_hashes: list[int], record_ids: list[str] | None = None, return_index_records: bool = False, newest_by_type: Json | None = None) -> Json:
         payload: Json = {"scope": scope, "record_types": record_types, "secondary_index_groups": secondary_index_groups, "selected_node_hashes": selected_node_hashes}
@@ -3439,7 +3449,7 @@ def _caller_deadline_ms(kwargs: Json) -> int:
     return 0
 
 
-class MatrixArkRustProxyClient:
+class MatrixArkRustProxyClient(_AppendRecordsViaBatch):
     """Persistent Rust proxy boundary around the Rust TemporalStore SDK.
 
     The Rust binary owns SDK linkage and runs in JSON-lines ``--serve`` mode as
@@ -4358,20 +4368,6 @@ class MatrixArkRustProxyClient:
             append_options=append_options or {},
         )
 
-    def matrixark_append_records(
-        self,
-        entries: list[Json],
-        *,
-        count_key: str | None = None,
-        count_value: str | None = None,
-        append_options: Json | None = None,
-    ) -> None:
-        self.matrixark_batch_append_records(
-            entries,
-            count_key=count_key,
-            count_value=count_value,
-            append_options=append_options,
-        )
 
     def matrixark_retrieve_context_pack(
         self,


### PR DESCRIPTION
Two methods written out identically in two classes each are now written once, as a small mixin in
the same file.

The larger point is what the other duplicated methods turned out to be. `tools/` looked like it
held 232 lines of duplicated method bodies; almost none of it was duplication to collapse:

| | lines |
|---|---|
| a dead island's copy of a live class | ~109 |
| a stale extraction the live code has moved past | ~47 |
| identical bodies under different method names | ~36 |
| **genuinely duplicated live methods** | **40** |

**The dead island.** `MatrixArkRustProxyClient` exists twice: once in `matrixark_mcp_temporal_adapters`
and once in `matrixark_mcp_rust_proxy_client`, which is part of a ten-module island nothing in
production reaches. Six method groups are that one class's copy. Removing an unreachable island is
its own change, not this one.

**The stale extraction.** `LatestContextStateAdapterMixin` has no users at all, and shares seven
method names with `_TemporalDirectBackendMixin` — but only two bodies match. The other five have
diverged: `_with_latest_context_state_records` is 4 lines there against 33 in the live code,
`_split_compacted_latest_context_state` 10 against 21. It is not a component the live code should
adopt; it is an extraction the live code moved past, and wiring it in would regress five methods to
older implementations.

## What this change does

Two cases where both classes are reachable, both bodies byte-identical, and both classes live in
the same file:

- `count` in `MatrixKVRecordLog` and `MatrixKVBackfillTarget` -> `_RecordCountFromKV`
- `matrixark_append_records` in `MatrixArkRustCdylibClient` and `MatrixArkRustProxyClient`
  -> `_AppendRecordsViaBatch`

A mixin rather than a module-level function because the bodies use `self`. Before extracting, each
class was checked to provide every attribute the body reaches — `kv` and `prefix` for the first,
`matrixark_batch_append_records` for the second — since two identical bodies still need the same
attributes on both classes. All four classes had no bases, so adding one cannot create a
method-resolution conflict.

## Verification

By object identity, the same way the function consolidations were checked: each method resolves on
every class, is the **same object** on both, and that object is the mixin's. Calling both and
comparing answers would pass just as well with two copies still present.

The whole `tools/` suite ran before and after with the control pinned to this exact commit:
**394 of 394 files on both sides, 357 pass / 37 fail on each, zero tests failing only after.**
