### PR TITLE
Make the manifest-conformance catalog fold unconditional

### DIFF
--- a/config/temporalstore.toml
+++ b/config/temporalstore.toml
@@ -79,8 +79,7 @@ page_store_compression_level = 3       # TS_PAGE_STORE_COMPRESSION_LEVEL    comp
 # which are both the smallest and the most repetitive in the system. Compressing everything is
 # worse again: at a 1-byte floor the saving stops and the median add rises to 256.0 ms.
 page_store_compression_min_bytes = 256  # TS_PAGE_STORE_COMPRESSION_MIN_BYTES  skip compressing pages smaller than this
-index_dump_oplog_gap_bytes = 1048576   # TS_INDEX_DUMP_WAL_GAP_BYTES  undumped index-log gap (bytes, 1 MiB) that triggers a background catalog/index dump under the manifest-parity catalog fold (TS_INDEX_CATALOG_FOLD); 0 disables the threshold cadence. TS_INDEX_DUMP_OPLOG_GAP_BYTES is the previous variable name, still honoured by the engine when this one is unset
-# index_catalog_fold = 1               # TS_INDEX_CATALOG_FOLD  1 = fold the band/zone catalog into the index-log MetaItem and drive it via the threshold dump above, instead of the per-write band-manifest file. Ships ON: the engine defaults it on and reads it in eight places, so this line is the way to turn it OFF, not on.
+index_dump_oplog_gap_bytes = 1048576   # TS_INDEX_DUMP_WAL_GAP_BYTES  undumped index-log gap (bytes, 1 MiB) that triggers a background catalog/index dump under the manifest-parity catalog fold; 0 disables the threshold cadence. TS_INDEX_DUMP_OPLOG_GAP_BYTES is the previous variable name, still honoured by the engine when this one is unset
 
 
 # -----------------------------------------------------------------------------

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -368,12 +368,9 @@ impl TemporalEngine {
         // reclaimed slabs with no live file. It never deletes a reconciled band and never lowers
         // physical bytes below the slab's real size, so it cannot lose durable state -- it is a
         // metadata refinement over the lossless disk-derived catalog, making the per-write
-        // band-manifest file unnecessary as the catalog's source of truth. Off, this is skipped
-        // entirely (byte-identical).
-        if crate::index_log::index_catalog_fold_enabled() {
-            if let Ok(Some(meta)) = self.index_log_store.latest_zone_catalog(request.shard_id) {
-                let _ = self.page_store.install_zone_catalog(&meta.zones);
-            }
+        // band-manifest file unnecessary as the catalog's source of truth.
+        if let Ok(Some(meta)) = self.index_log_store.latest_zone_catalog(request.shard_id) {
+            let _ = self.page_store.install_zone_catalog(&meta.zones);
         }
         let mut state = loaded.unwrap_or_default();
         promote_model_maps_to_bucket_index_authority(

--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -382,12 +382,8 @@ impl TemporalEngine {
 
     /// MANIFEST-CONFORMANCE FOLD threshold check: dump the index catalog when the undumped index-log
     /// gap has crossed `index_dump_wal_gap_bytes` (the index-meta dump gap
-    /// cadence). No-op with the `TS_INDEX_CATALOG_FOLD` gate off, so the background cycle is
-    /// byte-identical when the fold is not enabled. Returns whether a dump fired.
+    /// cadence). Returns whether a dump fired.
     pub fn maybe_dump_index_catalog(&self, shard_id: ShardId) -> bool {
-        if !crate::index_log::index_catalog_fold_enabled() {
-            return false;
-        }
         let gap = crate::storage_config::index_dump_wal_gap_bytes();
         let undumped = self.index_log_store.undumped_len_since_dump(shard_id);
         if !crate::index_log::should_dump_index_catalog(undumped, gap) {
@@ -405,9 +401,6 @@ impl TemporalEngine {
         shard_id: ShardId,
         gap_bytes: u64,
     ) -> bool {
-        if !crate::index_log::index_catalog_fold_enabled() {
-            return false;
-        }
         let undumped = self.index_log_store.undumped_len_since_dump(shard_id);
         if !crate::index_log::should_dump_index_catalog(undumped, gap_bytes) {
             return false;
@@ -433,9 +426,6 @@ impl TemporalEngine {
     /// below the anchor, index-log records whose own anchor is at or below it) is redundant,
     /// while the folded anchor record itself must survive.
     pub(super) fn dump_index_catalog_anchored(&self, shard_id: ShardId) -> Option<(u64, u64)> {
-        if !crate::index_log::index_catalog_fold_enabled() {
-            return None;
-        }
         // A dump for a shard this engine does not serve is a no-op; check BEFORE the durability
         // barrier so a background caller polling an unloaded shard does not pay (or issue) an
         // fsync for nothing.
@@ -514,9 +504,6 @@ impl TemporalEngine {
         &self,
         shard_id: ShardId,
     ) -> Option<super::reports::CatalogDumpReclaimReport> {
-        if !crate::index_log::index_catalog_fold_enabled() {
-            return None;
-        }
         let gap = crate::storage_config::index_dump_wal_gap_bytes();
         let undumped = self.index_log_store.undumped_len_since_dump(shard_id);
         if !crate::index_log::should_dump_index_catalog(undumped, gap) {
@@ -616,9 +603,6 @@ impl TemporalEngine {
         shard_id: ShardId,
         gap_bytes: u64,
     ) -> Option<super::reports::CatalogDumpReclaimReport> {
-        if !crate::index_log::index_catalog_fold_enabled() {
-            return None;
-        }
         let undumped = self.index_log_store.undumped_len_since_dump(shard_id);
         if !crate::index_log::should_dump_index_catalog(undumped, gap_bytes) {
             return None;

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -2221,30 +2221,6 @@ fn reconcile_does_not_resurrect_evicted_feature_points_on_reload() {
     );
 }
 
-/// Sets an env gate for the duration of a test and removes it on drop (even on panic), so a
-/// gated-behavior test never leaks its flag into the rest of the suite.
-struct FoldEnvGuard {
-    names: Vec<&'static str>,
-}
-
-impl FoldEnvGuard {
-    fn set(pairs: &[(&'static str, &str)]) -> Self {
-        let names = pairs.iter().map(|(name, _)| *name).collect();
-        for (name, value) in pairs {
-            std::env::set_var(name, value);
-        }
-        Self { names }
-    }
-}
-
-impl Drop for FoldEnvGuard {
-    fn drop(&mut self) {
-        for name in &self.names {
-            std::env::remove_var(name);
-        }
-    }
-}
-
 fn write_string(engine: &TemporalEngine, key: &str, value: &[u8]) {
     engine.execute(ExecuteRequest {
         shard_id: 1,
@@ -2276,7 +2252,6 @@ fn manifest_fold_threshold_dump_fires_only_past_the_gap_and_folds_the_catalog() 
     // undumped index-log has grown past it, folding the band/zone catalog into an index-log
     // MetaItem anchor; below the gap nothing is dumped. Matches
     // index-meta dump background cadence -- never a per-write dump.
-    let _guard = FoldEnvGuard::set(&[("TS_INDEX_CATALOG_FOLD", "1")]);
     let dir = tempfile::tempdir().unwrap();
     let page_dir = dir.path().join("pages");
     let index_dir = dir.path().join("indexes");
@@ -2320,7 +2295,6 @@ fn catalog_dump_reclaim_shrinks_both_logs_and_reload_stays_exact() {
     // index-log records the base reflects and the WAL prefix below the anchor are redundant --
     // reclaiming them must SHRINK both files on disk, keep the cadence alive (watermark
     // measured from the post-reclaim length), and leave a reload byte-exact.
-    let _guard = FoldEnvGuard::set(&[("TS_INDEX_CATALOG_FOLD", "1")]);
     let dir = tempfile::tempdir().unwrap();
     let page_dir = dir.path().join("pages");
     let index_dir = dir.path().join("indexes");
@@ -2389,7 +2363,6 @@ fn catalog_dump_reclaim_pins_wal_records_holding_block_in_wal_pages() {
     // An async write's page can live ONLY in its WAL record (served back through the
     // block-in-WAL registration). A post-dump WAL sweep must pin its floor at the lowest
     // registered sequence so that record survives, even when the dump anchor is far above it.
-    let _guard = FoldEnvGuard::set(&[("TS_INDEX_CATALOG_FOLD", "1")]);
     let dir = tempfile::tempdir().unwrap();
     let engine = TemporalEngine::with_local_dirs(
         1 << 20,
@@ -2444,7 +2417,6 @@ fn manifest_fold_reload_reconstructs_catalog_with_band_manifest_deleted() {
     // MANIFEST-CONFORMANCE FOLD round-trip: write, dump (folds the catalog), delete the band-manifest
     // file, reload -- every acked key must survive AND the band lifecycle must reconstruct from
     // the folded index-log MetaItem, proving the fold is a lossless catalog source.
-    let _guard = FoldEnvGuard::set(&[("TS_INDEX_CATALOG_FOLD", "1")]);
     let dir = tempfile::tempdir().unwrap();
     let page_dir = dir.path().join("pages");
     let index_dir = dir.path().join("indexes");
@@ -2497,7 +2469,6 @@ fn manifest_fold_on_does_not_resurrect_evicted_feature_points_on_reload() {
     // The #22 resurrection trap must still hold with the fold ON: the fold touches the band
     // catalog (M1), NOT the per-write served-index delta / key_states nor the WAL config-log, so
     // config-driven feature_max_size eviction stays durable and does not resurrect on reload.
-    let _guard = FoldEnvGuard::set(&[("TS_INDEX_CATALOG_FOLD", "1")]);
     let dir = tempfile::tempdir().unwrap();
     let page_dir = dir.path().join("pages");
     let index_dir = dir.path().join("indexes");

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -300,7 +300,7 @@ pub struct ZoneInfo {
 /// MetaItem's `start_WAL_id` role in the native WAL vocabulary.
 ///
 /// `zones` folds the band catalog into the anchor. It
-/// is populated ONLY at a threshold dump, and ONLY when the `TS_INDEX_CATALOG_FOLD` gate is on;
+/// is populated ONLY at a threshold dump;
 /// with the gate off it is always empty and (via `skip_serializing_if`) not serialized, so an
 /// anchor record is byte-identical to the pre-fold record. Legacy anchors without `zones`
 /// deserialize to an empty catalog and replay unchanged.
@@ -487,28 +487,19 @@ fn indexlog_wal_only_sync() -> bool {
     !crate::engine::wal_legacy_recovery()
 }
 
-/// MANIFEST-CONFORMANCE FOLD gate (default ON, opt-out). When on, the band/zone
-/// catalog is folded into the index-log anchor at a threshold dump
-/// and the per-write band-manifest file stops being the
-/// catalog's source of truth (it is reconstructed on load from the durable pages + the folded
-/// anchor). Off, none of that fold code runs: no `zones` are ever captured (so anchor records
-/// serialize identically), and recovery/persistence take the existing paths unchanged.
+/// MANIFEST-CONFORMANCE FOLD, always on: the band/zone catalog is folded into the index-log
+/// anchor at a threshold dump, and the per-write band-manifest file is no longer the catalog's
+/// source of truth (it is reconstructed on load from the durable pages plus the folded anchor).
+/// `TS_INDEX_CATALOG_FOLD` used to be able to skip all of it. It shipped dark (the flip once
+/// broke proxy tests), then defaulted on once the upsert-delta and single-barrier work landed,
+/// and nothing ever selected the off position again -- the five tests that exercise the fold
+/// pinned it ON rather than off. The threshold dump is also what lets the embedded (proxy)
+/// engine reclaim its index-log and WAL at all, so the off side disabled reclaim entirely.
 ///
-/// Shipped dark originally (the flip once broke proxy tests); the full lib + proxy suites are
-/// green with it on since the upsert-delta and single-barrier work landed, and the threshold
-/// dump is what lets the embedded (proxy) engine reclaim its index-log and WAL at all -- so it
-/// now defaults on. Set `TS_INDEX_CATALOG_FOLD=0` to restore the previous behaviour.
-pub fn index_catalog_fold_enabled() -> bool {
-    !matches!(
-        std::env::var("TS_INDEX_CATALOG_FOLD")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "0" | "false" | "no" | "off"
-    )
-}
-
+/// The off side's compatibility claim still holds and is not conditional on anything: an anchor
+/// whose `zones` is empty serializes with no `zones` key, byte-identical to a pre-fold MetaItem.
+/// `meta_item_without_zones_serializes_byte_identically_to_pre_fold` asserts exactly that.
+///
 /// Threshold decision for the background catalog/index dump, mirroring this design
 /// index-meta dump gate (the dump-delay check compares the undumped
 /// WAL length against the 1 MiB gap). `undumped_bytes` is the served-index-log growth since
@@ -1777,9 +1768,10 @@ mod tests {
         );
     }
 
+    #[test]
     fn meta_item_without_zones_serializes_byte_identically_to_pre_fold() {
-        // Byte-identical-when-off invariant: an anchor whose `zones` is empty (the only state
-        // reachable with TS_INDEX_CATALOG_FOLD off) must serialize with NO `zones` key and NO
+        // Pre-fold compatibility invariant: an anchor whose `zones` is empty must serialize with
+        // NO `zones` key and NO
         // `zone_version` beyond what a pre-fold MetaItem produced. `zone_version` defaults to 0
         // and is not skipped, so it appears; assert the value carries only the legacy three
         // fields plus a zero zone_version and no zones array.

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -4298,12 +4298,12 @@ fn open_engine(request: &RecordLogRequest) -> Result<RecordStore, String> {
     // `TS_INDEX_DUMP_WAL_GAP_BYTES`, dump the catalog and reclaim the log prefixes the dump
     // made redundant. The poll itself is one file-length stat per interval; the dump/reclaim
     // runs off the request path so no client write pays for the base-index materialization.
-    // No-op (thread not spawned) with the fold gate off or the interval set to 0.
+    // No-op (thread not spawned) with the interval set to 0.
     let reclaim_interval_ms = env::var("MATRIXARK_RUST_PROXY_LOG_RECLAIM_INTERVAL_MS")
         .ok()
         .and_then(|value| value.trim().parse::<u64>().ok())
         .unwrap_or(1000);
-    if temporalstore_rust::index_log::index_catalog_fold_enabled() && reclaim_interval_ms > 0 {
+    if reclaim_interval_ms > 0 {
         let reclaim_engine = engine.clone();
         let reclaim_root = root.clone();
         std::thread::spawn(move || loop {

--- a/crates/temporalstore-rust/src/storage_config.rs
+++ b/crates/temporalstore-rust/src/storage_config.rs
@@ -164,7 +164,7 @@ pub fn storage_zone_size_bytes() -> u64 {
 /// Undumped index-log-gap threshold (bytes) that triggers a background catalog/index dump under
 /// the MANIFEST-CONFORMANCE FOLD. Reads the `TS_INDEX_DUMP_WAL_GAP_BYTES` env override -- or the
 /// previous name for it, so existing deployments keep working -- falling back to the 1 MiB
-/// default. Only consulted when `index_catalog_fold_enabled()`.
+/// default. Only consulted by the catalog fold's threshold dump.
 pub fn index_dump_wal_gap_bytes() -> u64 {
     StorageTuningConfig::from_env().index_dump_wal_gap_bytes
 }

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -8,7 +8,7 @@ within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 288 of them, read by 89 functions.
+There are 287 of them, read by 88 functions.
 
 Deleting unreachable code is not the lever. An earlier version of this document argued that
 by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
@@ -60,13 +60,13 @@ Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 288 |
-| booleans whose default this could read off the source | 48 |
+| total | 287 |
+| booleans whose default this could read off the source | 47 |
 | numbers whose default this could read off the source | 70 |
 | **defaulting on, and set by nothing** | 5 |
 | offered on the portal | 27 |
 | **that nothing in this repository sets** | 157 |
-| documented as keeping an older path alive | 4 |
+| documented as keeping an older path alive | 3 |
 | reaching more than two files | 15 |
 | whose doc comment is really about another flag | 43 |
 
@@ -202,13 +202,12 @@ What is written, when it is flushed, and what is reclaimed. The escape hatches h
 | `TS_WAL_RESIDENT_PAGES` | 4096 | test | 1 | — |
 | `TS_WAL_SEGMENT_BYTES` | 262144 | nothing | 1 | — |
 
-## format (6)
+## format (5)
 
 The shape of what is written. Readers generally accept both shapes, which is what makes these safe to flip and hard to retire.
 
 | flag | default | set by | files | keeps an older path |
 |---|---|---|---|---|
-| `TS_INDEX_CATALOG_FOLD` | on | config | 1 | yes |
 | `TS_INDEX_CODEC` | — | test | 1 | — |
 | `TS_NODE_SUMMARY_VECTOR` | on | test, portal | 1 | — |
 | `TS_PROXY_BINARY_VERSION` | — | nothing | 1 | — |

--- a/tools/matrixark_load_config.py
+++ b/tools/matrixark_load_config.py
@@ -91,7 +91,6 @@ ENV_MAP: Dict[str, str] = {
     "storage.page_store_compression_min_bytes": "TS_PAGE_STORE_COMPRESSION_MIN_BYTES",
     # Offered by the config file, commented out, and mapped by nothing -- so uncommenting the line
     # would have set nothing. The flag is live: default ON, read in eight places.
-    "storage.index_catalog_fold": "TS_INDEX_CATALOG_FOLD",
     # The engine reads TS_INDEX_DUMP_WAL_GAP_BYTES first and falls back to
     # TS_INDEX_DUMP_OPLOG_GAP_BYTES only when it is unset, so exporting the older name put
     # every value from this file behind anything that set the current one -- including a

--- a/tools/test_the_loader_maps_every_config_key.py
+++ b/tools/test_the_loader_maps_every_config_key.py
@@ -15,7 +15,8 @@ Two were in that state and neither was visible:
     "`TS_WAL_COMMIT_DELAY_US` (config `[wal] commit_delay_us`)"), and both of its neighbours in
     the same section were mapped.
   * `[storage] index_catalog_fold`, commented out, naming a flag that defaults ON and is read in
-    eight places -- so uncommenting it would have done nothing.
+    eight places -- so uncommenting it would have done nothing. (That flag has since been retired:
+    the fold is unconditional, and the key and its mapping went with it.)
 
 Commented keys count. A commented line is an offer, and the only reason to write one is that
 somebody may uncomment it.


### PR DESCRIPTION
`TS_INDEX_CATALOG_FOLD` defaults on, and nothing selects the off position. The only
mention in a config file was a commented-out line, and the five tests that exercise the
fold pin the flag **ON** rather than off — so the suite already refuses to run the off
side. What the branch bought was eight early returns.

## What the off side actually did

The fold puts the band/zone catalog into the index-log anchor at a threshold dump, so the
per-write band-manifest file stops being the catalog's source of truth (it is rebuilt on
load from the durable pages plus the folded anchor). It shipped dark — the flip once broke
proxy tests — and defaulted on once the upsert-delta and single-barrier work landed.

The threshold dump is also what lets the embedded (proxy) engine reclaim its index-log and
WAL at all, so the off position did not merely skip an optimization: it disabled reclaim
for the serving proxy. That is the branch nobody selected, and it is the one that would
have grown the log without bound.

## The invariant it rested on had never run

The off side's claim was that it is byte-identical: with no fold, no `zones` are captured,
so an anchor record serializes exactly as a pre-fold `MetaItem` did.
`meta_item_without_zones_serializes_byte_identically_to_pre_fold` is the test that asserts
it — and it carried **no `#[test]` attribute**, so it had never executed once.

It has the attribute now, and it passes. That matters more after this change than before:
the invariant is no longer about an off position, it is the ongoing compatibility contract
that an anchor with an empty `zones` map is indistinguishable on the wire from one written
before the fold existed. Both the test and the doc comment now say that instead.

## What moved

- `index_catalog_fold_enabled()` deleted, and with it eight guards: five early returns in
  `engine/persistence.rs`, the zone-catalog install on the load path, and the proxy's
  reclaim thread (now spawned on the interval alone).
- `FoldEnvGuard` in `engine/tests/part2.rs` and its five call sites — the struct existed
  only to pin this one flag, so the tests now exercise the fold as shipped rather than as
  configured.
- The commented `[storage] index_catalog_fold` key, its `ENV_MAP` entry, and the two doc
  comments that told a reader to go and look at a gate.
- `docs/ops/temporalstore-engine-flags.md` regenerated.

The rationale is kept where the fold lives rather than deleted with the accessor, in the
shape this tree already uses for `TS_HOT_PAGE_SPILL`, so the behaviour reads as deliberate
and unconditional instead of as a switch someone removed.

## Checks

`cargo test --release -p temporalstore-rust --lib --tests --no-fail-fast
-- --test-threads=1`: the same eleven failures as main, none of them new — four
`single_barrier` plus `wal_is_self_sufficient`, three raft, two corpus, and
`storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_flags`, which
was verified to fail identically on `main` at the same commit this branch started from.

`test_the_loader_maps_every_config_key` and
`test_matrixark_the_portal_offers_what_the_config_file_does` pass: both derive their
expectations from the config file, so a key and its mapping removed together is the state
they are written to accept.

The serving deployment does not set this flag, and the position it defaulted to is the one
that stays.
