### PR TITLE
A test harness went quiet about a helper the page really uses

### DIFF
--- a/tools/portal/browse_failure_harness.js
+++ b/tools/portal/browse_failure_harness.js
@@ -16,13 +16,30 @@ const fs = require("fs");
 const page = fs.readFileSync(process.argv[2], "utf8");
 const failing = process.argv[3] || "users";
 
+/* The balanced-brace slice, now needed twice. */
+function sliceBlock(from) {
+  let depth = 0;
+  for (let i = page.indexOf("{", from); i < page.length; i++) {
+    if (page[i] === "{") depth++;
+    else if (page[i] === "}") { depth--; if (depth === 0) { return page.slice(from, i + 1); } }
+  }
+  return null;
+}
+
 const start = page.indexOf("function loadBrowse() {");
 if (start < 0) { console.log("FAIL loadBrowse is not on this page"); process.exit(2); }
-let depth = 0, end = -1;
-for (let i = page.indexOf("{", start); i < page.length; i++) {
-  if (page[i] === "{") depth++;
-  else if (page[i] === "}") { depth--; if (depth === 0) { end = i + 1; break; } }
-}
+const loadBrowseSrc = sliceBlock(start);
+
+/* loadBrowse formats each row's timestamp through `window.__matrixarkWhen`. Take the page's OWN
+   formatter rather than stubbing one: a stub would let a change to the shipped formatter pass here
+   unseen, and this harness exists to run what ships. `when_harness.js` slices it the same way.
+   Without it `window` is simply absent from the sandbox, the call raises, and the page's own catch
+   reports "Could not reach the gateway." -- a failure message on the mode that asserts there is
+   none. */
+const whenStart = page.indexOf("window.__matrixarkWhen = function (ms)");
+if (whenStart < 0) { console.log("FAIL __matrixarkWhen is not on this page"); process.exit(2); }
+const whenSrc = sliceBlock(whenStart).replace("window.__matrixarkWhen = ", "");
+const win = { __matrixarkWhen: new Function("return (" + whenSrc + ");")() };
 
 let failures = 0;
 function ok(what, condition, detail) {
@@ -55,6 +72,7 @@ const scope = {
   scopeQuery: () => "user_id=alice",
   failure: (status) => "The gateway answered " + status + ".",
   Date, JSON, String, Number, Promise,
+  window: win,
   fetch: (url) => {
     const key = String(url);
     if (key.indexOf("/v1/users") === 0) {
@@ -74,7 +92,7 @@ const scope = {
 
 const names = Object.keys(scope);
 const loadBrowse = new Function(...names,
-  page.slice(start, end) + "; return loadBrowse;")(...names.map((k) => scope[k]));
+  loadBrowseSrc + "; return loadBrowse;")(...names.map((k) => scope[k]));
 
 loadBrowse();
 


### PR DESCRIPTION
`test_matrixark_a_failed_list_is_not_an_empty_scope` has three tests red on `main`, and they fail
the same way on any branch cut from it. They are not about any of the three failing tests' own
subject matter -- the whole suite is collateral.

## What happens

`loadBrowse` formats each row's timestamp through the page's shared helper:

    esc(window.__matrixarkWhen(when)) + "</td></tr>";

`browse_failure_harness.js` runs the shipped `loadBrowse` inside a sandbox built from a fixed list
of names -- `$`, `esc`, `say`, `fetch` and so on. `window` is not one of them, so the call raises a
ReferenceError, `loadBrowse`'s own `.catch` turns any non-numeric throw into

    "Could not reach the gateway."

and the three tests that assert *no* failure message go red. The page is fine; the message is real
code doing what it should with an error the harness manufactured.

## The fix

Give the harness the page's OWN `__matrixarkWhen`, sliced out of the same file. `when_harness.js`
already does exactly this, and the harness's own header says the shipped function is sliced out and
run -- a stubbed formatter would let a change to the real one pass here unseen. The balanced-brace
slice that was inline for `loadBrowse` becomes a two-line `sliceBlock` used for both.

A page with no `__matrixarkWhen` now fails by name, rather than by way of a message about the
gateway.

## Test

All five modes report `all ok`, and the suite goes 5 passed / 3 failed -> 8 passed.

Both mutations discriminate, so the fix is exercised rather than merely quiet:

* rename `__matrixarkWhen` off the page -> `FAIL __matrixarkWhen is not on this page`
* make the shipped formatter throw -> the harness reports a failure; it does not swallow it

The second one matters most: it is the case the harness was silently in until now.
