### PR TITLE
Four resource helpers are re-exported instead of copied

### DIFF
--- a/tools/matrixark_mcp_resources.py
+++ b/tools/matrixark_mcp_resources.py
@@ -298,31 +298,16 @@ def _aws_cli_s3_cp(source: str, target: str) -> None:
         raise MatrixArkError(compact_ws(completed.stderr or completed.stdout or f"aws s3 cp failed: {source} -> {target}"))
 
 
-def upload_file_to_s3(path: Path, *, bucket: str, key: str) -> str:
-    client = _s3_client()
-    if client is not None:
-        try:
-            client.upload_file(str(path), bucket, key)
-            return f"s3://{bucket}/{key}"
-        except Exception as exc:
-            raise MatrixArkError(f"S3 upload failed for {path}: {exc}") from exc
-    target = f"s3://{bucket}/{key}"
-    _aws_cli_s3_cp(str(path), target)
-    return target
+try:  # the implementation lives in matrixark_mcp_core_resource_io; this module re-exports it
+    from .matrixark_mcp_core_resource_io import upload_file_to_s3
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_resource_io import upload_file_to_s3
 
 
-def download_s3_to_file(uri: str, target: Path) -> Path:
-    bucket, key = parse_s3_uri(uri)
-    target.parent.mkdir(parents=True, exist_ok=True)
-    client = _s3_client()
-    if client is not None:
-        try:
-            client.download_file(bucket, key, str(target))
-            return target
-        except Exception as exc:
-            raise MatrixArkError(f"S3 download failed for {uri}: {exc}") from exc
-    _aws_cli_s3_cp(uri, str(target))
-    return target
+try:  # the implementation lives in matrixark_mcp_core_resource_io; this module re-exports it
+    from .matrixark_mcp_core_resource_io import download_s3_to_file
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_resource_io import download_s3_to_file
 
 
 try:  # the implementation lives in matrixark_mcp_core_resource_io; this module re-exports it
@@ -402,39 +387,10 @@ except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_core_resource_io import infer_resource_suffix
 
 
-def rewrite_chunk_uris(chunks: list[Any], *, parse_uri: str, stored_raw_uri: str) -> list[Any]:
-    if not stored_raw_uri or stored_raw_uri == parse_uri:
-        return chunks
-    rewritten: list[Any] = []
-    for chunk in chunks:
-        metadata = dict(getattr(chunk, "metadata", {}) or {})
-        old_source_ref = str(getattr(chunk, "source_ref", ""))
-        fragment = old_source_ref.partition("#")[2]
-        relative_path = str(metadata.get("relative_path") or "").strip()
-        if relative_path and fragment:
-            new_source_ref = f"{stored_raw_uri}#path={relative_path}&{fragment}"
-        elif fragment:
-            new_source_ref = f"{stored_raw_uri}#{fragment}"
-        else:
-            new_source_ref = stored_raw_uri
-        metadata["raw_uri"] = stored_raw_uri
-        metadata["citation"] = new_source_ref
-        metadata["source_ref"] = new_source_ref
-        metadata["raw_storage_policy"] = "s3_raw_uri_only" if is_s3_uri(stored_raw_uri) else metadata.get("raw_storage_policy", "raw_uri_only")
-        metadata["raw_bytes_stored"] = False
-        piece_hash = str(metadata.get("content_hash") or content_hash(str(getattr(chunk, "text", ""))))
-        version = str(metadata.get("resource_version") or "")
-        chunk_hash = stable_hash(f"resource_chunk:{new_source_ref}:{version}:{piece_hash}")
-        rewritten.append(
-            chunk.__class__(
-                chunk_hash=chunk_hash,
-                source_ref=new_source_ref,
-                text=getattr(chunk, "text", ""),
-                token_estimate=int(getattr(chunk, "token_estimate", 1)),
-                metadata=metadata,
-            )
-        )
-    return rewritten
+try:  # the implementation lives in matrixark_mcp_core_resource_io; this module re-exports it
+    from .matrixark_mcp_core_resource_io import rewrite_chunk_uris
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_resource_io import rewrite_chunk_uris
 
 
 try:  # the implementation lives in matrixark_mcp_core_resource_io; this module re-exports it
@@ -443,14 +399,10 @@ except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_core_resource_io import cleanup_temp_paths
 
 
-def aggregate_parse_warnings_from_chunks(chunks: list[Any]) -> list[str]:
-    warnings: list[str] = []
-    for chunk in chunks:
-        metadata = getattr(chunk, "metadata", {}) or {}
-        for warning in normalize_parse_warnings(metadata):
-            if warning not in warnings:
-                warnings.append(warning)
-    return warnings
+try:  # the implementation lives in matrixark_mcp_core_resource_io; this module re-exports it
+    from .matrixark_mcp_core_resource_io import aggregate_parse_warnings_from_chunks
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_resource_io import aggregate_parse_warnings_from_chunks
 
 
 RESOURCE_FACT_KEYWORDS = re.compile(


### PR DESCRIPTION
`matrixark_mcp_resources` carried its own copies of four functions whose implementation lives in
`matrixark_mcp_core_resource_io`. The bodies are byte-identical, not merely equivalent.

The file already re-exports **six** names from that same module, each with the comment this change
follows:

    try:  # the implementation lives in matrixark_mcp_core_resource_io; this module re-exports it
        from .matrixark_mcp_core_resource_io import is_s3_uri
    except ImportError:  # Direct script execution from tools/.
        from matrixark_mcp_core_resource_io import is_s3_uri

`download_s3_to_file`, `upload_file_to_s3`, `rewrite_chunk_uris` and
`aggregate_parse_warnings_from_chunks` now do the same, so the S3 and chunk helpers all arrive from
one place instead of four of them being a second copy. 577 lines -> 529. `matrixark_mcp_core_resource_io`
does not import `matrixark_mcp_resources`, so nothing here is circular.

## Why these four

A sweep of `tools/` finds 69 duplicated function bodies. Most are NOT safe to collapse, and the
codebase says why: `build_cross_session_policy` delegates to its twin and carries a note that doing
so once read the other module's toggle and changed two budget ratios.

Classifying each duplicate by how the free names in its body are bound tells the two cases apart. A
name bound by an IMPORT resolves to the same object from either module. A name bound by a
module-level ASSIGNMENT is a constant or a toggle: the two modules can hold different values, or
rebind it later. That splits the duplicates 19 safe / 50 risky. These four are in the safe set, sit
in a module pair that already imports one way six times over, and follow the convention the file
itself established.

## Test

Every suite that reaches this module or these names, 54 tests, all green:

    test_a_module_only_tests_reach_is_not_live.py    4
    test_attachment_resource_policy.py               7
    test_blob_integrity_verify.py                    6
    test_engine_blob_tier.py                         7
    test_ingest_one_call_file_or_text.py            16
    test_temporalstore_blob_ingest.py               14

Each of the four names was also checked to resolve to the *same object* from both modules after the
change, which is the property that makes a re-export equivalent to a copy.
