### PR TITLE
A stream that breaks says why, like one that ends on purpose

### DIFF
--- a/docs/ops/matrixark-gateway-dashboard.json
+++ b/docs/ops/matrixark-gateway-dashboard.json
@@ -709,6 +709,35 @@
           "legendFormat": "peak {{source}} {{instance}}"
         }
       ]
+    },
+    {
+      "id": 19,
+      "type": "timeseries",
+      "title": "Live stream endings",
+      "description": "How the portal's live streams ended, per second, by reason. A stream is one request that lasts minutes, so the request rate cannot tell a deployment whose tabs are open from one breaking a stream every three seconds -- both are one request on /v1/admin/events. stream_max_age is the ten-minute rotation and is expected; client_gone is a tab closing; server_error is this gateway failing mid-stream, and the client reconnects straight into it for as long as it lasts.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 44
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (reason) (rate(matrixark_gateway_event_stream_ended_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "{{reason}}"
+        }
+      ]
     }
   ]
 }

--- a/tools/matrixark_gateway_metrics.py
+++ b/tools/matrixark_gateway_metrics.py
@@ -78,6 +78,10 @@ _EXACT_ROUTES = frozenset({
 })
 
 
+# Every way a live stream can end. The set is closed on purpose: this is a metric label, and one
+# taken from an open value is a cardinality bomb.
+STREAM_END_REASONS = ("stream_max_age", "server_error", "client_gone", "other")
+
 # Routes that stream. Their wall-clock duration is the length of a subscription, not a latency.
 STREAMING_ROUTES = frozenset({"/v1/admin/events"})
 
@@ -174,6 +178,11 @@ class GatewayMetrics:
 
         self._datanode: Optional[Tuple[str, float]] = None
 
+        # How the live streams ended, by reason. A stream is one request that lasts minutes, so
+        # the request counter cannot tell a deployment whose tabs are open from one breaking a
+        # stream every three seconds -- both are "one request on /v1/admin/events".
+        self._stream_ends: Dict[str, int] = {}
+
     # ---- recording -----------------------------------------------------------------------------
     def begin(self) -> None:
         with self._lock:
@@ -264,6 +273,23 @@ class GatewayMetrics:
         """Record what the readiness probe just found."""
         with self._lock:
             self._datanode = (str(state), time.time())
+
+    def note_stream_end(self, reason: str) -> None:
+        """Record how a live stream ended.
+
+        The reason becomes a label, so it is clamped to what this code can produce. A label taken
+        from a value that varies is a cardinality bomb in a dict that lives as long as the process,
+        and this one is written on a path any client can trigger by disconnecting.
+        """
+        label = str(reason or "other")
+        if label not in STREAM_END_REASONS:
+            label = "other"
+        with self._lock:
+            self._stream_ends[label] = self._stream_ends.get(label, 0) + 1
+
+    def stream_ends(self) -> Dict[str, int]:
+        with self._lock:
+            return dict(self._stream_ends)
 
     # ---- reading -------------------------------------------------------------------------------
     def series(self) -> Json:
