### PR TITLE
A reclaim that dropped 64 segments reported removing nothing

### DIFF
--- a/crates/temporalstore-rust/src/engine/reports.rs
+++ b/crates/temporalstore-rust/src/engine/reports.rs
@@ -2792,6 +2792,19 @@ pub struct StorageWalReclaimReport {
     pub wal_bytes_after: u64,
     pub index_log_bytes_before: u64,
     pub index_log_bytes_after: u64,
+    /// Whole rolled segments unlinked by this pass.
+    ///
+    /// Separate from `wal_records_removed` because they are different work: that counts records
+    /// rewritten out of the ACTIVE segment, while these are files dropped entire, never read and
+    /// never copied. A pass that drops segments and rewrites nothing is the normal case once a log
+    /// has rolled, and reporting only the rewrite made such a pass indistinguishable from one that
+    /// did nothing at all.
+    #[serde(default)]
+    pub wal_segments_dropped: usize,
+    /// Bytes held by those segments. `wal_bytes_before`/`_after` describe only the active
+    /// segment, so without this the size a reclaim recovered cannot be read off the report.
+    #[serde(default)]
+    pub wal_segment_bytes_dropped: u64,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -874,6 +874,17 @@ impl TemporalEngine {
             index_log_records_removed: 0,
             index_log_bytes_before: self.index_log_store.stats(plan.shard_id).bytes_written,
             index_log_bytes_after: self.index_log_store.stats(plan.shard_id).bytes_written,
+            // Whole segments dropped by this pass. The gc report has measured them all along;
+            // stopping here meant a pass that unlinked 64 files and freed 28 MB reported
+            // `wal_records_removed: 0` and byte counts covering only the active segment.
+            wal_segments_dropped: wal_gc
+                .as_ref()
+                .map(|report| report.dropped_segments)
+                .unwrap_or_default(),
+            wal_segment_bytes_dropped: wal_gc
+                .as_ref()
+                .map(|report| report.dropped_segment_bytes)
+                .unwrap_or_default(),
             plan,
         }
     }

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -17180,3 +17180,67 @@ fn pruning_keeps_the_manifests_reclaim_still_needs() {
         "the newest manifest is kept even when it covers no buckets"
     );
 }
+
+#[test]
+fn a_reclaim_that_drops_whole_segments_reports_them() {
+    // Small pieces, so the log rolls and reclaim's work is unlinking files rather than rewriting
+    // the active one. That is the shape a live log takes, and the shape the old counters missed.
+    crate::wal::set_wal_segment_bytes_for_test(Some(8 * 1024));
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        4 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+
+    for index in 0..400 {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("rolled-{index:04}"),
+                value: vec![118u8; 256],
+            },
+        });
+    }
+    engine
+        .create_bucket_dump_manifest(1, Vec::new())
+        .expect("a dump to anchor the frontier on");
+
+    let plan = engine.storage_wal_reclaim_plan(1, Vec::new(), Vec::new());
+    assert!(
+        plan.safe_to_reclaim,
+        "the dump should have made this reclaimable, or the test proves nothing: {plan:?}"
+    );
+
+    let report = engine.apply_storage_wal_reclaim(plan);
+    crate::wal::set_wal_segment_bytes_for_test(None);
+
+    assert!(report.applied, "{report:?}");
+    assert!(
+        report.wal_segments_dropped > 0,
+        "whole segments were unlinked and the report did not say so: {report:?}"
+    );
+    assert!(
+        report.wal_segment_bytes_dropped > 0,
+        "segments were dropped but their bytes went unreported: {report:?}"
+    );
+    // Segment bytes are ADDITIONAL to the active-file delta, not part of it: wal_bytes_before and
+    // wal_bytes_after describe only the segment being written. A reader adding those two together
+    // understates what the pass freed, by exactly this much.
+    //
+    // At production scale the understatement is total rather than partial: a live round dropped 64
+    // segments, about 28 MB, while reporting wal_records_removed 0 and wal_bytes_before 262144,
+    // because there was nothing left to rewrite in the active segment. This test runs small enough
+    // that the same pass also rewrites records, so it pins the additivity rather than that extreme.
+    let active_file_delta = report.wal_bytes_before.saturating_sub(report.wal_bytes_after);
+    assert!(
+        report.wal_segment_bytes_dropped > 0,
+        "segments were dropped but their bytes went unreported: {report:?}"
+    );
+    assert!(
+        active_file_delta + report.wal_segment_bytes_dropped > active_file_delta,
+        "the freed total must exceed the active-file delta once segments are counted: {report:?}"
+    );
+}


