### PR TITLE
Three comments in engine.rs describe something other than the code they sit on

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -2927,24 +2927,29 @@ pub(super) fn wal_single_barrier() -> bool {
     !wal_legacy_recovery()
 }
 
-// TS_ENGINE_CONCURRENT_COMMIT: run the WAL durability barrier OUTSIDE the global `shards`
-// write lock. When ON, a synchronous write reserves its WAL sequence and appends its record
-// UNDER the `shards` lock (preserving WAL-order == apply-order), then RELEASES the lock and
-// awaits the durable barrier (`commit_barrier`). This lets concurrent same-shard writers reach
-// the group-commit queue while a peer's fdatasync is in flight, so #45's fsync coalescing
-// actually engages (fewer fsyncs than writes; QPS scales with concurrency). Default ON; set
-// the variable to 0 for byte-identical behaviour to the legacy in-lock `append_with_sync`
-// barrier. The ack is always returned
-// strictly AFTER the covering barrier succeeds, so durability is never weakened.
+// CONCURRENT COMMIT: run the WAL durability barrier OUTSIDE the global `shards` write lock.
+// A synchronous write reserves its WAL sequence and appends its record UNDER the `shards` lock
+// (preserving WAL-order == apply-order), then RELEASES the lock and awaits the durable barrier
+// (`commit_barrier`). This lets concurrent same-shard writers reach the group-commit queue while
+// a peer's fdatasync is in flight, so #45's fsync coalescing actually engages (fewer fsyncs than
+// writes; QPS scales with concurrency). The ack is always returned strictly AFTER the covering
+// barrier succeeds, so durability is never weakened.
+//
+// This is the `concurrent_commit` field, per engine, true everywhere but the test that measures
+// what the in-lock barrier costs. `TS_ENGINE_CONCURRENT_COMMIT` used to decide it for every
+// engine in the process at once; it is read by nothing now, so setting it does nothing.
 
 
-// TS_RAFT_APPLY_COALESCE: on the raft state-machine apply path, coalesce the per-committed-entry
-// engine-WAL fdatasync across a whole committed batch (one fsync per AppendEntries batch / recovery
-// replay / pipelined-propose group instead of one per entry) and anchor the served index off the
-// O(1) cached WAL sequence. Default ON; set the variable to 0 for per-entry
-// `execute_raft_apply` (byte-identical). The
-// raft log stays the durability + reconstruction source; the coalesced barrier still completes
-// before the raft runtime advances the durable applied_index.
+// RAFT APPLY COALESCE: on the raft state-machine apply path, coalesce the per-committed-entry
+// engine-WAL fdatasync across a whole committed batch (one fsync per AppendEntries batch /
+// recovery replay / pipelined-propose group instead of one per entry) and anchor the served index
+// off the O(1) cached WAL sequence. The raft log stays the durability + reconstruction source;
+// the coalesced barrier still completes before the raft runtime advances the durable
+// applied_index.
+//
+// This is the `raft_apply_coalesce` field, per engine, true everywhere but the test that measures
+// the per-entry loop. `TS_RAFT_APPLY_COALESCE` used to decide it for every engine in the process
+// at once; it is read by nothing now, so setting it does nothing.
 
 fn env_flag_on(name: &str) -> bool {
     matches!(
@@ -2957,9 +2962,6 @@ fn env_flag_on(name: &str) -> bool {
     )
 }
 
-/// Default-ON gate read: the fix is LIVE unless explicitly disabled with
-/// `=0|false|no|off`. Shipped write-path/raft fixes use this so production gets the
-/// fixed behavior by default; the env var remains only as an escape hatch.
 /// Tuning for sampled eviction, read from the environment with defaults that mirror the
 /// established policy: sample several buckets per wanted victim, keep a bounded candidate pool
 /// across passes, and cap how far one pass may walk.
@@ -2978,6 +2980,9 @@ pub(crate) fn evict_sampler_config() -> eviction_sampler::EvictionSamplerConfig 
     }
 }
 
