### PR TITLE
Say which of the three things failed

### DIFF
--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -451,6 +451,36 @@
     return text;
   };
 
+  window.__matrixarkNeverArrived = function (e) {
+    /* True when the request never left. A status means it did leave and was answered, and any
+       other throw happened here, with the answer already in hand. The messages fetch itself
+       produces are a short known set; anything else is this page's own. */
+    if (typeof e === "number") { return false; }
+    var text = e && e.message ? String(e.message) : (e == null ? "" : String(e));
+    return !text
+      || /failed to fetch|networkerror|load failed|network request failed|the network connection was lost/i.test(text);
+  };
+
+  window.__matrixarkWhyFailed = function (e, failure) {
+    /* A rejection carrying a status is the deployment answering. A rejection from fetch itself is
+       the request never leaving. A throw after the answer arrived is THIS PAGE failing to show
+       what it was given -- and that used to read "Could not reach the gateway", about a gateway
+       that had just answered.
+
+       The last two are told apart by the message fetch produces, which is one of a short known
+       set. Where it is not recognised the page repeats what it caught rather than guessing: an
+       unfamiliar message shown as it came is still more than a sentence about the network. */
+    if (typeof e === "number") {
+      return (failure || window.__matrixarkFailure)(e);
+    }
+    if (window.__matrixarkNeverArrived(e)) {
+      return "Could not reach the gateway.";
+    }
+    var text = e && e.message ? String(e.message) : String(e);
+    return "The gateway answered, but this page could not show it \u2014 " + text
+      + ". That is a fault in this page, not in the deployment.";
+  };
+
   window.__matrixarkFailure = function (status, overrides) {
     if (overrides && overrides[status]) { return overrides[status]; }
     if (status === 401) { return "This key was not accepted."; }

--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -461,6 +461,18 @@
       || /failed to fetch|networkerror|load failed|network request failed|the network connection was lost/i.test(text);
   };
 
+  window.__matrixarkConnState = function (e) {
+    /* What the connection strip should say about this failure, as [state, words].
+
+       Three cases, not two. A first version asked only whether the request arrived and called
+       everything that did a fault in the page -- so a 404 or a 500, which is the deployment
+       answering, turned the strip amber. It showed up the moment the page was opened with
+       nothing behind it: every fetch came back 404 and the strip blamed the page. */
+    if (window.__matrixarkNeverArrived(e)) { return ["down", "gateway unreachable"]; }
+    if (typeof e === "number") { return ["live", "connected"]; }
+    return ["warn", "this page could not show the answer"];
+  };
+
   window.__matrixarkWhyFailed = function (e, failure) {
     /* A rejection carrying a status is the deployment answering. A rejection from fetch itself is
        the request never leaving. A throw after the answer arrived is THIS PAGE failing to show

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -503,6 +503,18 @@
       || /failed to fetch|networkerror|load failed|network request failed|the network connection was lost/i.test(text);
   };
 
+  window.__matrixarkConnState = function (e) {
+    /* What the connection strip should say about this failure, as [state, words].
+
+       Three cases, not two. A first version asked only whether the request arrived and called
+       everything that did a fault in the page -- so a 404 or a 500, which is the deployment
+       answering, turned the strip amber. It showed up the moment the page was opened with
+       nothing behind it: every fetch came back 404 and the strip blamed the page. */
+    if (window.__matrixarkNeverArrived(e)) { return ["down", "gateway unreachable"]; }
+    if (typeof e === "number") { return ["live", "connected"]; }
+    return ["warn", "this page could not show the answer"];
+  };
+
   window.__matrixarkWhyFailed = function (e, failure) {
     /* A rejection carrying a status is the deployment answering. A rejection from fetch itself is
        the request never leaving. A throw after the answer arrived is THIS PAGE failing to show
@@ -867,9 +879,8 @@
     .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
     .then(function (d) { conn("live", "connected"); ROUTES = d.routes || []; render(); })
     .catch(function (e) {
-      conn(window.__matrixarkNeverArrived(e) ? "down" : "warn",
-           window.__matrixarkNeverArrived(e) ? "gateway unreachable"
-                                             : "this page could not show the answer");
+      var connState = window.__matrixarkConnState(e);
+      conn(connState[0], connState[1]);
       $("routes").innerHTML = '<section><div class="msg err">'
         + esc(window.__matrixarkWhyFailed(e)) + "</div></section>";
     });

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -493,6 +493,36 @@
     return text;
   };
 
+  window.__matrixarkNeverArrived = function (e) {
+    /* True when the request never left. A status means it did leave and was answered, and any
+       other throw happened here, with the answer already in hand. The messages fetch itself
+       produces are a short known set; anything else is this page's own. */
+    if (typeof e === "number") { return false; }
+    var text = e && e.message ? String(e.message) : (e == null ? "" : String(e));
+    return !text
+      || /failed to fetch|networkerror|load failed|network request failed|the network connection was lost/i.test(text);
+  };
+
+  window.__matrixarkWhyFailed = function (e, failure) {
+    /* A rejection carrying a status is the deployment answering. A rejection from fetch itself is
+       the request never leaving. A throw after the answer arrived is THIS PAGE failing to show
+       what it was given -- and that used to read "Could not reach the gateway", about a gateway
+       that had just answered.
+
+       The last two are told apart by the message fetch produces, which is one of a short known
+       set. Where it is not recognised the page repeats what it caught rather than guessing: an
+       unfamiliar message shown as it came is still more than a sentence about the network. */
+    if (typeof e === "number") {
+      return (failure || window.__matrixarkFailure)(e);
+    }
+    if (window.__matrixarkNeverArrived(e)) {
+      return "Could not reach the gateway.";
+    }
+    var text = e && e.message ? String(e.message) : String(e);
+    return "The gateway answered, but this page could not show it \u2014 " + text
+      + ". That is a fault in this page, not in the deployment.";
+  };
+
   window.__matrixarkFailure = function (status, overrides) {
     if (overrides && overrides[status]) { return overrides[status]; }
     if (status === 401) { return "This key was not accepted."; }

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -866,10 +866,12 @@
   fetch("/v1/admin/routes")
     .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
     .then(function (d) { conn("live", "connected"); ROUTES = d.routes || []; render(); })
-    .catch(function () {
-      conn("down", "gateway unreachable");
-      $("routes").innerHTML = '<section><div class="msg err">Could not read the route list.' +
-        "</div></section>";
+    .catch(function (e) {
+      conn(window.__matrixarkNeverArrived(e) ? "down" : "warn",
+           window.__matrixarkNeverArrived(e) ? "gateway unreachable"
+                                             : "this page could not show the answer");
+      $("routes").innerHTML = '<section><div class="msg err">'
+        + esc(window.__matrixarkWhyFailed(e)) + "</div></section>";
     });
 }());
 </script>

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -5840,10 +5840,12 @@ API_JS = r"""
   fetch("/v1/admin/routes")
     .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
     .then(function (d) { conn("live", "connected"); ROUTES = d.routes || []; render(); })
-    .catch(function () {
-      conn("down", "gateway unreachable");
-      $("routes").innerHTML = '<section><div class="msg err">Could not read the route list.' +
-        "</div></section>";
+    .catch(function (e) {
+      conn(window.__matrixarkNeverArrived(e) ? "down" : "warn",
+           window.__matrixarkNeverArrived(e) ? "gateway unreachable"
+                                             : "this page could not show the answer");
+      $("routes").innerHTML = '<section><div class="msg err">'
+        + esc(window.__matrixarkWhyFailed(e)) + "</div></section>";
     });
 }());
 </script>

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -366,6 +366,18 @@ SHARED_JS = r'''<script>
       || /failed to fetch|networkerror|load failed|network request failed|the network connection was lost/i.test(text);
   };
 
+  window.__matrixarkConnState = function (e) {
+    /* What the connection strip should say about this failure, as [state, words].
+
+       Three cases, not two. A first version asked only whether the request arrived and called
+       everything that did a fault in the page -- so a 404 or a 500, which is the deployment
+       answering, turned the strip amber. It showed up the moment the page was opened with
+       nothing behind it: every fetch came back 404 and the strip blamed the page. */
+    if (window.__matrixarkNeverArrived(e)) { return ["down", "gateway unreachable"]; }
+    if (typeof e === "number") { return ["live", "connected"]; }
+    return ["warn", "this page could not show the answer"];
+  };
+
   window.__matrixarkWhyFailed = function (e, failure) {
     /* A rejection carrying a status is the deployment answering. A rejection from fetch itself is
        the request never leaving. A throw after the answer arrived is THIS PAGE failing to show
@@ -2479,9 +2491,8 @@ SETUP_JS = r"""
           $("presets").innerHTML = '<div class="empty">Enter an admin key to see the presets.</div>';
           $("models").innerHTML = '<div class="empty">Enter an admin key to choose models.</div>';
         } else {
-          conn(window.__matrixarkNeverArrived(e) ? "down" : "warn",
-               window.__matrixarkNeverArrived(e) ? "gateway unreachable"
-                                                : "this page could not show the answer");
+          var connState = window.__matrixarkConnState(e);
+          conn(connState[0], connState[1]);
           $("groups").innerHTML = '<section><div class="msg err">'
             + esc(window.__matrixarkWhyFailed(e)) + "</div></section>";
         }
