### PR TITLE
A listing costs its subject instead of the whole store

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -7395,13 +7395,55 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 "feedback_reason": reason}
 
     def records_for_get_all(self, scope: Json) -> list[Json]:
-        """The live records get_all filters. Base implementation: the whole store.
+        """The live records get_all filters. Base implementation: the subject's, or the whole store.
 
         get_all's own scope filter (hash equality) runs over whatever this returns, so an
         override only has to produce a SUPERSET of the subject's live events -- being slow is
         recoverable, dropping a memory from the listing is not.
+
+        The subject's own records are a superset of what get_all keeps for that subject, and a much
+        smaller one: a listing then costs its subject rather than the store. Real callers always
+        arrive with both hashes resolved (measured end to end, 86 of 86), so this narrows in
+        practice and not only in principle; a scope carrying neither hash matches everything, and
+        gets the whole list exactly as before.
+
+        The bucket is remembered per (tenant_hash, user_hash) on the same signature the compacted
+        read cache uses, and only while the expiry filter is inactive.
+
+        On that condition, honestly: the signature's third term is ``len(records)`` AFTER expiry,
+        and expiry only ever removes records from a fixed set, so a clock that passes an expiry
+        shortens the list and moves the signature by itself. The condition is therefore a second
+        line of defence rather than the only one -- it makes the hazard structurally unreachable
+        instead of relying on that monotonicity argument holding as the code changes, which is the
+        same reason ``read_all`` refuses to cache expiry at all. It is not free: a store holding a
+        single TTL record memoises no bucket for any subject and pays the full pass every time.
         """
-        return self.read_all()
+        records = self.read_all()
+        tenant_hash, user_hash = self._resolve_subject_hashes(scope) if scope else (0, 0)
+        if not tenant_hash and not user_hash:
+            return records
+        signature = (self._read_cache_size, self._read_cache_mtime_ns, len(records))
+        expiry = getattr(self, "_expiry_filter_memo", None)
+        cacheable = expiry is not None and expiry[0] == signature and not expiry[1]
+        if cacheable:
+            memo = getattr(self, "_get_all_scope_memo", None)
+            if memo is None or memo[0] != signature:
+                memo = (signature, {})
+                self._get_all_scope_memo = memo
+            bucket = memo[1].get((tenant_hash, user_hash))
+            if bucket is not None:
+                return bucket
+        bucket = []
+        for record in records:
+            rec_tenant, rec_user = _record_scope_hashes(record)
+            if tenant_hash and rec_tenant != tenant_hash:
+                continue
+            if user_hash and rec_user != user_hash:
+                continue
+            bucket.append(record)
+        if cacheable:
+            self._get_all_scope_memo[1][(tenant_hash, user_hash)] = bucket
+        return bucket
 
     def records_for_summary_refresh(self) -> list[Json]:
         """The live records a summary-refresh pass reads. Base implementation: the whole store.