+/// Default-ON gate read: the fix is LIVE unless explicitly disabled with
+/// `=0|false|no|off`. Shipped write-path/raft fixes use this so production gets the
+/// fixed behavior by default; the env var remains only as an escape hatch.
 fn env_flag_default_on(name: &str) -> bool {
     !matches!(
         std::env::var(name)

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -10011,7 +10011,6 @@ fn recording_results_still_coalesces_fsyncs() {
         dir.path().join("indexes"),
     ));
     engine.load_shard(1);
-    std::env::set_var("TS_ENGINE_CONCURRENT_COMMIT", "1");
     std::env::set_var("TS_WAL_OUTCOME_ITEMS", "1");
 
     let syncs_before = engine.write_ahead_log_store().stats(1).syncs;
@@ -10085,7 +10084,6 @@ fn a_group_commit_write_keeps_the_block_it_staged() {
         dir.path().join("indexes"),
     );
     engine.load_shard(1);
-    std::env::set_var("TS_ENGINE_CONCURRENT_COMMIT", "1");
 
     let response = engine.execute(ExecuteRequest {
         shard_id: 1,


### PR DESCRIPTION
Three comments in `engine.rs` describe something other than the code they sit on. None of them
changes behaviour; all three tell a reader something that is not true, and two of them tell an
operator to set a variable nothing reads.

## A doc comment separated from its function by another function

`env_flag_default_on` has no doc. Its doc — "Default-ON gate read: the fix is LIVE unless
explicitly disabled with `=0|false|no|off`" — sits twenty lines above it, with
`evict_sampler_config` in between. Rust attaches a doc comment to whatever item follows it, so
that text documents the eviction-sampler tuning function, which then carries two doc comments
in a row about entirely different subjects:

```
/// Default-ON gate read: the fix is LIVE unless explicitly disabled with ...
/// Tuning for sampled eviction, read from the environment with defaults that ...
pub(crate) fn evict_sampler_config() -> eviction_sampler::EvictionSamplerConfig {
```

Moved down onto the function it was written for.

## Two blocks that still describe retired variables as live switches

`TS_ENGINE_CONCURRENT_COMMIT` and `TS_RAFT_APPLY_COALESCE` both became per-engine fields —
`concurrent_commit` and `raft_apply_coalesce` — precisely so that one test measuring the slow
side could not change the behaviour of every other engine in the process. Both **fields** are
documented correctly and say the variable "used to decide it".

What was left behind is a pair of free-floating comment blocks further down the file, each
still ending:

> Default ON; set the variable to 0 for byte-identical behaviour ...

Neither variable is read anywhere. Setting either does nothing at all, and the sentence reads
as an operator instruction rather than as history. Rewritten to describe the field, keeping the
explanation of what the behaviour is and why, and saying plainly that the variable is read by
nothing now — the form this tree already uses for `TS_HOT_PAGE_SPILL`.

## Two tests that set a variable nothing reads

`recording_results_still_coalesces_fsyncs` and `a_group_commit_write_keeps_the_block_it_staged`
both call `set_var("TS_ENGINE_CONCURRENT_COMMIT", "1")`. Nothing reads it, and `1` was the
position the field already holds, so the line states an intent the run does not carry — a
reader would reasonably conclude the test covers the concurrent-commit path *because it was
switched on here*, when in fact it covers the default.

Both tests pass with the lines removed, which is the point: they were inert.

These two were also the only string literals of that name left in the tree, which is why the
generated flag inventory does not list the variable while the tree still mentions it in six
places.

## Checks

`flag_docs_state_the_default_the_code_actually_has` — the guard that reads a flag accessor's
doc block and compares it against which helper the body calls — passes; it inspects
`fn x() -> bool` items, so moving a doc onto `env_flag_default_on` is exactly the kind of change
it exists to keep honest. `test_env_flag_vocabulary`, `test_flag_readers_agree` and
`test_matrixark_engine_flag_legacy` pass. The two affected tests pass. `cargo check --release
--lib --tests` is clean.
