### PR TITLE
A skipped idle commit ranked below the schedule it completes

### DIFF
--- a/tools/matrixark_mcp_async_readiness.py
+++ b/tools/matrixark_mcp_async_readiness.py
@@ -18,6 +18,13 @@ def latest_async_pipeline_rows(rows: list[Json]) -> list[Json]:
         "idle_commit_failed": 1,
         "idle_commit_attempted": 1,
         "idle_commit_committed": 1,
+        # The drain's OTHER outcome, and the one it actually emits most: `session_commit` returning
+        # anything but accepted/committed is written as `idle_commit_skipped`
+        # (matrixark_local_adapter_retrieval). Leaving it out of this map did not make it rank
+        # low -- it made it rank -1, BELOW the `idle_commit_scheduled` it completes, so the
+        # completion lost to its own precursor and the task read as still scheduled forever.
+        # Terminal outcomes share a tier; only the ordering against `scheduled` matters here.
+        "idle_commit_skipped": 1,
         "extraction_committed": 2,
         "summary_completed": 3,
     }

--- a/tools/test_a_skipped_idle_commit_outranks_its_schedule.py
+++ b/tools/test_a_skipped_idle_commit_outranks_its_schedule.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Every terminal idle-commit outcome supersedes the schedule it completes.
+
+`latest_async_pipeline_rows` folds a task's rows to one, ranking by status and breaking ties on
+time. An unranked status does not sort low -- it sorts at -1, BELOW `idle_commit_scheduled`, so a
+completion written after its schedule loses to it and the task reads as scheduled forever.
+
+That is not hypothetical: `idle_commit_skipped` was missing from the map while every sibling
+outcome was present, and it is the outcome the drain emits whenever `session_commit` declines --
+which is most of them.
+
+Asserted per status rather than by comparing the map to a list, so a new outcome has to behave
+rather than be remembered.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+if TOOLS not in sys.path:
+    sys.path.insert(0, TOOLS)
+
+from matrixark_mcp_async_readiness import latest_async_pipeline_rows  # noqa: E402
+
+# Every status the drain can write as the END of an idle-commit attempt.
+TERMINAL_OUTCOMES = ("idle_commit_committed", "idle_commit_skipped", "idle_commit_failed",
+                     "idle_commit_attempted")
+
+
+def fold(*statuses: str) -> str:
+    """The status `latest_async_pipeline_rows` keeps, given rows in the order written."""
+    rows = [{"task_hash": 1, "status": status, "updated_at_ms": 100 * (index + 1)}
+            for index, status in enumerate(statuses)]
+    return str(latest_async_pipeline_rows(rows)[0]["status"])
+
+
+class ASkippedIdleCommitOutranksItsScheduleTest(unittest.TestCase):
+    def test_every_terminal_outcome_supersedes_the_schedule(self) -> None:
+        for outcome in TERMINAL_OUTCOMES:
+            self.assertEqual(
+                outcome, fold("idle_commit_scheduled", outcome),
+                f"{outcome} written after its schedule must win; if it is missing from the rank "
+                f"map it sorts at -1, below the schedule, and the task reads as still scheduled")
+
+    def test_a_schedule_does_not_supersede_an_outcome(self) -> None:
+        """The other direction, so the fix cannot be "rank everything equally"."""
+        for outcome in TERMINAL_OUTCOMES:
+            self.assertEqual(outcome, fold(outcome, "idle_commit_scheduled"),
+                             f"a re-schedule row must not undo {outcome}")
+
+    def test_the_fold_still_discriminates(self) -> None:
+        """The floor. If the fold returned its input unchanged both assertions above would pass."""
+        self.assertEqual("summary_completed", fold("pending", "summary_completed"))
+        self.assertEqual(1, len(latest_async_pipeline_rows(
+            [{"task_hash": 9, "status": "pending", "updated_at_ms": 1},
+             {"task_hash": 9, "status": "extraction_committed", "updated_at_ms": 2}])))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`latest_async_pipeline_rows` folds a task's rows to one, ranking by status and
breaking ties on time. Its map ranks `idle_commit_scheduled` at 0 and every
terminal outcome at 1 -- except `idle_commit_skipped`, which is absent.

An absent status does not rank low. It ranks -1, BELOW the schedule, so the
comparison `(row_rank, row_time) >= (current_rank, current_time)` refuses a
completion written after its own precursor. Measured on the three outcomes:

    later idle_commit_committed vs earlier scheduled -> idle_commit_committed
    later idle_commit_failed    vs earlier scheduled -> idle_commit_failed
    later idle_commit_skipped   vs earlier scheduled -> idle_commit_scheduled

Only the missing one loses, and it is the outcome the drain emits most: the
writer in matrixark_local_adapter_retrieval records `idle_commit_committed` when
`session_commit` returns accepted or committed and `idle_commit_skipped` for
everything else. So a task that skipped keeps reading as still scheduled, however
many times it is attempted and however long ago.

That is the shape behind the open note about idle-commit tasks that appear
scheduled for days while far fewer skipped records exist than attempts: the
skipped rows are there, they just never win the fold.

The fix is the one line the map was missing. Terminal outcomes share a tier;
what matters is only that they sort above `scheduled`.

The guard asserts behaviour rather than the map's contents -- each terminal
outcome must supersede a schedule, a re-schedule must not undo an outcome, and a
floor case keeps both from passing on a fold that returned its input. Written per
status, so a new outcome has to behave rather than be remembered in a list.
Mutation-tested: reverting the one line fails two of its three cases.

Not touched: the sibling copy in matrixark_mcp_dashboard ranks no idle_commit
status at all, so they tie at -1 and time decides, which happens to be right. It
is a different function with a different map and no caller in common with this
one; making them agree is a larger change than this defect needs.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>