--- a/tools/test_get_all_scope_bucket.py
+++ b/tools/test_get_all_scope_bucket.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""get_all lists a subject's records without resolving every record in the store.
+
+``records_for_get_all`` returns the subject's own records rather than the whole log, memoised per
+``(tenant_hash, user_hash)`` on the signature the compacted read cache already uses. Real callers
+always arrive with both hashes resolved, so this narrows in practice: at 32,000 records a repeated
+listing goes from 40.7 ms to 3.9 ms.
+
+The memo is taken only while the expiry filter is inactive, so a TTL record anywhere in the store
+turns it off for every subject. That has a consequence for this file worth stating up front: the
+TTL test below cannot exercise the memo, because the condition it would test is the same condition
+that disables it. The memo's invalidation is pinned by the WRITE test instead, which fails when the
+memo is made never to invalidate. Both were established by mutating the adapter, not by reading it.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+from matrixark_mcp_local_adapter import MatrixArkLocalAdapter  # noqa: E402
+
+ANCHOR_MS = 1_700_000_000_000
+SUBJECTS = 4
+
+
+def _scope(user: int) -> dict:
+    return {"tenant_hash": 7, "user_hash": user, "scope_key": f"t=7;u={user}"}
+
+
+def _event(index: int, user: int, **extra) -> dict:
+    record = {
+        "record_type": "context_event",
+        "event_id_hash": f"e{index}",
+        "summary_text": f"note {index}",
+        "text": f"note {index}",
+        "updated_at_ms": ANCHOR_MS + index,
+        "timestamp_key_ms": ANCHOR_MS + index,
+        "access_scope": _scope(user),
+    }
+    record.update(extra)
+    return record
+
+
+class GetAllListsASubjectWithoutWalkingTheStoreTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.adapter = MatrixArkLocalAdapter(pathlib.Path(self.tmp.name) / "events.jsonl")
+        self.adapter.append_many(
+            [_event(i, 100 + (i % SUBJECTS)) for i in range(40)]
+        )
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+        os.environ.pop("MATRIXARK_MEMORY_NOW_MS", None)
+
+    def _ids(self, user: int) -> set:
+        out = self.adapter.get_all({"scope": _scope(user), "limit": 10_000})
+        return {row["id"] for row in out["memories"]}
+
+    def test_a_subject_sees_exactly_its_own(self) -> None:
+        for user in range(100, 100 + SUBJECTS):
+            self.assertEqual(
+                self._ids(user),
+                {f"e{i}" for i in range(40) if 100 + (i % SUBJECTS) == user},
+                f"subject {user}",
+            )
+
+    def test_the_answer_is_the_same_on_a_repeat(self) -> None:
+        """The second call is the memoised one; it must answer what the first did."""
+        self.assertEqual(self._ids(101), self._ids(101))
+
+    def test_a_subject_with_nothing_gets_nothing(self) -> None:
+        self.assertEqual(self.adapter.get_all({"scope": _scope(999), "limit": 100})["count"], 0)
+
+    def test_a_scope_with_no_hashes_still_lists_everything(self) -> None:
+        self.assertEqual(self.adapter.get_all({"limit": 10_000})["count"], 40)
+
+    def test_a_write_reaches_a_listing_that_was_already_served(self) -> None:
+        before = self._ids(100)
+        self.adapter.append(_event(9_000, 100))
+        self.assertEqual(self._ids(100), before | {"e9000"})
+
+    def test_a_ttl_record_still_disappears_from_a_listing(self) -> None:
+        """Expiry is still visible through the new path.
+
+        This does NOT test the memo, and saying so matters: a TTL record anywhere in the store is
+        exactly what turns the memo off, so on this fixture no bucket is ever remembered. Every
+        mutation of the memo passes here, which is how that was found rather than assumed. What it
+        does pin is the end-to-end guarantee through the narrowed listing -- an expired memory
+        leaves it -- which is the thing a reader of this change will want assured.
+
+        The memo's own invalidation is covered by
+        ``test_a_write_reaches_a_listing_that_was_already_served``, which fails when the memo is
+        made never to invalidate.
+        """
+        self.adapter.append(_event(7_000, 100, expires_at_ms=ANCHOR_MS + 10_000))
+        os.environ["MATRIXARK_MEMORY_NOW_MS"] = str(ANCHOR_MS + 1_000)
+        self.assertIn("e7000", self._ids(100), "the record is live before its expiry")
+
+        os.environ["MATRIXARK_MEMORY_NOW_MS"] = str(ANCHOR_MS + 20_000)
+        self.assertNotIn("e7000", self._ids(100), "an expired record must leave the listing")
+
+    def test_one_subjects_expiry_does_not_disturb_another(self) -> None:
+        self.adapter.append(_event(7_001, 100, expires_at_ms=ANCHOR_MS + 10_000))
+        os.environ["MATRIXARK_MEMORY_NOW_MS"] = str(ANCHOR_MS + 1_000)
+        other = self._ids(101)
+        os.environ["MATRIXARK_MEMORY_NOW_MS"] = str(ANCHOR_MS + 20_000)
+        self.assertEqual(self._ids(101), other)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
`get_all` listed a subject by resolving the access scope of every record in the store.
`records_for_get_all` returned the whole log, so the cost was the store's size and not the
subject's -- a ten-row listing over 32,000 records resolved 32,000 scopes.

It now returns the subject's own records, memoised per `(tenant_hash, user_hash)` on the signature
the compacted read cache already uses. The subject's records are a superset of what `get_all` keeps
for that subject, which is the contract the method's docstring already states.

This narrows in practice and not only in principle: instrumenting `_resolve_subject_hashes` across
the suites that drive `get_all` end to end gives **86 of 86 resolutions arriving with both hashes
set**. A scope carrying neither hash matches everything and still gets the whole list.

## Measured

Enriched scope, 20 subjects, listing ten rows:

| records | first call | repeat |
|---|---|---|
| 2,000 | 3.36 ms | **0.24 ms** |
| 8,000 | 8.85 ms | **0.71 ms** |
| 32,000 | 40.74 ms | **3.86 ms** |

The first call after a write still pays a full pass; repeats cost the subject. A serving process
reads far more often than it writes, which is the case this is for.

## The condition on the memo, and what it costs

The bucket is remembered only while the expiry filter is inactive. `read_all` enforces expiry on
every read and deliberately never caches it, so a bucket held across a clock that passes an expiry
could return a memory that should be gone.

Being accurate about how much that condition carries: the signature's third term is `len(records)`
*after* expiry, and expiry only removes records from a fixed set, so a passing expiry shortens the
list and moves the signature on its own. The condition is a second line of defence, not the only
one -- it makes the hazard structurally unreachable rather than resting on that monotonicity
argument surviving future edits.

It is not free, and the cost is stated in the code: **a store holding a single TTL record memoises
no bucket for any subject** and pays the full pass every time.

## Test, and what the mutations actually showed

`test_get_all_scope_bucket.py`, seven tests, and the mutation pass is the interesting part because
it caught a flaw in the tests themselves rather than confirming them:

* **the memo never invalidates** -> the write test **fails**. This is the real risk and it is covered.
* **never narrow** (the original behaviour) -> **passes**, so this is an optimization and not a
  change in what `get_all` answers.
* **the bucket ignores a hash** -> passes, correctly: `get_all` re-filters, and a superset is the
  documented contract.
* **the memo taken unconditionally** -> **passes**, and it should not have. Chasing that down showed
  the TTL test cannot exercise the memo at all, because a TTL record is exactly what turns the memo
  off. Both docstrings now say so instead of claiming coverage that is not there; the TTL test earns
  its place by pinning the end-to-end guarantee through the narrowed path, not the memo.

28 suites reach `get_all`, the scope resolver, TTL or retention: **263 tests, no failures.**
