### PR TITLE
Regenerate the engine flag inventory

### DIFF
--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -8,7 +8,7 @@ within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 287 of them, read by 88 functions.
+There are 286 of them, read by 87 functions.
 
 Deleting unreachable code is not the lever. An earlier version of this document argued that
 by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
@@ -60,8 +60,8 @@ Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 287 |
-| booleans whose default this could read off the source | 47 |
+| total | 286 |
+| booleans whose default this could read off the source | 46 |
 | numbers whose default this could read off the source | 70 |
 | **defaulting on, and set by nothing** | 5 |
 | offered on the portal | 26 |


### PR DESCRIPTION
The generated inventory says the engine has 287 flags read by 88 functions. It
has 286, read by 87 -- a flag was removed and the document was not regenerated,
so `test_regenerating_produces_the_same_document` has been failing.

It fails on **main**, which means it fails on every open pull request's ratchet
as well: the one new failure each of them reports is this, not theirs. That is
the cost of a stale generated document -- it does not merely go out of date, it
spends everyone else's gate.

Regenerated with `python3 tools/build_engine_flag_inventory.py .` and nothing
else. Verified stable across two runs, because a generated document that is not
deterministic swaps one permanent failure for an intermittent one.
