### PR TITLE
A helper the page calls is defined before the page calls it

### DIFF
--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -417,6 +417,63 @@
 </main>
 
 <script>
+/* Helpers every page may call, placed before the page's own script.
+
+   This one lived in the nav block, which is emitted AFTER the page script. Three pages
+   called it from their own script and read as working, because a browser runs both blocks
+   before anyone clicks anything. The cost only showed when something ran a page's script on
+   its own: the call threw, the browse path caught it along with everything else, and the
+   screen said "Could not reach the gateway" about a gateway it had never asked. A helper
+   that is shared is defined where every caller can already see it. */
+  window.__matrixarkCopyText = function (text) {
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        return navigator.clipboard.writeText(text).then(
+          function () { return true; }, function () { return false; });
+      }
+    } catch (e) { /* falls through to the failure below */ }
+    return Promise.resolve(false);
+  };
+
+  window.__matrixarkWhy = function (body, fallback) {
+    body = body || {};
+    var text = body.detail || body.error || fallback;
+    if (body.required && body.required.length) {
+      text += " — this needs " + [].concat(body.required).join(" or ");
+    }
+    /* A backend failure now answers with a sentence that deliberately says nothing about the
+       inside of the deployment, and a token naming the log entry that does. Showing the token is
+       the whole point of it: without it the reader has a polite sentence and no way to get any
+       further, and an operator has a log they cannot tie to the report. */
+    if (body.incident) {
+      text += " — incident " + body.incident;
+    }
+    return text;
+  };
+
+  window.__matrixarkFailure = function (status, overrides) {
+    if (overrides && overrides[status]) { return overrides[status]; }
+    if (status === 401) { return "This key was not accepted."; }
+    if (status === 403) { return "This key lacks the scope for that call."; }
+    if (status === 413) { return "That request is larger than this deployment accepts."; }
+    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
+    if (status === 502) { return "The gateway could not reach the storage behind it."; }
+    if (status === 503) { return "The gateway is not ready to serve this yet."; }
+    if (status === 504) { return "The backend did not answer in time."; }
+    return "The gateway answered " + status + ".";
+  };
+
+  window.__matrixarkWhen = function (ms) {
+    /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
+       `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
+    if (!ms) { return "—"; }
+    var at = new Date(Number(ms));
+    if (isNaN(at.getTime())) { return "—"; }
+    try { return at.toLocaleString(undefined, { timeZoneName: "short" }); }
+    catch (e) { return at.toLocaleString(); }
+  };
+</script>
+<script>
 /* Tabs, for every portal page whose body declares a tablist.
  *
  * Shared rather than per page. The explore page had the only copy and this is the second caller;
@@ -1107,31 +1164,7 @@
    * `timeZoneName: "short"` rather than the IANA name: "GMT+1" beside the time reads at a glance
    * where "Europe/London" pushes the useful part off the end of a table cell. Falls back to the
    * bare local string on a runtime without it, which is no worse than what was there before. */
-  window.__matrixarkWhen = function (ms) {
-    /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
-       `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
-    if (!ms) { return "—"; }
-    var at = new Date(Number(ms));
-    if (isNaN(at.getTime())) { return "—"; }
-    try { return at.toLocaleString(undefined, { timeZoneName: "short" }); }
-    catch (e) { return at.toLocaleString(); }
-  };
 
-  window.__matrixarkWhy = function (body, fallback) {
-    body = body || {};
-    var text = body.detail || body.error || fallback;
-    if (body.required && body.required.length) {
-      text += " — this needs " + [].concat(body.required).join(" or ");
-    }
-    /* A backend failure now answers with a sentence that deliberately says nothing about the
-       inside of the deployment, and a token naming the log entry that does. Showing the token is
-       the whole point of it: without it the reader has a polite sentence and no way to get any
-       further, and an operator has a log they cannot tie to the report. */
-    if (body.incident) {
-      text += " — incident " + body.incident;
-    }
-    return text;
-  };
 
   /* One sentence per gateway status, for every page.
    *
@@ -1147,27 +1180,7 @@
    * This is the FALLBACK. A refusal that carries a body is explained by __matrixarkWhy from what
    * the gateway said; this is what the reader gets when there is nothing but a number.
    */
-  window.__matrixarkFailure = function (status, overrides) {
-    if (overrides && overrides[status]) { return overrides[status]; }
-    if (status === 401) { return "This key was not accepted."; }
-    if (status === 403) { return "This key lacks the scope for that call."; }
-    if (status === 413) { return "That request is larger than this deployment accepts."; }
-    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
-    if (status === 502) { return "The gateway could not reach the storage behind it."; }
-    if (status === 503) { return "The gateway is not ready to serve this yet."; }
-    if (status === 504) { return "The backend did not answer in time."; }
-    return "The gateway answered " + status + ".";
-  };
 
-  window.__matrixarkCopyText = function (text) {
-    try {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        return navigator.clipboard.writeText(text).then(
-          function () { return true; }, function () { return false; });
-      }
-    } catch (e) { /* falls through to the failure below */ }
-    return Promise.resolve(false);
-  };
 }());
 
 /* The shared live strip. One stream per page: a page that runs its own (Setup, Overview) claims

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -459,6 +459,63 @@
 
 </main>
 <script>
+/* Helpers every page may call, placed before the page's own script.
+
+   This one lived in the nav block, which is emitted AFTER the page script. Three pages
+   called it from their own script and read as working, because a browser runs both blocks
+   before anyone clicks anything. The cost only showed when something ran a page's script on
+   its own: the call threw, the browse path caught it along with everything else, and the
+   screen said "Could not reach the gateway" about a gateway it had never asked. A helper
+   that is shared is defined where every caller can already see it. */
+  window.__matrixarkCopyText = function (text) {
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        return navigator.clipboard.writeText(text).then(
+          function () { return true; }, function () { return false; });
+      }
+    } catch (e) { /* falls through to the failure below */ }
+    return Promise.resolve(false);
+  };
+
+  window.__matrixarkWhy = function (body, fallback) {
+    body = body || {};
+    var text = body.detail || body.error || fallback;
+    if (body.required && body.required.length) {
+      text += " — this needs " + [].concat(body.required).join(" or ");
+    }
+    /* A backend failure now answers with a sentence that deliberately says nothing about the
+       inside of the deployment, and a token naming the log entry that does. Showing the token is
+       the whole point of it: without it the reader has a polite sentence and no way to get any
+       further, and an operator has a log they cannot tie to the report. */
+    if (body.incident) {
+      text += " — incident " + body.incident;
+    }
+    return text;
+  };
+
+  window.__matrixarkFailure = function (status, overrides) {
+    if (overrides && overrides[status]) { return overrides[status]; }
+    if (status === 401) { return "This key was not accepted."; }
+    if (status === 403) { return "This key lacks the scope for that call."; }
+    if (status === 413) { return "That request is larger than this deployment accepts."; }
+    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
+    if (status === 502) { return "The gateway could not reach the storage behind it."; }
+    if (status === 503) { return "The gateway is not ready to serve this yet."; }
+    if (status === 504) { return "The backend did not answer in time."; }
+    return "The gateway answered " + status + ".";
+  };
+
+  window.__matrixarkWhen = function (ms) {
+    /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
+       `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
+    if (!ms) { return "—"; }
+    var at = new Date(Number(ms));
+    if (isNaN(at.getTime())) { return "—"; }
+    try { return at.toLocaleString(undefined, { timeZoneName: "short" }); }
+    catch (e) { return at.toLocaleString(); }
+  };
+</script>
+<script>
 /* Tabs, for every portal page whose body declares a tablist.
  *
  * Shared rather than per page. The explore page had the only copy and this is the second caller;
@@ -817,31 +874,7 @@
    * `timeZoneName: "short"` rather than the IANA name: "GMT+1" beside the time reads at a glance
    * where "Europe/London" pushes the useful part off the end of a table cell. Falls back to the
    * bare local string on a runtime without it, which is no worse than what was there before. */
-  window.__matrixarkWhen = function (ms) {
-    /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
-       `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
-    if (!ms) { return "—"; }
-    var at = new Date(Number(ms));
-    if (isNaN(at.getTime())) { return "—"; }
-    try { return at.toLocaleString(undefined, { timeZoneName: "short" }); }
-    catch (e) { return at.toLocaleString(); }
-  };
 