@@ -3705,9 +3716,8 @@ CATALOG_JS = r"""
         say($("listMsg"), "This key cannot read the catalog. It needs skill:read and resource:read.",
             "err");
       } else {
-        conn(window.__matrixarkNeverArrived(e) ? "down" : "warn",
-             window.__matrixarkNeverArrived(e) ? "gateway unreachable"
-                                              : "this page could not show the answer");
+        var connState = window.__matrixarkConnState(e);
+        conn(connState[0], connState[1]);
         say($("listMsg"), window.__matrixarkWhyFailed(e), "err");
       }
     });
@@ -4124,9 +4134,8 @@ OVERVIEW_JS = r"""
           $("checks").innerHTML = '<div class="empty">Enter an admin-scoped key above to check ' +
             "this deployment.</div>";
         } else {
-          conn(window.__matrixarkNeverArrived(e) ? "down" : "warn",
-               window.__matrixarkNeverArrived(e) ? "gateway unreachable"
-                                                : "this page could not show the answer");
+          var connState = window.__matrixarkConnState(e);
+          conn(connState[0], connState[1]);
           $("checks").innerHTML = '<div class="msg err">' + esc(window.__matrixarkWhyFailed(e))
             + "</div>";
         }
@@ -5841,9 +5850,8 @@ API_JS = r"""
     .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
     .then(function (d) { conn("live", "connected"); ROUTES = d.routes || []; render(); })
     .catch(function (e) {
-      conn(window.__matrixarkNeverArrived(e) ? "down" : "warn",
-           window.__matrixarkNeverArrived(e) ? "gateway unreachable"
-                                             : "this page could not show the answer");
+      var connState = window.__matrixarkConnState(e);
+      conn(connState[0], connState[1]);
       $("routes").innerHTML = '<section><div class="msg err">'
         + esc(window.__matrixarkWhyFailed(e)) + "</div></section>";
     });

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -356,6 +356,36 @@ SHARED_JS = r'''<script>
     return text;
   };
 
+  window.__matrixarkNeverArrived = function (e) {
+    /* True when the request never left. A status means it did leave and was answered, and any
+       other throw happened here, with the answer already in hand. The messages fetch itself
+       produces are a short known set; anything else is this page's own. */
+    if (typeof e === "number") { return false; }
+    var text = e && e.message ? String(e.message) : (e == null ? "" : String(e));
+    return !text
+      || /failed to fetch|networkerror|load failed|network request failed|the network connection was lost/i.test(text);
+  };
+
+  window.__matrixarkWhyFailed = function (e, failure) {
+    /* A rejection carrying a status is the deployment answering. A rejection from fetch itself is
+       the request never leaving. A throw after the answer arrived is THIS PAGE failing to show
+       what it was given -- and that used to read "Could not reach the gateway", about a gateway
+       that had just answered.
+
+       The last two are told apart by the message fetch produces, which is one of a short known
+       set. Where it is not recognised the page repeats what it caught rather than guessing: an
+       unfamiliar message shown as it came is still more than a sentence about the network. */
+    if (typeof e === "number") {
+      return (failure || window.__matrixarkFailure)(e);
+    }
+    if (window.__matrixarkNeverArrived(e)) {
+      return "Could not reach the gateway.";
+    }
+    var text = e && e.message ? String(e.message) : String(e);
+    return "The gateway answered, but this page could not show it \u2014 " + text
+      + ". That is a fault in this page, not in the deployment.";
+  };
+
   window.__matrixarkFailure = function (status, overrides) {
     if (overrides && overrides[status]) { return overrides[status]; }
     if (status === 401) { return "This key was not accepted."; }
@@ -1852,7 +1882,7 @@ SETUP_JS = r"""
       .catch(function (e) {
         /* A backend that cannot answer must not read as "nothing is pending". */
         $("encoding").innerHTML = '<div class="msg err">' +
-          esc(typeof e === "number" ? failure(e) : "Could not reach the gateway.") +
+          esc(window.__matrixarkWhyFailed(e, failure)) +
           " The encoding state is unknown, not empty.</div>";
         $("encodeAux").textContent = "unknown";
         encodePace(false);
@@ -2177,7 +2207,7 @@ SETUP_JS = r"""
       .catch(function (e) {
         policyView = null;
         $("policy").innerHTML = '<div class="empty">' +
-          esc(typeof e === "number" ? failure(e) : "Could not reach the gateway.") + "</div>";
+          esc(window.__matrixarkWhyFailed(e, failure)) + "</div>";
       });
   }
 
@@ -2298,7 +2328,7 @@ SETUP_JS = r"""
         if (!res.body.persisted && res.body.persist_note) { note += " " + res.body.persist_note; }
         say($("polMsg"), note, refused.length || !res.body.persisted ? "warn" : "ok");
       })
-      .catch(function () { say($("polMsg"), "Could not reach the gateway.", "err"); });
+      .catch(function (e) { say($("polMsg"), window.__matrixarkWhyFailed(e), "err"); });
   }
 
   function polLevelHint() {
@@ -2449,8 +2479,11 @@ SETUP_JS = r"""
           $("presets").innerHTML = '<div class="empty">Enter an admin key to see the presets.</div>';
           $("models").innerHTML = '<div class="empty">Enter an admin key to choose models.</div>';
         } else {
-          conn("down", "gateway unreachable");
-          $("groups").innerHTML = '<section><div class="msg err">Could not reach the gateway.</div></section>';
+          conn(window.__matrixarkNeverArrived(e) ? "down" : "warn",
+               window.__matrixarkNeverArrived(e) ? "gateway unreachable"
+                                                : "this page could not show the answer");
+          $("groups").innerHTML = '<section><div class="msg err">'
+            + esc(window.__matrixarkWhyFailed(e)) + "</div></section>";
         }
       });
   }
@@ -2491,9 +2524,9 @@ SETUP_JS = r"""
           : "Saved and live now." + elsewhere, restart.length || workers > 1 ? "info" : "ok");
         load();
       })
-      .catch(function () {
+      .catch(function (e) {
         $("save").disabled = false;
-        say($("saveMsg"), "Could not reach the gateway.", "err");
+        say($("saveMsg"), window.__matrixarkWhyFailed(e), "err");
       });
   }
 
@@ -2549,7 +2582,7 @@ SETUP_JS = r"""
       .catch(function (e) {
         $("test").disabled = false;
         $("probe").innerHTML = '<div class="msg err">' +
-          esc(typeof e === "number" ? failure(e) : "Could not reach the gateway.") + "</div>";
+          esc(window.__matrixarkWhyFailed(e, failure)) + "</div>";
       });
   }
 
@@ -2923,7 +2956,7 @@ SETUP_JS = r"""
           plan.ok ? (honoured ? "ok" : "info") : "err");
       })
       .catch(function (e) {
-        say($("depMsg"), typeof e === "number" ? failure(e) : "Could not reach the gateway.",
+        say($("depMsg"), window.__matrixarkWhyFailed(e, failure),
             "err");
       });
   }
@@ -3091,7 +3124,7 @@ SETUP_JS = r"""
         ? "Exported. " + d.secrets_omitted.join(", ") + " left out — set the key on the target."
         : "Exported.", "ok");
     }).catch(function (e) {
-      say($("importMsg"), typeof e === "number" ? failure(e) : "Could not reach the gateway.",
+      say($("importMsg"), window.__matrixarkWhyFailed(e, failure),
           "err");
     });
   });
@@ -3107,7 +3140,7 @@ SETUP_JS = r"""
         setTimeout(function () { $("copyCfgCurl").textContent = "copy as curl"; }, 1400);
       });
     }).catch(function (e) {
-      say($("importMsg"), typeof e === "number" ? failure(e) : "Could not reach the gateway.",
+      say($("importMsg"), window.__matrixarkWhyFailed(e, failure),
           "err");
     });
   });
