### PR TITLE
Retire two engine switches nothing selects the off position of

### DIFF
--- a/config/temporalstore.toml
+++ b/config/temporalstore.toml
@@ -79,9 +79,8 @@ page_store_compression_level = 3       # TS_PAGE_STORE_COMPRESSION_LEVEL    comp
 # which are both the smallest and the most repetitive in the system. Compressing everything is
 # worse again: at a 1-byte floor the saving stops and the median add rises to 256.0 ms.
 page_store_compression_min_bytes = 256  # TS_PAGE_STORE_COMPRESSION_MIN_BYTES  skip compressing pages smaller than this
-cross_shard_reclaim_guard = 1          # TS_CROSS_SHARD_RECLAIM_GUARD  1 = retain slabs referenced by ANY loaded shard during GC (safe default; 0 = legacy per-shard, unsafe under multi-shard hosting)
 index_dump_oplog_gap_bytes = 1048576   # TS_INDEX_DUMP_WAL_GAP_BYTES  undumped index-log gap (bytes, 1 MiB) that triggers a background catalog/index dump under the manifest-parity catalog fold (TS_INDEX_CATALOG_FOLD); 0 disables the threshold cadence. TS_INDEX_DUMP_OPLOG_GAP_BYTES is the previous variable name, still honoured by the engine when this one is unset
-# index_catalog_fold = 1               # TS_INDEX_CATALOG_FOLD  1 = fold the band/zone catalog into the index-log MetaItem (reference conformance) and drive it via the threshold dump above, instead of the per-write band-manifest file. Ships OFF (byte-identical); uncomment to enable.
+# index_catalog_fold = 1               # TS_INDEX_CATALOG_FOLD  1 = fold the band/zone catalog into the index-log MetaItem and drive it via the threshold dump above, instead of the per-write band-manifest file. Ships ON: the engine defaults it on and reads it in eight places, so this line is the way to turn it OFF, not on.
 
 
 # -----------------------------------------------------------------------------

--- a/crates/temporalstore-rust/src/data_node/task_execution.rs
+++ b/crates/temporalstore-rust/src/data_node/task_execution.rs
@@ -175,12 +175,7 @@ pub(super) fn run_gc_inner(inner: &DataNodeRuntimeInner, request: GcRequest) -> 
             // One engine shares a single page_store across every shard it hosts, so a slab can
             // hold pages from multiple shards. Retain slabs live in ANY loaded shard, not just
             // this request's shard; a per-shard live set would delete another shard's live pages.
-            let mut live_page_slab_ids =
-                if crate::engine::cross_shard_reclaim_guard_enabled() {
-                    inner.engine.live_page_slab_ids_all_shards()
-                } else {
-                    inner.engine.live_page_slab_ids(request.shard_id)
-                };
+            let mut live_page_slab_ids = inner.engine.live_page_slab_ids_all_shards();
             // Retain any page slab still referenced by a durable bucket-dump manifest. The
             // operator /gc RPC must not delete a slab a retained manifest needs: a lagging
             // follower's replay or a snapshot-install reads it, and deleting it makes the

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -42,7 +42,6 @@ pub(crate) mod eviction_sampler;
 // which previously kept a drifted subset that mis-classified context/control-state writes
 // as reads -> lifecycle-write-barrier bypass + missing dump scheduling).
 pub(crate) use command_validation::{command_object_keys, is_write_command};
-pub(crate) use storage_manager_cycle::cross_shard_reclaim_guard_enabled;
 #[cfg(test)]
 pub(crate) use storage_bucket_internals::uncovered_maintenance;
 mod storage_bucket_internals;

--- a/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
+++ b/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
@@ -2,25 +2,17 @@
 // Copyright 2026 MatrixArkAI
 
 //! Storage-manager cycle + merged-dump policy report for TemporalEngine, split from engine.rs.