-  window.__matrixarkWhy = function (body, fallback) {
-    body = body || {};
-    var text = body.detail || body.error || fallback;
-    if (body.required && body.required.length) {
-      text += " — this needs " + [].concat(body.required).join(" or ");
-    }
-    /* A backend failure now answers with a sentence that deliberately says nothing about the
-       inside of the deployment, and a token naming the log entry that does. Showing the token is
-       the whole point of it: without it the reader has a polite sentence and no way to get any
-       further, and an operator has a log they cannot tie to the report. */
-    if (body.incident) {
-      text += " — incident " + body.incident;
-    }
-    return text;
-  };
 
   /* One sentence per gateway status, for every page.
    *
@@ -857,27 +890,7 @@
    * This is the FALLBACK. A refusal that carries a body is explained by __matrixarkWhy from what
    * the gateway said; this is what the reader gets when there is nothing but a number.
    */
-  window.__matrixarkFailure = function (status, overrides) {
-    if (overrides && overrides[status]) { return overrides[status]; }
-    if (status === 401) { return "This key was not accepted."; }
-    if (status === 403) { return "This key lacks the scope for that call."; }
-    if (status === 413) { return "That request is larger than this deployment accepts."; }
-    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
-    if (status === 502) { return "The gateway could not reach the storage behind it."; }
-    if (status === 503) { return "The gateway is not ready to serve this yet."; }
-    if (status === 504) { return "The backend did not answer in time."; }
-    return "The gateway answered " + status + ".";
-  };
 