@@ -3157,9 +3190,9 @@ SETUP_JS = r"""
             "deployment: " + missing.join(", ") + ". An export never carries them.", "info");
         });
       })
-      .catch(function () {
+      .catch(function (e) {
         $("importCfg").disabled = false;
-        say($("importMsg"), "Could not reach the gateway.", "err");
+        say($("importMsg"), window.__matrixarkWhyFailed(e), "err");
       });
   });
 
@@ -3205,7 +3238,7 @@ SETUP_JS = r"""
       .catch(function (e) {
         say($("grafanaMsg"), e === 404
           ? "This deployment does not bundle the monitoring assets."
-          : (typeof e === "number" ? failure(e) : "Could not reach the gateway."), "err");
+          : (window.__matrixarkWhyFailed(e, failure)), "err");
       });
   }
 
@@ -3580,7 +3613,7 @@ CATALOG_JS = r"""
         load(true);
         say($("listMsg"), "Skill " + (to === "disabled" ? "disabled" : "enabled") + ".", "ok");
       })
-      .catch(function () { say($("listMsg"), "Could not reach the gateway.", "err"); });
+      .catch(function (e) { say($("listMsg"), window.__matrixarkWhyFailed(e), "err"); });
   }
 
   function resourcesHtml(rows) {
@@ -3672,8 +3705,10 @@ CATALOG_JS = r"""
         say($("listMsg"), "This key cannot read the catalog. It needs skill:read and resource:read.",
             "err");
       } else {
-        conn("down", "gateway unreachable");
-        say($("listMsg"), "Could not reach the gateway.", "err");
+        conn(window.__matrixarkNeverArrived(e) ? "down" : "warn",
+             window.__matrixarkNeverArrived(e) ? "gateway unreachable"
+                                              : "this page could not show the answer");
+        say($("listMsg"), window.__matrixarkWhyFailed(e), "err");
       }
     });
   }
@@ -4089,8 +4124,11 @@ OVERVIEW_JS = r"""
           $("checks").innerHTML = '<div class="empty">Enter an admin-scoped key above to check ' +
             "this deployment.</div>";
         } else {
-          conn("down", "gateway unreachable");
-          $("checks").innerHTML = '<div class="msg err">Could not reach the gateway.</div>';
+          conn(window.__matrixarkNeverArrived(e) ? "down" : "warn",
+               window.__matrixarkNeverArrived(e) ? "gateway unreachable"
+                                                : "this page could not show the answer");
+          $("checks").innerHTML = '<div class="msg err">' + esc(window.__matrixarkWhyFailed(e))
+            + "</div>";
         }
       });
   }
@@ -4573,7 +4611,7 @@ EXPLORE_JS = r"""
       .catch(function (e) {
         $("ask").disabled = false;
         $("pack").innerHTML = '<div class="empty">Nothing retrieved.</div>';
-        say($("askMsg"), typeof e === "number" ? failure(e) : "Could not reach the gateway.", "err");
+        say($("askMsg"), window.__matrixarkWhyFailed(e, failure), "err");
       });
   }
 
@@ -4602,9 +4640,9 @@ EXPLORE_JS = r"""
             + "see it yet.", "ok");
         $("note").value = "";
       })
-      .catch(function () {
+      .catch(function (e) {
         $("add").disabled = false;
-        say($("addMsg"), "Could not reach the gateway.", "err");
+        say($("addMsg"), window.__matrixarkWhyFailed(e), "err");
       });
   }
 
@@ -4632,7 +4670,7 @@ EXPLORE_JS = r"""
            Same wording and the same message line as that sibling, which already named the cause
            on failure while this one was silent. */
         $("users").innerHTML = '<div class="empty">Not loaded.</div>';
-        say($("browseMsg"), typeof e === "number" ? failure(e) : "Could not reach the gateway.",
+        say($("browseMsg"), window.__matrixarkWhyFailed(e, failure),
             "err");
       });
 
@@ -4658,7 +4696,7 @@ EXPLORE_JS = r"""
       })
       .catch(function (e) {
         $("memories").innerHTML = '<div class="empty">Not loaded.</div>';
-        say($("browseMsg"), typeof e === "number" ? failure(e) : "Could not reach the gateway.",
+        say($("browseMsg"), window.__matrixarkWhyFailed(e, failure),
             "err");
       });
   }
@@ -5175,7 +5213,7 @@ EXPLORE_JS = r"""
            against a box that still says the magic word. */
         if (res.ok && op.destructive && $("opConfirm")) { $("opConfirm").value = ""; }
       })
-      .catch(function () { say($("opMsg"), "Could not reach the gateway.", "err"); });
+      .catch(function (e) { say($("opMsg"), window.__matrixarkWhyFailed(e), "err"); });
   }
 
   renderOps();
