### PR TITLE
get_memory walked the whole store to answer one id

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -7182,13 +7182,48 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         return {"reset": True, "tenant_hash": tenant_hash, "removed_count": removed, "purge": purge}
 
     def records_for_get_memory(self, memory_id: str) -> list[Json]:
-        """The live records get_memory filters for one id. Base implementation: the whole store.
+        """The live records get_memory filters for one id. Base implementation: the id's own.
 
         get_memory's own matching (id equality and the provenance check) runs over whatever this
         returns, so an override only has to produce a SUPERSET of the id's live records -- being
         slow is recoverable, answering {found: false} for a live memory is not.
+
+        Both of those matches are indexable, and both are needed: an id reaches its own event
+        through ``event_id_hash``, and reaches each DERIVED record through the source ids that
+        record's provenance names. A plain id lookup would find the event and silently lose the
+        entities and summaries built from it, so the index keys on both.
+
+        Walking the whole store cost 16.6 ms per 32,000 records to answer one id, of which 13.4 ms
+        was resolving provenance for every record in it.
+
+        Remembered per generation on the compacted cache's signature, and only while the expiry
+        filter is inactive -- the same condition, for the same reason, as
+        ``records_for_get_all``: ``read_all`` enforces expiry per read and never caches it.
         """
-        return self.read_all()
+        records = self.read_all()
+        if not memory_id:
+            return records
+        signature = (self._read_cache_size, self._read_cache_mtime_ns, len(records))
+        expiry = getattr(self, "_expiry_filter_memo", None)
+        cacheable = expiry is not None and expiry[0] == signature and not expiry[1]
+        if cacheable:
+            memo = getattr(self, "_get_memory_index_memo", None)
+            if memo is not None and memo[0] == signature:
+                return memo[1].get(str(memory_id), [])
+        index: dict[str, list[Json]] = {}
+        for record in records:
+            keys: set[str] = set()
+            own = record.get("event_id_hash")
+            if own not in (None, ""):
+                keys.add(str(own))
+            provenance = _record_provenance_source_ids(record)
+            if provenance:
+                keys.update(str(source) for source in provenance)
+            for key in keys:
+                index.setdefault(key, []).append(record)
+        if cacheable:
+            self._get_memory_index_memo = (signature, index)
+        return index.get(str(memory_id), [])
 
     def get_memory(self, args: Json) -> Json:
         """Fetch a single memory by id (mem0 ``get``). Returns the live ``context_event`` for

