### PR TITLE
Three methods that repeated a policy module now delegate to it

### DIFF
--- a/tools/matrixark_local_adapter_context_node.py
+++ b/tools/matrixark_local_adapter_context_node.py
@@ -19,32 +19,33 @@ except ImportError:
     compact_context_embedding_record,
 )
 
+# The three below are written out in matrixark_mcp_session_policy as well, and were repeated here
+# verbatim. Aliased because a method body resolves globals rather than class scope, so the bare
+# name would work and would read as though the method called itself.
+try:  # package path
+    from tools.matrixark_mcp_session_policy import (
+        default_session_node_path as _policy_default_session_node_path,
+        default_shared_context_node_path as _policy_default_shared_context_node_path,
+        resource_sharing_scope as _policy_resource_sharing_scope,
+    )
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_session_policy import (
+        default_session_node_path as _policy_default_session_node_path,
+        default_shared_context_node_path as _policy_default_shared_context_node_path,
+        resource_sharing_scope as _policy_resource_sharing_scope,
+    )
+
 
 class _LocalAdapterContextNodeMixin:
     def default_session_node_path(self, scope: Json) -> list[str]:
-        tenant_id = str(scope.get("tenant_id") or "tenant_local_agent")
-        user_id = str(scope.get("user_id") or local_account_user_id())
-        session_id = str(scope.get("session_id") or user_id or "default_session")
-        return [f"tenant:{tenant_id}", f"user:{user_id}", f"session:{session_id}"]
+        return _policy_default_session_node_path(scope)
 
     def default_shared_context_node_path(self, scope: Json, *, kind: str, sharing_scope: str) -> list[str]:
-        collection = "skills" if kind == "skill" else "resources"
-        if sharing_scope == "global_shared":
-            return ["global", "shared", collection]
-        tenant_id = str(scope.get("tenant_id") or "tenant_local_agent")
-        return [f"tenant:{tenant_id}", "shared", collection]
+        return _policy_default_shared_context_node_path(
+            scope, kind=kind, sharing_scope=sharing_scope)
 
     def resource_sharing_scope(self, args: Json, envelope: Json, deployment_scope: str) -> str:
-        metadata = envelope.get("metadata", {}) if isinstance(envelope.get("metadata"), dict) else {}
-        explicit = str(args.get("sharing_scope") or metadata.get("sharing_scope") or "").strip().lower()
-        if explicit in {"tenant_shared", "global_shared", "private_user"}:
-            return explicit
-        if deployment_scope == "global":
-            return "global_shared"
-        scope = envelope.get("scope", {}) if isinstance(envelope.get("scope"), dict) else {}
-        if not scope.get("user_id") and not scope.get("session_id"):
-            return "tenant_shared" if scope.get("tenant_id") else "global_shared"
-        return "private_user"
+        return _policy_resource_sharing_scope(args, envelope, deployment_scope)
 
     def default_resource_node_path(self, args: Json, envelope: Json, *, deployment_scope: str, sharing_scope: str) -> list[str]:
         metadata = envelope.get("metadata", {}) if isinstance(envelope.get("metadata"), dict) else {}


### PR DESCRIPTION
Three methods on `_LocalAdapterContextNodeMixin` repeat `matrixark_mcp_session_policy` verbatim.
Each takes `self` and never uses it, and each body is byte-identical to the module function it
shadows. They now delegate.

`default_session_node_path`, `default_shared_context_node_path`, `resource_sharing_scope` — 22
lines of repeated body.

## What made this safe to do rather than assume

Four checks, because a method is not a module-level function and the usual rules do not all carry
over:

- **Both modules are reachable from production.** Choosing an owner inside a module production
  cannot reach would wire up a dead island, which is an architectural change rather than a
  cleanup.
- **The mixin's module already reaches the policy module**, so the import adds no edge to the
  module graph and no cycle can appear.
- **Every free name in the three bodies resolves to the same object in both modules.** Identical
  text is not identical behaviour when a global differs: the same source can call a different
  helper or raise a different exception class depending on which module holds it.
- **The star import does not already provide these names**, so an explicit import is required
  rather than optional.

## Why the import is aliased

A method body resolves names local -> enclosing -> global -> builtins; class scope is not in that
chain. An unaliased import would therefore work, and would read as though each method called
itself. The alias says what is happening.

## Verification

Behavioural, not by identity — a delegating method is deliberately not the same object as the
function it calls, so the identity check used for the module-level consolidations does not apply
here.

The method and the module function were compared across 69 input combinations, chosen to cover
what the bodies actually branch on: every subset of scope keys, both `kind` values, all three
`sharing_scope` values, all three `deployment_scope` values, and envelopes with and without
`metadata` and `scope`. All 69 agree.

The whole `tools/` suite ran before and after, with the control pinned to this exact commit.
