### PR TITLE
The resolved set listed a status nothing writes

### DIFF
--- a/tools/matrixark_mcp_retrieve_request.py
+++ b/tools/matrixark_mcp_retrieve_request.py
@@ -237,7 +237,20 @@ def pre_retrieval_idle_commit_flush(target: Any, args: Json, ranking: Json, *, s
         if record.get("record_type") != "matrixark_async_pipeline_task":
             continue
         status = str(record.get("status") or "")
-        if status in {"idle_commit_committed", "idle_commit_attempted", "idle_commit_failed"}:
+        # The statuses that mean "this task is done, stop re-attempting it".
+        #
+        # `idle_commit_attempted` used to be here and is gone: nothing in the repository ever
+        # writes it -- not Python, not the crates, not a fixture -- so it could never match, and
+        # listing it made this set look like it covered more outcomes than it does.
+        #
+        # `idle_commit_skipped` is NOT here, and that is the open question rather than an
+        # oversight. It is what the drain writes whenever `session_commit` declines
+        # (matrixark_local_adapter_retrieval), so it is the common outcome, and its completion
+        # record keeps `remaining_stages` set and `completed_stages` empty -- it is written as
+        # work still outstanding, which is an argument for re-attempting it. Adding it here would
+        # stop the re-attempts, and marking dead work resolved looks identical from outside to
+        # dropping live work. Settle what a skip means before changing this line.
+        if status in {"idle_commit_committed", "idle_commit_failed"}:
             try:
                 resolved_task_hashes.add(int(record.get("scheduled_task_hash") or record.get("task_hash") or 0))
             except (TypeError, ValueError):


### PR DESCRIPTION
`pre_retrieval_idle_commit_flush` decides a task is done when its status is one
of three. One of those three, `idle_commit_attempted`, is never written --
searched across Python, the crates, docs, config and fixtures, it appears exactly
twice and both are readers: this set, and a rank map in
matrixark_mcp_async_readiness. Nothing assigns it as a status value.

So the membership test could never match on it, which makes this a no-op change
in behaviour and a real one in meaning: the set read as though it covered three
outcomes when it covered two.

What it still does not cover is `idle_commit_skipped`, and that is left alone on
purpose. The drain writes exactly two statuses -- `idle_commit_committed` when
`session_commit` returns accepted or committed, and `idle_commit_skipped` for
everything else -- so skipped is the common outcome, and a skipped task is
therefore never marked resolved and returns on the next read.

Adding it here would stop that, and it is not obviously right: the completion
record for a skip keeps `remaining_stages` set and `completed_stages` empty, so
it is written as work still outstanding. Marking dead work resolved and dropping
live work look identical from outside. The comment now says this at the line, so
the next reader sees an open decision rather than an oversight, and knows what to
settle before changing it.

No test changes: nothing can exercise the removed member, and the file's suite
reports the same 11 pre-existing failures with and without this change.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>