-  window.__matrixarkCopyText = function (text) {
-    try {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        return navigator.clipboard.writeText(text).then(
-          function () { return true; }, function () { return false; });
-      }
-    } catch (e) { /* falls through to the failure below */ }
-    return Promise.resolve(false);
-  };
 }());
 
 /* The shared live strip. One stream per page: a page that runs its own (Setup, Overview) claims

--- a/tools/portal/browse_failure_harness.js
+++ b/tools/portal/browse_failure_harness.js
@@ -24,6 +24,17 @@ for (let i = page.indexOf("{", start); i < page.length; i++) {
   else if (page[i] === "}") { depth--; if (depth === 0) { end = i + 1; break; } }
 }
 
+/* The page's shared helpers are a script block of their own, emitted before the page's own
+ * script. The sandbox below models what the browse region can see, so it needs them too --
+ * and it RUNS the shipped block rather than stubbing it, because a stub would let the helper
+ * change without a single test noticing. */
+const sharedAt = page.indexOf("Helpers every page may call");
+if (sharedAt < 0) { console.log("FAIL the shared helper block is not on this page"); process.exit(2); }
+const sharedFrom = page.lastIndexOf("<script>", sharedAt) + "<script>".length;
+const sharedTo = page.indexOf("</script>", sharedFrom);
+const win = {};
+new Function("window", page.slice(sharedFrom, sharedTo))(win);
+
 let failures = 0;
 function ok(what, condition, detail) {
   if (condition) { console.log("ok   " + what); }
@@ -55,6 +66,7 @@ const scope = {
   scopeQuery: () => "user_id=alice",
   failure: (status) => "The gateway answered " + status + ".",
   Date, JSON, String, Number, Promise,
+  window: win,
   fetch: (url) => {
     const key = String(url);
     if (key.indexOf("/v1/users") === 0) {

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -321,6 +321,65 @@ EXTRA_CSS = """
 # The shared live strip's script, placed on every page: the generated ones through TAIL, the two
 # hand-maintained ones through `_with_nav_js`. It is deliberately self-contained -- no helper from
 # any page's own script -- because it has to run identically on pages that share nothing else.
+SHARED_JS = r'''<script>
+/* Helpers every page may call, placed before the page's own script.
+
+   This one lived in the nav block, which is emitted AFTER the page script. Three pages
+   called it from their own script and read as working, because a browser runs both blocks
+   before anyone clicks anything. The cost only showed when something ran a page's script on
+   its own: the call threw, the browse path caught it along with everything else, and the
+   screen said "Could not reach the gateway" about a gateway it had never asked. A helper
+   that is shared is defined where every caller can already see it. */
+  window.__matrixarkCopyText = function (text) {
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        return navigator.clipboard.writeText(text).then(
+          function () { return true; }, function () { return false; });
+      }
+    } catch (e) { /* falls through to the failure below */ }
+    return Promise.resolve(false);
+  };
+
+  window.__matrixarkWhy = function (body, fallback) {
+    body = body || {};
+    var text = body.detail || body.error || fallback;
+    if (body.required && body.required.length) {
+      text += " — this needs " + [].concat(body.required).join(" or ");
+    }
+    /* A backend failure now answers with a sentence that deliberately says nothing about the
+       inside of the deployment, and a token naming the log entry that does. Showing the token is
+       the whole point of it: without it the reader has a polite sentence and no way to get any
+       further, and an operator has a log they cannot tie to the report. */
+    if (body.incident) {
+      text += " — incident " + body.incident;
+    }
+    return text;
+  };
+
+  window.__matrixarkFailure = function (status, overrides) {
+    if (overrides && overrides[status]) { return overrides[status]; }
+    if (status === 401) { return "This key was not accepted."; }
+    if (status === 403) { return "This key lacks the scope for that call."; }
+    if (status === 413) { return "That request is larger than this deployment accepts."; }
+    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
+    if (status === 502) { return "The gateway could not reach the storage behind it."; }
+    if (status === 503) { return "The gateway is not ready to serve this yet."; }
+    if (status === 504) { return "The backend did not answer in time."; }
+    return "The gateway answered " + status + ".";
+  };
+
+  window.__matrixarkWhen = function (ms) {
+    /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
+       `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
+    if (!ms) { return "—"; }
+    var at = new Date(Number(ms));
+    if (isNaN(at.getTime())) { return "—"; }
+    try { return at.toLocaleString(undefined, { timeZoneName: "short" }); }
+    catch (e) { return at.toLocaleString(); }
+  };
+</script>'''
+
+
 NAV_JS = r'''<script>
 /* One copy helper for every page. It resolves true when the text reached the clipboard and false
    when it did not: no clipboard API at all (an http:// origin, which a self-hosted portal often
@@ -352,31 +411,7 @@ NAV_JS = r'''<script>
    * `timeZoneName: "short"` rather than the IANA name: "GMT+1" beside the time reads at a glance
    * where "Europe/London" pushes the useful part off the end of a table cell. Falls back to the
    * bare local string on a runtime without it, which is no worse than what was there before. */
-  window.__matrixarkWhen = function (ms) {
-    /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
-       `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
-    if (!ms) { return "—"; }
-    var at = new Date(Number(ms));
-    if (isNaN(at.getTime())) { return "—"; }
-    try { return at.toLocaleString(undefined, { timeZoneName: "short" }); }
-    catch (e) { return at.toLocaleString(); }
-  };
 
-  window.__matrixarkWhy = function (body, fallback) {
-    body = body || {};
-    var text = body.detail || body.error || fallback;
-    if (body.required && body.required.length) {
-      text += " — this needs " + [].concat(body.required).join(" or ");
-    }
-    /* A backend failure now answers with a sentence that deliberately says nothing about the
-       inside of the deployment, and a token naming the log entry that does. Showing the token is
-       the whole point of it: without it the reader has a polite sentence and no way to get any
-       further, and an operator has a log they cannot tie to the report. */
-    if (body.incident) {
-      text += " — incident " + body.incident;
-    }
-    return text;
-  };
 
   /* One sentence per gateway status, for every page.
    *
@@ -392,27 +427,7 @@ NAV_JS = r'''<script>
    * This is the FALLBACK. A refusal that carries a body is explained by __matrixarkWhy from what
    * the gateway said; this is what the reader gets when there is nothing but a number.
    */
-  window.__matrixarkFailure = function (status, overrides) {
-    if (overrides && overrides[status]) { return overrides[status]; }
-    if (status === 401) { return "This key was not accepted."; }
-    if (status === 403) { return "This key lacks the scope for that call."; }
-    if (status === 413) { return "That request is larger than this deployment accepts."; }
-    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
-    if (status === 502) { return "The gateway could not reach the storage behind it."; }
-    if (status === 503) { return "The gateway is not ready to serve this yet."; }
-    if (status === 504) { return "The backend did not answer in time."; }
-    return "The gateway answered " + status + ".";
-  };
 
-  window.__matrixarkCopyText = function (text) {
-    try {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        return navigator.clipboard.writeText(text).then(
-          function () { return true; }, function () { return false; });
-      }
-    } catch (e) { /* falls through to the failure below */ }
-    return Promise.resolve(false);
-  };
 }());
 
 /* The shared live strip. One stream per page: a page that runs its own (Setup, Overview) claims
@@ -5799,6 +5814,7 @@ API_JS = r"""
 
 TAIL = """
 </main>
+%(sharedjs)s
 %(js)s
 %(navjs)s
 </body>
@@ -5816,7 +5832,8 @@ def emit(filename, title, body, js, active):
         page_js = TABS_JS.strip() + "\n" + page_js
     html = (HEAD % {"title": title, "css": css}
             + rendered
-            + (TAIL % {"js": page_js, "navjs": NAV_JS.strip()}))
+            + (TAIL % {"sharedjs": SHARED_JS.strip(), "js": page_js,
+                       "navjs": NAV_JS.strip()}))
     path = os.path.join(PORTAL, filename)
     io.open(path, "w", encoding="utf-8", newline="\n").write(html)
     print("wrote %s (%d bytes)" % (path, len(html)))
@@ -5831,8 +5848,40 @@ emit("catalog_portal.html", "MatrixArk — Skills & Resources", CATALOG_BODY, CA
 
 
 # ---- add the nav to the two existing pages ------------------------------------------------------
+SHARED_JS_MARKER = "/* Helpers every page may call"
 TABS_JS_MARKER = "/* Tabs, for every portal page whose body declares a tablist."
 NAV_JS_MARKER = "/* The shared live strip."
+
+
+def _without_shared_js(text):
+    """Take out every copy of the shared helper block.
+
+    Every copy, not the first: the block was once prepended to a write that replaced only the nav
+    block beneath it, so a page could accumulate one per build. Taking them all out means a page
+    that collected some heals on the next run instead of carrying them forward.
+    """
+    while SHARED_JS_MARKER in text:
+        marker = text.index(SHARED_JS_MARKER)
+        start = text.rindex("<script>", 0, marker)
+        end = text.index("</script>", start) + len("</script>")
+        text = text[:start] + text[end:].lstrip(chr(10))
+    return text
+
+
+def _with_shared_js(text):
+    """Put the shared helpers in, before the page's own script.
+
+    Taken out and put back rather than replaced where they sit. These two pages are edited by
+    hand and rebuilt repeatedly, and the block was once written next to the nav -- at the END of
+    the body, after the script that calls it. Replacing in place would carry that position
+    forward for ever; removing and re-placing means the current rule always wins.
+    """
+    text = _without_shared_js(text)
+    if "<script>" not in text:
+        print("no <script> to place the shared helpers before")
+        sys.exit(1)
+    at = text.index("<script>")
+    return text[:at] + SHARED_JS.strip() + chr(10) + text[at:]
 
 
 def _with_nav_js(text):
@@ -5915,7 +5964,7 @@ def inject(filename, anchor, active):
         # The CSS is refreshed here too. It used to be written only on the first injection,
         # so these two pages kept a stylesheet that stopped matching the nav they were being
         # given -- the strip was styled on five pages and bare on two.
-        rendered = _with_tabs_js(_with_nav_js(_with_nav_css(replaced)))
+        rendered = _with_shared_js(_with_tabs_js(_with_nav_js(_with_nav_css(replaced))))
         io.open(path, "w", encoding="utf-8", newline="\n").write(rendered)
         print("nav refreshed in %s" % filename)
         return
@@ -5924,7 +5973,7 @@ def inject(filename, anchor, active):
         sys.exit(1)
     text = _with_nav_css(text)
     text = text.replace(anchor, anchor + "\n" + nav(active), 1)
-    text = _with_tabs_js(_with_nav_js(text))
+    text = _with_shared_js(_with_tabs_js(_with_nav_js(text)))
     io.open(path, "w", encoding="utf-8", newline="\n").write(text)
     print("nav added to %s" % filename)
 

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -513,6 +513,63 @@
 
 </main>
 <script>
+/* Helpers every page may call, placed before the page's own script.
+
+   This one lived in the nav block, which is emitted AFTER the page script. Three pages
+   called it from their own script and read as working, because a browser runs both blocks
+   before anyone clicks anything. The cost only showed when something ran a page's script on
+   its own: the call threw, the browse path caught it along with everything else, and the
+   screen said "Could not reach the gateway" about a gateway it had never asked. A helper
+   that is shared is defined where every caller can already see it. */
+  window.__matrixarkCopyText = function (text) {
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        return navigator.clipboard.writeText(text).then(
+          function () { return true; }, function () { return false; });
+      }
+    } catch (e) { /* falls through to the failure below */ }
+    return Promise.resolve(false);
+  };
+
+  window.__matrixarkWhy = function (body, fallback) {
+    body = body || {};
+    var text = body.detail || body.error || fallback;
+    if (body.required && body.required.length) {
+      text += " — this needs " + [].concat(body.required).join(" or ");
+    }
+    /* A backend failure now answers with a sentence that deliberately says nothing about the
+       inside of the deployment, and a token naming the log entry that does. Showing the token is
+       the whole point of it: without it the reader has a polite sentence and no way to get any
+       further, and an operator has a log they cannot tie to the report. */
+    if (body.incident) {
+      text += " — incident " + body.incident;
+    }
+    return text;
+  };
+
+  window.__matrixarkFailure = function (status, overrides) {
+    if (overrides && overrides[status]) { return overrides[status]; }
+    if (status === 401) { return "This key was not accepted."; }
+    if (status === 403) { return "This key lacks the scope for that call."; }
+    if (status === 413) { return "That request is larger than this deployment accepts."; }
+    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
+    if (status === 502) { return "The gateway could not reach the storage behind it."; }
+    if (status === 503) { return "The gateway is not ready to serve this yet."; }
+    if (status === 504) { return "The backend did not answer in time."; }
+    return "The gateway answered " + status + ".";
+  };
+
+  window.__matrixarkWhen = function (ms) {
+    /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
+       `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
+    if (!ms) { return "—"; }
+    var at = new Date(Number(ms));
+    if (isNaN(at.getTime())) { return "—"; }
+    try { return at.toLocaleString(undefined, { timeZoneName: "short" }); }
+    catch (e) { return at.toLocaleString(); }
+  };
+</script>
+<script>
 /* Tabs, for every portal page whose body declares a tablist.
  *
  * Shared rather than per page. The explore page had the only copy and this is the second caller;
@@ -958,31 +1015,7 @@
    * `timeZoneName: "short"` rather than the IANA name: "GMT+1" beside the time reads at a glance
    * where "Europe/London" pushes the useful part off the end of a table cell. Falls back to the
    * bare local string on a runtime without it, which is no worse than what was there before. */
-  window.__matrixarkWhen = function (ms) {
-    /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
-       `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
-    if (!ms) { return "—"; }
-    var at = new Date(Number(ms));
-    if (isNaN(at.getTime())) { return "—"; }
-    try { return at.toLocaleString(undefined, { timeZoneName: "short" }); }
-    catch (e) { return at.toLocaleString(); }
-  };
 
-  window.__matrixarkWhy = function (body, fallback) {
-    body = body || {};
-    var text = body.detail || body.error || fallback;
-    if (body.required && body.required.length) {
-      text += " — this needs " + [].concat(body.required).join(" or ");
-    }
-    /* A backend failure now answers with a sentence that deliberately says nothing about the
-       inside of the deployment, and a token naming the log entry that does. Showing the token is
-       the whole point of it: without it the reader has a polite sentence and no way to get any
-       further, and an operator has a log they cannot tie to the report. */
-    if (body.incident) {
-      text += " — incident " + body.incident;
-    }
-    return text;
-  };
 
   /* One sentence per gateway status, for every page.
    *
@@ -998,27 +1031,7 @@
    * This is the FALLBACK. A refusal that carries a body is explained by __matrixarkWhy from what
    * the gateway said; this is what the reader gets when there is nothing but a number.
    */
-  window.__matrixarkFailure = function (status, overrides) {
-    if (overrides && overrides[status]) { return overrides[status]; }
-    if (status === 401) { return "This key was not accepted."; }
-    if (status === 403) { return "This key lacks the scope for that call."; }
-    if (status === 413) { return "That request is larger than this deployment accepts."; }
-    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
-    if (status === 502) { return "The gateway could not reach the storage behind it."; }
-    if (status === 503) { return "The gateway is not ready to serve this yet."; }
-    if (status === 504) { return "The backend did not answer in time."; }
-    return "The gateway answered " + status + ".";
-  };
 
-  window.__matrixarkCopyText = function (text) {
-    try {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        return navigator.clipboard.writeText(text).then(
-          function () { return true; }, function () { return false; });
-      }
-    } catch (e) { /* falls through to the failure below */ }
-    return Promise.resolve(false);
-  };
 }());
 
 /* The shared live strip. One stream per page: a page that runs its own (Setup, Overview) claims

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -600,6 +600,63 @@
 
 </main>
 <script>
+/* Helpers every page may call, placed before the page's own script.
+
+   This one lived in the nav block, which is emitted AFTER the page script. Three pages
+   called it from their own script and read as working, because a browser runs both blocks
+   before anyone clicks anything. The cost only showed when something ran a page's script on
+   its own: the call threw, the browse path caught it along with everything else, and the
+   screen said "Could not reach the gateway" about a gateway it had never asked. A helper
+   that is shared is defined where every caller can already see it. */
+  window.__matrixarkCopyText = function (text) {
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        return navigator.clipboard.writeText(text).then(
+          function () { return true; }, function () { return false; });
+      }
+    } catch (e) { /* falls through to the failure below */ }
+    return Promise.resolve(false);
+  };
+
+  window.__matrixarkWhy = function (body, fallback) {
+    body = body || {};
+    var text = body.detail || body.error || fallback;
+    if (body.required && body.required.length) {
+      text += " — this needs " + [].concat(body.required).join(" or ");
+    }
+    /* A backend failure now answers with a sentence that deliberately says nothing about the
+       inside of the deployment, and a token naming the log entry that does. Showing the token is
+       the whole point of it: without it the reader has a polite sentence and no way to get any
+       further, and an operator has a log they cannot tie to the report. */
+    if (body.incident) {
+      text += " — incident " + body.incident;
+    }
+    return text;
+  };
+
+  window.__matrixarkFailure = function (status, overrides) {
+    if (overrides && overrides[status]) { return overrides[status]; }
+    if (status === 401) { return "This key was not accepted."; }
+    if (status === 403) { return "This key lacks the scope for that call."; }
+    if (status === 413) { return "That request is larger than this deployment accepts."; }
+    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
+    if (status === 502) { return "The gateway could not reach the storage behind it."; }
+    if (status === 503) { return "The gateway is not ready to serve this yet."; }
+    if (status === 504) { return "The backend did not answer in time."; }
+    return "The gateway answered " + status + ".";
+  };
+
+  window.__matrixarkWhen = function (ms) {
+    /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
+       `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
+    if (!ms) { return "—"; }
+    var at = new Date(Number(ms));
+    if (isNaN(at.getTime())) { return "—"; }
+    try { return at.toLocaleString(undefined, { timeZoneName: "short" }); }
+    catch (e) { return at.toLocaleString(); }
+  };
+</script>
+<script>
 /* Tabs, for every portal page whose body declares a tablist.
  *
  * Shared rather than per page. The explore page had the only copy and this is the second caller;
@@ -1903,31 +1960,7 @@
    * `timeZoneName: "short"` rather than the IANA name: "GMT+1" beside the time reads at a glance
    * where "Europe/London" pushes the useful part off the end of a table cell. Falls back to the
    * bare local string on a runtime without it, which is no worse than what was there before. */
-  window.__matrixarkWhen = function (ms) {
-    /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
-       `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
-    if (!ms) { return "—"; }
-    var at = new Date(Number(ms));
-    if (isNaN(at.getTime())) { return "—"; }
-    try { return at.toLocaleString(undefined, { timeZoneName: "short" }); }
-    catch (e) { return at.toLocaleString(); }
-  };
 
-  window.__matrixarkWhy = function (body, fallback) {
-    body = body || {};
-    var text = body.detail || body.error || fallback;
-    if (body.required && body.required.length) {
-      text += " — this needs " + [].concat(body.required).join(" or ");
-    }
-    /* A backend failure now answers with a sentence that deliberately says nothing about the
-       inside of the deployment, and a token naming the log entry that does. Showing the token is
-       the whole point of it: without it the reader has a polite sentence and no way to get any
-       further, and an operator has a log they cannot tie to the report. */
-    if (body.incident) {
-      text += " — incident " + body.incident;
-    }
-    return text;
-  };
 
   /* One sentence per gateway status, for every page.
    *
@@ -1943,27 +1976,7 @@
    * This is the FALLBACK. A refusal that carries a body is explained by __matrixarkWhy from what
    * the gateway said; this is what the reader gets when there is nothing but a number.
    */
-  window.__matrixarkFailure = function (status, overrides) {
-    if (overrides && overrides[status]) { return overrides[status]; }
-    if (status === 401) { return "This key was not accepted."; }
-    if (status === 403) { return "This key lacks the scope for that call."; }
-    if (status === 413) { return "That request is larger than this deployment accepts."; }
-    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
-    if (status === 502) { return "The gateway could not reach the storage behind it."; }
-    if (status === 503) { return "The gateway is not ready to serve this yet."; }
-    if (status === 504) { return "The backend did not answer in time."; }
-    return "The gateway answered " + status + ".";
-  };
 
-  window.__matrixarkCopyText = function (text) {
-    try {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        return navigator.clipboard.writeText(text).then(
-          function () { return true; }, function () { return false; });
-      }
-    } catch (e) { /* falls through to the failure below */ }
-    return Promise.resolve(false);
-  };
 }());
 
 /* The shared live strip. One stream per page: a page that runs its own (Setup, Overview) claims

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -292,6 +292,63 @@
 </main>
 
 <script>
+/* Helpers every page may call, placed before the page's own script.
+
+   This one lived in the nav block, which is emitted AFTER the page script. Three pages
+   called it from their own script and read as working, because a browser runs both blocks
+   before anyone clicks anything. The cost only showed when something ran a page's script on
+   its own: the call threw, the browse path caught it along with everything else, and the
+   screen said "Could not reach the gateway" about a gateway it had never asked. A helper
+   that is shared is defined where every caller can already see it. */
+  window.__matrixarkCopyText = function (text) {
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        return navigator.clipboard.writeText(text).then(
+          function () { return true; }, function () { return false; });
+      }
+    } catch (e) { /* falls through to the failure below */ }
+    return Promise.resolve(false);
+  };
+
+  window.__matrixarkWhy = function (body, fallback) {
+    body = body || {};
+    var text = body.detail || body.error || fallback;
+    if (body.required && body.required.length) {
+      text += " — this needs " + [].concat(body.required).join(" or ");
+    }
+    /* A backend failure now answers with a sentence that deliberately says nothing about the
+       inside of the deployment, and a token naming the log entry that does. Showing the token is
+       the whole point of it: without it the reader has a polite sentence and no way to get any
+       further, and an operator has a log they cannot tie to the report. */
+    if (body.incident) {
+      text += " — incident " + body.incident;
+    }
+    return text;
+  };
+
+  window.__matrixarkFailure = function (status, overrides) {
+    if (overrides && overrides[status]) { return overrides[status]; }
+    if (status === 401) { return "This key was not accepted."; }
+    if (status === 403) { return "This key lacks the scope for that call."; }
+    if (status === 413) { return "That request is larger than this deployment accepts."; }
+    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
+    if (status === 502) { return "The gateway could not reach the storage behind it."; }
+    if (status === 503) { return "The gateway is not ready to serve this yet."; }
+    if (status === 504) { return "The backend did not answer in time."; }
+    return "The gateway answered " + status + ".";
+  };
+
+  window.__matrixarkWhen = function (ms) {
+    /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
+       `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
+    if (!ms) { return "—"; }
+    var at = new Date(Number(ms));
+    if (isNaN(at.getTime())) { return "—"; }
+    try { return at.toLocaleString(undefined, { timeZoneName: "short" }); }
+    catch (e) { return at.toLocaleString(); }
+  };
+</script>
+<script>
 (function () {
   "use strict";
   var $ = function (id) { return document.getElementById(id); };
@@ -826,31 +883,7 @@
    * `timeZoneName: "short"` rather than the IANA name: "GMT+1" beside the time reads at a glance
    * where "Europe/London" pushes the useful part off the end of a table cell. Falls back to the
    * bare local string on a runtime without it, which is no worse than what was there before. */
-  window.__matrixarkWhen = function (ms) {
-    /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
-       `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
-    if (!ms) { return "—"; }
-    var at = new Date(Number(ms));
-    if (isNaN(at.getTime())) { return "—"; }
-    try { return at.toLocaleString(undefined, { timeZoneName: "short" }); }
-    catch (e) { return at.toLocaleString(); }
-  };
 
-  window.__matrixarkWhy = function (body, fallback) {
-    body = body || {};
-    var text = body.detail || body.error || fallback;
-    if (body.required && body.required.length) {
-      text += " — this needs " + [].concat(body.required).join(" or ");
-    }
-    /* A backend failure now answers with a sentence that deliberately says nothing about the
-       inside of the deployment, and a token naming the log entry that does. Showing the token is
-       the whole point of it: without it the reader has a polite sentence and no way to get any
-       further, and an operator has a log they cannot tie to the report. */
-    if (body.incident) {
-      text += " — incident " + body.incident;
-    }
-    return text;
-  };
 
   /* One sentence per gateway status, for every page.
    *
@@ -866,27 +899,7 @@
    * This is the FALLBACK. A refusal that carries a body is explained by __matrixarkWhy from what
    * the gateway said; this is what the reader gets when there is nothing but a number.
    */
-  window.__matrixarkFailure = function (status, overrides) {
-    if (overrides && overrides[status]) { return overrides[status]; }
-    if (status === 401) { return "This key was not accepted."; }
-    if (status === 403) { return "This key lacks the scope for that call."; }
-    if (status === 413) { return "That request is larger than this deployment accepts."; }
-    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
-    if (status === 502) { return "The gateway could not reach the storage behind it."; }
-    if (status === 503) { return "The gateway is not ready to serve this yet."; }
-    if (status === 504) { return "The backend did not answer in time."; }
-    return "The gateway answered " + status + ".";
-  };
 
-  window.__matrixarkCopyText = function (text) {
-    try {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        return navigator.clipboard.writeText(text).then(
-          function () { return true; }, function () { return false; });
-      }
-    } catch (e) { /* falls through to the failure below */ }
-    return Promise.resolve(false);
-  };
 }());
 
 /* The shared live strip. One stream per page: a page that runs its own (Setup, Overview) claims

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -493,6 +493,63 @@
 
 </main>
 <script>
+/* Helpers every page may call, placed before the page's own script.
+
+   This one lived in the nav block, which is emitted AFTER the page script. Three pages
+   called it from their own script and read as working, because a browser runs both blocks
+   before anyone clicks anything. The cost only showed when something ran a page's script on
+   its own: the call threw, the browse path caught it along with everything else, and the
+   screen said "Could not reach the gateway" about a gateway it had never asked. A helper
+   that is shared is defined where every caller can already see it. */
+  window.__matrixarkCopyText = function (text) {
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        return navigator.clipboard.writeText(text).then(
+          function () { return true; }, function () { return false; });
+      }
+    } catch (e) { /* falls through to the failure below */ }
+    return Promise.resolve(false);
+  };
+
+  window.__matrixarkWhy = function (body, fallback) {
+    body = body || {};
+    var text = body.detail || body.error || fallback;
+    if (body.required && body.required.length) {
+      text += " — this needs " + [].concat(body.required).join(" or ");
+    }
+    /* A backend failure now answers with a sentence that deliberately says nothing about the
+       inside of the deployment, and a token naming the log entry that does. Showing the token is
+       the whole point of it: without it the reader has a polite sentence and no way to get any
+       further, and an operator has a log they cannot tie to the report. */
+    if (body.incident) {
+      text += " — incident " + body.incident;
+    }
+    return text;
+  };
+
+  window.__matrixarkFailure = function (status, overrides) {
+    if (overrides && overrides[status]) { return overrides[status]; }
+    if (status === 401) { return "This key was not accepted."; }
+    if (status === 403) { return "This key lacks the scope for that call."; }
+    if (status === 413) { return "That request is larger than this deployment accepts."; }
+    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
+    if (status === 502) { return "The gateway could not reach the storage behind it."; }
+    if (status === 503) { return "The gateway is not ready to serve this yet."; }
+    if (status === 504) { return "The backend did not answer in time."; }
+    return "The gateway answered " + status + ".";
+  };
+
+  window.__matrixarkWhen = function (ms) {
+    /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
+       `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
+    if (!ms) { return "—"; }
+    var at = new Date(Number(ms));
+    if (isNaN(at.getTime())) { return "—"; }
+    try { return at.toLocaleString(undefined, { timeZoneName: "short" }); }
+    catch (e) { return at.toLocaleString(); }
+  };
+</script>
+<script>
 (function () {
   "use strict";
   var $ = function (id) { return document.getElementById(id); };
@@ -1105,31 +1162,7 @@ function liveStream(options) {
    * `timeZoneName: "short"` rather than the IANA name: "GMT+1" beside the time reads at a glance
    * where "Europe/London" pushes the useful part off the end of a table cell. Falls back to the
    * bare local string on a runtime without it, which is no worse than what was there before. */
-  window.__matrixarkWhen = function (ms) {
-    /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
-       `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
-    if (!ms) { return "—"; }
-    var at = new Date(Number(ms));
-    if (isNaN(at.getTime())) { return "—"; }
-    try { return at.toLocaleString(undefined, { timeZoneName: "short" }); }
-    catch (e) { return at.toLocaleString(); }
-  };
 
-  window.__matrixarkWhy = function (body, fallback) {
-    body = body || {};
-    var text = body.detail || body.error || fallback;
-    if (body.required && body.required.length) {
-      text += " — this needs " + [].concat(body.required).join(" or ");
-    }
-    /* A backend failure now answers with a sentence that deliberately says nothing about the
-       inside of the deployment, and a token naming the log entry that does. Showing the token is
-       the whole point of it: without it the reader has a polite sentence and no way to get any
-       further, and an operator has a log they cannot tie to the report. */
-    if (body.incident) {
-      text += " — incident " + body.incident;
-    }
-    return text;
-  };
 
   /* One sentence per gateway status, for every page.
    *
@@ -1145,27 +1178,7 @@ function liveStream(options) {
    * This is the FALLBACK. A refusal that carries a body is explained by __matrixarkWhy from what
    * the gateway said; this is what the reader gets when there is nothing but a number.
    */
-  window.__matrixarkFailure = function (status, overrides) {
-    if (overrides && overrides[status]) { return overrides[status]; }
-    if (status === 401) { return "This key was not accepted."; }
-    if (status === 403) { return "This key lacks the scope for that call."; }
-    if (status === 413) { return "That request is larger than this deployment accepts."; }
-    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
-    if (status === 502) { return "The gateway could not reach the storage behind it."; }
-    if (status === 503) { return "The gateway is not ready to serve this yet."; }
-    if (status === 504) { return "The backend did not answer in time."; }
-    return "The gateway answered " + status + ".";
-  };
 
-  window.__matrixarkCopyText = function (text) {
-    try {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        return navigator.clipboard.writeText(text).then(
-          function () { return true; }, function () { return false; });
-      }
-    } catch (e) { /* falls through to the failure below */ }
-    return Promise.resolve(false);
-  };
 }());
 
 /* The shared live strip. One stream per page: a page that runs its own (Setup, Overview) claims

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -748,6 +748,63 @@
 
 </main>
 <script>
+/* Helpers every page may call, placed before the page's own script.
+
+   This one lived in the nav block, which is emitted AFTER the page script. Three pages
+   called it from their own script and read as working, because a browser runs both blocks
+   before anyone clicks anything. The cost only showed when something ran a page's script on
+   its own: the call threw, the browse path caught it along with everything else, and the
+   screen said "Could not reach the gateway" about a gateway it had never asked. A helper
+   that is shared is defined where every caller can already see it. */
+  window.__matrixarkCopyText = function (text) {
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        return navigator.clipboard.writeText(text).then(
+          function () { return true; }, function () { return false; });
+      }
+    } catch (e) { /* falls through to the failure below */ }
+    return Promise.resolve(false);
+  };
+
+  window.__matrixarkWhy = function (body, fallback) {
+    body = body || {};
+    var text = body.detail || body.error || fallback;
+    if (body.required && body.required.length) {
+      text += " — this needs " + [].concat(body.required).join(" or ");
+    }
+    /* A backend failure now answers with a sentence that deliberately says nothing about the
+       inside of the deployment, and a token naming the log entry that does. Showing the token is
+       the whole point of it: without it the reader has a polite sentence and no way to get any
+       further, and an operator has a log they cannot tie to the report. */
+    if (body.incident) {
+      text += " — incident " + body.incident;
+    }
+    return text;
+  };
+
+  window.__matrixarkFailure = function (status, overrides) {
+    if (overrides && overrides[status]) { return overrides[status]; }
+    if (status === 401) { return "This key was not accepted."; }
+    if (status === 403) { return "This key lacks the scope for that call."; }
+    if (status === 413) { return "That request is larger than this deployment accepts."; }
+    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
+    if (status === 502) { return "The gateway could not reach the storage behind it."; }
+    if (status === 503) { return "The gateway is not ready to serve this yet."; }
+    if (status === 504) { return "The backend did not answer in time."; }
+    return "The gateway answered " + status + ".";
+  };
+
+  window.__matrixarkWhen = function (ms) {
+    /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
+       `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
+    if (!ms) { return "—"; }
+    var at = new Date(Number(ms));
+    if (isNaN(at.getTime())) { return "—"; }
+    try { return at.toLocaleString(undefined, { timeZoneName: "short" }); }
+    catch (e) { return at.toLocaleString(); }
+  };
+</script>
+<script>
 /* Tabs, for every portal page whose body declares a tablist.
  *
  * Shared rather than per page. The explore page had the only copy and this is the second caller;
@@ -3062,31 +3119,7 @@ function liveStream(options) {
    * `timeZoneName: "short"` rather than the IANA name: "GMT+1" beside the time reads at a glance
    * where "Europe/London" pushes the useful part off the end of a table cell. Falls back to the
    * bare local string on a runtime without it, which is no worse than what was there before. */
-  window.__matrixarkWhen = function (ms) {
-    /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
-       `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
-    if (!ms) { return "—"; }
-    var at = new Date(Number(ms));
-    if (isNaN(at.getTime())) { return "—"; }
-    try { return at.toLocaleString(undefined, { timeZoneName: "short" }); }
-    catch (e) { return at.toLocaleString(); }
-  };
 
-  window.__matrixarkWhy = function (body, fallback) {
-    body = body || {};
-    var text = body.detail || body.error || fallback;
-    if (body.required && body.required.length) {
-      text += " — this needs " + [].concat(body.required).join(" or ");
-    }
-    /* A backend failure now answers with a sentence that deliberately says nothing about the
-       inside of the deployment, and a token naming the log entry that does. Showing the token is
-       the whole point of it: without it the reader has a polite sentence and no way to get any
-       further, and an operator has a log they cannot tie to the report. */
-    if (body.incident) {
-      text += " — incident " + body.incident;
-    }
-    return text;
-  };
 
   /* One sentence per gateway status, for every page.
    *
@@ -3102,27 +3135,7 @@ function liveStream(options) {
    * This is the FALLBACK. A refusal that carries a body is explained by __matrixarkWhy from what
    * the gateway said; this is what the reader gets when there is nothing but a number.
    */
-  window.__matrixarkFailure = function (status, overrides) {
-    if (overrides && overrides[status]) { return overrides[status]; }
-    if (status === 401) { return "This key was not accepted."; }
-    if (status === 403) { return "This key lacks the scope for that call."; }
-    if (status === 413) { return "That request is larger than this deployment accepts."; }
-    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
-    if (status === 502) { return "The gateway could not reach the storage behind it."; }
-    if (status === 503) { return "The gateway is not ready to serve this yet."; }
-    if (status === 504) { return "The backend did not answer in time."; }
-    return "The gateway answered " + status + ".";
-  };
 
-  window.__matrixarkCopyText = function (text) {
-    try {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        return navigator.clipboard.writeText(text).then(
-          function () { return true; }, function () { return false; });
-      }
-    } catch (e) { /* falls through to the failure below */ }
-    return Promise.resolve(false);
-  };
 }());
 
 /* The shared live strip. One stream per page: a page that runs its own (Setup, Overview) claims

--- a/tools/test_matrixark_a_shared_helper_is_defined_before_it_is_called.py
+++ b/tools/test_matrixark_a_shared_helper_is_defined_before_it_is_called.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A helper a page calls is defined before the call, or the call asks whether it exists.
+
+The portal emits three script blocks per page: shared helpers, then the page's own script, then
+the live strip. A helper more than one page calls belongs in the first block. Four of them were in
+the LAST one instead, and every page still worked -- a browser has run all three blocks long
+before anyone clicks anything, so nothing on screen could tell you.
+
+What it cost showed up somewhere else. Explore's browse path catches everything its two fetches
+can throw and writes one message: "Could not reach the gateway." A call to a helper that is not
+defined yet is a ReferenceError, the catch does not care which it caught, and the page reported a
+network incident about a gateway it had never asked.
+
+**Two ways to be safe, and the second is not a loophole.** The strip's own helpers stay in the
+nav block, because they close over the state it keeps between frames -- moving them out cost five
+strip tests, which is "defined on window" and "shared" turning out to be different things. Page
+code reaches those through ``if (window.__matrixarkLiveFrame) { ... }``, which is correct on a
+page where the strip may not be installed at all. So the exception is read off the guard in the
+code rather than kept here as a list of names: a list would have to be edited by the same change
+that breaks it.
+
+Two things a first draft got wrong, both worth keeping in mind when editing this:
+
+* a helper is not always assigned a function literal. ``api_key`` aliases one of its own locals
+  (``window.__matrixarkCopy = copyText``), which is a definition like any other. Matching only
+  ``= function`` reported that page as calling something nothing defines.
+* ``__matrixarkCopy`` is a PREFIX of ``__matrixarkCopyText``, and both are on that page. A plain
+  substring search finds the longer name when asked for the shorter one, so the name has to end
+  where the search says it does.
+"""
+from __future__ import annotations
+
+import io
+import os
+import re
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+
+CALL = re.compile(r"window\.(__matrixark[A-Za-z0-9_]*)\s*\(")
+SHARED_BLOCK = "Helpers every page may call"
+LOOKBACK = 200
+
+
+def defined(helper: str) -> re.Pattern:
+    """Any assignment to the name, and only to that name -- `\\s*=` cannot follow a longer one."""
+    return re.compile(r"window\." + re.escape(helper) + r"\s*=\s*")
+
+
+def guarded(helper: str) -> re.Pattern:
+    """The name tested rather than called: `if (window.X)`, `window.X &&`, `window.X ?`."""
+    return re.compile(r"window\." + re.escape(helper) + r"\s*(?:\)|&&|\?)")
+
+
+def pages() -> list:
+    return sorted(f for f in os.listdir(PORTAL) if f.endswith("_portal.html"))
+
+
+def read(name: str) -> str:
+    with io.open(os.path.join(PORTAL, name), encoding="utf-8") as handle:
+        return handle.read()
+
+
+def first_unguarded_call(text: str, helper: str) -> int:
+    """Where this page first calls the helper without asking whether it is there. -1 if never."""
+    check = guarded(helper)
+    for match in CALL.finditer(text):
+        if match.group(1) != helper:
+            continue
+        if not check.search(text[max(0, match.start() - LOOKBACK):match.start()]):
+            return match.start()
+    return -1
+
+
+def called(text: str) -> set:
+    return set(match.group(1) for match in CALL.finditer(text))
+
+
+class ASharedHelperIsDefinedFirstTest(unittest.TestCase):
+
+    def test_every_call_reaches_something_that_exists(self) -> None:
+        """The floor: a name nothing on the page assigns is a ReferenceError however it is used."""
+        for name in pages():
+            text = read(name)
+            for helper in sorted(called(text)):
+                self.assertIsNotNone(
+                    defined(helper).search(text),
+                    "%s calls %s and nothing on the page defines it" % (name, helper))
+
+    def test_an_unguarded_call_has_its_definition_above_it(self) -> None:
+        for name in pages():
+            text = read(name)
+            for helper in sorted(called(text)):
+                call_at = first_unguarded_call(text, helper)
+                if call_at < 0:
+                    continue          # every call asks first, which is safe wherever it sits
+                at = defined(helper).search(text).start()
+                self.assertLess(
+                    at, call_at,
+                    "%s calls %s at %d without asking whether it is there, and defines it at "
+                    "%d -- anything that runs this page's own script by itself gets a "
+                    "ReferenceError, and Explore's browse path reports that as a gateway failure"
+                    % (name, helper, call_at, at))
+
+    def test_it_is_defined_once_per_page(self) -> None:
+        """Two copies is two things to keep in step, and the later one silently wins."""
+        for name in pages():
+            text = read(name)
+            for helper in sorted(called(text)):
+                found = len(defined(helper).findall(text))
+                self.assertEqual(1, found, "%s defines %s %d times" % (name, helper, found))
+
+    def test_the_pages_really_do_call_one(self) -> None:
+        """The positive control. Every assertion above passes perfectly on a portal that calls no
+        shared helper at all, and that is the state a bad edit would leave behind."""
+        calling = [name for name in pages() if called(read(name))]
+        self.assertGreaterEqual(len(calling), 3, "found calls on %s" % (calling or "no page"))
+
+    def test_some_call_is_actually_unguarded(self) -> None:
+        """The other positive control, for the exception rather than the rule. If every call on
+        every page were read as guarded -- one loose pattern would do it -- the ordering assertion
+        above would pass while checking nothing at all."""
+        unguarded = [(name, helper) for name in pages() for helper in sorted(called(read(name)))
+                     if first_unguarded_call(read(name), helper) >= 0]
+        self.assertGreaterEqual(len(unguarded), 5, "only %d unguarded calls found" % len(unguarded))
+
+    def test_the_shared_block_is_on_every_page_exactly_once(self) -> None:
+        """Once, not at least once: the block is injected into the two hand-maintained pages on
+        every build, and a build that adds a copy instead of replacing one leaves the page with
+        two definitions of everything in it."""
+        for name in pages():
+            self.assertEqual(1, read(name).count(SHARED_BLOCK),
+                             "%s does not carry exactly one shared helper block" % name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The portal writes three script blocks per page: shared helpers, the page's own
script, then the live strip. **Four helpers the pages call were in the last block.**

This is a fix for a break I landed in #1250, found by the suite rather than by
anyone looking at a screen.

## Why nothing showed it

Every page worked. A browser has run all three blocks long before anyone clicks
anything, so no page could tell you the definition came after the call. Nothing
did — until something ran one page's script by itself.

Then the call is a `ReferenceError`. Explore's browse path catches it along with
everything else its two fetches can throw, and writes the one message it has:

> Could not reach the gateway.

About a gateway it had never asked. Three tests read that message and went red on
a page that works fine in a browser — a rendering fault reported as a network
incident, which is the least useful thing a debugging surface can do.

## What moved, and what deliberately did not

| helper | where it lives now | why |
|---|---|---|
| `__matrixarkWhen`, `__matrixarkCopyText`, `__matrixarkWhy`, `__matrixarkFailure` | the shared block, emitted first | pure — values in, string out, nothing kept between calls |
| `__matrixarkOnFrame`, `__matrixarkLiveFrame`, `__matrixarkLiveState` | **stay in the nav block** | they close over the state the strip keeps between frames |

Moving all seven was the first attempt and it cost five strip tests: "defined on
`window`" and "shared" turn out to be different properties.

The two hand-maintained pages get the block **before** their own script, taken out
and re-placed on each build rather than replaced where it sits — so an old position
cannot survive a build. The tab helper already worked this way; this follows it.

## The harness runs the block, it does not stub it

The browse harness's sandbox models the globals the browse region can see, and had
no `window` at all. It now executes the page's own shared block. A stub would let
the shipped helper change underneath the test without a word.

## The guard

Driven off the pages, not a list of names — a list would have to be edited by the
same change that breaks it.

Two ways to be safe, and the second is not a loophole: **defined above the call**,
or **the call asks first**. `if (window.__matrixarkLiveFrame)` is correct on a page
where the strip may not be installed at all, so that exception is read off the guard
in the code rather than written down here.

## Checks

Seven mutations. Five over the builder — each reddens the ordering assertion, the
once-per-page assertion, or the floor. Two over the guard's own patterns, because
the two positive controls answer to *this test going blind*, which no mutation of
the builder can reach:

* read every call as guarded → the exception swallows the rule;
* recognise no call at all → every assertion passes on a portal that calls nothing.

Full Python suite ratchet run on the branch.
