### PR TITLE
A keyed recall searched the whole store for one key

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -7032,7 +7032,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         scope = optional_object(args, "scope")
         tenant_hash, user_hash = self._resolve_subject_hashes(scope)
         candidates: list[Json] = []
-        for record in self.read_all():
+        for record in self.records_for_identity_key(identity_key):
             if str(record.get("record_type") or "") != "context_event":
                 continue
             if str(record.get("identity_key") or "") != identity_key:
@@ -7180,6 +7180,38 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         # records + markers out of the log (crash-safe; the purged log replays to the same state).
         purge = self.purge_tombstones(force=True)
         return {"reset": True, "tenant_hash": tenant_hash, "removed_count": removed, "purge": purge}
+
+    def records_for_identity_key(self, identity_key: str) -> list[Json]:
+        """The live records a keyed recall filters. Base implementation: that key's own.
+
+        ``get_memory_by_identity_key`` re-checks the record type, the key and the scope over
+        whatever this returns, so an override only has to produce a SUPERSET of the key's live
+        records -- the same contract as ``records_for_get_memory`` beside it, and the same cost of
+        getting it wrong: a live keyed value that answers {found: false}.
+
+        Walking the whole store cost 7.2 ms per 32,000 records to answer one key. The index is
+        remembered per generation on the compacted cache's signature and only while the expiry
+        filter is inactive, for the reason ``records_for_get_all`` gives.
+        """
+        records = self.read_all()
+        if not identity_key:
+            return records
+        signature = (self._read_cache_size, self._read_cache_mtime_ns, len(records))
+        expiry = getattr(self, "_expiry_filter_memo", None)
+        cacheable = expiry is not None and expiry[0] == signature and not expiry[1]
+        if cacheable:
+            memo = getattr(self, "_identity_key_index_memo", None)
+            if memo is not None and memo[0] == signature:
+                return memo[1].get(str(identity_key), [])
+        index: dict[str, list[Json]] = {}
+        for record in records:
+            key = record.get("identity_key")
+            if key in (None, ""):
+                continue
+            index.setdefault(str(key), []).append(record)
+        if cacheable:
+            self._identity_key_index_memo = (signature, index)
+        return index.get(str(identity_key), [])
 
     def records_for_get_memory(self, memory_id: str) -> list[Json]:
         """The live records get_memory filters for one id. Base implementation: the id's own.

--- a/tools/test_keyed_recall_reads_an_index.py
+++ b/tools/test_keyed_recall_reads_an_index.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A keyed recall finds its key's records without walking the whole live store.
+
+``get_memory_by_identity_key`` filtered every record in the store to find one key: 7.2 ms per
+32,000 records. It reads an index now, through a new ``records_for_identity_key`` override point
+matching the two beside it.
+
+An index fails by omission -- a live keyed value answering ``{found: false}`` -- so the main test is
+differential and exhaustive: for every key the corpus holds, the indexed answer must equal the
+whole-store answer, compared as whole structures, with the whole-store side being the base
+implementation restored so the two cannot drift.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+from matrixark_mcp_local_adapter import MatrixArkLocalAdapter  # noqa: E402
+
+ANCHOR_MS = 1_700_000_000_000
+SCOPE = {"tenant_hash": 7, "user_hash": 11, "scope_key": "t=7;u=11"}
+OTHER = {"tenant_hash": 7, "user_hash": 22, "scope_key": "t=7;u=22"}
+
+
+class AKeyedRecallReadsAnIndexTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.adapter = MatrixArkLocalAdapter(pathlib.Path(self.tmp.name) / "events.jsonl")
+        records = []
+        for i in range(60):
+            records.append({"record_type": "context_event", "event_id_hash": f"f{i}",
+                            "identity_key": f"filler{i}", "summary_text": f"filler {i}",
+                            "text": f"filler {i}", "truth_rank": 1,
+                            "updated_at_ms": ANCHOR_MS + i, "timestamp_key_ms": ANCHOR_MS + i,
+                            "access_scope": SCOPE})
+        # One key held by several records, so the tie-break (highest truth_rank, then most recent)
+        # has something to choose between -- an index that returned only one would still look right
+        # without this.
+        records += [
+            {"record_type": "context_event", "event_id_hash": "a1", "identity_key": "home",
+             "summary_text": "old home", "text": "old home", "truth_rank": 1,
+             "updated_at_ms": ANCHOR_MS + 100, "timestamp_key_ms": ANCHOR_MS + 100,
+             "occurred_at_ms": ANCHOR_MS + 100, "access_scope": SCOPE},
+            {"record_type": "context_event", "event_id_hash": "a2", "identity_key": "home",
+             "summary_text": "new home", "text": "new home", "truth_rank": 3,
+             "updated_at_ms": ANCHOR_MS + 101, "timestamp_key_ms": ANCHOR_MS + 101,
+             "occurred_at_ms": ANCHOR_MS + 101, "access_scope": SCOPE},
+            {"record_type": "context_event", "event_id_hash": "a3", "identity_key": "home",
+             "summary_text": "someone else's home", "text": "someone else's home", "truth_rank": 9,
+             "updated_at_ms": ANCHOR_MS + 102, "timestamp_key_ms": ANCHOR_MS + 102,
+             "occurred_at_ms": ANCHOR_MS + 102, "access_scope": OTHER},
+            # A non-event carrying the same key: the type check must still exclude it.
+            {"record_type": "context_summary", "identity_key": "home", "summary_hash": "s1",
+             "summary_text": "a summary", "updated_at_ms": ANCHOR_MS + 103, "access_scope": SCOPE},
+        ]
+        self.adapter.append_many(records)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _by_full_scan(self, key: str, scope: dict) -> dict:
+        original = type(self.adapter).records_for_identity_key
+        try:
+            type(self.adapter).records_for_identity_key = lambda self, identity_key: self.read_all()
+            return self.adapter.get_memory_by_identity_key({"identity_key": key, "scope": scope})
+        finally:
+            type(self.adapter).records_for_identity_key = original
+
+    def test_every_key_answers_what_the_whole_store_answers(self) -> None:
+        keys = {str(r.get("identity_key")) for r in self.adapter.read_all()
+                if r.get("identity_key") not in (None, "")}
+        self.assertGreaterEqual(len(keys), 61, "the corpus must hold many keys or this proves little")
+        for key in sorted(keys):
+            for scope in (SCOPE, OTHER, {}):
+                self.assertEqual(
+                    self.adapter.get_memory_by_identity_key({"identity_key": key, "scope": scope}),
+                    self._by_full_scan(key, scope),
+                    f"identity_key={key} scope={scope} differs from the whole-store answer")
+
+    def test_a_key_the_store_never_held_agrees_too(self) -> None:
+        self.assertEqual(
+            self.adapter.get_memory_by_identity_key({"identity_key": "nosuchkey", "scope": SCOPE}),
+            self._by_full_scan("nosuchkey", SCOPE))
+
+    def test_the_highest_truth_rank_in_the_scope_wins(self) -> None:
+        """The positive control: an index returning one arbitrary record would pass a differential
+        test whose other side was broken the same way, but not this."""
+        out = self.adapter.get_memory_by_identity_key({"identity_key": "home", "scope": SCOPE})
+        self.assertTrue(out["found"])
+        self.assertEqual(out["id"], "a2")
+        self.assertEqual(out["truth_rank"], 3)
+
+    def test_another_subjects_record_does_not_win_the_key(self) -> None:
+        """a3 has the highest truth_rank of all, and belongs to someone else."""
+        self.assertEqual(
+            self.adapter.get_memory_by_identity_key({"identity_key": "home", "scope": OTHER})["id"],
+            "a3")
+
+    def test_a_write_reaches_a_recall_already_served(self) -> None:
+        before = self.adapter.get_memory_by_identity_key({"identity_key": "home", "scope": SCOPE})["id"]
+        self.assertEqual(before, "a2")
+        self.adapter.append({"record_type": "context_event", "event_id_hash": "a4",
+                             "identity_key": "home", "summary_text": "newest", "text": "newest",
+                             "truth_rank": 5, "updated_at_ms": ANCHOR_MS + 200,
+                             "timestamp_key_ms": ANCHOR_MS + 200,
+                             "occurred_at_ms": ANCHOR_MS + 200, "access_scope": SCOPE})
+        self.assertEqual(
+            self.adapter.get_memory_by_identity_key({"identity_key": "home", "scope": SCOPE})["id"],
+            "a4")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
`get_memory_by_identity_key` filtered every record in the live store to find one key's records:
**7.2 ms per 32,000**. It reads an index now, through a new `records_for_identity_key` override
point that matches the two beside it.

| records | before | after |
|---|---|---|
| 2,000 | 0.517 ms | 0.114 ms |
| 32,000 | **7.171 ms** | **0.320 ms** |

Growth 13.9x -> 2.8x. The residual is `read_all` itself, which grows the same amount over that
range; the keyed lookup no longer contributes any.

This is the last read API on the adapter that cost the store rather than its answer. Sweeping all
twelve at 2,000 and 32,000 records now leaves `get_all` alone above 3x, and its remaining growth is
proportional to the **subject** rather than the store -- 1,600 of the 32,000 records belong to the
subject being listed, which is the shape it is supposed to have.

## Test

Failure by omission means a live keyed value answering `{found: false}`, so the main test is
differential and exhaustive: for every key the corpus holds, under three different scopes, the
indexed answer must equal the whole-store answer as whole structures, with the whole-store side
being the base implementation restored.

The corpus gives the tie-break something to choose between -- one key held by three records with
different `truth_rank`s, one of them belonging to **another subject and carrying the highest rank of
all** -- plus a `context_summary` carrying the same key, which the type check must still exclude.
Without those, an index returning a single arbitrary record would look correct.

| mutation | result |
|---|---|
| the index keeps only one record per key | **3 failures, 1 error** |
| the index never invalidates | **1 failure** |
| return the whole store (the original) | **passes** -- an optimization, not a changed answer |

8 suites reach keyed recall, `truth_rank` or upsert: **115 tests, no failures.** The four index
tests shipped earlier in this series still pass alongside it.

---

## Correction to the note above about `get_all`

I wrote that `get_all`'s remaining growth is "proportional to the subject rather than the store".
That is most of it but not all of it, and the difference is worth stating rather than leaving as an
implication.

Measured properly -- holding the subject at 100 records while the store grows, by scaling the number
of subjects with it:

| store | subjects | rows returned | `get_all(limit=10)` |
|---|---|---|---|
| 2,000 | 20 | 100 | 0.164 ms |
| 8,000 | 80 | 100 | 0.295 ms |
| 32,000 | 320 | 100 | 0.263 ms |
| 64,000 | 640 | 100 | 0.519 ms |

3.2x for 32x the store, on a fixed subject. So a store-shaped part remains, and it is
`_read_all_compacted` copying the whole cached list on the way out (`served = list(...)`) -- an O(N)
copy every read API pays.

It is left alone deliberately. That copy is the only thing standing between a caller and the shared
cache: handing back the live list, or one shared list per generation, means any caller that mutates
what it gets corrupts every other reader. 0.14 ms per 32,000 records is not worth buying with that.