-use super::*;
+//!
+//! CROSS-SHARD RECLAIM, always on. Page-slab reclaim retains any slab referenced by ANY shard
+//! loaded into this engine, not only the shard whose cycle is running: one engine shares a single
+//! page_store across all its shards with a global slab cursor, so a slab can hold committed pages
+//! from multiple shards, and driving GC off a single shard's live set deletes another shard's live
+//! pages (silent data loss). `TS_CROSS_SHARD_RECLAIM_GUARD` used to be able to restore the legacy
+//! per-shard live set; nothing selected that position, and it was unsafe under multi-shard hosting
+//! by construction. For a single loaded shard the union equals that shard's live set, so
+//! single-shard behavior was byte-identical either way.
 
-/// TS_CROSS_SHARD_RECLAIM_GUARD (default ON): page-slab reclaim retains any slab referenced by
-/// ANY shard loaded into this engine, not only the shard whose cycle is running. One engine
-/// shares a single page_store across all its shards with a global slab cursor, so a slab can hold
-/// committed pages from multiple shards; driving GC off a single shard's live set deletes another
-/// shard's live pages (silent data loss). Set to "0"/"false"/"no"/"off" to restore the legacy
-/// per-shard live set (a kill-switch only; unsafe under multi-shard hosting). For a single loaded
-/// shard the union equals that shard's live set, so single-shard behavior is byte-identical.
-pub(crate) fn cross_shard_reclaim_guard_enabled() -> bool {
-    !matches!(
-        std::env::var("TS_CROSS_SHARD_RECLAIM_GUARD")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "0" | "false" | "no" | "off"
-    )
-}
+use super::*;
 
 impl TemporalEngine {
     pub fn run_storage_manager_cycle(
@@ -310,13 +302,9 @@ impl TemporalEngine {
                 .unwrap_or_default()
                 .saturating_add(1);
             // Retain slabs live in ANY shard sharing this engine's page_store, not just the
-            // shard being cycled (see cross_shard_reclaim_guard_enabled): otherwise a slab whose
-            // pages belong to another shard is absent from this shard's live set and gets deleted.
-            let reclaim_live_refs = if cross_shard_reclaim_guard_enabled() {
-                self.live_page_slab_ids_all_shards()
-            } else {
-                plan.live_page_slab_ids.clone()
-            };
+            // shard being cycled (see the module header): otherwise a slab whose pages belong to
+            // another shard is absent from this shard's live set and gets deleted.
+            let reclaim_live_refs = self.live_page_slab_ids_all_shards();
             match self.page_store.gc_slabs_before_with_live_refs_policy(
                 retain_from_page_slab_id,
                 reclaim_live_refs,

--- a/crates/temporalstore-rust/src/scratch.rs
+++ b/crates/temporalstore-rust/src/scratch.rs
@@ -73,24 +73,13 @@ pub(crate) fn owned_scratch_dir(kind: &str) -> Arc<ScratchDirGuard> {
     })
 }
 
-/// TS_SCRATCH_SWEEP: reclaim scratch directories whose owning process is gone. Default ON;
-/// set to a falsey value to leave abandoned directories in place.
-fn sweep_enabled() -> bool {
-    !matches!(
-        std::env::var("TS_SCRATCH_SWEEP")
-            .unwrap_or_default()
-            .to_ascii_lowercase()
-            .as_str(),
-        "0" | "false" | "no" | "off"
-    )
-}
-
 fn arm_background_sweep() {
+    // Always armed. `TS_SCRATCH_SWEEP` used to be able to skip it. Nothing selected the off
+    // position, and what it bought was a directory belonging to an exited process left on
+    // disk -- which the sweep already reports before removing, and which only a live process
+    // is ever kept for.
     static ARMED: std::sync::Once = std::sync::Once::new();
     ARMED.call_once(|| {
-        if !sweep_enabled() {
-            return;
-        }
         std::thread::spawn(|| {
             let report = sweep_dead_scratch_dirs(&std::env::temp_dir());
             if report.removed > 0 || report.failed > 0 {

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -8,7 +8,7 @@ within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 290 of them, read by 91 functions.
+There are 288 of them, read by 89 functions.
 
 Deleting unreachable code is not the lever. An earlier version of this document argued that
 by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
@@ -60,13 +60,13 @@ Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 290 |
-| booleans whose default this could read off the source | 50 |
+| total | 288 |
+| booleans whose default this could read off the source | 48 |
 | numbers whose default this could read off the source | 70 |
 | **defaulting on, and set by nothing** | 5 |
-| offered on the portal | 28 |
+| offered on the portal | 27 |
 | **that nothing in this repository sets** | 157 |
-| documented as keeping an older path alive | 5 |
+| documented as keeping an older path alive | 4 |
 | reaching more than two files | 15 |
 | whose doc comment is really about another flag | 43 |
 
@@ -173,7 +173,7 @@ Secrets. Never a form field, never in a launch artifact.
 | `TS_API_AUTH_TOKEN` | — | nothing | 1 | — |
 | `TS_META_ADMIN_TOKEN` | — | nothing | 1 | — |
 
-## durability (23)
+## durability (22)
 
 What is written, when it is flushed, and what is reclaimed. The escape hatches here trade throughput for a more conservative barrier.
 
@@ -183,7 +183,6 @@ What is written, when it is flushed, and what is reclaimed. The escape hatches h
 | `TS_RAFT_SNAPSHOT_CHECK_INTERVAL_MS` | 30000 | nothing | 2 | — |
 | `MATRIXARK_RUST_PROXY_LOG_RECLAIM_INTERVAL_MS` | 1000 | nothing | 1 | — |
 | `TS_BARRIER_PROFILE_WRITES` | 50 | nothing | 1 | — |
-| `TS_CROSS_SHARD_RECLAIM_GUARD` | on | config | 1 | yes |
 | `TS_DATA_NODE_LIFECYCLE_SNAPSHOT` | — | nothing | 1 | — |
 | `TS_INDEX_DUMP_WAL_GAP_BYTES` | 1048576 | config, portal | 1 | — |
 | `TS_META_RAFT_SNAPSHOT_CHECK_INTERVAL_MS` | 30000 | nothing | 1 | — |
@@ -368,7 +367,7 @@ Read only by the benchmark harnesses. Never consulted on a serving path.
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_SELECTED_ID_LIMIT` | 128 | script | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_SOURCE_ORDER_RANKING` | off | script | 1 | — |
 
-## behaviour (62)
+## behaviour (61)
 
 Everything else that changes what the engine does.
 
@@ -421,7 +420,6 @@ Everything else that changes what the engine does.
 | `TS_RAFT_REPLICATION_DEADLINE_MS` | — | test | 1 | — |
 | `TS_RAFT_SECURITY_MODE` | — | nothing | 1 | — |
 | `TS_RAFT_TRANSPORT_SECURITY` | — | nothing | 1 | — |
-| `TS_SCRATCH_SWEEP` | on | portal | 1 | — |
 | `TS_SERVER_JOIN_EMPTY` | off | script | 1 | — |
 | `TS_SERVER_RAFT` | off | nothing | 1 | — |
 | `TS_SERVER_RAFT_READ_MODE` | — | nothing | 1 | — |

--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -815,11 +815,6 @@ SETTINGS: List[Setting] = [
             "On, the engine asks the allocator to hand back memory it is no longer using. What is "
             "returned is memory the process was not using, so the trade is one-sided -- the escape "
             "hatch exists because a trim costs a walk of the allocator's free lists."),
-    Setting("storage_engine.scratch_sweep", "storage_engine",
-            "TS_SCRATCH_SWEEP",
-            "Reclaim scratch directories from dead processes", "bool", "1", "live",
-            "On, scratch directories whose owning process is gone are reclaimed. Turn it off only "
-            "to keep an abandoned directory for inspection."),
     Setting("storage_engine.max_retained_finished_jobs", "storage_engine",
             "TS_MAX_RETAINED_FINISHED_JOBS",
             "Completed job statuses kept queryable", "int", "64", "live",

--- a/tools/matrixark_load_config.py
+++ b/tools/matrixark_load_config.py
@@ -89,7 +89,6 @@ ENV_MAP: Dict[str, str] = {
     "storage.page_store_compression_enabled": "TS_PAGE_STORE_COMPRESSION_ENABLED",
     "storage.page_store_compression_level": "TS_PAGE_STORE_COMPRESSION_LEVEL",
     "storage.page_store_compression_min_bytes": "TS_PAGE_STORE_COMPRESSION_MIN_BYTES",
-    "storage.cross_shard_reclaim_guard": "TS_CROSS_SHARD_RECLAIM_GUARD",
     # Offered by the config file, commented out, and mapped by nothing -- so uncommenting the line
     # would have set nothing. The flag is live: default ON, read in eight places.
     "storage.index_catalog_fold": "TS_INDEX_CATALOG_FOLD",


### PR DESCRIPTION
Two boolean switches in the engine default ON, and nothing anywhere selects the off
position — not a test, not a launcher, not a config file, not a shell script, and not a
struct field reached by some route other than the variable. A switch no one can be shown
to turn off is not a switch, it is a branch. Both are made unconditional here and the dead
side deleted.

## `TS_CROSS_SHARD_RECLAIM_GUARD`

Page-slab reclaim retains any slab that any shard loaded into this engine still points at, not
only the shard whose cycle is running. One engine shares a single page_store across all
its shards with a global slab cursor, so a slab can hold committed pages from several
shards; driving GC off a single shard's live set deletes another shard's live pages.

The off side restored that per-shard live set. Its own doc comment called it "a kill-switch
only; unsafe under multi-shard hosting" — so the branch that existed to be selected was
the one documented as causing silent data loss, and for a single loaded shard it computed
the same set anyway. Two call sites (the storage-manager cycle and the operator `/gc` RPC)
now call `live_page_slab_ids_all_shards()` directly.

## `TS_SCRATCH_SWEEP`

Scratch directories whose owning process has exited are reclaimed on a background thread,
armed once. Off, the thread was never spawned and an abandoned directory stayed on disk.
The sweep already keeps anything belonging to a live process, anything whose name does not
parse, and everything on a platform where liveness cannot be checked, so what the off side
protected was a dead process's directory — and the sweep prints what it removed.

## Also

`config/temporalstore.toml` described `index_catalog_fold` as "Ships OFF (byte-identical);
uncomment to enable". The engine defaults it **on** and reads it in eight places, so that
line told an operator the opposite of what the code does: uncommenting `= 1` changes
nothing, and the only thing the line is good for is turning the fold off. Corrected to say
so.

## What moved

- Engine: `cross_shard_reclaim_guard_enabled()` and `sweep_enabled()` deleted, both call
  sites and the arming guard unconditional, and the reclaim rationale kept as the
  `storage_manager_cycle` module header rather than as an accessor doc comment for a
  function that no longer exists.
- Surfaces: the `[storage] cross_shard_reclaim_guard` key, its `ENV_MAP` entry, and the
  portal's `storage_engine.scratch_sweep` setting — the three places a deployment could
  have named either flag.
- `docs/ops/temporalstore-engine-flags.md` regenerated: 290 flags to 288, and the
  "documented as keeping an older path alive" count from 5 to 4.

Each retirement leaves the note in place, in the shape this tree already uses for
`TS_HOT_PAGE_SPILL` ("Always installed. `TS_HOT_PAGE_SPILL` used to be able to skip it"),
so the next reader learns the behaviour is deliberate and unconditional rather than
inferring a switch that is gone.

## Checks

`cargo test --release -p temporalstore-rust --lib --tests --no-fail-fast
-- --test-threads=1`: no failure that main does not already have. The three
`ENV_MAP`/portal guards (`test_the_loader_maps_every_config_key`,
`test_matrixark_the_portal_offers_what_the_config_file_does`,
`test_matrixark_the_wal_compresses_a_record_by_default`) pass — they are derived from the
config file rather than from a name list, so removing a key and its mapping together is
what keeps them green.

Neither flag is set on the serving deployment, so nothing about the live path changes.
