### PR TITLE
Two fixes for one problem left the harness unparseable

### DIFF
--- a/tools/portal/browse_failure_harness.js
+++ b/tools/portal/browse_failure_harness.js
@@ -16,7 +16,7 @@ const fs = require("fs");
 const page = fs.readFileSync(process.argv[2], "utf8");
 const failing = process.argv[3] || "users";
 
-/* The balanced-brace slice, now needed twice. */
+/* The balanced-brace slice that takes loadBrowse out of the page. */
 function sliceBlock(from) {
   let depth = 0;
   for (let i = page.indexOf("{", from); i < page.length; i++) {
@@ -29,17 +29,6 @@ function sliceBlock(from) {
 const start = page.indexOf("function loadBrowse() {");
 if (start < 0) { console.log("FAIL loadBrowse is not on this page"); process.exit(2); }
 const loadBrowseSrc = sliceBlock(start);
-
-/* loadBrowse formats each row's timestamp through `window.__matrixarkWhen`. Take the page's OWN
-   formatter rather than stubbing one: a stub would let a change to the shipped formatter pass here
-   unseen, and this harness exists to run what ships. `when_harness.js` slices it the same way.
-   Without it `window` is simply absent from the sandbox, the call raises, and the page's own catch
-   reports "Could not reach the gateway." -- a failure message on the mode that asserts there is
-   none. */
-const whenStart = page.indexOf("window.__matrixarkWhen = function (ms)");
-if (whenStart < 0) { console.log("FAIL __matrixarkWhen is not on this page"); process.exit(2); }
-const whenSrc = sliceBlock(whenStart).replace("window.__matrixarkWhen = ", "");
-const win = { __matrixarkWhen: new Function("return (" + whenSrc + ");")() };
 
 /* The page's shared helpers are a script block of their own, emitted before the page's own
  * script. The sandbox below models what the browse region can see, so it needs them too --


### PR DESCRIPTION
`browse_failure_harness.js` does not parse on `main`, so all eight tests in
`test_matrixark_a_failed_list_is_not_an_empty_scope` fail:

    browse_failure_harness.js:52
    const win = {};
          ^
    SyntaxError: Identifier 'win' has already been declared

Two changes gave the harness a `window` within minutes of each other, and both declared `const win`.
Each was correct alone and neither could see the other; together the file stopped parsing and took
the whole suite with it -- including the three tests both were fixing.

#1261's version is strictly the more general. It runs the page's entire shared-helper block, so all
four helpers are present and a later page change that adds a fifth needs nothing here. #1259's
sliced out `__matrixarkWhen` alone. So #1261's stays and #1259's is removed -- this is not a revert
of the fix, it is removing the second copy of it.

`sliceBlock` stays, since `loadBrowse` is still taken out of the page that way. Its comment said it
was "needed twice" and now says what its one caller is.

## Test

`node --check` parses the file, all five harness modes report `all ok`, and the suite goes from 5
failed to 8 passed.

Checked rather than assumed: exactly one `const win` remains, nothing still refers to the removed
block, `sliceBlock` still has its one caller, and the sandbox still receives `window` -- each
asserted by the change itself before it would write the file.
