### PR TITLE
Three more modules re-export instead of copying

### DIFF
--- a/tools/matrixark_mcp_budget_pack.py
+++ b/tools/matrixark_mcp_budget_pack.py
@@ -78,17 +78,10 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
     )
 
 
-def context_text_hashes(text: str) -> set[int]:
-    compact = " ".join(str(text).split())
-    variants = {compact[:512]}
-    without_role = re.sub(r"^(user|assistant|tool|system):\s*", "", compact, flags=re.IGNORECASE)
-    variants.add(without_role[:512])
-    tokenized = tokens(compact)
-    if tokenized:
-        variants.add(" ".join(tokenized)[:512])
-        if tokenized[0] in {"user", "assistant", "tool", "system"}:
-            variants.add(" ".join(tokenized[1:])[:512])
-    return {stable_hash(variant) for variant in variants if variant}
+try:  # the implementation lives in matrixark_mcp_core_packing; this module re-exports it
+    from .matrixark_mcp_core_packing import context_text_hashes
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_packing import context_text_hashes
 
 
 try:  # the implementation lives in matrixark_mcp_core_identity; this module re-exports it

--- a/tools/matrixark_mcp_query.py
+++ b/tools/matrixark_mcp_query.py
@@ -730,33 +730,13 @@ def candidate_index_terms(
     return {term for term in terms if term}
 
 
-def passes_secondary_index_filters(candidate_terms: set[str], required_groups: list[set[str]], *, mode: str = "all_groups") -> bool:
-    if not required_groups:
-        return True
-    if mode == "any_group":
-        return any(bool(candidate_terms.intersection(group)) for group in required_groups)
-    return all(bool(candidate_terms.intersection(group)) for group in required_groups)
+try:  # the implementation lives in matrixark_mcp_core_scoring; this module re-exports it
+    from .matrixark_mcp_core_scoring import passes_secondary_index_filters
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_scoring import passes_secondary_index_filters
 
 
-def passes_applicable_secondary_index_filters(
-    candidate_terms: set[str],
-    required_groups: list[set[str]],
-    *,
-    mode: str = "all_groups",
-) -> bool:
-    """Apply only filter groups whose index prefix is present on this candidate."""
-    candidate_prefixes = {term.split(":", 1)[0] for term in candidate_terms if ":" in term}
-    candidate_is_context_asset = bool(
-        candidate_terms.intersection({"source_type:resource", "source_type:skill"})
-    )
-    applicable_groups = [
-        group
-        for group in required_groups
-        if candidate_prefixes.intersection({term.split(":", 1)[0] for term in group if ":" in term})
-        and not (
-            candidate_is_context_asset
-            and {term.split(":", 1)[0] for term in group if ":" in term} == {"source_type"}
-            and not candidate_terms.intersection(group)
-        )
-    ]
-    return passes_secondary_index_filters(candidate_terms, applicable_groups, mode=mode)
+try:  # the implementation lives in matrixark_mcp_core_scoring; this module re-exports it
+    from .matrixark_mcp_core_scoring import passes_applicable_secondary_index_filters
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_scoring import passes_applicable_secondary_index_filters

--- a/tools/matrixark_mcp_segments.py
+++ b/tools/matrixark_mcp_segments.py
@@ -177,25 +177,10 @@ def semantic_saliency_score(text: str) -> float:
     return min(score, 1.0)
 
 
-def infer_segment_topic(text: str) -> str:
-    lower = text.lower()
-    topic_keywords = [
-        ("recursion", ["recursion", "recursive", "base case", "merge sort", "call stack"]),
-        ("game_algorithm", ["game", "minimax", "alpha beta", "pathfinding", "npc"]),
-        ("preference", ["prefer", "favorite", "likes", "loves"]),
-        ("location", ["moved", "moving", "located", "location", "live", "lives", "staying"]),
-        ("approval_budget", ["approved", "approval", "budget", "cost", "purchase"]),
-        ("incident_runbook", ["incident", "runbook", "alert", "outage", "rollback", "postmortem"]),
-        ("task_decision", ["decision", "decided", "owner", "owns", "deadline", "checklist", "reviewer", "require", "requires", "required"]),
-        ("metric_sla", ["metric", "latency", "p95", "p99", "qps", "sla", "error rate"]),
-        ("plan_status", ["plan", "current", "status", "going to", "will"]),
-        ("correction", ["correction", "instead", "wrong", "changed", "updated"]),
-    ]
-    for topic, keywords in topic_keywords:
-        if any(keyword in lower for keyword in keywords):
-            return topic
-    token_list = [token for token in tokens(text) if len(token) > 4]
-    return token_list[0] if token_list else "general"
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import infer_segment_topic
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import infer_segment_topic
 
 
 try:  # the implementation lives in matrixark_mcp_core; this module re-exports it


### PR DESCRIPTION
Three more modules carried their own copies of functions implemented elsewhere, byte-identical to
the originals:

| module | now re-exports | from |
|---|---|---|
| `matrixark_mcp_segments` | `infer_segment_topic` | `matrixark_mcp_core` |
| `matrixark_mcp_budget_pack` | `context_text_hashes` | `matrixark_mcp_core_packing` |
| `matrixark_mcp_query` | `passes_secondary_index_filters`, `passes_applicable_secondary_index_filters` | `matrixark_mcp_core_scoring` |

Each uses the try/except form the codebase already uses for this, and each name was checked to
resolve to the *same object* from both modules afterwards. 2,101 lines -> 2,059.

## A fourth one was tried and dropped, because it broke two suites

The obvious fourth was `bounded_max_children_scored_per_parent` in `matrixark_mcp_budget_policies`.
It looks exactly like the others -- identical body, and `matrixark_mcp_core_candidate_policy` does
not import `matrixark_mcp_budget_policies`, so the new edge is not itself a cycle.

It still broke two suites, which went from 12 and 25 tests to zero:

    matrixark_mcp_budget_policies
      -> matrixark_mcp_core_candidate_policy
        -> matrixark_mcp_core
          -> from matrixark_mcp_core_packing import *
            -> matrixark_mcp_core     ImportError: cannot import name
                                      'candidate_codex_outcome_terms' from partially
                                      initialized module

`matrixark_mcp_core` and `matrixark_mcp_core_packing` already import each other. That cycle is
tolerated today because every live entry point reaches it in an order that resolves; the new edge
gave it an entry point that does not. Nothing about the duplicate was unsafe -- the *path to it*
was. The three above were each applied alone and re-measured against those two suites, which is how
the fourth was separated from them.

So this leaves one duplicated body in place deliberately, and the cycle it exposed untouched:
unpicking `core` <-> `core_packing` is a real change to module structure, not a de-duplication, and
it belongs in its own PR.

## Test

Every suite reaching the three changed modules -- 8 suites, 50 tests, no failures -- plus the two
suites above confirmed back at their full 12 and 25.

The six remaining suites in that set run zero tests standalone both before and after this change:
they are fragments of aggregators whose parts import each other. That was measured on clean `main`
at the same moment, not assumed.

## One thing a reviewer should know

`matrixark_mcp_budget_pack` cannot be imported standalone from a cold interpreter, on `main` and on
this branch alike -- the same `core` <-> `core_packing` cycle. This change does not fix that and
does not cause it, but it does move which name the cycle trips on first, from `canonical_scope_key`
to `candidate_memory_layer_name`. Same failure, different first casualty. It was checked rather than
assumed: `matrixark_mcp_query`, `matrixark_mcp_segments`, `matrixark_mcp_resources` and
`matrixark_mcp_extraction_normalization` each import standalone before and after; `budget_pack`
fails both.