@@ -5272,7 +5310,7 @@ EXPLORE_JS = r"""
           " records. It runs on the server — this tab can be closed.", "ok");
         watchBatch(res.body.job_id, res.body.total);
       })
-      .catch(function () { say($("batchMsg"), "Could not reach the gateway.", "err"); });
+      .catch(function (e) { say($("batchMsg"), window.__matrixarkWhyFailed(e), "err"); });
   }
 
   /* Watched from the shared stream rather than a timer of its own: the job's progress is already

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -557,6 +557,18 @@
       || /failed to fetch|networkerror|load failed|network request failed|the network connection was lost/i.test(text);
   };
 
+  window.__matrixarkConnState = function (e) {
+    /* What the connection strip should say about this failure, as [state, words].
+
+       Three cases, not two. A first version asked only whether the request arrived and called
+       everything that did a fault in the page -- so a 404 or a 500, which is the deployment
+       answering, turned the strip amber. It showed up the moment the page was opened with
+       nothing behind it: every fetch came back 404 and the strip blamed the page. */
+    if (window.__matrixarkNeverArrived(e)) { return ["down", "gateway unreachable"]; }
+    if (typeof e === "number") { return ["live", "connected"]; }
+    return ["warn", "this page could not show the answer"];
+  };
+
   window.__matrixarkWhyFailed = function (e, failure) {
     /* A rejection carrying a status is the deployment answering. A rejection from fetch itself is
        the request never leaving. A throw after the answer arrived is THIS PAGE failing to show
@@ -906,9 +918,8 @@
         say($("listMsg"), "This key cannot read the catalog. It needs skill:read and resource:read.",
             "err");
       } else {
-        conn(window.__matrixarkNeverArrived(e) ? "down" : "warn",
-             window.__matrixarkNeverArrived(e) ? "gateway unreachable"
-                                              : "this page could not show the answer");
+        var connState = window.__matrixarkConnState(e);
+        conn(connState[0], connState[1]);
         say($("listMsg"), window.__matrixarkWhyFailed(e), "err");
       }
     });

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -547,6 +547,36 @@
     return text;
   };
 
+  window.__matrixarkNeverArrived = function (e) {
+    /* True when the request never left. A status means it did leave and was answered, and any
+       other throw happened here, with the answer already in hand. The messages fetch itself
+       produces are a short known set; anything else is this page's own. */
+    if (typeof e === "number") { return false; }
+    var text = e && e.message ? String(e.message) : (e == null ? "" : String(e));
+    return !text
+      || /failed to fetch|networkerror|load failed|network request failed|the network connection was lost/i.test(text);
+  };
+
+  window.__matrixarkWhyFailed = function (e, failure) {
+    /* A rejection carrying a status is the deployment answering. A rejection from fetch itself is
+       the request never leaving. A throw after the answer arrived is THIS PAGE failing to show
+       what it was given -- and that used to read "Could not reach the gateway", about a gateway
+       that had just answered.
+
+       The last two are told apart by the message fetch produces, which is one of a short known
+       set. Where it is not recognised the page repeats what it caught rather than guessing: an
+       unfamiliar message shown as it came is still more than a sentence about the network. */
+    if (typeof e === "number") {
+      return (failure || window.__matrixarkFailure)(e);
+    }
+    if (window.__matrixarkNeverArrived(e)) {
+      return "Could not reach the gateway.";
+    }
+    var text = e && e.message ? String(e.message) : String(e);
+    return "The gateway answered, but this page could not show it \u2014 " + text
+      + ". That is a fault in this page, not in the deployment.";
+  };
+
   window.__matrixarkFailure = function (status, overrides) {
     if (overrides && overrides[status]) { return overrides[status]; }
     if (status === 401) { return "This key was not accepted."; }
@@ -784,7 +814,7 @@
         load(true);
         say($("listMsg"), "Skill " + (to === "disabled" ? "disabled" : "enabled") + ".", "ok");
       })
-      .catch(function () { say($("listMsg"), "Could not reach the gateway.", "err"); });
+      .catch(function (e) { say($("listMsg"), window.__matrixarkWhyFailed(e), "err"); });
   }
 
   function resourcesHtml(rows) {
@@ -876,8 +906,10 @@
         say($("listMsg"), "This key cannot read the catalog. It needs skill:read and resource:read.",
             "err");
       } else {
-        conn("down", "gateway unreachable");
-        say($("listMsg"), "Could not reach the gateway.", "err");
+        conn(window.__matrixarkNeverArrived(e) ? "down" : "warn",
+             window.__matrixarkNeverArrived(e) ? "gateway unreachable"
+                                              : "this page could not show the answer");
+        say($("listMsg"), window.__matrixarkWhyFailed(e), "err");
       }
     });
   }

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -634,6 +634,36 @@
     return text;
   };
 
+  window.__matrixarkNeverArrived = function (e) {
+    /* True when the request never left. A status means it did leave and was answered, and any
+       other throw happened here, with the answer already in hand. The messages fetch itself
+       produces are a short known set; anything else is this page's own. */
+    if (typeof e === "number") { return false; }
+    var text = e && e.message ? String(e.message) : (e == null ? "" : String(e));
+    return !text
+      || /failed to fetch|networkerror|load failed|network request failed|the network connection was lost/i.test(text);
+  };
+
+  window.__matrixarkWhyFailed = function (e, failure) {
+    /* A rejection carrying a status is the deployment answering. A rejection from fetch itself is
+       the request never leaving. A throw after the answer arrived is THIS PAGE failing to show
+       what it was given -- and that used to read "Could not reach the gateway", about a gateway
+       that had just answered.
+
+       The last two are told apart by the message fetch produces, which is one of a short known
+       set. Where it is not recognised the page repeats what it caught rather than guessing: an
+       unfamiliar message shown as it came is still more than a sentence about the network. */
+    if (typeof e === "number") {
+      return (failure || window.__matrixarkFailure)(e);
+    }
+    if (window.__matrixarkNeverArrived(e)) {
+      return "Could not reach the gateway.";
+    }
+    var text = e && e.message ? String(e.message) : String(e);
+    return "The gateway answered, but this page could not show it \u2014 " + text
+      + ". That is a fault in this page, not in the deployment.";
+  };
+
   window.__matrixarkFailure = function (status, overrides) {
     if (overrides && overrides[status]) { return overrides[status]; }
     if (status === 401) { return "This key was not accepted."; }
@@ -947,7 +977,7 @@
       .catch(function (e) {
         $("ask").disabled = false;
         $("pack").innerHTML = '<div class="empty">Nothing retrieved.</div>';
-        say($("askMsg"), typeof e === "number" ? failure(e) : "Could not reach the gateway.", "err");
+        say($("askMsg"), window.__matrixarkWhyFailed(e, failure), "err");
       });
   }
 
@@ -976,9 +1006,9 @@
             + "see it yet.", "ok");
         $("note").value = "";
       })
-      .catch(function () {
+      .catch(function (e) {
         $("add").disabled = false;
-        say($("addMsg"), "Could not reach the gateway.", "err");
+        say($("addMsg"), window.__matrixarkWhyFailed(e), "err");
       });
   }
 
@@ -1006,7 +1036,7 @@
            Same wording and the same message line as that sibling, which already named the cause
            on failure while this one was silent. */
         $("users").innerHTML = '<div class="empty">Not loaded.</div>';
-        say($("browseMsg"), typeof e === "number" ? failure(e) : "Could not reach the gateway.",
+        say($("browseMsg"), window.__matrixarkWhyFailed(e, failure),
             "err");
       });
 
@@ -1032,7 +1062,7 @@
       })
       .catch(function (e) {
         $("memories").innerHTML = '<div class="empty">Not loaded.</div>';
-        say($("browseMsg"), typeof e === "number" ? failure(e) : "Could not reach the gateway.",
+        say($("browseMsg"), window.__matrixarkWhyFailed(e, failure),
             "err");
       });
   }
@@ -1549,7 +1579,7 @@
            against a box that still says the magic word. */
         if (res.ok && op.destructive && $("opConfirm")) { $("opConfirm").value = ""; }
       })
-      .catch(function () { say($("opMsg"), "Could not reach the gateway.", "err"); });
+      .catch(function (e) { say($("opMsg"), window.__matrixarkWhyFailed(e), "err"); });
   }
 
   renderOps();
@@ -1646,7 +1676,7 @@
           " records. It runs on the server — this tab can be closed.", "ok");
         watchBatch(res.body.job_id, res.body.total);
       })
-      .catch(function () { say($("batchMsg"), "Could not reach the gateway.", "err"); });
+      .catch(function (e) { say($("batchMsg"), window.__matrixarkWhyFailed(e), "err"); });
   }
 
   /* Watched from the shared stream rather than a timer of its own: the job's progress is already

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -644,6 +644,18 @@
       || /failed to fetch|networkerror|load failed|network request failed|the network connection was lost/i.test(text);
   };
 
+  window.__matrixarkConnState = function (e) {
+    /* What the connection strip should say about this failure, as [state, words].
+
+       Three cases, not two. A first version asked only whether the request arrived and called
+       everything that did a fault in the page -- so a 404 or a 500, which is the deployment
+       answering, turned the strip amber. It showed up the moment the page was opened with
+       nothing behind it: every fetch came back 404 and the strip blamed the page. */
+    if (window.__matrixarkNeverArrived(e)) { return ["down", "gateway unreachable"]; }
+    if (typeof e === "number") { return ["live", "connected"]; }
+    return ["warn", "this page could not show the answer"];
+  };
+
   window.__matrixarkWhyFailed = function (e, failure) {
     /* A rejection carrying a status is the deployment answering. A rejection from fetch itself is
        the request never leaving. A throw after the answer arrived is THIS PAGE failing to show

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -336,6 +336,18 @@
       || /failed to fetch|networkerror|load failed|network request failed|the network connection was lost/i.test(text);
   };
 
+  window.__matrixarkConnState = function (e) {
+    /* What the connection strip should say about this failure, as [state, words].
+
+       Three cases, not two. A first version asked only whether the request arrived and called
+       everything that did a fault in the page -- so a 404 or a 500, which is the deployment
+       answering, turned the strip amber. It showed up the moment the page was opened with
+       nothing behind it: every fetch came back 404 and the strip blamed the page. */
+    if (window.__matrixarkNeverArrived(e)) { return ["down", "gateway unreachable"]; }
+    if (typeof e === "number") { return ["live", "connected"]; }
+    return ["warn", "this page could not show the answer"];
+  };
+
   window.__matrixarkWhyFailed = function (e, failure) {
     /* A rejection carrying a status is the deployment answering. A rejection from fetch itself is
        the request never leaving. A throw after the answer arrived is THIS PAGE failing to show
@@ -502,9 +514,8 @@
           $("config").innerHTML = '<div class="empty">Enter an admin key above to see how this ' +
             "deployment is configured.</div>";
         } else {
-          conn(window.__matrixarkNeverArrived(e) ? "down" : "warn",
-               window.__matrixarkNeverArrived(e) ? "gateway unreachable"
-                                                : "this page could not show the answer");
+          var connState = window.__matrixarkConnState(e);
+          conn(connState[0], connState[1]);
           $("config").innerHTML = '<div class="msg err">'
             + esc(window.__matrixarkWhyFailed(e)) + "</div>";
         }
@@ -675,9 +686,8 @@
           $("jobs").innerHTML = '<div class="empty">Enter an admin key to list imports.</div>';
           renderSummary([]);
         } else {
-          conn(window.__matrixarkNeverArrived(e) ? "down" : "warn",
-               window.__matrixarkNeverArrived(e) ? "gateway unreachable"
-                                                : "this page could not show the answer");
+          var connState = window.__matrixarkConnState(e);
+          conn(connState[0], connState[1]);
         }
       });
   }

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -326,6 +326,36 @@
     return text;
   };
 
+  window.__matrixarkNeverArrived = function (e) {
+    /* True when the request never left. A status means it did leave and was answered, and any
+       other throw happened here, with the answer already in hand. The messages fetch itself
+       produces are a short known set; anything else is this page's own. */
+    if (typeof e === "number") { return false; }
+    var text = e && e.message ? String(e.message) : (e == null ? "" : String(e));
+    return !text
+      || /failed to fetch|networkerror|load failed|network request failed|the network connection was lost/i.test(text);
+  };
+
+  window.__matrixarkWhyFailed = function (e, failure) {
+    /* A rejection carrying a status is the deployment answering. A rejection from fetch itself is
+       the request never leaving. A throw after the answer arrived is THIS PAGE failing to show
+       what it was given -- and that used to read "Could not reach the gateway", about a gateway
+       that had just answered.
+
+       The last two are told apart by the message fetch produces, which is one of a short known
+       set. Where it is not recognised the page repeats what it caught rather than guessing: an
+       unfamiliar message shown as it came is still more than a sentence about the network. */
+    if (typeof e === "number") {
+      return (failure || window.__matrixarkFailure)(e);
+    }
+    if (window.__matrixarkNeverArrived(e)) {
+      return "Could not reach the gateway.";
+    }
+    var text = e && e.message ? String(e.message) : String(e);
+    return "The gateway answered, but this page could not show it \u2014 " + text
+      + ". That is a fault in this page, not in the deployment.";
+  };
+
   window.__matrixarkFailure = function (status, overrides) {
     if (overrides && overrides[status]) { return overrides[status]; }
     if (status === 401) { return "This key was not accepted."; }

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -502,8 +502,11 @@
           $("config").innerHTML = '<div class="empty">Enter an admin key above to see how this ' +
             "deployment is configured.</div>";
         } else {
-          conn("down", "gateway unreachable");
-          $("config").innerHTML = '<div class="msg err">Could not reach the gateway.</div>';
+          conn(window.__matrixarkNeverArrived(e) ? "down" : "warn",
+               window.__matrixarkNeverArrived(e) ? "gateway unreachable"
+                                                : "this page could not show the answer");
+          $("config").innerHTML = '<div class="msg err">'
+            + esc(window.__matrixarkWhyFailed(e)) + "</div>";
         }
       });
   }
@@ -530,7 +533,7 @@
           (res.body.total === 1 ? "" : "s") + " as " + res.body.job_id + ".", "ok");
         loadJobs();
       })
-      .catch(function () { say($("startMsg"), "Could not reach the gateway.", "err"); });
+      .catch(function (e) { say($("startMsg"), window.__matrixarkWhyFailed(e), "err"); });
   }
 
   function jobHtml(j) {
@@ -671,7 +674,11 @@
         if (e === 401 || e === 403) {
           $("jobs").innerHTML = '<div class="empty">Enter an admin key to list imports.</div>';
           renderSummary([]);
-        } else { conn("down", "gateway unreachable"); }
+        } else {
+          conn(window.__matrixarkNeverArrived(e) ? "down" : "warn",
+               window.__matrixarkNeverArrived(e) ? "gateway unreachable"
+                                                : "this page could not show the answer");
+        }
       });
   }
 
@@ -767,8 +774,8 @@
         " match, " + bytes(res.d.bytes) + " of source. Ready to import.</div>" +
         "<pre style='margin-top:10px'>" + esc(sample) +
         (res.d.truncated ? "\n… and " + (res.d.total - res.d.sample.length) + " more" : "") + "</pre>";
-    }).catch(function () {
-      say($("startMsg"), "Could not reach the gateway.", "err");
+    }).catch(function (e) {
+      say($("startMsg"), window.__matrixarkWhyFailed(e), "err");
     }).then(function () { $("preview").disabled = false; });
   });
 
@@ -786,8 +793,8 @@
         say($("startMsg"), explain(res), "err");
         $("start").disabled = false;
       }
-    }).catch(function () {
-      say($("startMsg"), "Could not reach the gateway.", "err");
+    }).catch(function (e) {
+      say($("startMsg"), window.__matrixarkWhyFailed(e), "err");
       $("start").disabled = false;
     });
   });

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -527,6 +527,36 @@
     return text;
   };
 
+  window.__matrixarkNeverArrived = function (e) {
+    /* True when the request never left. A status means it did leave and was answered, and any
+       other throw happened here, with the answer already in hand. The messages fetch itself
+       produces are a short known set; anything else is this page's own. */
+    if (typeof e === "number") { return false; }
+    var text = e && e.message ? String(e.message) : (e == null ? "" : String(e));
+    return !text
+      || /failed to fetch|networkerror|load failed|network request failed|the network connection was lost/i.test(text);
+  };
+
+  window.__matrixarkWhyFailed = function (e, failure) {
+    /* A rejection carrying a status is the deployment answering. A rejection from fetch itself is
+       the request never leaving. A throw after the answer arrived is THIS PAGE failing to show
+       what it was given -- and that used to read "Could not reach the gateway", about a gateway
+       that had just answered.
+
+       The last two are told apart by the message fetch produces, which is one of a short known
+       set. Where it is not recognised the page repeats what it caught rather than guessing: an
+       unfamiliar message shown as it came is still more than a sentence about the network. */
+    if (typeof e === "number") {
+      return (failure || window.__matrixarkFailure)(e);
+    }
+    if (window.__matrixarkNeverArrived(e)) {
+      return "Could not reach the gateway.";
+    }
+    var text = e && e.message ? String(e.message) : String(e);
+    return "The gateway answered, but this page could not show it \u2014 " + text
+      + ". That is a fault in this page, not in the deployment.";
+  };
+
   window.__matrixarkFailure = function (status, overrides) {
     if (overrides && overrides[status]) { return overrides[status]; }
     if (status === 401) { return "This key was not accepted."; }
@@ -1005,8 +1035,11 @@ function liveStream(options) {
           $("checks").innerHTML = '<div class="empty">Enter an admin-scoped key above to check ' +
             "this deployment.</div>";
         } else {
-          conn("down", "gateway unreachable");
-          $("checks").innerHTML = '<div class="msg err">Could not reach the gateway.</div>';
+          conn(window.__matrixarkNeverArrived(e) ? "down" : "warn",
+               window.__matrixarkNeverArrived(e) ? "gateway unreachable"
+                                                : "this page could not show the answer");
+          $("checks").innerHTML = '<div class="msg err">' + esc(window.__matrixarkWhyFailed(e))
+            + "</div>";
         }
       });
   }

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -537,6 +537,18 @@
       || /failed to fetch|networkerror|load failed|network request failed|the network connection was lost/i.test(text);
   };
 
+  window.__matrixarkConnState = function (e) {
+    /* What the connection strip should say about this failure, as [state, words].
+
+       Three cases, not two. A first version asked only whether the request arrived and called
+       everything that did a fault in the page -- so a 404 or a 500, which is the deployment
+       answering, turned the strip amber. It showed up the moment the page was opened with
+       nothing behind it: every fetch came back 404 and the strip blamed the page. */
+    if (window.__matrixarkNeverArrived(e)) { return ["down", "gateway unreachable"]; }
+    if (typeof e === "number") { return ["live", "connected"]; }
+    return ["warn", "this page could not show the answer"];
+  };
+
   window.__matrixarkWhyFailed = function (e, failure) {
     /* A rejection carrying a status is the deployment answering. A rejection from fetch itself is
        the request never leaving. A throw after the answer arrived is THIS PAGE failing to show
@@ -1035,9 +1047,8 @@ function liveStream(options) {
           $("checks").innerHTML = '<div class="empty">Enter an admin-scoped key above to check ' +
             "this deployment.</div>";
         } else {
-          conn(window.__matrixarkNeverArrived(e) ? "down" : "warn",
-               window.__matrixarkNeverArrived(e) ? "gateway unreachable"
-                                                : "this page could not show the answer");
+          var connState = window.__matrixarkConnState(e);
+          conn(connState[0], connState[1]);
           $("checks").innerHTML = '<div class="msg err">' + esc(window.__matrixarkWhyFailed(e))
             + "</div>";
         }

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -782,6 +782,36 @@
     return text;
   };
 
+  window.__matrixarkNeverArrived = function (e) {
+    /* True when the request never left. A status means it did leave and was answered, and any
+       other throw happened here, with the answer already in hand. The messages fetch itself
+       produces are a short known set; anything else is this page's own. */
+    if (typeof e === "number") { return false; }
+    var text = e && e.message ? String(e.message) : (e == null ? "" : String(e));
+    return !text
+      || /failed to fetch|networkerror|load failed|network request failed|the network connection was lost/i.test(text);
+  };
+
+  window.__matrixarkWhyFailed = function (e, failure) {
+    /* A rejection carrying a status is the deployment answering. A rejection from fetch itself is
+       the request never leaving. A throw after the answer arrived is THIS PAGE failing to show
+       what it was given -- and that used to read "Could not reach the gateway", about a gateway
+       that had just answered.
+
+       The last two are told apart by the message fetch produces, which is one of a short known
+       set. Where it is not recognised the page repeats what it caught rather than guessing: an
+       unfamiliar message shown as it came is still more than a sentence about the network. */
+    if (typeof e === "number") {
+      return (failure || window.__matrixarkFailure)(e);
+    }
+    if (window.__matrixarkNeverArrived(e)) {
+      return "Could not reach the gateway.";
+    }
+    var text = e && e.message ? String(e.message) : String(e);
+    return "The gateway answered, but this page could not show it \u2014 " + text
+      + ". That is a fault in this page, not in the deployment.";
+  };
+
   window.__matrixarkFailure = function (status, overrides) {
     if (overrides && overrides[status]) { return overrides[status]; }
     if (status === 401) { return "This key was not accepted."; }
@@ -1555,7 +1585,7 @@ function liveStream(options) {
       .catch(function (e) {
         /* A backend that cannot answer must not read as "nothing is pending". */
         $("encoding").innerHTML = '<div class="msg err">' +
-          esc(typeof e === "number" ? failure(e) : "Could not reach the gateway.") +
+          esc(window.__matrixarkWhyFailed(e, failure)) +
           " The encoding state is unknown, not empty.</div>";
         $("encodeAux").textContent = "unknown";
         encodePace(false);
@@ -1880,7 +1910,7 @@ function liveStream(options) {
       .catch(function (e) {
         policyView = null;
         $("policy").innerHTML = '<div class="empty">' +
-          esc(typeof e === "number" ? failure(e) : "Could not reach the gateway.") + "</div>";
+          esc(window.__matrixarkWhyFailed(e, failure)) + "</div>";
       });
   }
 
@@ -2001,7 +2031,7 @@ function liveStream(options) {
         if (!res.body.persisted && res.body.persist_note) { note += " " + res.body.persist_note; }
         say($("polMsg"), note, refused.length || !res.body.persisted ? "warn" : "ok");
       })
-      .catch(function () { say($("polMsg"), "Could not reach the gateway.", "err"); });
+      .catch(function (e) { say($("polMsg"), window.__matrixarkWhyFailed(e), "err"); });
   }
 
   function polLevelHint() {
@@ -2152,8 +2182,11 @@ function liveStream(options) {
           $("presets").innerHTML = '<div class="empty">Enter an admin key to see the presets.</div>';
           $("models").innerHTML = '<div class="empty">Enter an admin key to choose models.</div>';
         } else {
-          conn("down", "gateway unreachable");
-          $("groups").innerHTML = '<section><div class="msg err">Could not reach the gateway.</div></section>';
+          conn(window.__matrixarkNeverArrived(e) ? "down" : "warn",
+               window.__matrixarkNeverArrived(e) ? "gateway unreachable"
+                                                : "this page could not show the answer");
+          $("groups").innerHTML = '<section><div class="msg err">'
+            + esc(window.__matrixarkWhyFailed(e)) + "</div></section>";
         }
       });
   }
@@ -2194,9 +2227,9 @@ function liveStream(options) {
           : "Saved and live now." + elsewhere, restart.length || workers > 1 ? "info" : "ok");
         load();
       })
-      .catch(function () {
+      .catch(function (e) {
         $("save").disabled = false;
-        say($("saveMsg"), "Could not reach the gateway.", "err");
+        say($("saveMsg"), window.__matrixarkWhyFailed(e), "err");
       });
   }
 
@@ -2252,7 +2285,7 @@ function liveStream(options) {
       .catch(function (e) {
         $("test").disabled = false;
         $("probe").innerHTML = '<div class="msg err">' +
-          esc(typeof e === "number" ? failure(e) : "Could not reach the gateway.") + "</div>";
+          esc(window.__matrixarkWhyFailed(e, failure)) + "</div>";
       });
   }
 
@@ -2626,7 +2659,7 @@ function liveStream(options) {
           plan.ok ? (honoured ? "ok" : "info") : "err");
       })
       .catch(function (e) {
-        say($("depMsg"), typeof e === "number" ? failure(e) : "Could not reach the gateway.",
+        say($("depMsg"), window.__matrixarkWhyFailed(e, failure),
             "err");
       });
   }
@@ -2794,7 +2827,7 @@ function liveStream(options) {
         ? "Exported. " + d.secrets_omitted.join(", ") + " left out — set the key on the target."
         : "Exported.", "ok");
     }).catch(function (e) {
-      say($("importMsg"), typeof e === "number" ? failure(e) : "Could not reach the gateway.",
+      say($("importMsg"), window.__matrixarkWhyFailed(e, failure),
           "err");
     });
   });
@@ -2810,7 +2843,7 @@ function liveStream(options) {
         setTimeout(function () { $("copyCfgCurl").textContent = "copy as curl"; }, 1400);
       });
     }).catch(function (e) {
-      say($("importMsg"), typeof e === "number" ? failure(e) : "Could not reach the gateway.",
+      say($("importMsg"), window.__matrixarkWhyFailed(e, failure),
           "err");
     });
   });
@@ -2860,9 +2893,9 @@ function liveStream(options) {
             "deployment: " + missing.join(", ") + ". An export never carries them.", "info");
         });
       })
-      .catch(function () {
+      .catch(function (e) {
         $("importCfg").disabled = false;
-        say($("importMsg"), "Could not reach the gateway.", "err");
+        say($("importMsg"), window.__matrixarkWhyFailed(e), "err");
       });
   });
 
@@ -2908,7 +2941,7 @@ function liveStream(options) {
       .catch(function (e) {
         say($("grafanaMsg"), e === 404
           ? "This deployment does not bundle the monitoring assets."
-          : (typeof e === "number" ? failure(e) : "Could not reach the gateway."), "err");
+          : (window.__matrixarkWhyFailed(e, failure)), "err");
       });
   }
 

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -792,6 +792,18 @@
       || /failed to fetch|networkerror|load failed|network request failed|the network connection was lost/i.test(text);
   };
 
+  window.__matrixarkConnState = function (e) {
+    /* What the connection strip should say about this failure, as [state, words].
+
+       Three cases, not two. A first version asked only whether the request arrived and called
+       everything that did a fault in the page -- so a 404 or a 500, which is the deployment
+       answering, turned the strip amber. It showed up the moment the page was opened with
+       nothing behind it: every fetch came back 404 and the strip blamed the page. */
+    if (window.__matrixarkNeverArrived(e)) { return ["down", "gateway unreachable"]; }
+    if (typeof e === "number") { return ["live", "connected"]; }
+    return ["warn", "this page could not show the answer"];
+  };
+
   window.__matrixarkWhyFailed = function (e, failure) {
     /* A rejection carrying a status is the deployment answering. A rejection from fetch itself is
        the request never leaving. A throw after the answer arrived is THIS PAGE failing to show
@@ -2182,9 +2194,8 @@ function liveStream(options) {
           $("presets").innerHTML = '<div class="empty">Enter an admin key to see the presets.</div>';
           $("models").innerHTML = '<div class="empty">Enter an admin key to choose models.</div>';
         } else {
-          conn(window.__matrixarkNeverArrived(e) ? "down" : "warn",
-               window.__matrixarkNeverArrived(e) ? "gateway unreachable"
-                                                : "this page could not show the answer");
+          var connState = window.__matrixarkConnState(e);
+          conn(connState[0], connState[1]);
           $("groups").innerHTML = '<section><div class="msg err">'
             + esc(window.__matrixarkWhyFailed(e)) + "</div></section>";
         }

--- a/tools/portal/why_failed_harness.js
+++ b/tools/portal/why_failed_harness.js
@@ -44,4 +44,13 @@ const arrived = {
     new TypeError("window.__matrixarkWhen is not a function"))
 };
 
-console.log(JSON.stringify({ said: cases, neverArrived: arrived }, null, 1));
+/* What the connection strip is told. Three cases, not two: a status means the deployment
+   answered, so the strip stays "connected" and the sentence says what it said. */
+const strip = {
+  never_arrived: win.__matrixarkConnState(new TypeError("Failed to fetch")),
+  a_status_404: win.__matrixarkConnState(404),
+  a_status_500: win.__matrixarkConnState(500),
+  a_render_throw: win.__matrixarkConnState(new TypeError("window.__matrixarkWhen is not a function"))
+};
+
+console.log(JSON.stringify({ said: cases, neverArrived: arrived, strip: strip }, null, 1));

--- a/tools/portal/why_failed_harness.js
+++ b/tools/portal/why_failed_harness.js
@@ -1,0 +1,47 @@
+/* Run the page's OWN failure classifier against the three things that reach a catch.
+ *
+ * The shared helper block is executed, not stubbed: the whole point of the change is what the
+ * shipped classifier answers, and a copy of it here could drift from the page without a word.
+ *
+ * Usage: node why_failed_harness.js <page.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+
+const sharedAt = page.indexOf("Helpers every page may call");
+if (sharedAt < 0) { console.log(JSON.stringify({ error: "no shared helper block" })); process.exit(2); }
+const from = page.lastIndexOf("<script>", sharedAt) + "<script>".length;
+const to = page.indexOf("</script>", from);
+
+const win = {};
+new Function("window", page.slice(from, to))(win);
+
+/* A page's own failure() may add its own wording for some statuses; the browse path passes one.
+   Answered here by the shared one, which is what a page without overrides uses. */
+const cases = {
+  a_status_the_deployment_answered: win.__matrixarkWhyFailed(503),
+  a_status_with_an_override: win.__matrixarkWhyFailed(413, function () {
+    return "That file is larger than this deployment accepts.";
+  }),
+  the_request_never_left: win.__matrixarkWhyFailed(new TypeError("Failed to fetch")),
+  the_request_never_left_firefox: win.__matrixarkWhyFailed(
+    new TypeError("NetworkError when attempting to fetch resource.")),
+  the_request_never_left_safari: win.__matrixarkWhyFailed(new TypeError("Load failed")),
+  nothing_at_all: win.__matrixarkWhyFailed(undefined),
+  /* The one that used to be indistinguishable, and the exact throw that caused it. */
+  the_page_threw_while_showing: win.__matrixarkWhyFailed(
+    new TypeError("window.__matrixarkWhen is not a function")),
+  a_bad_body: win.__matrixarkWhyFailed(new SyntaxError("Unexpected token < in JSON at position 0"))
+};
+
+const arrived = {
+  a_status: win.__matrixarkNeverArrived(503),
+  fetch_failure: win.__matrixarkNeverArrived(new TypeError("Failed to fetch")),
+  nothing_at_all: win.__matrixarkNeverArrived(undefined),
+  a_render_throw: win.__matrixarkNeverArrived(
+    new TypeError("window.__matrixarkWhen is not a function"))
+};
+
+console.log(JSON.stringify({ said: cases, neverArrived: arrived }, null, 1));

--- a/tools/test_matrixark_a_page_fault_is_not_a_gateway_failure.py
+++ b/tools/test_matrixark_a_page_fault_is_not_a_gateway_failure.py
@@ -107,6 +107,41 @@ class TheClassifierAnswersTest(unittest.TestCase):
         self.assertTrue(arrived["nothing_at_all"])
 
 
+    def test_a_status_leaves_the_strip_connected(self) -> None:
+        """Found by opening the page rather than by reading it. With nothing behind the portal
+        every fetch comes back 404 -- a status, so the request plainly arrived -- and the strip
+        read "this page could not show the answer" in amber. The first version of this asked only
+        whether the request arrived and called everything that did a fault in the page.
+        """
+        for case in ("a_status_404", "a_status_500"):
+            with self.subTest(case=case):
+                state, words = self.result["strip"][case]
+                self.assertEqual("live", state, "a status is the deployment answering")
+                self.assertEqual("connected", words)
+
+    def test_a_request_that_never_left_takes_the_strip_down(self) -> None:
+        state, words = self.result["strip"]["never_arrived"]
+        self.assertEqual("down", state)
+        self.assertIn("unreachable", words)
+
+    def test_only_a_page_fault_turns_the_strip_amber(self) -> None:
+        state, words = self.result["strip"]["a_render_throw"]
+        self.assertEqual("warn", state)
+        self.assertIn("could not show", words)
+
+    def test_the_strip_and_the_sentence_never_disagree(self) -> None:
+        """The two are read by different people at the same moment -- the dot at a glance, the
+        sentence when they look. Saying the gateway is unreachable beside a sentence explaining
+        that it answered is worse than either alone."""
+        for case, said_key in (("never_arrived", "the_request_never_left"),
+                               ("a_render_throw", "the_page_threw_while_showing")):
+            with self.subTest(case=case):
+                state = self.result["strip"][case][0]
+                said = self.said(said_key)
+                self.assertEqual(state == "down", UNREACHABLE == said,
+                                 "the strip says %r while the sentence says %r" % (state, said))
+
+
 class NoPageSaysItItselfTest(unittest.TestCase):
 
     def test_the_sentence_is_written_in_one_place(self) -> None:

--- a/tools/test_matrixark_a_page_fault_is_not_a_gateway_failure.py
+++ b/tools/test_matrixark_a_page_fault_is_not_a_gateway_failure.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A fault in the page is not reported as a fault in the deployment.
+
+Twenty-one places answered a failed call with "Could not reach the gateway." Three different
+things arrive at those lines:
+
+* a rejection carrying a **status** -- the deployment answered, and said no;
+* a rejection from **fetch itself** -- the request never left;
+* a **throw after the answer arrived** -- this page failing to show what it was given.
+
+Ten sites told the first apart. None told the third apart from the second, and the third is the
+one that cost two sessions an hour: a helper defined in the wrong script block raised a
+ReferenceError inside a render, and the screen reported a gateway that had just answered as
+unreachable. Seven more sites were written ``.catch(function () {``, discarding the error, so even
+a status they held was reported as unreachable.
+
+Three were worse again. They handle 401 and 403 by name and treat everything else as unreachable,
+so a render throw did not merely print the wrong sentence -- it turned the **live strip** to
+"gateway unreachable" about a deployment that was answering. The strip is what a reader glances at
+to decide whether the deployment is alive.
+
+The classifier is RUN here, not read. What it answers is the whole change; a copy of its rules in
+this file could drift from the page without a word.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import re
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+HARNESS = os.path.join(PORTAL, "why_failed_harness.js")
+UNREACHABLE = "Could not reach the gateway."
+
+
+def pages() -> list:
+    return sorted(f for f in os.listdir(PORTAL) if f.endswith("_portal.html"))
+
+
+def read(name: str) -> str:
+    with io.open(os.path.join(PORTAL, name), encoding="utf-8") as handle:
+        return handle.read()
+
+
+class TheClassifierAnswersTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            raise unittest.SkipTest("node is not available")
+        out = subprocess.run(["node", HARNESS, os.path.join(PORTAL, "overview_portal.html")],
+                             capture_output=True, text=True, timeout=300)
+        if out.returncode != 0:
+            raise AssertionError(out.stderr[-900:])
+        cls.result = json.loads(out.stdout)
+
+    def said(self, case: str) -> str:
+        return self.result["said"][case]
+
+    def test_a_status_is_the_deployment_answering(self) -> None:
+        """A mapped status is answered with its sentence, which carries no digits -- a first
+        draft looked for "503" in it and failed on a classifier that was working."""
+        said = self.said("a_status_the_deployment_answered")
+        self.assertNotIn(UNREACHABLE, said)
+        self.assertIn("not ready to serve", said)
+        self.assertNotIn("could not show it", said, "a status is not this page's fault")
+
+    def test_a_page_may_still_word_a_status_its_own_way(self) -> None:
+        """The upload panel says "that file is larger" rather than "that request is larger". The
+        classifier must not take that away from it."""
+        self.assertIn("file", self.said("a_status_with_an_override"))
+
+    def test_a_request_that_never_left_says_so(self) -> None:
+        """All three browsers word it differently, and none of them is this page's fault."""
+        for case in ("the_request_never_left", "the_request_never_left_firefox",
+                     "the_request_never_left_safari", "nothing_at_all"):
+            with self.subTest(case=case):
+                self.assertEqual(UNREACHABLE, self.said(case))
+
+    def test_a_throw_while_showing_the_answer_does_not_blame_the_gateway(self) -> None:
+        """The one that was indistinguishable, and the exact throw that made it matter."""
+        said = self.said("the_page_threw_while_showing")
+        self.assertNotIn(UNREACHABLE, said)
+        self.assertIn("could not show it", said)
+        self.assertIn("__matrixarkWhen", said, "the message it caught is not repeated")
+        self.assertIn("not in the deployment", said)
+
+    def test_an_unreadable_answer_is_not_an_unreachable_one(self) -> None:
+        said = self.said("a_bad_body")
+        self.assertNotIn(UNREACHABLE, said)
+        self.assertIn("JSON", said)
+
+    def test_the_predicate_and_the_sentence_agree(self) -> None:
+        """They are asked separately -- by the message and by the live strip -- so they have to
+        come from one rule, or the page can say the gateway is down while explaining that it is
+        not."""
+        arrived = self.result["neverArrived"]
+        self.assertFalse(arrived["a_status"])
+        self.assertFalse(arrived["a_render_throw"])
+        self.assertTrue(arrived["fetch_failure"])
+        self.assertTrue(arrived["nothing_at_all"])
+
+
+class NoPageSaysItItselfTest(unittest.TestCase):
+
+    def test_the_sentence_is_written_in_one_place(self) -> None:
+        """Every page carries the shared block, so the sentence appears once per page for that.
+
+        A second copy on a page is a catch answering for itself, which is how the wording got out
+        of step with what actually happened in the first place.
+        """
+        for name in pages():
+            text = read(name)
+            extra = text.count(UNREACHABLE) - text.count("return \"" + UNREACHABLE + "\"")
+            # An XHR's onerror IS a network failure and says so correctly; it is the one caller
+            # that already knows which of the three it has.
+            extra -= len(re.findall(r"onerror = function[^}]*?" + re.escape(UNREACHABLE),
+                                    text, re.S))
+            self.assertEqual(0, extra,
+                             "%s writes the sentence itself %d times" % (name, extra))
+
+    def test_the_strip_only_calls_it_down_when_it_never_arrived(self) -> None:
+        """The live strip is the page's loudest claim. It must not make it about a render fault."""
+        for name in pages():
+            text = read(name)
+            for match in re.finditer(r'conn\(\s*"down"', text):
+                before = text[max(0, match.start() - 260):match.start()]
+                # The stream's own retry state is the exception, and a real one: "reconnecting in
+                # 4s" is reported by the strip client when the socket is genuinely gone, with no
+                # request and no answer to classify.
+                if ".catch(" not in before:
+                    continue
+                self.assertIn(
+                    "__matrixarkNeverArrived", text[match.start() - 260:match.start() + 260],
+                    "%s sets the strip to down from a catch without asking whether the request "
+                    "ever arrived" % name)
+
+    def test_the_pages_actually_use_the_classifier(self) -> None:
+        """The positive control. Every assertion above passes on a portal that reports nothing at
+        all, which is exactly what deleting the catches would leave behind."""
+        used = sum(read(name).count("__matrixarkWhyFailed(") for name in pages())
+        self.assertGreaterEqual(used, 20, "the classifier is called %d times" % used)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_a_page_fault_is_not_a_gateway_failure.py
+++ b/tools/test_matrixark_a_page_fault_is_not_a_gateway_failure.py
@@ -125,21 +125,27 @@ class NoPageSaysItItselfTest(unittest.TestCase):
             self.assertEqual(0, extra,
                              "%s writes the sentence itself %d times" % (name, extra))
 
