### PR TITLE
Two extracted cache-key builders gave every tenant one key

### DIFF
--- a/tools/matrixark_mcp_retrieval_records.py
+++ b/tools/matrixark_mcp_retrieval_records.py
@@ -10,7 +10,7 @@ try:
         Json,
         access_scope_matches_before_scoring,
         candidate_access_scope,
-        canonical_scope_key,
+        cache_scope_key,
         scope_matches,
         session_scope_mode,
     )
@@ -19,7 +19,7 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
         Json,
         access_scope_matches_before_scoring,
         candidate_access_scope,
-        canonical_scope_key,
+        cache_scope_key,
         scope_matches,
         session_scope_mode,
     )
@@ -60,7 +60,7 @@ def retrieval_records_cache_key(
     selected_key = tuple(sorted(int(item) for item in (selected_node_hashes or set())))
     return (
         generation,
-        canonical_scope_key(scope),
+        cache_scope_key(scope),
         session_scope_mode(scope),
         tuple(sorted(allowed_types)),
         secondary_key,

--- a/tools/matrixark_mcp_retrieve_cache.py
+++ b/tools/matrixark_mcp_retrieve_cache.py
@@ -12,14 +12,14 @@ from typing import Any
 try:
     from tools.matrixark_mcp_core import (
         Json,
-        canonical_scope_key,
+        cache_scope_key,
         compact_context_pack_for_serving_flat as compact_context_pack_for_serving,
         python_hot_cache_allowed,
     )
 except ModuleNotFoundError:  # Direct script execution from tools/.
     from matrixark_mcp_core import (
         Json,
-        canonical_scope_key,
+        cache_scope_key,
         compact_context_pack_for_serving_flat as compact_context_pack_for_serving,
         python_hot_cache_allowed,
     )
@@ -47,7 +47,7 @@ def context_pack_cache_key(
 ) -> tuple[Any, ...]:
     return (
         target._retrieval_records_cache_generation,
-        canonical_scope_key(scope),
+        cache_scope_key(scope),
         query,
         question_type,
         retrieval_session_scope,

--- a/tools/test_matrixark_cache_key_separates_tenants.py
+++ b/tools/test_matrixark_cache_key_separates_tenants.py
@@ -15,6 +15,7 @@ The MCP entry point normalises the scope before this point, so the served paths 
 That is not something to rely on: nothing at the cache said so, and a caller skipping
 normalisation got cross-tenant answers with no error to notice.
 """
+import ast
 import json
 import os
 import sys
@@ -23,6 +24,7 @@ import unittest
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 import matrixark_mcp_local_adapter as adapter_module
 import matrixark_mcp_core_identity as core_identity
@@ -97,6 +99,95 @@ class CacheKeySeparatesTenants(unittest.TestCase):
         for scope in (ACME, GLOBEX, {"scope_key": "x"}, {}):
             self.assertEqual(core_identity.cache_scope_key(scope), identity.cache_scope_key(scope),
                              "the two copies disagree for %r" % (scope,))
+
+
+class EveryCacheKeyBuilderSeparatesTenants(unittest.TestCase):
+    """The fix above went in where the incident was found: the live retrieve path, which builds its
+    key inline, and the two identity helpers. It did not reach the EXTRACTED builders, which exist
+    so that inline code can be replaced by them -- so adopting either extraction would have put the
+    incident straight back. `context_pack_cache_key` and `retrieval_records_cache_key` are the two
+    caches the module docstring above names, in their extracted form.
+
+    Derived from the source rather than from a list of the two, because a list cannot see the copy
+    somebody extracts next month -- which is precisely how these two came to be missed.
+    """
+
+    #: A builder keyed on a scope must not key on the function that returns "" for a raw scope.
+    COLLAPSING = "canonical_scope_key"
+    SEPARATING = "cache_scope_key"
+
+    @staticmethod
+    def _builders():
+        """(module file, function name, names it calls) for every cache-key builder in tools/."""
+        found = []
+        for entry in sorted(os.listdir(TOOLS_DIR)):
+            if not entry.endswith(".py") or entry.startswith("test_"):
+                continue
+            try:
+                tree = ast.parse(Path(TOOLS_DIR, entry).read_text(encoding="utf-8"))
+            except (SyntaxError, UnicodeDecodeError):
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                if "cache_key" not in node.name:
+                    continue
+                calls = set()
+                for sub in ast.walk(node):
+                    if isinstance(sub, ast.Call):
+                        if isinstance(sub.func, ast.Name):
+                            calls.add(sub.func.id)
+                        elif isinstance(sub.func, ast.Attribute):
+                            calls.add(sub.func.attr)
+                found.append((entry, node.name, calls))
+        return found
+
+    def test_the_scan_finds_the_builders(self):
+        """Without this, a scan that matched nothing would report every builder clean."""
+        builders = self._builders()
+        self.assertGreaterEqual(
+            len(builders), 10,
+            "found %d cache-key builders under tools/, expected at least 10 -- the scan stopped "
+            "matching, so the check below proves nothing" % len(builders))
+        self.assertIn(
+            ("matrixark_mcp_retrieve_cache.py", "context_pack_cache_key"),
+            [(f, n) for f, n, _c in builders],
+            "the builder this guard was written for is no longer being scanned")
+
+    def test_no_builder_keys_on_the_collapsing_scope_key(self):
+        offenders = [
+            "%s:%s" % (f, n) for f, n, calls in self._builders()
+            if self.COLLAPSING in calls and self.SEPARATING not in calls
+        ]
+        self.assertEqual(
+            [], offenders,
+            "these cache-key builders key on %s, which is \"\" for the documented public scope "
+            "shape, so every tenant shares one entry: %s" % (self.COLLAPSING, ", ".join(offenders)))
+
+    def test_the_extracted_builders_give_two_tenants_two_keys(self):
+        """The behaviour, not the spelling -- a builder could collapse some other way."""
+        import matrixark_mcp_retrieval_records as records
+        import matrixark_mcp_retrieve_cache as pack_cache
+
+        keys = []
+        for scope in (ACME, GLOBEX):
+            keys.append(records.retrieval_records_cache_key(
+                generation=1, scope=scope, allowed_types={"context_event"}))
+        self.assertNotEqual(keys[0], keys[1],
+                            "retrieval_records_cache_key gives two tenants one key")
+
+        class _Target:
+            _retrieval_records_cache_generation = 1
+
+        keys = []
+        for scope in (ACME, GLOBEX):
+            keys.append(pack_cache.context_pack_cache_key(
+                _Target(), scope=scope, query=QUERY, question_type="general",
+                retrieval_session_scope="session", max_context_tokens=1000,
+                local_budget={"token_estimate": 0, "text_hashes": set()},
+                ranking={}, include_superseded=False))
+        self.assertNotEqual(keys[0], keys[1],
+                            "context_pack_cache_key gives two tenants one key")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two cache-key builders keyed on `canonical_scope_key`, which returns `""` for a scope carrying
neither `scope_key` nor `tenant_hash` — the shape of the documented public scope,
`{tenant_id, user_id, session_id}`. A key built on it collapses, so every tenant lands on one
cache entry and the second caller to ask a question is served the first one's answer.

That is not hypothetical here. `test_matrixark_cache_key_separates_tenants` already records it,
reproduced on one adapter with two tenants: tenant B asked what its own pet was called and was
given tenant A's. The remedy was `cache_scope_key`, which keeps the tenant, user and session
distinct when there is no canonical key to use.

The remedy reached the paths where the problem was found — the retrieve path, which builds its key
as an inline tuple, and the two identity helpers. It did not reach the **extracted** builders:

| builder | keyed on |
|---|---|
| `matrixark_mcp_retrieve_cache.context_pack_cache_key` | `canonical_scope_key` |
| `matrixark_mcp_retrieval_records.retrieval_records_cache_key` | `canonical_scope_key` |

Those two are the extracted forms of the very caches the recorded incident names — the
context-pack cache and the retrieval-records cache. They exist so the inline code can be replaced
by them, which means adopting either extraction would have put the incident straight back, on a
path where nothing at the cache says the scope must be normalised first.

Neither is reached by a request today: the function holding the context-pack lookup,
`prepare_retrieval_request`, is called only from tests. So this changes no behaviour now, and is
worth doing precisely because the code is waiting to be adopted.

## What changed

Both builders now key on `cache_scope_key`. Measured on the two tenants from the existing test:

```
canonical_scope_key({tenant_id: acme, ...})   = ''
canonical_scope_key({tenant_id: globex, ...}) = ''      <- one entry for both
cache_scope_key({tenant_id: acme, ...})   = ('raw', 'acme', 'dana', 's1', '')
cache_scope_key({tenant_id: globex, ...}) = ('raw', 'globex', 'rui', 's1', '')
```

## The guard

Three tests, added to the file that records the incident.

The structural one is **derived from the source**, not written as a list of the two builders
fixed here: it walks every `*cache_key*` function under `tools/` and fails any that calls the
collapsing function without the separating one. A list would not have seen these two — that is how
they came to be missed — and would not see the next extraction either. It currently scans 14
builders.

It carries its own positive control, because a scan that quietly stops matching would otherwise
report every builder clean: one test asserts the scan still finds at least 10 builders and still
finds the specific one this guard was written for.

The third is behavioural rather than textual, since a builder could collapse some other way: it
calls both builders with the two tenants and asserts the keys differ.

Verified discriminating — with the change reverted, both new assertions fail, the behavioural one
showing the two tenants producing a byte-identical key:

```
AssertionError: (1, '', 'only', ('context_event',), (), ())
             == (1, '', 'only', ('context_event',), (), ())
   : retrieval_records_cache_key gives two tenants one key
```

## Still not safe to adopt, for a separate reason

Worth recording while it is in view, since it is the same kind of drift and this PR does not
address it. The extracted key carries 10 elements; the live inline key carries 21. The extracted
one omits inputs the pack content varies on:

    cross_session_policy
    shared_context_policy
    source_role_budget_tokens
    memory_layer_budget_tokens
    memory_selection_policy_budget_tokens
    extraction_phase_budget_tokens
    the pre_retrieval_summary_refresh and pre_retrieval_idle_commit blocks

Two requests differing only in those would share one entry, and one would be served the other's
pack. (The debug and metrics flags are also absent from the extracted key, but that one looks
deliberate: the getter compacts per request via include_debug, so debug is handled at projection
time rather than in the key.)

Widening the key means widening the builder's signature, which is a decision about the shape the
extraction is meant to take, so it is left for whoever adopts it.