--- a/tools/test_get_memory_reads_an_index.py
+++ b/tools/test_get_memory_reads_an_index.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""get_memory answers one id without walking the whole live store.
+
+Two matches reach a record, and both are indexed because both are needed: an id finds its own event
+through ``event_id_hash``, and finds each DERIVED record through the source ids that record's
+provenance names. An index on the id alone would return the event and silently lose the entities and
+summaries built from it -- `{found: true}` with an empty `derived`, which reads like a memory that
+simply has no derivatives.
+
+That is a failure by omission, so the main test is differential and exhaustive: for every id the
+corpus mentions, through either match, the indexed answer must equal the whole-store answer,
+compared as whole structures. The whole-store side is the base implementation, restored, so the two
+cannot drift.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+from matrixark_mcp_local_adapter import MatrixArkLocalAdapter  # noqa: E402
+import matrixark_mcp_local_adapter as adapter_module  # noqa: E402
+
+ANCHOR_MS = 1_700_000_000_000
+
+
+class GetMemoryReadsAnIndexNotTheStoreTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.adapter = MatrixArkLocalAdapter(pathlib.Path(self.tmp.name) / "events.jsonl")
+        records: list[dict] = []
+        # Filler, so any one id's records are a small minority -- the condition the index exists
+        # for and the one where a missed key hides.
+        for i in range(60):
+            records.append({"record_type": "context_event", "event_id_hash": str(9_000 + i),
+                            "summary_text": f"filler {i}", "text": f"filler {i}",
+                            "updated_at_ms": ANCHOR_MS + i, "timestamp_key_ms": ANCHOR_MS + i})
+        # One event with derivatives reaching it by each of the three provenance fields, plus a
+        # derivative built from TWO sources, which must appear under both.
+        records += [
+            {"record_type": "context_event", "event_id_hash": "101", "summary_text": "the memory",
+             "text": "the memory", "updated_at_ms": ANCHOR_MS + 100, "timestamp_key_ms": ANCHOR_MS + 100},
+            {"record_type": "context_event", "event_id_hash": "102", "summary_text": "another",
+             "text": "another", "updated_at_ms": ANCHOR_MS + 101, "timestamp_key_ms": ANCHOR_MS + 101},
+            {"record_type": "context_entity", "entity_hash": "ent1", "entity_name": "Ada",
+             "source_event_ids": [101], "text": "Ada", "updated_at_ms": ANCHOR_MS + 102},
+            {"record_type": "context_summary", "summary_hash": "sum1", "summary_type": "session",
+             "source_refs": ["101"], "summary_text": "a summary", "updated_at_ms": ANCHOR_MS + 103},
+            {"record_type": "context_segment", "source_event_hash": "101",
+             "text": "a segment", "updated_at_ms": ANCHOR_MS + 104},
+            {"record_type": "context_summary", "summary_hash": "sum2", "summary_type": "rollup",
+             "source_event_ids": [101, 102], "summary_text": "both", "updated_at_ms": ANCHOR_MS + 105},
+            # A leaf that is NOT a derivative: it must not be pulled in by the provenance path.
+            {"record_type": "context_embedding", "ref_type": "event", "ref_hash": "101",
+             "updated_at_ms": ANCHOR_MS + 106},
+        ]
+        self.adapter.append_many(records)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _by_full_scan(self, memory_id: str) -> dict:
+        original = type(self.adapter).records_for_get_memory
+        try:
+            type(self.adapter).records_for_get_memory = lambda self, memory_id: self.read_all()
+            return self.adapter.get_memory({"memory_id": memory_id})
+        finally:
+            type(self.adapter).records_for_get_memory = original
+
+    def _every_id(self) -> set:
+        ids = set()
+        for record in self.adapter.read_all():
+            own = record.get("event_id_hash")
+            if own not in (None, ""):
+                ids.add(str(own))
+            provenance = adapter_module._record_provenance_source_ids(record)
+            if provenance:
+                ids.update(str(source) for source in provenance)
+        return ids
+
+    def test_every_id_answers_what_the_whole_store_answers(self) -> None:
+        ids = self._every_id()
+        self.assertGreaterEqual(len(ids), 62, "the corpus must mention many ids or this proves little")
+        for memory_id in sorted(ids):
+            self.assertEqual(self.adapter.get_memory({"memory_id": memory_id}),
+                             self._by_full_scan(memory_id),
+                             f"get_memory({memory_id}) differs from the whole-store answer")
+
+    def test_an_id_the_store_never_mentions_agrees_too(self) -> None:
+        self.assertEqual(self.adapter.get_memory({"memory_id": "nosuchid"}),
+                         self._by_full_scan("nosuchid"))
+
+    def test_the_derivatives_are_actually_there(self) -> None:
+        """The positive control: without it, an index returning only the event would pass the
+        differential test against a full scan that had been broken the same way."""
+        out = self.adapter.get_memory({"memory_id": "101"})
+        self.assertTrue(out["found"])
+        kinds = sorted(row["record_type"] for row in out["derived"])
+        self.assertEqual(kinds, ["context_entity", "context_segment", "context_summary", "context_summary"])
+
+    def test_a_two_source_derivative_reaches_both_ids(self) -> None:
+        for memory_id in ("101", "102"):
+            texts = [row["text"] for row in self.adapter.get_memory({"memory_id": memory_id})["derived"]]
+            self.assertIn("both", texts, f"the two-source summary is missing from {memory_id}")
+
+    def test_a_write_reaches_a_read_already_served(self) -> None:
+        before = len(self.adapter.get_memory({"memory_id": "101"})["derived"])
+        self.adapter.append({"record_type": "context_entity", "entity_hash": "ent2",
+                             "entity_name": "Grace", "source_event_ids": [101], "text": "Grace",
+                             "updated_at_ms": ANCHOR_MS + 300})
+        self.assertEqual(len(self.adapter.get_memory({"memory_id": "101"})["derived"]), before + 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
`get_memory` walked the whole live store to answer one id: **16.6 ms per 32,000 records**, of which
**13.4 ms was `_record_provenance_source_ids` over every record in it**.

It reads an index now, and the index has to key on two things because `get_memory` performs two
matches. An id reaches its own event through `event_id_hash`, and reaches each **derived** record
through the source ids that record's provenance names. An index on the id alone would return the
event and silently drop the entities and summaries built from it -- `{found: true}` with an empty
`derived`, which reads exactly like a memory that has no derivatives.

| records | before | after |
|---|---|---|
| 2,000 | 1.541 ms | 0.270 ms |
| 32,000 | **15.377 ms** | **0.236 ms** |

Growth 10.0x -> 0.9x: flat, not merely faster.

`records_for_get_memory` was already the override point, and its docstring already stated the
contract this keeps -- a superset is fine, "answering {found: false} for a live memory is not". The
index is remembered per generation on the compacted cache's signature and only while the expiry
filter is inactive: the same condition, for the same reason, as `records_for_get_all`.

## Test

Failure by omission again, so the main test is differential and exhaustive: for every id the corpus
mentions **through either match**, the indexed answer must equal the whole-store answer, compared as
whole structures, with the whole-store side being the base implementation restored.

The corpus carries a derivative reaching its source by each of the three provenance fields
(`source_event_ids`, `source_refs`, `source_event_hash`), one built from **two** sources that must
appear under both, and a `context_embedding` that is *not* a derivative and must not be pulled in.

| mutation | result |
|---|---|
| index the id only, drop provenance | **4 failures** |
| index provenance only, drop the event's own id | **2 failures, 2 errors** |
| the index never invalidates | **1 failure** |
| return the whole store (the original) | **passes** -- an optimization, not a changed answer |

98 suites reach `get_memory`, provenance or the derived record types: **896 tests, 2 failures, and
both are pre-existing.** `test_locomo_reader_hints` (2) and
`test_matrixark_engine_flag_inventory::test_regenerating_produces_the_same_document` (1) fail
identically on clean `main` measured at the same moment.
