### PR TITLE
A retrieve that raised was read as an answer

### DIFF
--- a/tools/matrixark_hook_pack_cache.py
+++ b/tools/matrixark_hook_pack_cache.py
@@ -146,6 +146,18 @@ def store_answered(retrieve: object) -> bool:
     """
     if not isinstance(retrieve, dict) or retrieve.get("_hook_tool_timeout"):
         return False
+    # A retrieve that RAISED is not an answer. The dispatcher replaces it with a deadline fallback
+    # pack, which carries a `context_pack_id` like any other -- so without this the checks below
+    # read a failure as an answer and suppress the previous-pack fallback exactly when it is needed.
+    # Seen live: a turn served 0 bytes while a 7,886-byte pack sat in the cache, 18.7 min old
+    # against a 1,440-min ceiling.
+    #
+    # Only the EXCEPTION path counts. `request_deadline_after_retrieve` means the retrieve finished
+    # and was merely late; those packs carry real refs, and serving a stale pack over a fresh one
+    # would be worse than the bug this fixes.
+    if any("request_deadline_exception" in str(warning)
+           for warning in retrieval_warnings(retrieve)):
+        return False
     return any(bool(retrieve.get(key)) for key in
                ("pack_id", "context_pack_id", "context", "refs", "selected_refs"))
 

--- a/tools/test_a_retrieve_that_raised_is_not_an_answer.py
+++ b/tools/test_a_retrieve_that_raised_is_not_an_answer.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A retrieve that RAISED is not an answer, and must not suppress the previous-pack fallback.
+
+Observed live under load: a turn took 344.8 s and served the agent 0 bytes, with
+
+    warnings    = ["retrieval_deadline_exceeded:request_deadline_exception", "request_deadline_exception"]
+    pack_source = None
+
+`request_deadline_exception` is the raise path — `adapter.retrieve` threw and the dispatcher
+substituted an empty deadline fallback pack, which is right, because there is no pack to serve
+there. What was wrong is that the hook's last-good-pack fallback did not fire: the fallback pack
+carries a `context_pack_id` like any other, so `store_answered()` read a failure as an answer. A
+7,886-byte pack was in the cache at that moment, 18.7 minutes old against a 1,440-minute ceiling.
+
+The boundary is the whole point of these tests. `request_deadline_after_retrieve` means the retrieve
+FINISHED and was merely late; mx#1214 stopped those packs being discarded, so they carry real refs
+and must keep suppressing the stale fallback. Serving stale context over fresh context would be
+worse than the bug being fixed.
+"""
+from __future__ import annotations
+
+import unittest
+
+try:  # package path
+    from tools import matrixark_hook_pack_cache as pack_cache
+except ImportError:  # run from tools/
+    import matrixark_hook_pack_cache as pack_cache  # type: ignore
+
+
+class StoreAnsweredTest(unittest.TestCase):
+    def test_a_raised_retrieve_did_not_answer(self) -> None:
+        pack = {
+            "context_pack_id": "deadline-fallback",
+            "warnings": ["retrieval_deadline_exceeded:request_deadline_exception",
+                         "request_deadline_exception"],
+        }
+        self.assertFalse(
+            pack_cache.store_answered(pack),
+            "a raised retrieve read as an answer, suppressing the previous-pack fallback",
+        )
+
+    def test_the_full_pack_spelling_is_recognised_too(self) -> None:
+        # The compact serving pack says `warnings`; the uncompacted one says `quality_warnings`.
+        pack = {"context_pack_id": "x", "quality_warnings": ["request_deadline_exception"]}
+        self.assertFalse(pack_cache.store_answered(pack))
+
+    def test_a_late_but_complete_pack_IS_an_answer(self) -> None:
+        # The boundary. This pack finished and carries refs; serving a stale pack instead would be
+        # a regression, not a fix.
+        pack = {
+            "context_pack_id": "rust-native-1-2",
+            "warnings": ["request_deadline_after_retrieve"],
+            "selected_refs": [{"text": "a real ref"}],
+        }
+        self.assertTrue(
+            pack_cache.store_answered(pack),
+            "a late but complete pack was treated as a failure",
+        )
+
+    def test_an_ordinary_pack_is_still_an_answer(self) -> None:
+        self.assertTrue(pack_cache.store_answered({"context_pack_id": "plain"}))
+
+    def test_a_deliberately_empty_answer_is_still_an_answer(self) -> None:
+        # A turn whose pack renders to nothing on purpose must not get stale context injected.
+        self.assertTrue(pack_cache.store_answered({"context_pack_id": "empty", "warnings": []}))
+
+    def test_a_tool_timeout_is_still_not_an_answer(self) -> None:
+        self.assertFalse(pack_cache.store_answered({"context_pack_id": "x", "_hook_tool_timeout": True}))
+
+    def test_a_non_dict_is_not_an_answer(self) -> None:
+        self.assertFalse(pack_cache.store_answered(None))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Observed live under load (loadavg 29.7): a hook turn took 344.8 s and served the agent **0 bytes**.

```
warnings    = ["retrieval_deadline_exceeded:request_deadline_exception", "request_deadline_exception"]
pack_source = None
```

`request_deadline_exception` is the raise path in `dispatch_matrixark_tool`: `adapter.retrieve`
threw, so the dispatcher substitutes `_retrieve_timeout_fallback`, which on a native backend builds
from `records = []`. **That substitution is correct** — there is no pack to serve there, and it is
deliberately untouched.

What is wrong is what happens next. The hook has a last-good-pack fallback for exactly this case and
it did not fire — `pack_source` is unset. `store_answered()` gates it, and it answers on the presence
of an id:

```python
return any(bool(retrieve.get(key)) for key in
           ("pack_id", "context_pack_id", "context", "refs", "selected_refs"))
```

The deadline fallback pack carries a `context_pack_id` like any other, so a failure reads as an
answer. Measured at the moment of that failure: a previous pack was cached, **7,886 bytes, 18.7
minutes old, against a 1,440-minute ceiling**. The agent was told it had no history while that sat
one call away.

### The change

`store_answered()` now returns False when the pack reports `request_deadline_exception`, using the
`retrieval_warnings()` helper so it reads both the compact spelling (`warnings`) and the full one
(`quality_warnings`).

### The boundary, which is the point

Only the **exception** path counts as unanswered:

- `request_deadline_exception` — the retrieve threw; the pack is a stub and nothing was computed.
- `request_deadline_after_retrieve` — the retrieve **completed** and was merely late. Those packs
  carry real refs, so they are answers and must keep suppressing the stale-pack fallback. Treating
  lateness as failure would serve stale context in place of fresh context, which is worse than the
  bug being fixed.

A turn whose pack renders to nothing *on purpose* also still counts as answered, so nothing injects
stale context into a turn that deliberately has none.

### Tests

`tools/test_a_retrieve_that_raised_is_not_an_answer.py`. Against unmodified code two fail, one with
`a raised retrieve read as an answer, suppressing the previous-pack fallback`. Five pass on both
arms, pinning what must not change: a late-but-complete pack is still an answer, an ordinary pack is
still an answer, a deliberately empty answer is still an answer, a tool timeout is still not one.

Every suite touching this code passes on the branch:
`test_a_failure_notice_is_never_remembered_as_a_pack`,
`test_a_late_context_pack_is_served_not_discarded`,
`test_a_turn_that_cannot_build_a_pack_serves_the_last_one`,
`test_matrixark_the_previous_pack_is_for_a_turn_that_got_no_answer` — which pins these exact
semantics — and `test_sibling_worktrees_share_one_context_pack`.
