### PR TITLE
Replay decodes each record once, not twice

### DIFF
--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -1535,34 +1535,40 @@ impl TemporalEngine {
             .wal_store
             .log_id_after_sequence(shard_id, watermark)
             .unwrap_or(0);
-        let records = match self.wal_store.scan(shard_id, start_at, u64::MAX, u64::MAX) {
+        // `scan_decoded`, not `scan`: the walk decodes every record to verify it, and asking
+        // for the bytes instead threw that away and decoded the whole window a second time here.
+        let records = match self
+            .wal_store
+            .scan_decoded(shard_id, start_at, u64::MAX, u64::MAX)
+            .map(|(records, _truncated)| records)
+        {
             Ok(records) => records,
             Err(err) => {
+                // A record that will not decode is corruption and says so; anything else is an
+                // ordinary scan failure. The decode moved into the walk, so this is where that
+                // distinction has to be drawn now -- losing it would report a bit-flip as an I/O
+                // problem, which sends an operator looking in the wrong place.
+                let code = match err {
+                    crate::wal::WriteAheadLogError::Corruption(_) => "wal_record_corruption",
+                    _ => "wal_scan_failed",
+                };
                 return Err(Status::error(
-                    "wal_scan_failed",
+                    code,
                     format!(
                         "WAL scan failed during recovery for shard {shard_id}; refusing load rather than serving a truncated prefix: {err}"
                     ),
                 ));
             }
         };
-        // Decode each record through the integrity-verifying framing decoder and PROPAGATE a
-        // failure (a value-preserving bit-flip surfaces as `Corruption`) instead of dropping
-        // the record via `.ok()`, which would silently truncate the replayed tail.
+        // The walk above decoded and integrity-checked every record and PROPAGATED a failure
+        // rather than dropping it via `.ok()`, which would silently truncate the replayed tail.
+        // What is left here is choosing which of those records to replay.
         let mut pending: Vec<WriteAheadLogRecord> = Vec::new();
         // Where each record physically lives. The scan hands this back and replay used to drop
         // it (`for (_, line)`), which is why the registration below could not be done at all.
         let mut log_id_by_sequence: std::collections::HashMap<u64, u64> =
             std::collections::HashMap::new();
-        for (log_id, line) in records {
-            let record = crate::wal::decode_wal_line(&line).map_err(|err| {
-                Status::error(
-                    "wal_record_corruption",
-                    format!(
-                        "WAL record integrity failure during recovery for shard {shard_id}; refusing load: {err}"
-                    ),
-                )
-            })?;
+        for (log_id, record) in records {
             if record.sequence > watermark {
                 log_id_by_sequence.insert(record.sequence, log_id);
                 pending.push(record);

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -1577,6 +1577,38 @@ impl LocalWriteAheadLogStore {
         end_offset: u64,
         max_bytes: u64,
     ) -> Result<(Vec<(u64, Vec<u8>)>, bool), WriteAheadLogError> {
+        self.scan_collect(shard_id, start_offset, end_offset, max_bytes, |log_id, line, _| {
+            Some((log_id, line))
+        })
+    }
+
+    /// The records in the window, decoded once.
+    ///
+    /// `scan_bounded` returns the bytes, and every caller that wants records then decodes them --
+    /// while this walk has already decoded each one to verify it. Recovery took that bill twice.
+    /// This hands back what the verification produced, so the second decode does not happen.
+    /// A blank line carries no record and is not returned.
+    pub fn scan_decoded(
+        &self,
+        shard_id: ShardId,
+        start_offset: u64,
+        end_offset: u64,
+        max_bytes: u64,
+    ) -> Result<(Vec<(u64, WriteAheadLogRecord)>, bool), WriteAheadLogError> {
+        self.scan_collect(shard_id, start_offset, end_offset, max_bytes, |log_id, _line, decoded| {
+            decoded.map(|record| (log_id, record))
+        })
+    }
+
+    /// The one walk both scans share, so they cannot drift about what a window contains.
+    fn scan_collect<T>(
+        &self,
+        shard_id: ShardId,
+        start_offset: u64,
+        end_offset: u64,
+        max_bytes: u64,
+        mut take: impl FnMut(u64, Vec<u8>, Option<WriteAheadLogRecord>) -> Option<T>,
+    ) -> Result<(Vec<T>, bool), WriteAheadLogError> {
         let mut inner = self.inner.lock().expect("write-ahead log lock poisoned");
         let segments = wal_segment_paths(&inner.root, shard_id)
             .into_iter()
@@ -1592,7 +1624,7 @@ impl LocalWriteAheadLogStore {
         let _ = last_wal_sequence_at(&inner.root, shard_id)?;
         let mut total = 0;
         let mut truncated = false;
-        let mut records = Vec::new();
+        let mut records: Vec<T> = Vec::new();
         'segments: for path in segments {
             // Each piece says where in the log's history its contents begin, so a record's position
             // is that plus how far into the piece it sits. Positions are log ids: an offset into
@@ -1674,10 +1706,18 @@ impl LocalWriteAheadLogStore {
                 // a side effect of walking the whole file to find the log's end; that walk no longer
                 // reads everything, and a guarantee that depends on unrelated work is not a
                 // guarantee. A blank line carries nothing to verify and is passed through as before.
-                if !line.iter().all(|byte| byte.is_ascii_whitespace()) {
-                    decode_wal_line(&line)?;
+                // The decode that verifies the record is also the decode the caller needs. It
+                // used to be thrown away here and repeated by every caller -- replay decoded the
+                // whole window twice, once for nothing. A blank line carries no record and is
+                // passed through undecoded, as before.
+                let decoded = if line.iter().all(|byte| byte.is_ascii_whitespace()) {
+                    None
+                } else {
+                    Some(decode_wal_line(&line)?)
+                };
+                if let Some(item) = take(log_id, line, decoded) {
+                    records.push(item);
                 }
-                records.push((log_id, line));
                 log_id = next_log_id;
                 total += read as u64;
             }


### PR DESCRIPTION
`scan_bounded` decodes every record in the window to verify it, throws the record away, and returns
the bytes. `replay_wal_into_shard` then decodes those same bytes again. Recovery paid for the whole
window twice, and the second pass produced what the first had already computed.

The decode is not the part to remove -- it is what refuses a corrupt record where it is read, and an
earlier attempt to narrow it to the framing check alone took a reclaim test from failing 2 runs in 4
to failing 4 in 4. So this keeps the decode exactly where it is and keeps its RESULT instead.

`scan_collect` is now the single walk. `scan_bounded` is a thin wrapper that asks for the bytes, as
before, and every existing caller is untouched. `scan_decoded` asks for the records the walk already
built, and recovery uses that.

Measured on one compressed record, release build: the discarded decode was 7.261 us against 0.063 us
for the length-and-checksum check beside it, so it is the expensive half of the walk and it happened
for nothing. Recovery also drops most of what it decodes -- `sequence > watermark` filters the window
after the fact -- so the wasted pass covered records that were then discarded.

One thing that had to be carried across deliberately: a decode failure used to be turned into
`wal_record_corruption` at the call site, and moving the decode into the walk would have collapsed it
into `wal_scan_failed`. Nothing asserts that string, so it would have gone silently and told an
operator a bit-flip was an I/O fault. The error variant is matched now and the distinction is drawn
where the decode ended up.

Verified single-threaded, which is what separates a real failure from this suite's environment races:
`engine::tests::part4` is 158 passed and 0 failed on this branch and on main, with nothing failing
here that does not fail there.