-    def test_the_strip_only_calls_it_down_when_it_never_arrived(self) -> None:
-        """The live strip is the page's loudest claim. It must not make it about a render fault."""
+    def test_the_strip_never_calls_it_unreachable_without_asking(self) -> None:
+        """The live strip is the page's loudest claim, and it must not make it about a render
+        fault. Asserted as the absence of the unguarded phrase rather than by looking near each
+        `conn("down"` for a guard: the sites sit close together, so a window around one of them
+        catches the guard belonging to its neighbour. A mutation that unguarded a single site
+        survived that version of this test.
+
+        The only "down" left on any page is the strip client's own `reconnecting in Ns`, which is
+        reported when the socket is genuinely gone -- no request, and no answer to classify.
+        """
         for name in pages():
             text = read(name)
+            self.assertEqual(
+                0, text.count('conn("down", "gateway unreachable")'),
+                "%s tells the strip the gateway is unreachable without asking whether the "
+                "request ever arrived" % name)
             for match in re.finditer(r'conn\(\s*"down"', text):
-                before = text[max(0, match.start() - 260):match.start()]
-                # The stream's own retry state is the exception, and a real one: "reconnecting in
-                # 4s" is reported by the strip client when the socket is genuinely gone, with no
-                # request and no answer to classify.
-                if ".catch(" not in before:
-                    continue
-                self.assertIn(
-                    "__matrixarkNeverArrived", text[match.start() - 260:match.start() + 260],
-                    "%s sets the strip to down from a catch without asking whether the request "
-                    "ever arrived" % name)
+                after = text[match.start():match.start() + 120]
+                self.assertIn("reconnecting", after,
+                              "%s has a down state that is neither guarded nor the socket "
+                              "retry: %s" % (name, after[:70]))
 
     def test_the_pages_actually_use_the_classifier(self) -> None:
         """The positive control. Every assertion above passes on a portal that reports nothing at


### PR DESCRIPTION
Twenty-one places answered a failed call with **"Could not reach the gateway."**
Three different things arrive at those lines:

| what happened | what it means | what it said |
|---|---|---|
| a rejection carrying a **status** | the deployment answered, and said no | ten sites got this right |
| a rejection from **fetch itself** | the request never left | correct |
| a **throw after the answer arrived** | *this page* failing to show what it was given | "Could not reach the gateway." |

Not one site told the third apart from the second — and the third is the one that
cost two sessions an hour today. A helper defined in the wrong script block raised
a `ReferenceError` inside a render, and the screen reported a gateway that had just
answered as unreachable.

## Seven sites were worse than that

Written `.catch(function () {`, they **discard the error entirely** — so a status
the page was handed is still reported as "could not reach".

## Three were worse again

They handle 401 and 403 by name and treat everything else as unreachable. So a
throw while rendering did not merely print the wrong sentence — it turned the
**live strip** to "gateway unreachable" about a deployment that was answering. The
strip is what a reader glances at to decide whether the deployment is alive.

## One rule, in one place

`__matrixarkNeverArrived` names the classification once, so the sentence and the
strip cannot disagree about it. A status means the request left and was answered;
the messages fetch itself produces are a short known set; anything else happened
here, with the answer already in hand.

Where the message is not recognised the page **repeats what it caught** rather than
guessing — an unfamiliar message shown as it came is still more than a sentence
about the network.

## A status is the deployment answering

Found by opening the page, not by reading it. With nothing behind the portal every
fetch comes back **404** — a status, so the request plainly arrived — and the strip
read "this page could not show the answer" in amber.

The first version of this asked only *whether the request arrived* and then treated
everything that did as a fault in the page. Three cases need three answers:

```
never arrived  ->  down, gateway unreachable
a status       ->  live, connected
anything else  ->  warn, this page could not show the answer
```

## Checks

Six mutations, each reddening a distinct assertion. The classifier is **run**, not
read: the harness executes the page's own shared block and asks it about a status,
the three wordings browsers use for a request that never left, a render throw, and
an unreadable body.

Two things worth knowing for whoever edits this next:

* a mutation that unguarded a single `conn("down")` **survived** the first version
  of the strip assertion — the sites sit close together, so a character window
  around one catches the guard belonging to its neighbour. It is asserted as the
  absence of the unguarded phrase now, which a neighbour cannot satisfy.
* taking the number branch out of `__matrixarkNeverArrived` is an **equivalent
  mutant**: `String(503)` matches no network wording either. The branch that
  decides a status is in `__matrixarkWhyFailed`.

Full ratchet run on the branch. Its one new failure is
`test_regenerating_produces_the_same_document`, which fails on **main** as well —
a stale generated document, fixed separately in #1276.
