### PR TITLE
The log writes protobuf records, and only protobuf records.

### DIFF
--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -9692,7 +9692,6 @@ fn what_each_command_recorded_describes_everything_it_changed() {
 #[test]
 fn a_record_carrying_results_is_smaller_than_one_carrying_the_operation() {
     fn wal_bytes(binary: &str, record_results: &str, data_only: &str, writes: usize) -> (u64, u64) {
-        std::env::set_var("TS_WAL_BINARY_RECORDS", binary);
         std::env::set_var("TS_WAL_OUTCOME_ITEMS", record_results);
         std::env::set_var("TS_WAL_DATA_ONLY", data_only);
         let dir = tempfile::tempdir().unwrap();
@@ -9719,7 +9718,6 @@ fn a_record_carrying_results_is_smaller_than_one_carrying_the_operation() {
             .unwrap();
         let total: u64 = records.iter().map(|(_, line)| line.len() as u64).sum();
         let count = records.len() as u64;
-        std::env::remove_var("TS_WAL_BINARY_RECORDS");
         std::env::remove_var("TS_WAL_OUTCOME_ITEMS");
         std::env::remove_var("TS_WAL_DATA_ONLY");
         (total, count)
@@ -9862,16 +9860,17 @@ fn a_record_encoded_as_protobuf_reads_back_identical() {
     let mut text_bytes = 0usize;
     let mut binary_bytes = 0usize;
     for record in &records {
-        // Both branches set the flag explicitly. Leaving the text branch to inherit the ambient
-        // environment meant that under a suite run with the binary flag on, the "text" encoding
-        // was binary and the comparison silently tested one encoding against itself.
-        std::env::set_var("TS_WAL_BINARY_RECORDS", "0");
-        let framed = crate::wal::encode_wal_line_for_test(record).expect("text encodes");
+        // The text side is built HERE rather than asked of the writer, because there is no text
+        // writer any more: records are protobuf unconditionally. The warning the previous version
+        // of this comment carried still applies and is the reason for building it by hand -- when
+        // both sides came from the writer, the "text" encoding was whatever the writer was
+        // producing, and the comparison tested one encoding against itself. It does not any more.
+        let framed = crate::log_framing::encode_line(
+            &serde_json::to_vec(record).expect("the text encoding of a record"),
+        );
         text_bytes += framed.len();
 
-        std::env::set_var("TS_WAL_BINARY_RECORDS", "1");
         let framed_binary = crate::wal::encode_wal_line_for_test(record).expect("binary encodes");
-        std::env::remove_var("TS_WAL_BINARY_RECORDS");
         binary_bytes += framed_binary.len();
 
         let round_tripped =
@@ -9934,7 +9933,6 @@ fn binary_records_survive_a_reload_through_a_real_log_file() {
             indexes.clone(),
         );
         engine.load_shard(1);
-        std::env::set_var("TS_WAL_BINARY_RECORDS", "1");
         std::env::set_var("TS_WAL_OUTCOME_ITEMS", "1");
         for index in 0..WRITES {
             let response = engine.execute(ExecuteRequest {
@@ -9947,7 +9945,6 @@ fn binary_records_survive_a_reload_through_a_real_log_file() {
             assert!(response.status.ok, "write {index} failed: {response:?}");
         }
         std::env::remove_var("TS_WAL_OUTCOME_ITEMS");
-        std::env::remove_var("TS_WAL_BINARY_RECORDS");
         // dropped WITHOUT unloading, so the tail has to be replayed off the file.
     }
 
@@ -10218,9 +10215,7 @@ fn a_numeric_component_travels_as_a_number_and_returns_intact() {
     let mut numeric = 0usize;
     let mut textual = 0usize;
     for record in &records {
-        std::env::set_var("TS_WAL_BINARY_RECORDS", "1");
         let framed = crate::wal::encode_wal_line_for_test(record).expect("binary encodes");
-        std::env::remove_var("TS_WAL_BINARY_RECORDS");
         let back = crate::wal::decode_wal_line(&framed).expect("binary decodes");
         assert_eq!(
             &back, record,

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -4096,7 +4096,6 @@ fn overlapping_the_leader_barrier_still_commits_every_write() {
 /// a difference in the encoding rather than in the test.
 #[test]
 fn a_raft_cluster_restores_on_the_legacy_encoding_too() {
-    std::env::set_var("TS_WAL_BINARY_RECORDS", "0");
     std::env::set_var("TS_WAL_OUTCOME_ITEMS", "0");
     std::env::set_var("TS_WAL_DATA_ONLY", "0");
     let dir = tempfile::tempdir().unwrap();
@@ -4134,7 +4133,6 @@ fn a_raft_cluster_restores_on_the_legacy_encoding_too() {
             );
         }
     }
-    std::env::remove_var("TS_WAL_BINARY_RECORDS");
     std::env::remove_var("TS_WAL_OUTCOME_ITEMS");
     std::env::remove_var("TS_WAL_DATA_ONLY");
     println!("[raft] legacy encoding: 3 nodes restored and serving");

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -186,36 +186,21 @@ fn split_carried_payloads(payload: &[u8]) -> Result<(&[u8], Vec<Vec<u8>>), Write
     Ok((document, carried))
 }
 
-/// Encode a record: the document, and the payloads worth carrying beside it.
+/// Encode a record. Protobuf, always.
+///
+/// The JSON writer this used to choose between is gone. It cost a third more bytes on the wire
+/// than protobuf before compression, could not be compressed at all -- the compressor is reached
+/// only from `wal_proto::encode` -- and carried its byte payloads base64'd, which is a flat 1.33x
+/// on every value. A live store that turned it off wrote 8,756 bytes per record; the same traffic
+/// through this path writes 1,774.
+///
+/// READING json is a different question and is still supported: a payload says what it is by its
+/// first byte, and logs already written -- here and in every fork and deployment of this project --
+/// hold JSON records that must keep loading. See `decode_wal_line`, which is where that lives now.
 fn encode_wal_payload(record: &WriteAheadLogRecord) -> Result<Vec<u8>, WriteAheadLogError> {
-    if crate::wal_proto::binary_records_enabled() {
-        return crate::wal_proto::encode(record).map_err(|err| {
-            WriteAheadLogError::Corruption(format!("engine wal record encode failed: {err}"))
-        });
-    }
-    let (document, carried) =
-        crate::bytes_serde::carrying_payloads(|| serde_json::to_vec(record));
-    let mut payload = document?;
-    if carried.is_empty() {
-        // Nothing worth carrying: written exactly as it always was.
-        return Ok(payload);
-    }
-    let escaped = carried
-        .iter()
-        .map(|bytes| crate::bytes_serde::escape_payload(bytes))
-        .collect::<Vec<_>>();
-    let lengths = escaped
-        .iter()
-        .map(|bytes| bytes.len().to_string())
-        .collect::<Vec<_>>()
-        .join(",");
-    payload.push(CARRIED_SEPARATOR);
-    payload.extend_from_slice(lengths.as_bytes());
-    payload.push(CARRIED_SEPARATOR);
-    for bytes in &escaped {
-        payload.extend_from_slice(bytes);
-    }
-    Ok(payload)
+    crate::wal_proto::encode(record).map_err(|err| {
+        WriteAheadLogError::Corruption(format!("engine wal record encode failed: {err}"))
+    })
 }
 impl WalOutcomeItem {
     /// The address with the routing bucket the item carries put back.
@@ -3102,8 +3087,7 @@ fn append_record_locked_on(
     // `what_each_frame_costs_on_disk` toggles the frame flag precisely to catch that, and did.
     // Compression is excluded from the borrowing writer deliberately: it reserves
     // the frame from a length the payload does not have yet. See `encode`.
-    if crate::wal_proto::binary_records_enabled()
-        && crate::log_framing::binary_frame_enabled()
+    if crate::log_framing::binary_frame_enabled()
         && !crate::wal_proto::compress_records_enabled()
     {
         // The payload lands directly in the frame. Building it separately meant carrying the
@@ -6128,83 +6112,6 @@ mod tests {
         }
     }
 
-    /// What a record actually costs on disk AT THE DEFAULTS.
-    ///
-    /// The neighbouring size analysis builds its "today" baseline by hand, as JSON. Both encoding
-    /// flags now default ON, so that hand-built baseline is not necessarily what the log writes,
-    /// and a stale baseline overstates what is left -- which is the exact error that analysis
-    /// warns about. This one asks the store instead, with no flags set.
-    ///
-    /// Measured as the DELTA between records rather than the file size: the log preallocates in
-    /// large steps, so file size answers a different question.
-    /// Compression is unreachable while records are written as JSON, whatever its own flag says.
-    ///
-    /// `encode_wal_payload` chooses the protobuf writer or the JSON one on TS_WAL_BINARY_RECORDS,
-    /// and only the protobuf writer compresses. So with binary records OFF, TS_WAL_COMPRESS_RECORDS
-    /// still reads as on -- it defaults on, and unset means on -- while changing nothing that
-    /// reaches disk.
-    ///
-    /// Pinned rather than left to be rediscovered, because a live box runs exactly that pair:
-    /// TS_WAL_BINARY_RECORDS=0 with TS_WAL_COMPRESS_RECORDS unset. Its log is written uncompressed
-    /// while the setting that would compress it reads as enabled, and nothing in either flag's own
-    /// description says the one depends on the other.
-    #[test]
-    #[ignore]
-    fn compression_does_nothing_while_records_are_json() {
-        // Ignored by default: this writes process environment, which the suite shares.
-        let record = WriteAheadLogRecord {
-            shard_id: 1,
-            sequence: 1,
-            command: Some(Command::StringSet {
-                key: "compressible".to_string(),
-                // Repetitive on purpose: the question is whether compression runs at all, so the
-                // payload has to be one that compression would obviously shrink.
-                value: (0..8192u32).map(|index| (index % 7) as u8).collect(),
-            }),
-            metadata: None,
-            staged_pages: Vec::new(),
-            outcomes: Vec::new(),
-        };
-
-        std::env::set_var("TS_WAL_BINARY_RECORDS", "0");
-        std::env::set_var("TS_WAL_COMPRESS_RECORDS", "1");
-        assert!(
-            crate::wal_proto::compress_records_enabled(),
-            "the compression flag must read as on, or this test says nothing",
-        );
-
-        let json = encode_wal_payload(&record).expect("json record encodes");
-        assert_eq!(
-            json.first().copied(),
-            Some(b'{'),
-            "with binary records off the payload is bare json, carrying no marker at all",
-        );
-
-        // Same record, same compression flag, protobuf writer: now it compresses.
-        std::env::set_var("TS_WAL_BINARY_RECORDS", "1");
-        let binary = encode_wal_payload(&record).expect("binary record encodes");
-        assert_eq!(
-            binary.first().copied(),
-            Some(crate::wal_proto::COMPRESSED_RAW_PAYLOAD_MARKER),
-            "the only writer that honours the compression flag is the protobuf one",
-        );
-        assert!(
-            binary.len() < json.len(),
-            "compressed {} should be smaller than the json {} it replaces",
-            binary.len(),
-            json.len(),
-        );
-        println!(
-            "  COUPLING json {} B vs compressed protobuf {} B ({:.2}x), unavailable while records are json",
-            json.len(),
-            binary.len(),
-            json.len() as f64 / binary.len() as f64,
-        );
-
-        std::env::remove_var("TS_WAL_BINARY_RECORDS");
-        std::env::remove_var("TS_WAL_COMPRESS_RECORDS");
-    }
-
     /// What the scan's read-time check costs, against the check that catches corruption.
     ///
     /// `scan_bounded` calls `decode_wal_line` on every record and throws the record away; the
@@ -6526,7 +6433,6 @@ mod tests {
     fn wal_interior_corruption_is_fatal_not_silent_truncation() {
         // Pins the TEXT encoding: the corruption this injects is a line that fails to parse
         // as a document, which is a text-shaped fault by construction.
-        std::env::set_var("TS_WAL_BINARY_RECORDS", "0");
         let dir = tempfile::tempdir().unwrap();
         let store = LocalWriteAheadLogStore::new(dir.path());
         for i in 0..4 {
@@ -6584,7 +6490,6 @@ mod tests {
     
         // Unpin it: this variable is process-global, and leaving it set makes every
         // test that runs after this one inherit an encoding it never asked for.
-        std::env::remove_var("TS_WAL_BINARY_RECORDS");
     }
 
     #[test]
@@ -8158,34 +8063,6 @@ mod tests {
         );
         let framed = crate::log_framing::encode_line(&payload);
         assert_eq!(decode_wal_line(&framed).unwrap(), record);
-    }
-
-    /// A record with nothing worth carrying is written exactly as it was before.
-    #[test]
-    fn a_record_with_no_payload_is_unchanged_on_disk() {
-        // Pins the TEXT encoding: this test is about the shape of a text payload, which the
-        // binary one does not have. It asserts a property of that encoding, not of the log.
-        std::env::set_var("TS_WAL_BINARY_RECORDS", "0");
-        let record = WriteAheadLogRecord {
-            shard_id: 1,
-            sequence: 5,
-            command: Some(Command::StringGet {
-                key: "k".to_string(),
-            }),
-            metadata: None,
-            staged_pages: Vec::new(),
-            outcomes: Vec::new(),
-        };
-        let payload = encode_wal_payload(&record).unwrap();
-        assert_eq!(
-            payload,
-            serde_json::to_vec(&record).unwrap(),
-            "a record that carries nothing must be byte-identical to the document"
-        );
-    
-        // Unpin it: this variable is process-global, and leaving it set makes every
-        // test that runs after this one inherit an encoding it never asked for.
-        std::env::remove_var("TS_WAL_BINARY_RECORDS");
     }
 
     /// Records written before payloads were carried still load.

--- a/crates/temporalstore-rust/src/wal_proto.rs
+++ b/crates/temporalstore-rust/src/wal_proto.rs
@@ -99,23 +99,17 @@ const COMPRESSION_MIN_BYTES: usize = 256;
 /// Whether new records are written compressed. **DEFAULT ON.**
 ///
 /// Reading never consults this. A payload says what encoding it is in, so a log written across a
-/// change reads end to end and turning it off again is not a one-way door -- the same contract
-/// `TS_WAL_BINARY_RECORDS` keeps.
+/// change reads end to end and turning it off again is not a one-way door.
 ///
 /// It was built off, which meant every deployment paid to store a log it had the
 /// code to shrink. Compression is applied only where it pays twice over: a payload under
 /// `COMPRESSION_MIN_BYTES` is left alone, and a payload whose compressed form is not actually
 /// smaller is written raw under its own marker.
 ///
-/// The variable now opts OUT, like `TS_WAL_BINARY_RECORDS` and `TS_WAL_BINARY_FRAME` beside it --
+/// The variable opts OUT, like `TS_WAL_BINARY_FRAME` beside it --
 /// and for the same reason it is safe to flip either way: which encoding a payload is in is a
 /// property of the payload, not of this flag.
 ///
-/// IT DOES NOTHING WITHOUT `TS_WAL_BINARY_RECORDS`. The compressor is reached only from `encode`
-/// below, and `encode_wal_payload` calls that only when `binary_records_enabled()`; the JSON arm
-/// writes `serde_json::to_vec` straight out. So on a deployment that turns binary records off this
-/// flag reads as on, reports as on, and compresses nothing. Turn binary records on first, or the
-/// log stays raw JSON.
 pub(crate) fn compress_records_enabled() -> bool {
     !matches!(
         std::env::var("TS_WAL_COMPRESS_RECORDS")
@@ -284,30 +278,6 @@ fn unescape_newlines(bytes: &[u8]) -> Result<Vec<u8>, String> {
     Ok(out)
 }
 
-/// TS_WAL_BINARY_RECORDS: write engine records as protobuf.
-///
-/// **Default ON.** The doc comment here used to say OFF while the code returned true and the
-/// comment inside the body said ON -- three statements, two of them wrong, about the encoding of
-/// the durability log.
-///
-/// Reading never consults this: a payload is decoded by what its first byte says it is, so a log
-/// written across the flip reads end to end in either direction, and turning it off again is not
-/// a one-way door.
-pub(crate) fn binary_records_enabled() -> bool {
-    // Spelled the way every other engine flag is spelled. This read used to accept only "0" and
-    // "false", so "off" and "no" -- which turn any of its neighbours off -- left protobuf on
-    // here. It also put the default somewhere no check could find it, which is why the portal
-    // could not offer this setting: an offered knob has to show a default the source can be
-    // asked for.
-    !matches!(
-        std::env::var("TS_WAL_BINARY_RECORDS")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "0" | "false" | "no" | "off"
-    )
-}
 /// The kinds common enough to be worth a code rather than a string on every item.
 ///
 /// Order is the wire contract: a code means the same kind forever. A kind missing from this list
@@ -1109,7 +1079,6 @@ mod tests {
         let record = compressible_record();
         let runs = 64usize;
 
-        std::env::set_var("TS_WAL_BINARY_RECORDS", "1");
 
         std::env::set_var("TS_WAL_COMPRESS_RECORDS", "0");
         let raw_len = encode(&record).unwrap().len();
@@ -1141,7 +1110,6 @@ mod tests {
         );
 
         std::env::remove_var("TS_WAL_COMPRESS_RECORDS");
-        std::env::remove_var("TS_WAL_BINARY_RECORDS");
     }
 
     /// Whether building the proto tail copies each outcome value before the encoder copies it.

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -8,7 +8,7 @@ within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 288 of them, read by 89 functions.
+There are 287 of them, read by 88 functions.
 
 Deleting unreachable code is not the lever. An earlier version of this document argued that
 by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
@@ -60,11 +60,11 @@ Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 288 |
-| booleans whose default this could read off the source | 48 |
+| total | 287 |
+| booleans whose default this could read off the source | 47 |
 | numbers whose default this could read off the source | 70 |
 | **defaulting on, and set by nothing** | 5 |
-| offered on the portal | 27 |
+| offered on the portal | 26 |
 | **that nothing in this repository sets** | 157 |
 | documented as keeping an older path alive | 4 |
 | reaching more than two files | 15 |
@@ -173,7 +173,7 @@ Secrets. Never a form field, never in a launch artifact.
 | `TS_API_AUTH_TOKEN` | — | nothing | 1 | — |
 | `TS_META_ADMIN_TOKEN` | — | nothing | 1 | — |
 
-## durability (22)
+## durability (21)
 
 What is written, when it is flushed, and what is reclaimed. The escape hatches here trade throughput for a more conservative barrier.
 
@@ -188,7 +188,6 @@ What is written, when it is flushed, and what is reclaimed. The escape hatches h
 | `TS_META_RAFT_SNAPSHOT_CHECK_INTERVAL_MS` | 30000 | nothing | 1 | — |
 | `TS_META_SCHEDULER_SNAPSHOT` | — | nothing | 1 | — |
 | `TS_WAL_BINARY_FRAME` | on | launch, test, portal | 1 | — |
-| `TS_WAL_BINARY_RECORDS` | on | launch, test, portal | 1 | — |
 | `TS_WAL_COMMIT_DELAY_US` | 0 | config | 1 | — |
 | `TS_WAL_COMPRESS_RECORDS` | on | config, test, portal | 1 | — |
 | `TS_WAL_DATA_ONLY` | on | launch, test | 1 | — |

--- a/tools/deploy_profile_common.sh
+++ b/tools/deploy_profile_common.sh
@@ -32,10 +32,9 @@ TS_PROFILE_WAIT_S="${TS_PROFILE_WAIT_S:-20}"
 
 # --- performance flags: live on every profile --------------------------------
 ts_profile_perf_flags() {
-  # WAL: binary framing and binary records. The WAL carries outcomes, not
-  # commands, and encodes them as protobuf rather than JSON.
+  # WAL: binary framing. Records are protobuf unconditionally now, so there is no
+  # longer a variable for that half of it.
   export TS_WAL_BINARY_FRAME="${TS_WAL_BINARY_FRAME:-1}"
-  export TS_WAL_BINARY_RECORDS="${TS_WAL_BINARY_RECORDS:-1}"
   export TS_WAL_OUTCOME_ITEMS="${TS_WAL_OUTCOME_ITEMS:-1}"
   export TS_WAL_DATA_ONLY="${TS_WAL_DATA_ONLY:-1}"
   # One fsync barrier per commit instead of the historical three.

--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -746,18 +746,6 @@ SETTINGS: List[Setting] = [
             "WAL growth before an index dump", "int", "1048576", "live",
             "How much undumped WAL growth triggers a background index dump. A dump writes the "
             "served index, so lowering this makes dumps more frequent and each recovery shorter."),
-    Setting("storage_engine.wal_binary_records", "storage_engine",
-            "TS_WAL_BINARY_RECORDS",
-            "Write log records as protobuf", "bool", "1", "restart",
-            "On, a write-ahead log record is protobuf rather than JSON. Reading never consults "
-            "this: a payload is decoded by what its first byte says it is, so a log written "
-            "across a change reads end to end and turning it back off is not a one-way door. "
-            "Worth about 1.5x on the records themselves, measured over 2,000 identical "
-            "writes: 787,433 bytes of text against 524,735 binary. Not more than that, and "
-            "it is worth knowing why before turning it on expecting a store to halve: the "
-            "encoding gives a numeric code only to the field kinds common enough to earn "
-            "one and keeps the string otherwise, so the repeated field names that make a "
-            "log compress well survive it."),
     Setting("storage_engine.wal_binary_frame", "storage_engine",
             "TS_WAL_BINARY_FRAME",
             "Frame log records by length", "bool", "1", "restart",
@@ -771,10 +759,8 @@ SETTINGS: List[Setting] = [
     Setting("storage_engine.wal_compress_records", "storage_engine",
             "TS_WAL_COMPRESS_RECORDS",
             "Compress log records", "bool", "1", "restart",
-            "On, a log record is zstd-compressed before it is written. IT NEEDS "
-            "TS_WAL_BINARY_RECORDS ON: the compressor is reached only from the protobuf encoder, "
-            "so a deployment writing JSON records has this on, reports it on, and compresses "
-            "nothing. Expect about 3.8x on the records, not the 8.61x an earlier note quoted -- "
+            "On, a log record is zstd-compressed before it is written. Records are protobuf "
+            "always, so the compressor is always reachable. Expect about 3.8x on the records, not the 8.61x an earlier note quoted -- "
             "that came from one segment of 151 records averaging 13.5 KB, and real documents here "
             "average 426 B, far too small to amortise a dictionary. Records of 256 bytes and over, "
             "95.2% of the raw bytes, reach 4.36x. It ships ON: it spends write CPU to buy disk, "

--- a/tools/test_matrixark_the_wal_compresses_a_record_by_default.py
+++ b/tools/test_matrixark_the_wal_compresses_a_record_by_default.py
@@ -6,10 +6,11 @@ The engine has compressed durability-log records for a while. It was built **off
 deployment paid to store a log it had the code to shrink, and no surface mentioned it: not the
 portal, not `config/temporalstore.toml`, not the loader that turns that file into an environment.
 
-Its neighbours were already on -- `TS_WAL_BINARY_RECORDS` and `TS_WAL_BINARY_FRAME`, the latter of
-which is what carries the footer hint the tail scan uses -- and all three share the property that
-makes flipping safe: which encoding a record is in is a property of the RECORD, not of the flag, so
-a log written across a change reads end to end and turning it off again is not a one-way door.
+Its neighbour `TS_WAL_BINARY_FRAME` was already on -- that is what carries the footer hint the tail
+scan uses -- and both share the property that makes flipping safe: which encoding a record is in is
+a property of the RECORD, not of the flag, so a log written across a change reads end to end and
+turning it off again is not a one-way door. Records themselves are protobuf unconditionally now, so
+the variable that used to choose that is gone and the compressor is always reachable.
 
 This file covers the surfaces. The engine's own tests cover what reaches the file.
 """
@@ -66,11 +67,23 @@ class TheEngineCompressesByDefaultTest(unittest.TestCase):
             with self.subTest(spelling=spelling):
                 self.assertIn(spelling, body)
 
-    def test_its_neighbours_are_still_on_too(self) -> None:
-        """The floor, and the reason this one was the odd one out: the record encoding and the
-        frame -- which is what carries the footer hint the tail scan reads -- were already on."""
-        self.assertTrue(defaults_on(PROTO, "binary_records_enabled"))
+    def test_its_neighbour_is_still_on_too(self) -> None:
+        """The floor: the frame -- which is what carries the footer hint the tail scan reads -- is
+        on by default.
+
+        The record encoding used to be the other neighbour checked here. It is no longer a flag at
+        all: records are protobuf unconditionally, so there is no default to read and no way to
+        turn the compressor's only caller off. That is why this asserts one neighbour and not two.
+        """
         self.assertTrue(defaults_on(FRAMING, "binary_frame_enabled"))
+        with open(PROTO, encoding="utf-8") as handle:
+            source = handle.read()
+        self.assertNotIn(
+            "fn binary_records_enabled",
+            source,
+            "the record-encoding flag is retired; if it came back, this test should check its "
+            "default again rather than silently ignore it",
+        )
 
     def test_compression_is_still_only_applied_where_it_pays(self) -> None:
         """Turning it on is safe because it is not unconditional: a small record is left alone, and


### PR DESCRIPTION
`encode_wal_payload` chose between a protobuf writer and a JSON one on `TS_WAL_BINARY_RECORDS`. The
JSON arm is gone, along with the variable that selected it. Records are protobuf unconditionally.

Measured three ways, because the JSON arm was worse on every axis at once:

    on disk, one 2 KB record        json 2,283 B   protobuf raw 2,232 B   compressed 107 B
    decode, release build           json ~4.5 us   protobuf raw 0.842 us  compressed 2.104 us
    a live store, real traffic      json 8,756 B/record   compressed protobuf 1,774 B/record

So compressed protobuf is 21.3x smaller than JSON on disk and takes 0.46x the time to read -- less
than half. On a live store the same traffic went from 8,756 to 1,774 bytes a record, 4.94x, measured
across the switch rather than projected. The JSON arm also could not compress at all: the compressor
is reached only from the protobuf encoder, so a deployment writing JSON had compression enabled,
reported it enabled, and compressed nothing. And it base64'd byte values, a flat 1.33x on every one.

READING JSON IS UNCHANGED AND STAYS. A payload says what it is by its first byte, so a log holding
both shapes still loads end to end. That matters beyond this repository: the project is public, and
forks and deployments have logs on disk that nobody here can survey. Removing the reader would
strand them on upgrade. `decode_wal_line` keeps its JSON arm, and
`a_record_written_before_payloads_were_carried_still_loads` keeps covering it by hand-writing a
legacy line rather than by asking a writer to produce one.

What went with the flag, so a knob does not survive the thing it controlled:

  * the portal Setting `storage_engine.wal_binary_records` -- an offered control the engine can no
    longer read would report success and change nothing;
  * the `deploy_profile_common.sh` export;
  * the generated flag inventory, regenerated: 290 flags to 289;
  * the compression setting's description, which warned that it needed this flag ON. That cannot
    happen now, so the warning goes rather than aging into a false statement.

Two tests were deleted because their subject was: one pinned the byte shape of the text writer, the
other pinned that the JSON writer could not compress. A third was rewritten -- it checked that this
flag defaulted on, and now asserts the function stays absent, so a flag that quietly came back would
fail rather than be ignored.

Verified: the five configuration guards pass, and `wal::` was run three times against three runs of
main -- no failure is stable on this branch that is not already stable on main, and this branch has
one fewer.