@@ -601,6 +627,23 @@ def worker_count(argv: Optional[List[str]] = None,
     return workers if workers > 0 else 1
 
 
+def stream_lines() -> List[str]:
+    """How the live streams ended, by reason.
+
+    Every reason is emitted, including the ones at zero: a counter that appears only once it fires
+    cannot be alerted on before it has ever fired, which is the moment an alert is worth having.
+    """
+    ends = METRICS.stream_ends()
+    lines = [
+        "# HELP matrixark_gateway_event_stream_ended_total Live streams ended, by reason.",
+        "# TYPE matrixark_gateway_event_stream_ended_total counter",
+    ]
+    for reason in STREAM_END_REASONS:
+        lines.append('matrixark_gateway_event_stream_ended_total{reason="%s"} %d'
+                     % (reason, ends.get(reason, 0)))
+    return lines
+
+
 def worker_lines() -> List[str]:
     """The footprint gauges, rendered here rather than appended by the route.
 
@@ -641,6 +684,7 @@ def prometheus_text(config_snapshot: Optional[Json] = None,
     lines += config_health_lines(config_snapshot)
     lines += config_change_lines()
     lines += worker_lines()
+    lines += stream_lines()
     if extra_lines:
         lines += extra_lines
     return "\n".join(lines) + "\n"

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -2896,6 +2896,19 @@ async def _event_stream(server: Any, cfg: GatewayConfig, scope: Json, receive: C
     except (asyncio.CancelledError, ConnectionResetError, BrokenPipeError, OSError):
         # The client went away mid-write. Nothing to report: this is how a stream normally ends.
         pass
+    except Exception as exc:  # the reason has to reach the page, whatever it was
+        # This side broke. Told nothing, a browser sees only silence, reconnects on the `retry`
+        # above, and breaks again -- for as long as the fault lasts, with nothing to separate it
+        # from a network that died. The planned ending already says why it is going; so does this
+        # one, carrying the token that names the log entry rather than the fault itself.
+        body = _failure(scope, "backend_error", exc)
+        try:
+            await emit(b"event: bye\ndata: " + json.dumps(
+                {"reason": "server_error", "incident": body.get("incident")}
+            ).encode("utf-8") + b"\n\n")
+        except Exception:
+            # The connection is gone as well. The incident is logged either way.
+            pass
     finally:
         watcher.cancel()
         try:

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -2888,6 +2888,7 @@ async def _event_stream(server: Any, cfg: GatewayConfig, scope: Json, receive: C
             if (time.time() - started) >= max_age:
                 # Say why before going, so a reconnect is not mistaken for a fault.
                 await emit(b"event: bye\ndata: {\"reason\": \"stream_max_age\"}\n\n")
+                _gwmetrics.METRICS.note_stream_end("stream_max_age")
                 break
             try:
                 await asyncio.wait_for(disconnected.wait(), timeout=EVENT_TICK_S)
@@ -2895,12 +2896,13 @@ async def _event_stream(server: Any, cfg: GatewayConfig, scope: Json, receive: C
                 pass
     except (asyncio.CancelledError, ConnectionResetError, BrokenPipeError, OSError):
         # The client went away mid-write. Nothing to report: this is how a stream normally ends.
-        pass
+        _gwmetrics.METRICS.note_stream_end("client_gone")
     except Exception as exc:  # the reason has to reach the page, whatever it was
         # This side broke. Told nothing, a browser sees only silence, reconnects on the `retry`
         # above, and breaks again -- for as long as the fault lasts, with nothing to separate it
         # from a network that died. The planned ending already says why it is going; so does this
         # one, carrying the token that names the log entry rather than the fault itself.
+        _gwmetrics.METRICS.note_stream_end("server_error")
         body = _failure(scope, "backend_error", exc)
         try:
             await emit(b"event: bye\ndata: " + json.dumps(

--- a/tools/temporalstore-prometheus/matrixark-gateway-alerts.yml
+++ b/tools/temporalstore-prometheus/matrixark-gateway-alerts.yml
@@ -6,6 +6,23 @@
 # indistinguishable from a healthy one on latency, error rate, and every storage metric. Without
 # these rules the failure mode is silent for as long as nobody looks at retrieval quality.
 groups:
+  - name: matrixark-gateway-stream
+    rules:
+      - alert: MatrixArkEventStreamBreaking
+        expr: sum(rate(matrixark_gateway_event_stream_ended_total{reason="server_error"}[5m])) > 0.05
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "The portal's live stream is breaking on the server ({{ $labels.instance }})"
+          description: >-
+            Live streams are ending with reason=server_error. EventSource reconnects on the
+            cadence the stream itself sets, so the client walks straight back into the fault and
+            the portal shows stale state between attempts. Only this reason is alerted on:
+            stream_max_age is the ten-minute rotation and client_gone is a tab closing, so a rule
+            over the total would fire on a healthy deployment. The gateway log carries an incident
+            token for each one.
+
   - name: matrixark-gateway-config
     rules:
       - alert: MatrixArkRetrievalNotSemantic

--- a/tools/test_matrixark_a_stream_that_breaks_says_why.py
+++ b/tools/test_matrixark_a_stream_that_breaks_says_why.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A stream that breaks says why, the same as one that ends on purpose.
+
+The planned ending already carries a reason -- *"Say why before going, so a reconnect is not
+mistaken for a fault"* is the comment on it. A stream that breaks on the server's side said
+nothing at all: the body generator raised, the response ended mid-flight, and the browser saw
+silence.
+
+EventSource then reconnects on the ``retry`` cadence the stream itself set, and breaks again, for
+as long as the fault lasts. So a persistent backend failure is a reconnect every three seconds
+that nothing counts, and that no page can tell from a network that died -- the two look identical
+from the client, and only one of them is the deployment's fault.
+
+The reason goes out with the token that names the log entry, not the fault: a portal reader is not
+told the inside of the deployment, and that is the shape every other refusal here uses.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_v1_gateway as gw  # noqa: E402
+from test_matrixark_v1_gateway import _FakeServer, _cfg  # noqa: E402
+
+ADMIN = {"Authorization": "Bearer k-acme"}
+
+
+def drive(app, *, fail_after=1, timeout=10.0):
+    """Open a stream, let it emit, then make the NEXT tick raise. Returns what was sent."""
+    scope = {"type": "http", "method": "GET", "path": "/v1/admin/events",
+             "query_string": b"",
+             "headers": [(k.lower().encode(), v.encode()) for k, v in ADMIN.items()]}
+    sent = []
+    seen = {"count": 0}
+    disconnect = asyncio.Event()
+
+    async def receive():
+        if not seen.get("opened"):
+            seen["opened"] = True
+            return {"type": "http.request", "body": b"", "more_body": False}
+        await disconnect.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message):
+        sent.append(message)
+        body = message.get("body") or b""
+        if body.startswith(b"event: status") or body.startswith(b": keepalive"):
+            seen["count"] += 1
+            if seen["count"] >= fail_after:
+                # From here on the frame builder is broken, the way a backend outage breaks it.
+                gw._event_frame = _explode
+        if body.startswith(b"event: bye"):
+            disconnect.set()
+
+    async def run():
+        await asyncio.wait_for(app(scope, receive, send), timeout=timeout)
+
+    asyncio.run(run())
+    return b"".join(m.get("body", b"") for m in sent if m["type"] == "http.response.body")
+
+
+async def _explode(*args, **kwargs):
+    raise RuntimeError("the backend is not answering")
+
+
+class AStreamThatBreaksSaysWhyTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.original = gw._event_frame
+        self.addCleanup(setattr, gw, "_event_frame", self.original)
+        self.app = gw.make_v1_app(_FakeServer(), _cfg())
+
+    def _bye(self, body: bytes) -> dict:
+        self.assertIn(b"event: bye", body, "the stream ended without saying anything")
+        chunk = body.split(b"event: bye", 1)[1]
+        line = [l for l in chunk.split(b"\n") if l.startswith(b"data:")][0]
+        return json.loads(line[5:].strip())
+
+    def test_it_says_the_server_broke(self) -> None:
+        said = self._bye(drive(self.app))
+        self.assertEqual("server_error", said.get("reason"))
+
+    def test_it_carries_the_token_that_names_the_log_entry(self) -> None:
+        """The one string a reader can take to an operator. Without it the page has a sentence and
+        no way to get any further, and the operator has a log they cannot tie to the report."""
+        said = self._bye(drive(self.app))
+        self.assertTrue(said.get("incident"), "no incident token on the reason")
+
+    def test_it_does_not_leak_what_actually_broke(self) -> None:
+        """A portal reader is not told the inside of the deployment -- the token is the handle."""
+        body = drive(self.app)
+        self.assertNotIn(b"the backend is not answering", body)
+        self.assertNotIn(b"RuntimeError", body)
+        self.assertNotIn(b"Traceback", body)
+
+    def test_a_planned_ending_is_still_told_apart(self) -> None:
+        """Both endings are a bye, so the reason is the only thing separating them -- and the page
+        treats one as routine and the other as a fault."""
+        self.assertNotEqual("stream_max_age", self._bye(drive(self.app)).get("reason"))
+
+    def test_a_stream_that_is_not_broken_says_no_such_thing(self) -> None:
+        """The floor. A stream that always announced a server error would pass every assertion
+        above, and would tell every page the deployment is faulty on every rotation."""
+        scope = {"type": "http", "method": "GET", "path": "/v1/admin/events",
+                 "query_string": b"",
+                 "headers": [(k.lower().encode(), v.encode()) for k, v in ADMIN.items()]}
+        sent = []
+        seen = {"count": 0}
+        disconnect = asyncio.Event()
+
+        async def receive():
+            if not seen.get("opened"):
+                seen["opened"] = True
+                return {"type": "http.request", "body": b"", "more_body": False}
+            await disconnect.wait()
+            return {"type": "http.disconnect"}
+
+        async def send(message):
+            sent.append(message)
+            body = message.get("body") or b""
+            if body.startswith(b"event: status") or body.startswith(b": keepalive"):
+                seen["count"] += 1
+                if seen["count"] >= 2:
+                    disconnect.set()
+
+        asyncio.run(asyncio.wait_for(self.app(scope, receive, send), timeout=10.0))
+        body = b"".join(m.get("body", b"") for m in sent if m["type"] == "http.response.body")
+        self.assertNotIn(b"server_error", body)
+        self.assertIn(b"event: status", body, "the stream sent nothing at all, so this proves little")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_a_stream_that_breaks_says_why.py
+++ b/tools/test_matrixark_a_stream_that_breaks_says_why.py
@@ -28,7 +28,6 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import matrixark_gateway_metrics as gwm  # noqa: E402
 import matrixark_v1_gateway as gw  # noqa: E402
-from test_matrixark_v1_gateway import _FakeServer, _cfg  # noqa: E402
 
 ADMIN = {"Authorization": "Bearer k-acme"}
 
@@ -74,6 +73,11 @@ async def _explode(*args, **kwargs):
 class AStreamThatBreaksSaysWhyTest(unittest.TestCase):
 
     def setUp(self) -> None:
+        # Imported here rather than at module scope: importing another test module at import time
+        # reorders `unittest discover`, which can fail tests this file has nothing to do with --
+        # in CI, while passing locally.
+        from test_matrixark_v1_gateway import _FakeServer, _cfg
+
         self.original = gw._event_frame
         self.addCleanup(setattr, gw, "_event_frame", self.original)
         self.app = gw.make_v1_app(_FakeServer(), _cfg())
@@ -144,6 +148,11 @@ class HowTheStreamsEndedIsCountedTest(unittest.TestCase):
     series the gateway publishes."""
 
     def setUp(self) -> None:
+        # Imported here rather than at module scope: importing another test module at import time
+        # reorders `unittest discover`, which can fail tests this file has nothing to do with --
+        # in CI, while passing locally.
+        from test_matrixark_v1_gateway import _FakeServer, _cfg
+
         self.original = gw._event_frame
         self.addCleanup(setattr, gw, "_event_frame", self.original)
         self.app = gw.make_v1_app(_FakeServer(), _cfg())

--- a/tools/test_matrixark_a_stream_that_breaks_says_why.py
+++ b/tools/test_matrixark_a_stream_that_breaks_says_why.py
@@ -26,6 +26,7 @@ import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
+import matrixark_gateway_metrics as gwm  # noqa: E402
 import matrixark_v1_gateway as gw  # noqa: E402
 from test_matrixark_v1_gateway import _FakeServer, _cfg  # noqa: E402
 
@@ -134,6 +135,54 @@ class AStreamThatBreaksSaysWhyTest(unittest.TestCase):
         body = b"".join(m.get("body", b"") for m in sent if m["type"] == "http.response.body")
         self.assertNotIn(b"server_error", body)
         self.assertIn(b"event: status", body, "the stream sent nothing at all, so this proves little")
+
+
+class HowTheStreamsEndedIsCountedTest(unittest.TestCase):
+    """A stream is one request that lasts minutes, so the request counter cannot tell a deployment
+    whose tabs are open from one breaking a stream every three seconds -- both are one request on
+    /v1/admin/events. Without a count of the reasons, a reconnect storm is invisible in every
+    series the gateway publishes."""
+
+    def setUp(self) -> None:
+        self.original = gw._event_frame
+        self.addCleanup(setattr, gw, "_event_frame", self.original)
+        self.app = gw.make_v1_app(_FakeServer(), _cfg())
+
+    @staticmethod
+    def _scrape() -> str:
+        return gwm.prometheus_text({"extraction": {"provider": "deterministic"},
+                                    "embedding": {"provider": "deterministic"},
+                                    "warnings": []})
+
+    @staticmethod
+    def _count(reason: str) -> int:
+        return gwm.METRICS.stream_ends().get(reason, 0)
+
+    def test_a_broken_stream_is_counted_as_one(self) -> None:
+        before = self._count("server_error")
+        drive(self.app)
+        self.assertEqual(before + 1, self._count("server_error"))
+
+    def test_an_unknown_reason_cannot_invent_a_label(self) -> None:
+        """The reason is a metric label, and one taken from an open value is a cardinality bomb in
+        a dict that lives as long as the process -- on a path any client can trigger."""
+        before = self._count("other")
+        gwm.METRICS.note_stream_end("something nobody wrote")
+        self.assertEqual(before + 1, self._count("other"))
+        self.assertNotIn("something nobody wrote", self._scrape())
+
+    def test_every_reason_is_published_even_at_zero(self) -> None:
+        """A counter that appears only once it fires cannot be alerted on until it has fired,
+        which is exactly the moment the alert was worth having."""
+        text = self._scrape()
+        for reason in gwm.STREAM_END_REASONS:
+            with self.subTest(reason=reason):
+                self.assertIn('matrixark_gateway_event_stream_ended_total{reason="%s"}' % reason,
+                              text)
+
+    def test_it_is_in_the_scrape_at_all(self) -> None:
+        """The positive control: every assertion above passes on a build that publishes nothing."""
+        self.assertIn("matrixark_gateway_event_stream_ended_total", self._scrape())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The live stream already says why it is going when it ends **on purpose**. The
comment on that line is the whole argument for this change:

> Say why before going, so a reconnect is not mistaken for a fault.

A stream that breaks on the server's side said nothing at all. The body generator
raises, the response ends mid-flight, and the browser sees silence.

## Why silence is the expensive answer

`EventSource` reconnects on the `retry: 3000` cadence the stream itself set — and
breaks again, for as long as the fault lasts.

So a persistent backend failure is a reconnect every three seconds that nothing
counts, and that no page can tell apart from a network that died. From the client
the two are identical, and only one of them is the deployment's fault.

## What it says now

```
event: bye
data: {"reason": "server_error", "incident": "fa9ce4d24331"}
```

The **token**, not the fault. A portal reader is not told the inside of the
deployment, and that is the shape every other refusal on this gateway already
uses — the token is what ties their report to the operator's log.

The emit is itself wrapped: if the connection is gone too, there is nothing to say
and the incident is logged either way.

## Checks

Five tests, driven through a real ASGI stream that is broken mid-flight rather
than a mocked one:

* it says the server broke, and carries the token;
* it leaks neither the exception, its type, nor a traceback;
* a planned ending is still told apart — both are a `bye`, so the reason is the
  only thing separating them, and the page treats one as routine and the other as
  a fault;
* **the floor**: a stream that is *not* broken says no such thing. Without that,
  a stream that announced a server error unconditionally would pass everything
  above, and would tell every page the deployment is faulty on every rotation.

The three existing stream suites still pass.

## Known follow-up

The strip client currently treats **any** `bye` as planned (`planned = true`), so
it will reconnect quietly rather than showing this. That half lives in the portal
builder, which has changes in flight; it follows separately rather than being
wedged into the same diff.

---

## And counting how they ended

Telling the page is half of it. A stream is one request that lasts minutes, so the
request counter cannot separate a deployment whose tabs are open from one breaking a
stream every three seconds — both are *one request on `/v1/admin/events`*. A reconnect
storm was invisible in every series the gateway publishes.

`matrixark_gateway_event_stream_ended_total{reason}` counts the three endings.

* The reason is a **label**, so the set is closed. An open value here is a cardinality
  bomb in a dict that lives as long as the process, on a path any client can trigger by
  disconnecting. Anything unrecognised becomes `other`.
* **Every reason is emitted even at zero**, because a counter that only appears once it
  fires cannot be alerted on until it has fired — which is exactly the moment the alert
  was worth having.

A panel, and an alert on **`server_error` only**. Rotations happen every ten minutes by
design and clients disconnect constantly, so a rule over the total would fire on a
healthy deployment — the fastest way to teach somebody to ignore it.

Four more tests: a broken stream counts as one, an unknown reason cannot invent a label
and never reaches the scrape, every reason is published at zero, and the positive control
that the series is in the scrape at all.
