### PR TITLE
Three copied helpers in the baseline runners become re-exports

### DIFF
--- a/tools/run_external_baseline_direct_retrieval.py
+++ b/tools/run_external_baseline_direct_retrieval.py
@@ -270,20 +270,10 @@ def reader_policy_context(question: str, context: str, args: argparse.Namespace)
     return context
 
 
-def extract_candidate_hint(question: str, context: str) -> str:
-    q_terms = terms(question)
-    best_score = -1.0
-    best_sentence = ""
-    for sentence in re.split(r"(?<=[.!?])\s+|\n+", context):
-        clean = re.sub(r"\s+", " ", sentence).strip()
-        if not clean:
-            continue
-        s_terms = terms(clean)
-        score = len(q_terms & s_terms) + sum(1 for term in q_terms if len(term) > 4 and term in clean.lower()) * 0.25
-        if score > best_score:
-            best_score = score
-            best_sentence = clean
-    return best_sentence[:500]
+try:  # the implementation lives in run_external_baseline_longmem_source_retrieval; this module re-exports it
+    from .run_external_baseline_longmem_source_retrieval import extract_candidate_hint
+except ImportError:  # Direct script execution from tools/.
+    from run_external_baseline_longmem_source_retrieval import extract_candidate_hint
 
 
 try:  # the implementation lives in run_external_baseline_longmem_source_retrieval; this module re-exports it
@@ -433,12 +423,10 @@ def finish(report: dict[str, Any], path: str, started: float, code: int) -> int:
     return code
 
 
-def finish_with_contract_gate(report: dict[str, Any], path: str, started: float, require_contract: bool) -> int:
-    contract = report.get("benchmark_model_contract")
-    if require_contract and not (isinstance(contract, dict) and contract.get("shared_oss_model_contract_passed")):
-        report.setdefault("blockers", []).append("shared_oss_model_contract_mismatch")
-        return finish(report, path, started, 2)
-    return finish(report, path, started, 0)
+try:  # the implementation lives in run_external_baseline_longmem_source_retrieval; this module re-exports it
+    from .run_external_baseline_longmem_source_retrieval import finish_with_contract_gate
+except ImportError:  # Direct script execution from tools/.
+    from run_external_baseline_longmem_source_retrieval import finish_with_contract_gate
 
 
 if __name__ == "__main__":

--- a/tools/run_external_baseline_locomo_source_retrieval.py
+++ b/tools/run_external_baseline_locomo_source_retrieval.py
@@ -574,12 +574,10 @@ except ImportError:  # Direct script execution from tools/.
     from run_external_baseline_longmem_source_retrieval import reduction_percent
 
 
-def finish_with_contract_gate(report: dict[str, Any], path: str, started: float, require_contract: bool) -> int:
-    contract = report.get("benchmark_model_contract")
-    if require_contract and not (isinstance(contract, dict) and contract.get("shared_oss_model_contract_passed")):
-        report.setdefault("blockers", []).append("shared_oss_model_contract_mismatch")
-        return finish(report, path, started, 2)
-    return finish(report, path, started, 0)
+try:  # the implementation lives in run_external_baseline_longmem_source_retrieval; this module re-exports it
+    from .run_external_baseline_longmem_source_retrieval import finish_with_contract_gate
+except ImportError:  # Direct script execution from tools/.
+    from run_external_baseline_longmem_source_retrieval import finish_with_contract_gate
 
 
 def finish(report: dict[str, Any], path: str, started: float, code: int) -> int:


### PR DESCRIPTION
`finish_with_contract_gate` existed three times, byte-identical, and `extract_candidate_hint` twice.
Both are implemented in `run_external_baseline_longmem_source_retrieval`, which the other two
scripts already import from:

    try:  # the implementation lives in run_external_baseline_longmem_source_retrieval; this module re-exports it
        from .run_external_baseline_longmem_source_retrieval import call_reader
    except ImportError:  # Direct script execution from tools/.
        from run_external_baseline_longmem_source_retrieval import call_reader

`direct_retrieval` re-exports three names that way already; these follow it. `longmem` imports
neither of the others, so nothing is circular.

## What this is gated on, and what it is not

**No test suite reaches these three files.** Nothing under `tools/test_*.py` mentions them, so
there is no suite whose result would change either way, and it would be wrong to imply otherwise.

What is checked:

* the three bodies are byte-identical to the implementation, compared as bytes rather than by eye;
* after the change each name resolves to the **same object** from both modules;
* both scripts still import and run -- `--help` exits 0 on each.

That last one is the failure mode a re-export actually has: it either resolves at import time or the
script does not start. It is a narrower gate than a suite, and it is the one available here.

Adding coverage for these baseline runners is worth doing, but it is a different change from
removing the duplicates and would be a poor thing to bundle into it.
