### PR TITLE
One more resource helper is re-exported instead of copied

### DIFF
--- a/tools/matrixark_mcp_resources.py
+++ b/tools/matrixark_mcp_resources.py
@@ -146,14 +146,10 @@ except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_core import source_locator_from_ref
 
 
-def source_ref_from_locator(raw_uri: str, source_locator: str) -> str:
-    raw_uri = str(raw_uri or "")
-    source_locator = str(source_locator or "")
-    if not source_locator:
-        return raw_uri
-    if source_locator.startswith(("file:", "s3://", "http://", "https://", "/")):
-        return source_locator
-    return f"{raw_uri}#{source_locator}" if raw_uri else source_locator
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import source_ref_from_locator
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import source_ref_from_locator
 
 
 def registry_access_scope(scope: Json, *, sharing_scope: str = "private_user") -> Json:


### PR DESCRIPTION
`matrixark_mcp_resources` carried a byte-identical copy of `source_ref_from_locator`, which is
implemented in `matrixark_mcp_core`. The file already re-exports ten names from elsewhere with the
comment this follows; this is the eleventh. 529 lines -> 525.

## This is the last one that can be collapsed

Three duplicated bodies remain and stay where they are, because they cannot be re-exported at all:

| function | would import | result |
|---|---|---|
| `ordered_unique_any` | `matrixark_mcp_core` from `matrixark_mcp_indexing` | two suites 12 and 25 -> **0** |
| `sparse_lexical_score` | `matrixark_mcp_core` from `matrixark_mcp_scoring` | two suites 12 and 25 -> **0** |
| `hybrid_origin_score` | `matrixark_mcp_core_scoring` from `matrixark_mcp_scoring` | two suites 12 and 25 -> **0** |

`matrixark_mcp_core` imports the module that would have to import it back, so the re-export closes a
cycle that is currently open in one direction only. Each was applied **on its own** and measured,
rather than inferred from the batch: the static check and the measurement agree on all four, which
is why the three are left as duplicates instead of worked around.

## Test

14 suites reach this module: **170 tests, no failures**.

`test_locomo_reader_hints` fails 2 of 53, and that is not this change. It fails identically on
`main`, and on `main` before the previous change in this series -- three points measured, same two
test names each time. It is one of the ratchet's recorded baseline failures.
