### PR TITLE
get_all resolved a scope for every record before checking if it needed one

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -7115,11 +7115,17 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         for record in self.records_for_get_all(scope):
             if str(record.get("record_type") or "") != "context_event":
                 continue
-            rec_tenant, rec_user = _record_scope_hashes(record)
-            if tenant_hash and rec_tenant != tenant_hash:
-                continue
-            if user_hash and rec_user != user_hash:
-                continue
+            # Only resolve the record's scope if there is something to compare it against. The
+            # two lines below are the ONLY readers of the pair, so when the request scope carries
+            # neither hash -- which is any scope not identity-enriched upstream -- this resolved a
+            # scope per record and dropped it. 32,000 records: 16 ms when they carry their hashes,
+            # 57 ms when they do not, on a listing that returns ten rows.
+            if tenant_hash or user_hash:
+                rec_tenant, rec_user = _record_scope_hashes(record)
+                if tenant_hash and rec_tenant != tenant_hash:
+                    continue
+                if user_hash and rec_user != user_hash:
+                    continue
             created_at_ms = record.get("updated_at_ms") or record.get("timestamp_key_ms")
             selected.append((int(created_at_ms or 0), record))
         selected.sort(key=lambda pair: pair[0])

--- a/tools/test_get_all_scope_guard.py
+++ b/tools/test_get_all_scope_guard.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""get_all resolves a record's scope only when it has one to compare it against.
+
+`_resolve_subject_hashes` returns ``(0, 0)`` for any request scope that was not identity-enriched
+upstream, and the resolved pair is read by exactly two comparisons, both guarded on those hashes.
+So on such a call the resolution ran once per record in the store and was dropped -- 16 ms per
+32,000 records when the records carry their hashes, 57 ms when they do not, on a listing returning
+ten rows.
+
+Skipping work is only correct if the work was not needed, so the filtering half is asserted here
+too, in the same file: an enriched scope must still see ONLY its own subject's memories. A test
+that asserted just the fast path would pass just as well on a get_all that had stopped filtering.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+from matrixark_mcp_local_adapter import MatrixArkLocalAdapter  # noqa: E402
+
+
+def _event(index: int, tenant: int, user: int) -> dict:
+    return {
+        "record_type": "context_event",
+        "event_id_hash": f"e{index}",
+        "summary_text": f"note {index}",
+        "text": f"note {index}",
+        "updated_at_ms": 1_700_000_000_000 + index,
+        "timestamp_key_ms": 1_700_000_000_000 + index,
+        "access_scope": {"tenant_hash": tenant, "user_hash": user,
+                         "scope_key": f"t={tenant};u={user}"},
+    }
+
+
+class GetAllResolvesAScopeOnlyWhenItComparesOneTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.adapter = MatrixArkLocalAdapter(pathlib.Path(self.tmp.name) / "events.jsonl")
+        # Two subjects under one tenant, interleaved, so an off-by-one in the filter shows up as
+        # the wrong subject rather than as a short list.
+        self.adapter.append_many(
+            [_event(i, 7, 11 if i % 2 == 0 else 22) for i in range(20)]
+        )
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_an_enriched_scope_sees_only_its_own_subject(self) -> None:
+        """The positive control. This is the branch the guard skips, and it must still filter."""
+        out = self.adapter.get_all({"scope": {"tenant_hash": 7, "user_hash": 11}, "limit": 100})
+        got = {row["id"] for row in out["memories"]}
+        self.assertEqual(got, {f"e{i}" for i in range(0, 20, 2)})
+        self.assertEqual(out["count"], 10)
+
+    def test_the_other_subject_sees_the_other_half(self) -> None:
+        out = self.adapter.get_all({"scope": {"tenant_hash": 7, "user_hash": 22}, "limit": 100})
+        self.assertEqual({row["id"] for row in out["memories"]},
+                         {f"e{i}" for i in range(1, 20, 2)})
+
+    def test_a_tenant_hash_alone_still_narrows(self) -> None:
+        """Only one of the two hashes set -- the guard must run the branch for either, not both."""
+        self.assertEqual(self.adapter.get_all({"scope": {"tenant_hash": 7}, "limit": 100})["count"], 20)
+        self.assertEqual(self.adapter.get_all({"scope": {"tenant_hash": 999}, "limit": 100})["count"], 0)
+
+    def test_a_user_hash_alone_still_narrows(self) -> None:
+        self.assertEqual(self.adapter.get_all({"scope": {"user_hash": 11}, "limit": 100})["count"], 10)
+        self.assertEqual(self.adapter.get_all({"scope": {"user_hash": 999}, "limit": 100})["count"], 0)
+
+    def test_an_unenriched_scope_lists_everything(self) -> None:
+        """The branch the guard skips entirely: neither hash, so nothing to compare, so no
+        resolution. The answer is the same one the unguarded code gave."""
+        self.assertEqual(self.adapter.get_all({"limit": 100})["count"], 20)
+
+    def test_the_newest_are_the_ones_a_limit_keeps(self) -> None:
+        """Guarding the filter must not disturb which records a limit selects."""
+        out = self.adapter.get_all({"scope": {"tenant_hash": 7, "user_hash": 11}, "limit": 3})
+        self.assertEqual([row["id"] for row in out["memories"]], ["e14", "e16", "e18"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
`get_all` resolved every record's access scope before asking whether it had one to compare it
against.

The loop read `_record_scope_hashes(record)` unconditionally, and the resolved pair is read by
exactly two lines, both guarded on the request's own hashes:

    rec_tenant, rec_user = _record_scope_hashes(record)
    if tenant_hash and rec_tenant != tenant_hash:
        continue
    if user_hash and rec_user != user_hash:
        continue

`_resolve_subject_hashes` returns `(0, 0)` for any scope that was not identity-enriched upstream --
including `{"user_id": "alice", "tenant_id": "t1"}` as written. On such a call both comparisons are
skipped, so the resolution ran once per record in the store and every result was discarded. Asking
the cheap question first is the whole change.

## Measured

Warm, same process, listing ten rows:

| records | before | after | |
|---|---|---|---|
| 500 | 1.65 ms | 0.44 ms | 3.8x |
| 2,000 | 6.28 ms | 2.04 ms | 3.1x |
| 8,000 | 20.64 ms | 4.26 ms | **4.8x** |
| 32,000 | 86.02 ms | 28.03 ms | **3.1x** |

2.69 -> 0.88 us per record. The resolution itself costs 16.5 ms per 32,000 records when they carry
their hashes and 57.2 ms when they do not, so the saving depends on the corpus's shape, and both
were measured rather than one assumed.

`get_all` is still linear in the corpus rather than the limit -- `records_for_get_all` returns the
whole store by design, and its docstring says an override only has to produce a superset. That is a
larger change and not this one.

## One alternative measured and rejected

The obvious other target is the full sort of every candidate before slicing `limit`. It is not
worth touching: over 32,000 pairs the sort costs **2.78 ms**, because they arrive nearly ordered and
Timsort's best case is linear. `heapq.nlargest(10, ...)` in its place costs **13.71 ms** -- five
times worse. Both return an identical list, which is how that was checked rather than reasoned
about.

## Test

`test_get_all_scope_guard.py`, six tests. Skipping work is only correct if the work was not needed,
so the filtering half is asserted in the same file: an enriched scope must still see only its own
subject, and either hash alone must still narrow.

Three mutations, because a test that cannot fail is not coverage:

* `or` -> `and` in the guard: **2 failures** (the single-hash cases)
* the filter removed entirely: **5 failures**
* the guard replaced by `if True` -- the original code -- **passes**, which is the one that matters:
  it says this is an optimization and not a change in what `get_all` answers.

22 suites reach `get_all` or the scope resolver: **223 tests, no failures**.

---

## Follow-up measurement: which callers this actually helps

Instrumenting `_resolve_subject_hashes` and running the suites that drive `get_all` end to end
through the gateway and the dispatcher: **86 of 86 resolutions arrived with both hashes set.**

So the guard skips work for callers that reach the adapter directly with an un-enriched scope --
tests, `matrixark_mcp_dispatch` when the request carries no identity, and any embedding caller -- and
not for the gateway path, which always enriches. The table above is the direct-adapter case and
should be read as such, rather than as a general speed-up.

The measured fact this turns up is the more useful one: because production callers always carry
`tenant_hash` and `user_hash`, a per-scope index over the cached record list *could* make `get_all`
cost the matching records rather than the whole store, which the guard cannot do. That is the
change worth making next, and `records_for_get_all` is already the override point for it.