### PR DESCRIPTION
Once a WAL has rolled, the work a reclaim does is **unlinking whole segments**. That is not records
rewritten out of the active segment, and not bytes of the active file — so `wal_records_removed`,
`wal_bytes_before` and `wal_bytes_after` all sit still while the log shrinks by megabytes.

Measured on a live box. A round deleted **64 rolled segments — 785 files down to 721, about 28 MB** —
and reported:

```
applied=true  wal_records_removed=0  wal_bytes_before=262144  wal_bytes_after=132459
```

`262144` is 256 KiB: the active segment alone. Three such rounds are logged, all reading
`wal_records_removed=0`, and the only conclusion those logs support — *reclaim frees nothing* — is
false. They were dropping segments the whole time.

The engine has measured this all along. `WriteAheadLogGcReport` carries `dropped_segments` and
`dropped_segment_bytes`; `apply_storage_wal_reclaim` copies `records_removed`, `bytes_before` and
`bytes_after` out of that report and leaves the other two behind. This carries them.

### Why it matters beyond tidiness

Restart cost on that box **is** WAL size. Measured on a copy, page cache dropped before every load,
record count identical on every run:

| open | latency | peak RSS |
|---|---|---|
| fresh start | 191.0 s | 388 MB |
| restart | 94.4 s | 388 MB |
| second restart | 39.6 s | 389 MB |

39.6 s against ~306 MB is roughly 0.13 s/MB. So the counter that says whether the WAL is shrinking is
what any restart-latency work depends on, and it read zero while the WAL was shrinking.

It also hides the thing that actually limits reclaim there: `TS_WAL_RECLAIM_MAX_SEGMENTS_PER_PASS`
(default 64) against a 721-segment backlog on a six-hourly cadence. That ceiling is invisible while
the count reads zero — and it is deliberately left alone here, because raising it holds the append
lock longer and wants its own measurement.

### Tests

`a_reclaim_that_drops_whole_segments_reports_them` in `engine/tests/part4.rs` rolls the log with
8 KiB segments, anchors a frontier with a dump, and asserts the report names the segments and their
bytes — and that those bytes are **additional** to the active-file delta, which is the property that
makes the old counters insufficient rather than merely incomplete.

Being honest about its strength: since this adds fields, the test does not *compile* against
unmodified code rather than failing behaviourally. The behavioural evidence is the live measurement
above. The test's real job is to stop the two fields being dropped again on the way through.

The test also documents the production extreme it was generalised from: at scale the pass dropped 64
segments while rewriting nothing, so `wal_records_removed` was 0. At test scale the same pass also
rewrites records (3 segments dropped, 58 records rewritten), so it pins additivity rather than that
extreme — an earlier draft asserted the extreme and was wrong.

### Suite

`cargo test -p temporalstore-rust --lib -- --test-threads=1`: **1700 passed, 4 failed**. All four
fail identically without this change:

- `storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_flags` — verified
  pre-existing by reverting this change and re-running it alone; it fails the same way.
- `emptied_buckets_are_dropped_without_walking_the_map` — a per-write ratio assertion, already
  documented in-test as not attributable to the walk it was written for.
- two `raft::tests::part2::http_raft_transport_*` — `io error: Resource temporarily unavailable
  (os error 11)`, a loaded-machine resource failure, not a logic one.

The 34 `reclaim`-filtered tests pass.
