### PR TITLE
A delegation note described the opposite of what the delegate decides

### DIFF
--- a/tools/matrixark_mcp_core_compact.py
+++ b/tools/matrixark_mcp_core_compact.py
@@ -468,11 +468,20 @@ def latest_context_state_key(record: Json) -> tuple[Any, ...] | None:
     """Return the logical latest-state key for versionless context records.
 
     Delegates deliberately: the single definition lives in matrixark_mcp_serving_records. This
-    module used to carry its own copy, and the two drifted -- the other one learned to give
-    `matrixark_async_pipeline_task` an identity and this one did not. Because the write path
-    resolves THIS module (it does `import *`, and this module re-exports the name), tasks kept
-    their append-log rows and every status transition accumulated, which is the cost that
-    identity exists to remove.
+    module used to carry its own copy and the two drifted, which is the reason for delegating --
+    the write path resolves THIS module (it does `import *`, and this module re-exports the
+    name), so a copy that answered differently here was the answer that shipped.
+
+    What the delegate decides is worth reading there rather than inferring from here, because it
+    is not the obvious answer: `matrixark_async_pipeline_task` deliberately has NO latest-state
+    identity. Collapsing each task to one row looks free and is not -- the latest-state hash is
+    read WHOLESALE on every idle-commit check, so it is only cheap while its identity count stays
+    small, and tasks are per event. Measured on a 600-add store, giving them an identity cut the
+    per-call task count 545.8 -> 310.8 and made an add 143.2 -> 265.6 ms.
+
+    So task rows are NOT collapsed by compaction: every status transition stays in the append
+    log, and a reader that wants the latest status folds the rows itself. Do not read this
+    delegation as "tasks have an identity now".
     """
     global _SERVING_LATEST_CONTEXT_STATE_KEY
     delegate = _SERVING_LATEST_CONTEXT_STATE_KEY


### PR DESCRIPTION
`latest_context_state_key` in matrixark_mcp_core_compact delegates to the copy in
matrixark_mcp_serving_records, and its docstring explains why: the two copies had
drifted, "the other one learned to give `matrixark_async_pipeline_task` an
identity and this one did not", so tasks "kept their append-log rows and every
status transition accumulated, which is the cost that identity exists to remove".

The delegate says the opposite, and says it with measurements:

    `matrixark_async_pipeline_task` deliberately has NO latest-state identity ...
    giving them an identity cut the per-call task count 545.8 -> 310.8 and made
    an add 143.2 -> 265.6 ms ... The append log is the right home for a record
    type with unbounded distinct identities.

There is no branch for that record type; it falls through to `return None`.
Confirmed both ways rather than by reading: the delegate returns None for a task
row and a real key for a context_summary, and compacting two task rows that share
a task_hash returns BOTH, with their statuses intact.

So the note claimed the delegation had given tasks an identity when the delegate
had deliberately taken it away, and a reader trusting it concludes that
compaction collapses each task to its latest status. It does not: every
transition stays in the append log and a reader that wants the latest status
folds the rows itself.

That matters beyond tidiness. Reading a task's status is exactly what the
idle-commit drain does, and there is an open question about tasks that appear to
stay scheduled for days; "compaction collapses them" is a wrong premise to start
from, and it cost me an hour before I checked the delegate.

The reasoning for delegating was right and is kept. What changes is that the note
now points at the delegate for the decision instead of restating it, states the
decision correctly, and says plainly what follows from it.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>
