### PR TITLE
Restore the status the flush writes, and test it by running the flush

### DIFF
--- a/tools/matrixark_mcp_retrieve_request.py
+++ b/tools/matrixark_mcp_retrieve_request.py
@@ -202,6 +202,28 @@ def commit_session_buffer_before_retrieval(
     return summary
 
 
+# The statuses that mean "this task is done, stop re-attempting it".
+#
+# `idle_commit_attempted` belongs here and was briefly removed on the grounds that nothing writes
+# it. `pre_retrieval_idle_commit_flush` writes it itself, in this file, as
+# `f"idle_commit_{status}"` where `status` is "committed" or "attempted" -- a name that is built
+# rather than spelled, which a search for the literal cannot find. While it was missing, a task
+# that took the "attempted" outcome was never marked resolved and came back on every retrieve.
+# `test_the_resolved_set_covers_what_the_flush_writes` now drives the flush and compares what it
+# WRITES against this set, so pruning it means answering a behaviour instead of a grep.
+#
+# `idle_commit_skipped` is deliberately NOT here, and that is an open question rather than an
+# oversight. It is what the drain writes whenever `session_commit` declines
+# (matrixark_local_adapter_retrieval), so it is the common outcome, and its completion record
+# keeps `remaining_stages` set and `completed_stages` empty -- it is written as work still
+# outstanding, which is an argument for re-attempting it. Adding it here would stop the
+# re-attempts, and marking dead work resolved looks identical from outside to dropping live work.
+# Settle what a skip means before changing it.
+IDLE_COMMIT_RESOLVED_STATUSES = frozenset(
+    {"idle_commit_committed", "idle_commit_attempted", "idle_commit_failed"}
+)
+
+
 def pre_retrieval_idle_commit_flush(target: Any, args: Json, ranking: Json, *, scope: Json) -> Json:
     enabled = (
         args.get("pre_retrieval_idle_commit_flush")
@@ -237,20 +259,7 @@ def pre_retrieval_idle_commit_flush(target: Any, args: Json, ranking: Json, *, s
         if record.get("record_type") != "matrixark_async_pipeline_task":
             continue
         status = str(record.get("status") or "")
-        # The statuses that mean "this task is done, stop re-attempting it".
-        #
-        # `idle_commit_attempted` used to be here and is gone: nothing in the repository ever
-        # writes it -- not Python, not the crates, not a fixture -- so it could never match, and
-        # listing it made this set look like it covered more outcomes than it does.
-        #
-        # `idle_commit_skipped` is NOT here, and that is the open question rather than an
-        # oversight. It is what the drain writes whenever `session_commit` declines
-        # (matrixark_local_adapter_retrieval), so it is the common outcome, and its completion
-        # record keeps `remaining_stages` set and `completed_stages` empty -- it is written as
-        # work still outstanding, which is an argument for re-attempting it. Adding it here would
-        # stop the re-attempts, and marking dead work resolved looks identical from outside to
-        # dropping live work. Settle what a skip means before changing this line.
-        if status in {"idle_commit_committed", "idle_commit_failed"}:
+        if status in IDLE_COMMIT_RESOLVED_STATUSES:
             try:
                 resolved_task_hashes.add(int(record.get("scheduled_task_hash") or record.get("task_hash") or 0))
             except (TypeError, ValueError):

--- a/tools/test_the_resolved_set_covers_what_the_flush_writes.py
+++ b/tools/test_the_resolved_set_covers_what_the_flush_writes.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The resolved-status set must cover the statuses the flush actually writes.
+
+`pre_retrieval_idle_commit_flush` decides a task is done by looking its status up in
+`IDLE_COMMIT_RESOLVED_STATUSES`, and it writes those statuses itself, in the same function. A
+status it writes but does not list is a task that is never marked resolved and is re-attempted on
+every retrieve, forever, with no error anywhere.
+
+That happened. `idle_commit_attempted` was removed from the set because a search of the repository
+for the name found nothing -- it is built, not spelled:
+
+    status = "committed" if commit_status == "committed" else "attempted"
+    ...
+    "status": f"idle_commit_{status}",
+
+So this test does not search for names. It runs the flush and reads what it wrote.
+"""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import matrixark_mcp_retrieve_request as flush_module
+
+SCOPE = {"tenant_id": "acme", "user_id": "dana", "session_id": "s-1"}
+
+
+class _Target:
+    """Only what the flush reaches for: session_commit, task records, append."""
+
+    def __init__(self, commit_status, resolution_records=()):
+        self.commit_status = commit_status
+        self.appended = []
+        self._resolutions = list(resolution_records)
+
+    def session_commit(self, commit_args):
+        return {"status": self.commit_status, "committed_event_count": 1}
+
+    def idle_commit_task_records(self, scope):
+        scheduled = {
+            "record_type": "matrixark_async_pipeline_task",
+            "status": "idle_commit_scheduled",
+            "task_hash": 4242,
+            "event_id_hash": 7,
+            "scope": SCOPE,
+            "idle_commit_deadline_ms": 1,          # long past
+            "idle_commit_timeout_ms": 1000,
+            "threshold_messages": 20,
+            "updated_at_ms": 1,
+            "stages": ["extraction", "summary"],
+        }
+        return [scheduled] + self._resolutions
+
+    def append(self, record):
+        self.appended.append(record)
+
+
+def _flush(target):
+    return flush_module.pre_retrieval_idle_commit_flush(
+        target, {"pre_retrieval_idle_commit_flush": True}, {}, scope=SCOPE)
+
+
+def _written_statuses(target):
+    return [r.get("status") for r in target.appended
+            if r.get("record_type") == "matrixark_async_pipeline_task"]
+
+
+class TheResolvedSetCoversWhatTheFlushWrites(unittest.TestCase):
+    def test_the_attempted_outcome_is_written_and_is_resolved(self):
+        """A commit that returns anything but "committed" writes idle_commit_attempted."""
+        target = _Target("accepted")
+        _flush(target)
+
+        written = _written_statuses(target)
+        self.assertIn("idle_commit_attempted", written,
+                      "the flush no longer writes this status; the guard below is then vacuous")
+        self.assertIn(
+            "idle_commit_attempted", flush_module.IDLE_COMMIT_RESOLVED_STATUSES,
+            "the flush writes idle_commit_attempted but does not count it as resolved, so the "
+            "task is re-attempted on every retrieve and nothing reports it",
+        )
+
+    def test_the_committed_outcome_is_written_and_is_resolved(self):
+        target = _Target("committed")
+        _flush(target)
+
+        written = _written_statuses(target)
+        self.assertIn("idle_commit_committed", written)
+        self.assertIn("idle_commit_committed", flush_module.IDLE_COMMIT_RESOLVED_STATUSES)
+
+    def test_every_status_the_flush_writes_is_accounted_for(self):
+        """The general form, so a NEW outcome cannot be added without a decision about it.
+
+        A status is accounted for if it resolves the task, or if it is one the file documents as
+        deliberately unresolved. `idle_commit_skipped` is that second kind and is written by the
+        drain rather than here; it is listed so this test states the whole contract in one place.
+        """
+        deliberately_unresolved = {"idle_commit_skipped"}
+        for commit_status in ("committed", "accepted", "deferred", ""):
+            target = _Target(commit_status)
+            _flush(target)
+            for status in _written_statuses(target):
+                with self.subTest(commit_status=commit_status, written=status):
+                    self.assertIn(
+                        status,
+                        set(flush_module.IDLE_COMMIT_RESOLVED_STATUSES) | deliberately_unresolved,
+                        "the flush writes %r, which neither resolves the task nor is a documented "
+                        "exception; such a task returns on every retrieve" % (status,),
+                    )
+
+    def test_a_resolved_task_is_not_attempted_again(self):
+        """What the set is FOR: the resolution record must stop the re-attempt."""
+        target = _Target("accepted")
+        _flush(target)
+        resolution = [r for r in target.appended
+                      if r.get("status") == "idle_commit_attempted"]
+        self.assertTrue(resolution, "nothing was written to resolve the task")
+
+        again = _Target("accepted", resolution_records=resolution)
+        result = _flush(again)
+        self.assertEqual(
+            [], _written_statuses(again),
+            "the task was re-attempted even though a resolution record for it exists: %r" % (result,),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Restore the status the flush writes, and test it by running the flush

This corrects #1278, which I got wrong. That change removed `idle_commit_attempted` from the set
of statuses that mark an idle-commit task resolved, on the stated grounds that nothing in the
repository writes it. `pre_retrieval_idle_commit_flush` writes it itself, 160 lines below the set,
in the same function:

    status = "committed" if commit_status == "committed" else "attempted"
    ...
    "status": f"idle_commit_{status}",

The name is built, not spelled, so the search that "confirmed" nothing wrote it could not have
found it. Any commit returning a status other than "committed" -- "accepted" among them -- takes
that branch.

The effect is the failure the set exists to prevent: the flush writes a resolution record, the
next retrieve does not recognise it, and the task is re-attempted. Forever, silently, on every
retrieve. This is the same shape as the 49 tasks already known to be re-attempted for days, and
#1278 added a second way in rather than closing the first.

Demonstrated rather than argued. Against main, the new test fails with:

    the task was re-attempted even though a resolution record for it exists

and passes here.

The set is now a module constant, and the test drives the flush and reads what it WROTE instead of
searching for names. It covers four commit outcomes, asserts each written status either resolves
the task or is a documented exception, and includes the two controls that make the rest mean
something: that the flush still writes `idle_commit_attempted` at all (otherwise the guard is
vacuous), and that a resolution record actually stops the re-attempt.

`idle_commit_skipped` is still deliberately outside the set, for the reason #1278 recorded and
this keeps: its completion record carries `remaining_stages` set and `completed_stages` empty, so
it is written as work still outstanding. That question is unchanged and still open. What changed
is that pruning this set now requires answering a behaviour instead of a grep.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>
