### PR TITLE
The page says what it asked, and what came back

### DIFF
--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -115,6 +115,13 @@
   .live-seg.warn b{color:var(--warn)}
   .live-seg.busy b{color:var(--accent)}
   .live-dot{width:7px;height:7px;border-radius:50%;background:var(--ok);flex:0 0 auto}
+  .calllog{margin:0 0 18px;max-height:340px;overflow:auto;border:1px solid var(--line);
+           border-radius:8px}
+  .calllog table{width:100%;border-collapse:collapse;font-size:12.5px;
+                 font-variant-numeric:tabular-nums}
+  .calllog th,.calllog td{text-align:left;padding:5px 9px;border-bottom:1px solid var(--line)}
+  .calllog td.mono{font-family:"IBM Plex Mono",monospace;font-size:11.5px}
+  .calllog tr.bad td{color:var(--crit)}
   .live-dot.stale{background:var(--warn)}
   .live-dot.down{background:var(--crit)}
   @media (max-width:820px){ .livestrip{margin-left:0;width:100%;padding-top:6px} }
@@ -177,9 +184,15 @@
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
       <a class="live-seg warn" href="/v1/admin/setup#warnings" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup#awaitingRestart" id="liveWaiting" hidden></a>
+      <button class="live-seg" id="liveCalls" type="button" aria-expanded="false"
+              aria-controls="callLog" title="What this page has asked the gateway, and what came back"></button>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>
+  <div class="calllog" id="callLog" hidden>
+    <table class="inv"><thead><tr><th>When</th><th>Call</th><th>Answered</th><th>Took</th></tr>
+      </thead><tbody id="callLogRows"></tbody></table>
+  </div>
 
   <!-- ============================ Connection ============================ -->
   <section class="card">
@@ -504,6 +517,49 @@
     if (status === 504) { return "The backend did not answer in time."; }
     return "The gateway answered " + status + ".";
   };
+
+  window.__matrixarkTrace = (function () {
+    /* The last calls this page made, newest last. Bounded: a portal tab is left open for days and
+       an unbounded list of every request is a leak that only shows on the busiest deployment. */
+    var calls = [], LIMIT = 60;
+    var listeners = [];
+
+    function note(entry) {
+      calls.push(entry);
+      if (calls.length > LIMIT) { calls.shift(); }
+      for (var i = 0; i < listeners.length; i++) {
+        try { listeners[i](calls.length); } catch (e) { /* a listener must not break a request */ }
+      }
+    }
+
+    var original = typeof window.fetch === "function" ? window.fetch : null;
+    if (original) {
+      window.fetch = function (input, init) {
+        var at = Date.now();
+        var method = String((init && init.method) || (input && input.method) || "GET").toUpperCase();
+        var url = String((input && input.url) || input || "");
+        return original.apply(this, arguments).then(function (response) {
+          /* Untouched. Reading the body here to pull out an incident token would consume it and
+             hand the caller an empty one -- breaking the panels this exists to help diagnose. */
+          note({ at: at, ms: Date.now() - at, method: method, url: url, status: response.status });
+          return response;
+        }, function (err) {
+          /* Status 0 is "never answered", which is a different row from a 500 and has to read as
+             one. The message is the browser's own; it is what tells a blocked request from a
+             refused one. */
+          note({ at: at, ms: Date.now() - at, method: method, url: url, status: 0,
+                 detail: (err && err.message) ? String(err.message) : String(err) });
+          throw err;
+        });
+      };
+    }
+
+    return {
+      calls: function () { return calls.slice(); },
+      onChange: function (fn) { if (typeof fn === "function") { listeners.push(fn); } },
+      note: note
+    };
+  }());
 
   window.__matrixarkWhen = function (ms) {
     /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
@@ -1448,7 +1504,21 @@
               if (line.indexOf("event:") === 0) { name = line.slice(6).trim(); }
               else if (line.indexOf("data:") === 0) { payload = line.slice(5).trim(); }
             });
-            if (name === "bye") { planned = true; return; }
+            if (name === "bye") {
+              planned = true;
+              /* The strip has no message line, so the reason goes where a reader can still get at
+                 it: the dot's own title. A goodbye that is a fault leaves the dot down rather than
+                 letting the next keepalive clear it back to live. */
+              try {
+                var why = JSON.parse(payload || "{}");
+                if (why.reason && why.reason !== "stream_max_age") {
+                  dot.className = "live-dot down";
+                  dot.title = "the stream failed on the gateway"
+                    + (why.incident ? " \u2014 incident " + why.incident : "");
+                }
+              } catch (e) { /* an older gateway says goodbye with no body */ }
+              return;
+            }
             if (name !== "status" || !payload) { return; }
             try {
               var frame = JSON.parse(payload);
@@ -1520,6 +1590,76 @@
 
   reveal();
   if (window.addEventListener) { window.addEventListener("hashchange", reveal); }
+}());
+
+/* ---------- what this page asked, and what came back ----------
+ *
+ * Every panel here is drawn from a call, and the only evidence one was made was whether the panel
+ * filled in. When something is wrong the first question is which request failed and what it
+ * answered -- and the only way to find out was the browser's own developer tools, which is a fine
+ * answer for whoever wrote the page and no answer at all for an operator looking at a deployment
+ * they did not build.
+ *
+ * Folded away until asked for: this is a debugging surface, not part of the page's job. */
+(function () {
+  var button = document.getElementById("liveCalls");
+  var panel = document.getElementById("callLog");
+  var rows = document.getElementById("callLogRows");
+  if (!button || !panel || !rows || !window.__matrixarkTrace) { return; }
+
+  function esc(s) {
+    return String(s).replace(/[&<>"]/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c];
+    });
+  }
+
+  /* The path, not the whole URL. Every one of these is this deployment, so the origin is the same
+     on every row and spends the width that the query -- which is what differs -- needs. */
+  function shorten(url) {
+    try {
+      var parsed = new URL(String(url), location.href);
+      return parsed.pathname + (parsed.search || "");
+    } catch (e) { return String(url); }
+  }
+
+  function label(n) {
+    button.hidden = !n;
+    button.textContent = n === 1 ? "1 call" : n + " calls";
+  }
+
+  function render() {
+    var calls = window.__matrixarkTrace.calls();
+    if (!calls.length) {
+      rows.innerHTML = '<tr><td colspan="4">Nothing asked yet.</td></tr>';
+      return;
+    }
+    /* Newest first: the call somebody is trying to explain is the one they just made. */
+    rows.innerHTML = calls.slice().reverse().map(function (c) {
+      /* A status of 0 is "never answered", which is a different row from a 500 and reads as one.
+         The browser's own message is what separates a blocked request from a refused one. */
+      var answered = c.status ? String(c.status) : (c.detail || "never answered");
+      return '<tr class="' + (!c.status || c.status >= 400 ? "bad" : "") + '"><td>'
+        + esc(window.__matrixarkWhen ? window.__matrixarkWhen(c.at) : c.at)
+        + '</td><td class="mono">' + esc(c.method + " " + shorten(c.url))
+        + "</td><td>" + esc(answered)
+        + "</td><td>" + esc(c.ms + " ms") + "</td></tr>";
+    }).join("");
+  }
+
+  button.addEventListener("click", function () {
+    var show = panel.hidden;
+    panel.hidden = !show;
+    button.setAttribute("aria-expanded", show ? "true" : "false");
+    if (show) { render(); }
+  });
+
+  window.__matrixarkTrace.onChange(function (n) {
+    label(n);
+    /* Only while it is open. Rebuilding a hidden table on every request is work nobody asked for
+       on a page that is left open for days. */
+    if (!panel.hidden) { render(); }
+  });
+  label(window.__matrixarkTrace.calls().length);
 }());
 </script>
 </body>

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -186,6 +186,13 @@
   .live-seg.warn b{color:var(--warn)}
   .live-seg.busy b{color:var(--accent)}
   .live-dot{width:7px;height:7px;border-radius:50%;background:var(--ok);flex:0 0 auto}
+  .calllog{margin:0 0 18px;max-height:340px;overflow:auto;border:1px solid var(--line);
+           border-radius:8px}
+  .calllog table{width:100%;border-collapse:collapse;font-size:12.5px;
+                 font-variant-numeric:tabular-nums}
+  .calllog th,.calllog td{text-align:left;padding:5px 9px;border-bottom:1px solid var(--line)}
+  .calllog td.mono{font-family:"IBM Plex Mono",monospace;font-size:11.5px}
+  .calllog tr.bad td{color:var(--crit)}
   .live-dot.stale{background:var(--warn)}
   .live-dot.down{background:var(--crit)}
   @media (max-width:820px){ .livestrip{margin-left:0;width:100%;padding-top:6px} }
@@ -435,9 +442,15 @@
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
       <a class="live-seg warn" href="/v1/admin/setup#warnings" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup#awaitingRestart" id="liveWaiting" hidden></a>
+      <button class="live-seg" id="liveCalls" type="button" aria-expanded="false"
+              aria-controls="callLog" title="What this page has asked the gateway, and what came back"></button>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>
+  <div class="calllog" id="callLog" hidden>
+    <table class="inv"><thead><tr><th>When</th><th>Call</th><th>Answered</th><th>Took</th></tr>
+      </thead><tbody id="callLogRows"></tbody></table>
+  </div>
   <p class="lede">Every route this deployment serves, with the scope it needs and a request that
     runs against this host. Served from the gateway itself, so what you read here is what this
     process actually answers.</p>
@@ -546,6 +559,49 @@
     if (status === 504) { return "The backend did not answer in time."; }
     return "The gateway answered " + status + ".";
   };
+
+  window.__matrixarkTrace = (function () {
+    /* The last calls this page made, newest last. Bounded: a portal tab is left open for days and
+       an unbounded list of every request is a leak that only shows on the busiest deployment. */
+    var calls = [], LIMIT = 60;
+    var listeners = [];
+
+    function note(entry) {
+      calls.push(entry);
+      if (calls.length > LIMIT) { calls.shift(); }
+      for (var i = 0; i < listeners.length; i++) {
+        try { listeners[i](calls.length); } catch (e) { /* a listener must not break a request */ }
+      }
+    }
+
+    var original = typeof window.fetch === "function" ? window.fetch : null;
+    if (original) {
+      window.fetch = function (input, init) {
+        var at = Date.now();
+        var method = String((init && init.method) || (input && input.method) || "GET").toUpperCase();
+        var url = String((input && input.url) || input || "");
+        return original.apply(this, arguments).then(function (response) {
+          /* Untouched. Reading the body here to pull out an incident token would consume it and
+             hand the caller an empty one -- breaking the panels this exists to help diagnose. */
+          note({ at: at, ms: Date.now() - at, method: method, url: url, status: response.status });
+          return response;
+        }, function (err) {
+          /* Status 0 is "never answered", which is a different row from a 500 and has to read as
+             one. The message is the browser's own; it is what tells a blocked request from a
+             refused one. */
+          note({ at: at, ms: Date.now() - at, method: method, url: url, status: 0,
+                 detail: (err && err.message) ? String(err.message) : String(err) });
+          throw err;
+        });
+      };
+    }
+
+    return {
+      calls: function () { return calls.slice(); },
+      onChange: function (fn) { if (typeof fn === "function") { listeners.push(fn); } },
+      note: note
+    };
+  }());
 
   window.__matrixarkWhen = function (ms) {
     /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
@@ -1159,7 +1215,21 @@
               if (line.indexOf("event:") === 0) { name = line.slice(6).trim(); }
               else if (line.indexOf("data:") === 0) { payload = line.slice(5).trim(); }
             });
-            if (name === "bye") { planned = true; return; }
+            if (name === "bye") {
+              planned = true;
+              /* The strip has no message line, so the reason goes where a reader can still get at
+                 it: the dot's own title. A goodbye that is a fault leaves the dot down rather than
+                 letting the next keepalive clear it back to live. */
+              try {
+                var why = JSON.parse(payload || "{}");
+                if (why.reason && why.reason !== "stream_max_age") {
+                  dot.className = "live-dot down";
+                  dot.title = "the stream failed on the gateway"
+                    + (why.incident ? " \u2014 incident " + why.incident : "");
+                }
+              } catch (e) { /* an older gateway says goodbye with no body */ }
+              return;
+            }
             if (name !== "status" || !payload) { return; }
             try {
               var frame = JSON.parse(payload);
@@ -1231,6 +1301,76 @@
 
   reveal();
   if (window.addEventListener) { window.addEventListener("hashchange", reveal); }
+}());
+
+/* ---------- what this page asked, and what came back ----------
+ *
+ * Every panel here is drawn from a call, and the only evidence one was made was whether the panel
+ * filled in. When something is wrong the first question is which request failed and what it
+ * answered -- and the only way to find out was the browser's own developer tools, which is a fine
+ * answer for whoever wrote the page and no answer at all for an operator looking at a deployment
+ * they did not build.
+ *
+ * Folded away until asked for: this is a debugging surface, not part of the page's job. */
+(function () {
+  var button = document.getElementById("liveCalls");
+  var panel = document.getElementById("callLog");
+  var rows = document.getElementById("callLogRows");
+  if (!button || !panel || !rows || !window.__matrixarkTrace) { return; }
+
+  function esc(s) {
+    return String(s).replace(/[&<>"]/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c];
+    });
+  }
+
+  /* The path, not the whole URL. Every one of these is this deployment, so the origin is the same
+     on every row and spends the width that the query -- which is what differs -- needs. */
+  function shorten(url) {
+    try {
+      var parsed = new URL(String(url), location.href);
+      return parsed.pathname + (parsed.search || "");
+    } catch (e) { return String(url); }
+  }
+
+  function label(n) {
+    button.hidden = !n;
+    button.textContent = n === 1 ? "1 call" : n + " calls";
+  }
+
+  function render() {
+    var calls = window.__matrixarkTrace.calls();
+    if (!calls.length) {
+      rows.innerHTML = '<tr><td colspan="4">Nothing asked yet.</td></tr>';
+      return;
+    }
+    /* Newest first: the call somebody is trying to explain is the one they just made. */
+    rows.innerHTML = calls.slice().reverse().map(function (c) {
+      /* A status of 0 is "never answered", which is a different row from a 500 and reads as one.
+         The browser's own message is what separates a blocked request from a refused one. */
+      var answered = c.status ? String(c.status) : (c.detail || "never answered");
+      return '<tr class="' + (!c.status || c.status >= 400 ? "bad" : "") + '"><td>'
+        + esc(window.__matrixarkWhen ? window.__matrixarkWhen(c.at) : c.at)
+        + '</td><td class="mono">' + esc(c.method + " " + shorten(c.url))
+        + "</td><td>" + esc(answered)
+        + "</td><td>" + esc(c.ms + " ms") + "</td></tr>";
+    }).join("");
+  }
+
+  button.addEventListener("click", function () {
+    var show = panel.hidden;
+    panel.hidden = !show;
+    button.setAttribute("aria-expanded", show ? "true" : "false");
+    if (show) { render(); }
+  });
+
+  window.__matrixarkTrace.onChange(function (n) {
+    label(n);
+    /* Only while it is open. Rebuilding a hidden table on every request is work nobody asked for
+       on a page that is left open for days. */
+    if (!panel.hidden) { render(); }
+  });
+  label(window.__matrixarkTrace.calls().length);
 }());
 </script>
 </body>

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -88,6 +88,13 @@ NAV_CSS = """
   .live-seg.warn b{color:var(--warn)}
   .live-seg.busy b{color:var(--accent)}
   .live-dot{width:7px;height:7px;border-radius:50%;background:var(--ok);flex:0 0 auto}
+  .calllog{margin:0 0 18px;max-height:340px;overflow:auto;border:1px solid var(--line);
+           border-radius:8px}
+  .calllog table{width:100%;border-collapse:collapse;font-size:12.5px;
+                 font-variant-numeric:tabular-nums}
+  .calllog th,.calllog td{text-align:left;padding:5px 9px;border-bottom:1px solid var(--line)}
+  .calllog td.mono{font-family:"IBM Plex Mono",monospace;font-size:11.5px}
+  .calllog tr.bad td{color:var(--crit)}
   .live-dot.stale{background:var(--warn)}
   .live-dot.down{background:var(--crit)}
   @media (max-width:820px){ .livestrip{margin-left:0;width:100%;padding-top:6px} }
@@ -410,6 +417,49 @@ SHARED_JS = r'''<script>
     return "The gateway answered " + status + ".";
   };
 
+  window.__matrixarkTrace = (function () {
+    /* The last calls this page made, newest last. Bounded: a portal tab is left open for days and
+       an unbounded list of every request is a leak that only shows on the busiest deployment. */
+    var calls = [], LIMIT = 60;
+    var listeners = [];
+
+    function note(entry) {
+      calls.push(entry);
+      if (calls.length > LIMIT) { calls.shift(); }
+      for (var i = 0; i < listeners.length; i++) {
+        try { listeners[i](calls.length); } catch (e) { /* a listener must not break a request */ }
+      }
+    }
+
+    var original = typeof window.fetch === "function" ? window.fetch : null;
+    if (original) {
+      window.fetch = function (input, init) {
+        var at = Date.now();
+        var method = String((init && init.method) || (input && input.method) || "GET").toUpperCase();
+        var url = String((input && input.url) || input || "");
+        return original.apply(this, arguments).then(function (response) {
+          /* Untouched. Reading the body here to pull out an incident token would consume it and
+             hand the caller an empty one -- breaking the panels this exists to help diagnose. */
+          note({ at: at, ms: Date.now() - at, method: method, url: url, status: response.status });
+          return response;
+        }, function (err) {
+          /* Status 0 is "never answered", which is a different row from a 500 and has to read as
+             one. The message is the browser's own; it is what tells a blocked request from a
+             refused one. */
+          note({ at: at, ms: Date.now() - at, method: method, url: url, status: 0,
+                 detail: (err && err.message) ? String(err.message) : String(err) });
+          throw err;
+        });
+      };
+    }
+
+    return {
+      calls: function () { return calls.slice(); },
+      onChange: function (fn) { if (typeof fn === "function") { listeners.push(fn); } },
+      note: note
+    };
+  }());
+
   window.__matrixarkWhen = function (ms) {
     /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
        `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
@@ -695,7 +745,21 @@ NAV_JS = r'''<script>
               if (line.indexOf("event:") === 0) { name = line.slice(6).trim(); }
               else if (line.indexOf("data:") === 0) { payload = line.slice(5).trim(); }
             });
-            if (name === "bye") { planned = true; return; }
+            if (name === "bye") {
+              planned = true;
+              /* The strip has no message line, so the reason goes where a reader can still get at
+                 it: the dot's own title. A goodbye that is a fault leaves the dot down rather than
+                 letting the next keepalive clear it back to live. */
+              try {
+                var why = JSON.parse(payload || "{}");
+                if (why.reason && why.reason !== "stream_max_age") {
+                  dot.className = "live-dot down";
+                  dot.title = "the stream failed on the gateway"
+                    + (why.incident ? " \u2014 incident " + why.incident : "");
+                }
+              } catch (e) { /* an older gateway says goodbye with no body */ }
+              return;
+            }
             if (name !== "status" || !payload) { return; }
             try {
               var frame = JSON.parse(payload);
@@ -768,6 +832,76 @@ NAV_JS = r'''<script>
   reveal();
   if (window.addEventListener) { window.addEventListener("hashchange", reveal); }
 }());
+
+/* ---------- what this page asked, and what came back ----------
+ *
+ * Every panel here is drawn from a call, and the only evidence one was made was whether the panel
+ * filled in. When something is wrong the first question is which request failed and what it
+ * answered -- and the only way to find out was the browser's own developer tools, which is a fine
+ * answer for whoever wrote the page and no answer at all for an operator looking at a deployment
+ * they did not build.
+ *
+ * Folded away until asked for: this is a debugging surface, not part of the page's job. */
+(function () {
+  var button = document.getElementById("liveCalls");
+  var panel = document.getElementById("callLog");
+  var rows = document.getElementById("callLogRows");
+  if (!button || !panel || !rows || !window.__matrixarkTrace) { return; }
+
+  function esc(s) {
+    return String(s).replace(/[&<>"]/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c];
+    });
+  }
+
+  /* The path, not the whole URL. Every one of these is this deployment, so the origin is the same
+     on every row and spends the width that the query -- which is what differs -- needs. */
+  function shorten(url) {
+    try {
+      var parsed = new URL(String(url), location.href);
+      return parsed.pathname + (parsed.search || "");
+    } catch (e) { return String(url); }
+  }
+
+  function label(n) {
+    button.hidden = !n;
+    button.textContent = n === 1 ? "1 call" : n + " calls";
+  }
+
+  function render() {
+    var calls = window.__matrixarkTrace.calls();
+    if (!calls.length) {
+      rows.innerHTML = '<tr><td colspan="4">Nothing asked yet.</td></tr>';
+      return;
+    }
+    /* Newest first: the call somebody is trying to explain is the one they just made. */
+    rows.innerHTML = calls.slice().reverse().map(function (c) {
+      /* A status of 0 is "never answered", which is a different row from a 500 and reads as one.
+         The browser's own message is what separates a blocked request from a refused one. */
+      var answered = c.status ? String(c.status) : (c.detail || "never answered");
+      return '<tr class="' + (!c.status || c.status >= 400 ? "bad" : "") + '"><td>'
+        + esc(window.__matrixarkWhen ? window.__matrixarkWhen(c.at) : c.at)
+        + '</td><td class="mono">' + esc(c.method + " " + shorten(c.url))
+        + "</td><td>" + esc(answered)
+        + "</td><td>" + esc(c.ms + " ms") + "</td></tr>";
+    }).join("");
+  }
+
+  button.addEventListener("click", function () {
+    var show = panel.hidden;
+    panel.hidden = !show;
+    button.setAttribute("aria-expanded", show ? "true" : "false");
+    if (show) { render(); }
+  });
+
+  window.__matrixarkTrace.onChange(function (n) {
+    label(n);
+    /* Only while it is open. Rebuilding a hidden table on every request is work nobody asked for
+       on a page that is left open for days. */
+    if (!panel.hidden) { render(); }
+  });
+  label(window.__matrixarkTrace.calls().length);
+}());
 </script>
 '''
 
@@ -791,8 +925,19 @@ LIVE_STRIP = """
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
       <a class="live-seg warn" href="/v1/admin/setup#warnings" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup#awaitingRestart" id="liveWaiting" hidden></a>
+      <button class="live-seg" id="liveCalls" type="button" aria-expanded="false"
+              aria-controls="callLog" title="What this page has asked the gateway, and what came back"></button>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>"""
+
+# Shown under the nav rather than inside the strip: the strip is a row of single words and this is
+# a table. Present on every page, including the two the builder only injects a nav into, because
+# the question it answers -- which call failed -- is asked on whichever page went wrong.
+CALL_LOG = """
+  <div class="calllog" id="callLog" hidden>
+    <table class="inv"><thead><tr><th>When</th><th>Call</th><th>Answered</th><th>Took</th></tr>
+      </thead><tbody id="callLogRows"></tbody></table>
+  </div>"""
 
 
 def nav(active):
@@ -800,7 +945,7 @@ def nav(active):
     for href, label in NAV_LINKS:
         current = ' aria-current="page"' if href == active else ""
         parts.append('    <a href="%s"%s>%s</a>' % (href, current, label))
-    return ('  <nav class="portalnav">\n' + "\n".join(parts) + LIVE_STRIP + "\n  </nav>")
+    return ('  <nav class="portalnav">\n' + "\n".join(parts) + LIVE_STRIP + "\n  </nav>" + CALL_LOG)
 
 
 LIVE_STREAM_JS = r"""
@@ -904,7 +1049,20 @@ function liveStream(options) {
        that looks only for `data:` hands {"reason": "stream_max_age"} to the frame handler as
        though it were the deployment's state -- and a page rendering from an object with none of
        the fields blanks the traffic table, the failures panel and the strip, every ten minutes. */
-    if (name === "bye") { planned = true; return; }
+    if (name === "bye") {
+      /* A rotation and a fault are both a bye. Treating every bye as planned reconnected at once
+         into a gateway that had just said it was failing -- and `planned` is exactly what makes
+         that reconnect immediate, so a fault has to clear it and take the backoff instead. */
+      var why = null;
+      try { why = JSON.parse(payload || "{}"); } catch (e) { why = null; }
+      if (why && why.reason && why.reason !== "stream_max_age") {
+        planned = false;
+        onState("failed", 0, why.incident || "");
+        return;
+      }
+      planned = true;
+      return;
+    }
     if (name !== "status" || !payload) { return; }
     try {
       var frame = JSON.parse(payload);
@@ -3292,7 +3450,7 @@ SETUP_JS = r"""
     if (live) { live.restart(); return; }
     live = liveStream({
       headers: auth,
-      onState: function (state, seconds) {
+      onState: function (state, seconds, incident) {
         streamLive = (state === "live");
         if (state === "live") { conn("live", "live"); }
         else if (state === "denied") { conn("live", "connected"); }
@@ -3300,6 +3458,12 @@ SETUP_JS = r"""
         /* Connected and receiving nothing. Not "down" -- the socket is open and a reconnect would
            not help -- and not "live", which is what it said before. */
         else if (state === "stalled") { conn("warn", "no update for " + seconds + "s"); }
+        /* The gateway said it was going, and why. Distinct from "stalled", which is a stream that
+           is still open and quiet, and from "retrying", which claims nothing about the cause. */
+        else if (state === "failed") {
+          conn("warn", "the stream failed on the gateway"
+               + (incident ? " \u2014 incident " + incident : ""));
+        }
         if (window.__matrixarkLiveState) {
           window.__matrixarkLiveState(state === "live" ? "live"
             : (state === "retrying" ? "down" : "stale"));
@@ -4164,13 +4328,19 @@ OVERVIEW_JS = r"""
     if (live) { live.restart(); return; }
     live = liveStream({
       headers: auth,
-      onState: function (state, seconds) {
+      onState: function (state, seconds, incident) {
         if (state === "live") { conn("live", "live"); }
         else if (state === "denied") { conn("live", "connected"); }
         else if (state === "retrying") { conn("down", "reconnecting in " + seconds + "s"); }
         /* Connected and receiving nothing. Not "down" -- the socket is open and a reconnect would
            not help -- and not "live", which is what it said before. */
         else if (state === "stalled") { conn("warn", "no update for " + seconds + "s"); }
+        /* The gateway said it was going, and why. Distinct from "stalled", which is a stream that
+           is still open and quiet, and from "retrying", which claims nothing about the cause. */
+        else if (state === "failed") {
+          conn("warn", "the stream failed on the gateway"
+               + (incident ? " \u2014 incident " + incident : ""));
+        }
         if (window.__matrixarkLiveState) {
           window.__matrixarkLiveState(state === "live" ? "live"
             : (state === "retrying" ? "down" : "stale"));
@@ -5896,6 +6066,7 @@ emit("catalog_portal.html", "MatrixArk — Skills & Resources", CATALOG_BODY, CA
 
 
 # ---- add the nav to the two existing pages ------------------------------------------------------
+CALL_LOG_MARKER = '<div class="calllog" id="callLog"'
 SHARED_JS_MARKER = "/* Helpers every page may call"
 TABS_JS_MARKER = "/* Tabs, for every portal page whose body declares a tablist."
 NAV_JS_MARKER = "/* The shared live strip."
@@ -5930,6 +6101,20 @@ def _with_shared_js(text):
         sys.exit(1)
     at = text.index("<script>")
     return text[:at] + SHARED_JS.strip() + chr(10) + text[at:]
+
+
+def _without_call_log(text):
+    """Take out every copy of the call log.
+
+    Every copy, not the first: it is emitted after the closing </nav>, and the nav substitution
+    replaces only up to that tag -- so a page could collect one per build. Taking them all out
+    means a page that collected some heals on the next run rather than carrying them forward.
+    """
+    while CALL_LOG_MARKER in text:
+        start = text.index(CALL_LOG_MARKER)
+        end = text.index("</div>", text.index("</table>", start)) + len("</div>")
+        text = text[:start].rstrip() + text[end:]
+    return text
 
 
 def _with_nav_js(text):
@@ -6003,6 +6188,7 @@ def inject(filename, anchor, active):
     """
     path = os.path.join(PORTAL, filename)
     text = io.open(path, encoding="utf-8").read()
+    text = _without_call_log(text)
     if "portalnav" in text:
         replaced, count = re.subn(r'  <nav class="portalnav">.*?</nav>', lambda _m: nav(active),
                                   text, count=1, flags=re.S)

--- a/tools/portal/bye_reason_harness.js
+++ b/tools/portal/bye_reason_harness.js
@@ -1,0 +1,108 @@
+// Drives the SHIPPED stream client through a goodbye, and reports what the page did about it.
+//
+// A rotation and a fault are both `event: bye`. The client used to set `planned` for either, and
+// `planned` is exactly what makes the next reconnect immediate -- so a gateway that had just said
+// it was failing got reconnected into at once, by a page showing nothing wrong.
+//
+// Usage: node bye_reason_harness.js <page.html> '{"reason":"server_error","incident":"abc"}'
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const input = JSON.parse(process.argv[3] || "{}");
+
+function sliceFn(marker) {
+  const start = page.indexOf(marker);
+  if (start < 0) throw new Error("not found: " + marker);
+  let depth = 0;
+  for (let i = page.indexOf("{", start); i < page.length; i++) {
+    if (page[i] === "{") depth++;
+    else if (page[i] === "}") { depth--; if (depth === 0) return page.slice(start, i + 1); }
+  }
+  throw new Error("unclosed: " + marker);
+}
+
+const ORIGIN = 1_760_000_000_000;
+const clockStart = page.indexOf("var liveServerMs = 0;");
+const source = page.slice(clockStart, page.indexOf("function liveStream(options)"))
+  + "\n" + sliceFn("function liveStream(options)");
+
+let clock = ORIGIN;
+const states = [];
+
+/* The stream opens, sends one frame, then says goodbye and ends. Ending it is what makes the
+   client decide whether to reconnect at once or back off, which is the behaviour under test. */
+const chunks = [
+  "retry: 3000\n\n" + "event: status\ndata: " + JSON.stringify({ ts: 1760000000, tick_s: 2 }) + "\n\n",
+];
+
+/* A PLANNED goodbye reconnects at once, so a harness that serves a fresh stream every time is an
+   infinite loop -- it was, and it exhausted the heap twice. The second connection never answers,
+   rather than refusing: refusing drives the client round again. This bounds the run at one
+   reconnect and still records that one was attempted. */
+let opens = 0;
+
+const scope = {
+  Date: { now: () => clock },
+  fetch: () => (++opens > 1 ? new Promise(() => {}) : Promise.resolve({
+    ok: true,
+    body: {
+      getReader: () => {
+        let step = 0;
+        return {
+          read: () => {
+            step += 1;
+            if (step === 1) { return Promise.resolve({ done: false, value: chunks[0] }); }
+            if (step === 2) {
+              /* Long enough that the client believes a rotation really was one: it checks the
+                 goodbye against how long the stream actually lasted. */
+              clock += input.livedMs === undefined ? 60000 : input.livedMs;
+              return Promise.resolve({
+                done: false,
+                value: "event: bye\ndata: " + JSON.stringify(input.bye || {}) + "\n\n",
+              });
+            }
+            /* A case that only needs to see what the goodbye REPORTED leaves the stream
+               open instead of ending it, so no reconnect is attempted at all. */
+            if (input.keepOpen) { return new Promise(() => {}); }
+            return Promise.resolve({ done: true });
+          },
+        };
+      },
+    },
+  })),
+  TextDecoder: function () { this.decode = (v) => (v === undefined ? "" : String(v)); },
+  AbortController: function () { this.abort = () => {}; this.signal = null; },
+  document: { hidden: false, addEventListener: () => {} },
+  window: { addEventListener: () => {} },
+  setTimeout: () => 0,
+  setInterval: () => 1,
+  clearInterval: () => {},
+};
+
+const names = Object.keys(scope);
+const liveStream = new Function(...names, source + "; return liveStream;")(
+  ...names.map((k) => scope[k]));
+
+liveStream({
+  headers: () => ({}),
+  onState: (state, seconds, incident) =>
+    states.push({ state: state, seconds: seconds, incident: incident || "" }),
+  onFrame: () => {},
+});
+
+const wait = () => new Promise((r) => globalThis.setTimeout(r, 15));
+
+(async () => {
+  await wait();
+  const seen = states.map((s) => s.state);
+  process.stdout.write(JSON.stringify({
+    states: states,
+    /* "connecting" after the goodbye means it reconnected AT ONCE; "retrying" means it backed
+       off. A fault must take the second road. */
+    reconnectedImmediately: opens > 1,
+    backedOff: seen.includes("retrying"),
+    reportedAFault: seen.includes("failed"),
+    faultIncident: (states.find((s) => s.state === "failed") || {}).incident || "",
+  }, null, 1));
+})();

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -186,6 +186,13 @@
   .live-seg.warn b{color:var(--warn)}
   .live-seg.busy b{color:var(--accent)}
   .live-dot{width:7px;height:7px;border-radius:50%;background:var(--ok);flex:0 0 auto}
+  .calllog{margin:0 0 18px;max-height:340px;overflow:auto;border:1px solid var(--line);
+           border-radius:8px}
+  .calllog table{width:100%;border-collapse:collapse;font-size:12.5px;
+                 font-variant-numeric:tabular-nums}
+  .calllog th,.calllog td{text-align:left;padding:5px 9px;border-bottom:1px solid var(--line)}
+  .calllog td.mono{font-family:"IBM Plex Mono",monospace;font-size:11.5px}
+  .calllog tr.bad td{color:var(--crit)}
   .live-dot.stale{background:var(--warn)}
   .live-dot.down{background:var(--crit)}
   @media (max-width:820px){ .livestrip{margin-left:0;width:100%;padding-top:6px} }
@@ -435,9 +442,15 @@
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
       <a class="live-seg warn" href="/v1/admin/setup#warnings" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup#awaitingRestart" id="liveWaiting" hidden></a>
+      <button class="live-seg" id="liveCalls" type="button" aria-expanded="false"
+              aria-controls="callLog" title="What this page has asked the gateway, and what came back"></button>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>
+  <div class="calllog" id="callLog" hidden>
+    <table class="inv"><thead><tr><th>When</th><th>Call</th><th>Answered</th><th>Took</th></tr>
+      </thead><tbody id="callLogRows"></tbody></table>
+  </div>
   <p class="lede">What this deployment actually holds: every governed skill and resource visible to a
     scope, and the stored text behind any one of them.</p>
 
@@ -600,6 +613,49 @@
     if (status === 504) { return "The backend did not answer in time."; }
     return "The gateway answered " + status + ".";
   };
+
+  window.__matrixarkTrace = (function () {
+    /* The last calls this page made, newest last. Bounded: a portal tab is left open for days and
+       an unbounded list of every request is a leak that only shows on the busiest deployment. */
+    var calls = [], LIMIT = 60;
+    var listeners = [];
+
+    function note(entry) {
+      calls.push(entry);
+      if (calls.length > LIMIT) { calls.shift(); }
+      for (var i = 0; i < listeners.length; i++) {
+        try { listeners[i](calls.length); } catch (e) { /* a listener must not break a request */ }
+      }
+    }
+
+    var original = typeof window.fetch === "function" ? window.fetch : null;
+    if (original) {
+      window.fetch = function (input, init) {
+        var at = Date.now();
+        var method = String((init && init.method) || (input && input.method) || "GET").toUpperCase();
+        var url = String((input && input.url) || input || "");
+        return original.apply(this, arguments).then(function (response) {
+          /* Untouched. Reading the body here to pull out an incident token would consume it and
+             hand the caller an empty one -- breaking the panels this exists to help diagnose. */
+          note({ at: at, ms: Date.now() - at, method: method, url: url, status: response.status });
+          return response;
+        }, function (err) {
+          /* Status 0 is "never answered", which is a different row from a 500 and has to read as
+             one. The message is the browser's own; it is what tells a blocked request from a
+             refused one. */
+          note({ at: at, ms: Date.now() - at, method: method, url: url, status: 0,
+                 detail: (err && err.message) ? String(err.message) : String(err) });
+          throw err;
+        });
+      };
+    }
+
+    return {
+      calls: function () { return calls.slice(); },
+      onChange: function (fn) { if (typeof fn === "function") { listeners.push(fn); } },
+      note: note
+    };
+  }());
 
   window.__matrixarkWhen = function (ms) {
     /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
@@ -1300,7 +1356,21 @@
               if (line.indexOf("event:") === 0) { name = line.slice(6).trim(); }
               else if (line.indexOf("data:") === 0) { payload = line.slice(5).trim(); }
             });
-            if (name === "bye") { planned = true; return; }
+            if (name === "bye") {
+              planned = true;
+              /* The strip has no message line, so the reason goes where a reader can still get at
+                 it: the dot's own title. A goodbye that is a fault leaves the dot down rather than
+                 letting the next keepalive clear it back to live. */
+              try {
+                var why = JSON.parse(payload || "{}");
+                if (why.reason && why.reason !== "stream_max_age") {
+                  dot.className = "live-dot down";
+                  dot.title = "the stream failed on the gateway"
+                    + (why.incident ? " \u2014 incident " + why.incident : "");
+                }
+              } catch (e) { /* an older gateway says goodbye with no body */ }
+              return;
+            }
             if (name !== "status" || !payload) { return; }
             try {
               var frame = JSON.parse(payload);
@@ -1372,6 +1442,76 @@
 
   reveal();
   if (window.addEventListener) { window.addEventListener("hashchange", reveal); }
+}());
+
+/* ---------- what this page asked, and what came back ----------
+ *
+ * Every panel here is drawn from a call, and the only evidence one was made was whether the panel
+ * filled in. When something is wrong the first question is which request failed and what it
+ * answered -- and the only way to find out was the browser's own developer tools, which is a fine
+ * answer for whoever wrote the page and no answer at all for an operator looking at a deployment
+ * they did not build.
+ *
+ * Folded away until asked for: this is a debugging surface, not part of the page's job. */
+(function () {
+  var button = document.getElementById("liveCalls");
+  var panel = document.getElementById("callLog");
+  var rows = document.getElementById("callLogRows");
+  if (!button || !panel || !rows || !window.__matrixarkTrace) { return; }
+
+  function esc(s) {
+    return String(s).replace(/[&<>"]/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c];
+    });
+  }
+
+  /* The path, not the whole URL. Every one of these is this deployment, so the origin is the same
+     on every row and spends the width that the query -- which is what differs -- needs. */
+  function shorten(url) {
+    try {
+      var parsed = new URL(String(url), location.href);
+      return parsed.pathname + (parsed.search || "");
+    } catch (e) { return String(url); }
+  }
+
+  function label(n) {
+    button.hidden = !n;
+    button.textContent = n === 1 ? "1 call" : n + " calls";
+  }
+
+  function render() {
+    var calls = window.__matrixarkTrace.calls();
+    if (!calls.length) {
+      rows.innerHTML = '<tr><td colspan="4">Nothing asked yet.</td></tr>';
+      return;
+    }
+    /* Newest first: the call somebody is trying to explain is the one they just made. */
+    rows.innerHTML = calls.slice().reverse().map(function (c) {
+      /* A status of 0 is "never answered", which is a different row from a 500 and reads as one.
+         The browser's own message is what separates a blocked request from a refused one. */
+      var answered = c.status ? String(c.status) : (c.detail || "never answered");
+      return '<tr class="' + (!c.status || c.status >= 400 ? "bad" : "") + '"><td>'
+        + esc(window.__matrixarkWhen ? window.__matrixarkWhen(c.at) : c.at)
+        + '</td><td class="mono">' + esc(c.method + " " + shorten(c.url))
+        + "</td><td>" + esc(answered)
+        + "</td><td>" + esc(c.ms + " ms") + "</td></tr>";
+    }).join("");
+  }
+
+  button.addEventListener("click", function () {
+    var show = panel.hidden;
+    panel.hidden = !show;
+    button.setAttribute("aria-expanded", show ? "true" : "false");
+    if (show) { render(); }
+  });
+
+  window.__matrixarkTrace.onChange(function (n) {
+    label(n);
+    /* Only while it is open. Rebuilding a hidden table on every request is work nobody asked for
+       on a page that is left open for days. */
+    if (!panel.hidden) { render(); }
+  });
+  label(window.__matrixarkTrace.calls().length);
 }());
 </script>
 </body>

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -186,6 +186,13 @@
   .live-seg.warn b{color:var(--warn)}
   .live-seg.busy b{color:var(--accent)}
   .live-dot{width:7px;height:7px;border-radius:50%;background:var(--ok);flex:0 0 auto}
+  .calllog{margin:0 0 18px;max-height:340px;overflow:auto;border:1px solid var(--line);
+           border-radius:8px}
+  .calllog table{width:100%;border-collapse:collapse;font-size:12.5px;
+                 font-variant-numeric:tabular-nums}
+  .calllog th,.calllog td{text-align:left;padding:5px 9px;border-bottom:1px solid var(--line)}
+  .calllog td.mono{font-family:"IBM Plex Mono",monospace;font-size:11.5px}
+  .calllog tr.bad td{color:var(--crit)}
   .live-dot.stale{background:var(--warn)}
   .live-dot.down{background:var(--crit)}
   @media (max-width:820px){ .livestrip{margin-left:0;width:100%;padding-top:6px} }
@@ -435,9 +442,15 @@
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
       <a class="live-seg warn" href="/v1/admin/setup#warnings" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup#awaitingRestart" id="liveWaiting" hidden></a>
+      <button class="live-seg" id="liveCalls" type="button" aria-expanded="false"
+              aria-controls="callLog" title="What this page has asked the gateway, and what came back"></button>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>
+  <div class="calllog" id="callLog" hidden>
+    <table class="inv"><thead><tr><th>When</th><th>Call</th><th>Answered</th><th>Took</th></tr>
+      </thead><tbody id="callLogRows"></tbody></table>
+  </div>
   <p class="lede">Run the pipeline against your own data: ingest a note, ask a question, read what
     comes back. A retrieve that returns the right thing is the only check that covers ingestion,
     extraction, encoding and ranking at once.</p>
@@ -687,6 +700,49 @@
     if (status === 504) { return "The backend did not answer in time."; }
     return "The gateway answered " + status + ".";
   };
+
+  window.__matrixarkTrace = (function () {
+    /* The last calls this page made, newest last. Bounded: a portal tab is left open for days and
+       an unbounded list of every request is a leak that only shows on the busiest deployment. */
+    var calls = [], LIMIT = 60;
+    var listeners = [];
+
+    function note(entry) {
+      calls.push(entry);
+      if (calls.length > LIMIT) { calls.shift(); }
+      for (var i = 0; i < listeners.length; i++) {
+        try { listeners[i](calls.length); } catch (e) { /* a listener must not break a request */ }
+      }
+    }
+
+    var original = typeof window.fetch === "function" ? window.fetch : null;
+    if (original) {
+      window.fetch = function (input, init) {
+        var at = Date.now();
+        var method = String((init && init.method) || (input && input.method) || "GET").toUpperCase();
+        var url = String((input && input.url) || input || "");
+        return original.apply(this, arguments).then(function (response) {
+          /* Untouched. Reading the body here to pull out an incident token would consume it and
+             hand the caller an empty one -- breaking the panels this exists to help diagnose. */
+          note({ at: at, ms: Date.now() - at, method: method, url: url, status: response.status });
+          return response;
+        }, function (err) {
+          /* Status 0 is "never answered", which is a different row from a 500 and has to read as
+             one. The message is the browser's own; it is what tells a blocked request from a
+             refused one. */
+          note({ at: at, ms: Date.now() - at, method: method, url: url, status: 0,
+                 detail: (err && err.message) ? String(err.message) : String(err) });
+          throw err;
+        });
+      };
+    }
+
+    return {
+      calls: function () { return calls.slice(); },
+      onChange: function (fn) { if (typeof fn === "function") { listeners.push(fn); } },
+      note: note
+    };
+  }());
 
   window.__matrixarkWhen = function (ms) {
     /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
@@ -2244,7 +2300,21 @@
               if (line.indexOf("event:") === 0) { name = line.slice(6).trim(); }
               else if (line.indexOf("data:") === 0) { payload = line.slice(5).trim(); }
             });
-            if (name === "bye") { planned = true; return; }
+            if (name === "bye") {
+              planned = true;
+              /* The strip has no message line, so the reason goes where a reader can still get at
+                 it: the dot's own title. A goodbye that is a fault leaves the dot down rather than
+                 letting the next keepalive clear it back to live. */
+              try {
+                var why = JSON.parse(payload || "{}");
+                if (why.reason && why.reason !== "stream_max_age") {
+                  dot.className = "live-dot down";
+                  dot.title = "the stream failed on the gateway"
+                    + (why.incident ? " \u2014 incident " + why.incident : "");
+                }
+              } catch (e) { /* an older gateway says goodbye with no body */ }
+              return;
+            }
             if (name !== "status" || !payload) { return; }
             try {
               var frame = JSON.parse(payload);
@@ -2316,6 +2386,76 @@
 
   reveal();
   if (window.addEventListener) { window.addEventListener("hashchange", reveal); }
+}());
+
+/* ---------- what this page asked, and what came back ----------
+ *
+ * Every panel here is drawn from a call, and the only evidence one was made was whether the panel
+ * filled in. When something is wrong the first question is which request failed and what it
+ * answered -- and the only way to find out was the browser's own developer tools, which is a fine
+ * answer for whoever wrote the page and no answer at all for an operator looking at a deployment
+ * they did not build.
+ *
+ * Folded away until asked for: this is a debugging surface, not part of the page's job. */
+(function () {
+  var button = document.getElementById("liveCalls");
+  var panel = document.getElementById("callLog");
+  var rows = document.getElementById("callLogRows");
+  if (!button || !panel || !rows || !window.__matrixarkTrace) { return; }
+
+  function esc(s) {
+    return String(s).replace(/[&<>"]/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c];
+    });
+  }
+
+  /* The path, not the whole URL. Every one of these is this deployment, so the origin is the same
+     on every row and spends the width that the query -- which is what differs -- needs. */
+  function shorten(url) {
+    try {
+      var parsed = new URL(String(url), location.href);
+      return parsed.pathname + (parsed.search || "");
+    } catch (e) { return String(url); }
+  }
+
+  function label(n) {
+    button.hidden = !n;
+    button.textContent = n === 1 ? "1 call" : n + " calls";
+  }
+
+  function render() {
+    var calls = window.__matrixarkTrace.calls();
+    if (!calls.length) {
+      rows.innerHTML = '<tr><td colspan="4">Nothing asked yet.</td></tr>';
+      return;
+    }
+    /* Newest first: the call somebody is trying to explain is the one they just made. */
+    rows.innerHTML = calls.slice().reverse().map(function (c) {
+      /* A status of 0 is "never answered", which is a different row from a 500 and reads as one.
+         The browser's own message is what separates a blocked request from a refused one. */
+      var answered = c.status ? String(c.status) : (c.detail || "never answered");
+      return '<tr class="' + (!c.status || c.status >= 400 ? "bad" : "") + '"><td>'
+        + esc(window.__matrixarkWhen ? window.__matrixarkWhen(c.at) : c.at)
+        + '</td><td class="mono">' + esc(c.method + " " + shorten(c.url))
+        + "</td><td>" + esc(answered)
+        + "</td><td>" + esc(c.ms + " ms") + "</td></tr>";
+    }).join("");
+  }
+
+  button.addEventListener("click", function () {
+    var show = panel.hidden;
+    panel.hidden = !show;
+    button.setAttribute("aria-expanded", show ? "true" : "false");
+    if (show) { render(); }
+  });
+
+  window.__matrixarkTrace.onChange(function (n) {
+    label(n);
+    /* Only while it is open. Rebuilding a hidden table on every request is work nobody asked for
+       on a page that is left open for days. */
+    if (!panel.hidden) { render(); }
+  });
+  label(window.__matrixarkTrace.calls().length);
 }());
 </script>
 </body>

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -182,6 +182,13 @@
   .live-seg.warn b{color:var(--warn)}
   .live-seg.busy b{color:var(--accent)}
   .live-dot{width:7px;height:7px;border-radius:50%;background:var(--ok);flex:0 0 auto}
+  .calllog{margin:0 0 18px;max-height:340px;overflow:auto;border:1px solid var(--line);
+           border-radius:8px}
+  .calllog table{width:100%;border-collapse:collapse;font-size:12.5px;
+                 font-variant-numeric:tabular-nums}
+  .calllog th,.calllog td{text-align:left;padding:5px 9px;border-bottom:1px solid var(--line)}
+  .calllog td.mono{font-family:"IBM Plex Mono",monospace;font-size:11.5px}
+  .calllog tr.bad td{color:var(--crit)}
   .live-dot.stale{background:var(--warn)}
   .live-dot.down{background:var(--crit)}
   @media (max-width:820px){ .livestrip{margin-left:0;width:100%;padding-top:6px} }
@@ -214,9 +221,15 @@
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
       <a class="live-seg warn" href="/v1/admin/setup#warnings" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup#awaitingRestart" id="liveWaiting" hidden></a>
+      <button class="live-seg" id="liveCalls" type="button" aria-expanded="false"
+              aria-controls="callLog" title="What this page has asked the gateway, and what came back"></button>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>
+  <div class="calllog" id="callLog" hidden>
+    <table class="inv"><thead><tr><th>When</th><th>Call</th><th>Answered</th><th>Took</th></tr>
+      </thead><tbody id="callLogRows"></tbody></table>
+  </div>
   <p class="lede">Point MatrixArk at a set of skill documents, watch the import run, and confirm the
     deployment is configured the way you expect before you commit to a long one.</p>
 
@@ -379,6 +392,49 @@
     if (status === 504) { return "The backend did not answer in time."; }
     return "The gateway answered " + status + ".";
   };
+
+  window.__matrixarkTrace = (function () {
+    /* The last calls this page made, newest last. Bounded: a portal tab is left open for days and
+       an unbounded list of every request is a leak that only shows on the busiest deployment. */
+    var calls = [], LIMIT = 60;
+    var listeners = [];
+
+    function note(entry) {
+      calls.push(entry);
+      if (calls.length > LIMIT) { calls.shift(); }
+      for (var i = 0; i < listeners.length; i++) {
+        try { listeners[i](calls.length); } catch (e) { /* a listener must not break a request */ }
+      }
+    }
+
+    var original = typeof window.fetch === "function" ? window.fetch : null;
+    if (original) {
+      window.fetch = function (input, init) {
+        var at = Date.now();
+        var method = String((init && init.method) || (input && input.method) || "GET").toUpperCase();
+        var url = String((input && input.url) || input || "");
+        return original.apply(this, arguments).then(function (response) {
+          /* Untouched. Reading the body here to pull out an incident token would consume it and
+             hand the caller an empty one -- breaking the panels this exists to help diagnose. */
+          note({ at: at, ms: Date.now() - at, method: method, url: url, status: response.status });
+          return response;
+        }, function (err) {
+          /* Status 0 is "never answered", which is a different row from a 500 and has to read as
+             one. The message is the browser's own; it is what tells a blocked request from a
+             refused one. */
+          note({ at: at, ms: Date.now() - at, method: method, url: url, status: 0,
+                 detail: (err && err.message) ? String(err.message) : String(err) });
+          throw err;
+        });
+      };
+    }
+
+    return {
+      calls: function () { return calls.slice(); },
+      onChange: function (fn) { if (typeof fn === "function") { listeners.push(fn); } },
+      note: note
+    };
+  }());
 
   window.__matrixarkWhen = function (ms) {
     /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
@@ -1172,7 +1228,21 @@
               if (line.indexOf("event:") === 0) { name = line.slice(6).trim(); }
               else if (line.indexOf("data:") === 0) { payload = line.slice(5).trim(); }
             });
-            if (name === "bye") { planned = true; return; }
+            if (name === "bye") {
+              planned = true;
+              /* The strip has no message line, so the reason goes where a reader can still get at
+                 it: the dot's own title. A goodbye that is a fault leaves the dot down rather than
+                 letting the next keepalive clear it back to live. */
+              try {
+                var why = JSON.parse(payload || "{}");
+                if (why.reason && why.reason !== "stream_max_age") {
+                  dot.className = "live-dot down";
+                  dot.title = "the stream failed on the gateway"
+                    + (why.incident ? " \u2014 incident " + why.incident : "");
+                }
+              } catch (e) { /* an older gateway says goodbye with no body */ }
+              return;
+            }
             if (name !== "status" || !payload) { return; }
             try {
               var frame = JSON.parse(payload);
@@ -1244,6 +1314,76 @@
 
   reveal();
   if (window.addEventListener) { window.addEventListener("hashchange", reveal); }
+}());
+
+/* ---------- what this page asked, and what came back ----------
+ *
+ * Every panel here is drawn from a call, and the only evidence one was made was whether the panel
+ * filled in. When something is wrong the first question is which request failed and what it
+ * answered -- and the only way to find out was the browser's own developer tools, which is a fine
+ * answer for whoever wrote the page and no answer at all for an operator looking at a deployment
+ * they did not build.
+ *
+ * Folded away until asked for: this is a debugging surface, not part of the page's job. */
+(function () {
+  var button = document.getElementById("liveCalls");
+  var panel = document.getElementById("callLog");
+  var rows = document.getElementById("callLogRows");
+  if (!button || !panel || !rows || !window.__matrixarkTrace) { return; }
+
+  function esc(s) {
+    return String(s).replace(/[&<>"]/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c];
+    });
+  }
+
+  /* The path, not the whole URL. Every one of these is this deployment, so the origin is the same
+     on every row and spends the width that the query -- which is what differs -- needs. */
+  function shorten(url) {
+    try {
+      var parsed = new URL(String(url), location.href);
+      return parsed.pathname + (parsed.search || "");
+    } catch (e) { return String(url); }
+  }
+
+  function label(n) {
+    button.hidden = !n;
+    button.textContent = n === 1 ? "1 call" : n + " calls";
+  }
+
+  function render() {
+    var calls = window.__matrixarkTrace.calls();
+    if (!calls.length) {
+      rows.innerHTML = '<tr><td colspan="4">Nothing asked yet.</td></tr>';
+      return;
+    }
+    /* Newest first: the call somebody is trying to explain is the one they just made. */
+    rows.innerHTML = calls.slice().reverse().map(function (c) {
+      /* A status of 0 is "never answered", which is a different row from a 500 and reads as one.
+         The browser's own message is what separates a blocked request from a refused one. */
+      var answered = c.status ? String(c.status) : (c.detail || "never answered");
+      return '<tr class="' + (!c.status || c.status >= 400 ? "bad" : "") + '"><td>'
+        + esc(window.__matrixarkWhen ? window.__matrixarkWhen(c.at) : c.at)
+        + '</td><td class="mono">' + esc(c.method + " " + shorten(c.url))
+        + "</td><td>" + esc(answered)
+        + "</td><td>" + esc(c.ms + " ms") + "</td></tr>";
+    }).join("");
+  }
+
+  button.addEventListener("click", function () {
+    var show = panel.hidden;
+    panel.hidden = !show;
+    button.setAttribute("aria-expanded", show ? "true" : "false");
+    if (show) { render(); }
+  });
+
+  window.__matrixarkTrace.onChange(function (n) {
+    label(n);
+    /* Only while it is open. Rebuilding a hidden table on every request is work nobody asked for
+       on a page that is left open for days. */
+    if (!panel.hidden) { render(); }
+  });
+  label(window.__matrixarkTrace.calls().length);
 }());
 </script>
 </body>

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -186,6 +186,13 @@
   .live-seg.warn b{color:var(--warn)}
   .live-seg.busy b{color:var(--accent)}
   .live-dot{width:7px;height:7px;border-radius:50%;background:var(--ok);flex:0 0 auto}
+  .calllog{margin:0 0 18px;max-height:340px;overflow:auto;border:1px solid var(--line);
+           border-radius:8px}
+  .calllog table{width:100%;border-collapse:collapse;font-size:12.5px;
+                 font-variant-numeric:tabular-nums}
+  .calllog th,.calllog td{text-align:left;padding:5px 9px;border-bottom:1px solid var(--line)}
+  .calllog td.mono{font-family:"IBM Plex Mono",monospace;font-size:11.5px}
+  .calllog tr.bad td{color:var(--crit)}
   .live-dot.stale{background:var(--warn)}
   .live-dot.down{background:var(--crit)}
   @media (max-width:820px){ .livestrip{margin-left:0;width:100%;padding-top:6px} }
@@ -435,9 +442,15 @@
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
       <a class="live-seg warn" href="/v1/admin/setup#warnings" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup#awaitingRestart" id="liveWaiting" hidden></a>
+      <button class="live-seg" id="liveCalls" type="button" aria-expanded="false"
+              aria-controls="callLog" title="What this page has asked the gateway, and what came back"></button>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>
+  <div class="calllog" id="callLog" hidden>
+    <table class="inv"><thead><tr><th>When</th><th>Call</th><th>Answered</th><th>Took</th></tr>
+      </thead><tbody id="callLogRows"></tbody></table>
+  </div>
   <p class="lede">Where this deployment stands. Every item below fails quietly on its own — an
     unconfigured model still answers 200, an unset ingestion root only surfaces when an import is
     refused — so they are worth reading once even when nothing looks wrong.</p>
@@ -581,6 +594,49 @@
     return "The gateway answered " + status + ".";
   };
 
+  window.__matrixarkTrace = (function () {
+    /* The last calls this page made, newest last. Bounded: a portal tab is left open for days and
+       an unbounded list of every request is a leak that only shows on the busiest deployment. */
+    var calls = [], LIMIT = 60;
+    var listeners = [];
+
+    function note(entry) {
+      calls.push(entry);
+      if (calls.length > LIMIT) { calls.shift(); }
+      for (var i = 0; i < listeners.length; i++) {
+        try { listeners[i](calls.length); } catch (e) { /* a listener must not break a request */ }
+      }
+    }
+
+    var original = typeof window.fetch === "function" ? window.fetch : null;
+    if (original) {
+      window.fetch = function (input, init) {
+        var at = Date.now();
+        var method = String((init && init.method) || (input && input.method) || "GET").toUpperCase();
+        var url = String((input && input.url) || input || "");
+        return original.apply(this, arguments).then(function (response) {
+          /* Untouched. Reading the body here to pull out an incident token would consume it and
+             hand the caller an empty one -- breaking the panels this exists to help diagnose. */
+          note({ at: at, ms: Date.now() - at, method: method, url: url, status: response.status });
+          return response;
+        }, function (err) {
+          /* Status 0 is "never answered", which is a different row from a 500 and has to read as
+             one. The message is the browser's own; it is what tells a blocked request from a
+             refused one. */
+          note({ at: at, ms: Date.now() - at, method: method, url: url, status: 0,
+                 detail: (err && err.message) ? String(err.message) : String(err) });
+          throw err;
+        });
+      };
+    }
+
+    return {
+      calls: function () { return calls.slice(); },
+      onChange: function (fn) { if (typeof fn === "function") { listeners.push(fn); } },
+      note: note
+    };
+  }());
+
   window.__matrixarkWhen = function (ms) {
     /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
        `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
@@ -700,7 +756,20 @@ function liveStream(options) {
        that looks only for `data:` hands {"reason": "stream_max_age"} to the frame handler as
        though it were the deployment's state -- and a page rendering from an object with none of
        the fields blanks the traffic table, the failures panel and the strip, every ten minutes. */
-    if (name === "bye") { planned = true; return; }
+    if (name === "bye") {
+      /* A rotation and a fault are both a bye. Treating every bye as planned reconnected at once
+         into a gateway that had just said it was failing -- and `planned` is exactly what makes
+         that reconnect immediate, so a fault has to clear it and take the backoff instead. */
+      var why = null;
+      try { why = JSON.parse(payload || "{}"); } catch (e) { why = null; }
+      if (why && why.reason && why.reason !== "stream_max_age") {
+        planned = false;
+        onState("failed", 0, why.incident || "");
+        return;
+      }
+      planned = true;
+      return;
+    }
     if (name !== "status" || !payload) { return; }
     try {
       var frame = JSON.parse(payload);
@@ -1077,13 +1146,19 @@ function liveStream(options) {
     if (live) { live.restart(); return; }
     live = liveStream({
       headers: auth,
-      onState: function (state, seconds) {
+      onState: function (state, seconds, incident) {
         if (state === "live") { conn("live", "live"); }
         else if (state === "denied") { conn("live", "connected"); }
         else if (state === "retrying") { conn("down", "reconnecting in " + seconds + "s"); }
         /* Connected and receiving nothing. Not "down" -- the socket is open and a reconnect would
            not help -- and not "live", which is what it said before. */
         else if (state === "stalled") { conn("warn", "no update for " + seconds + "s"); }
+        /* The gateway said it was going, and why. Distinct from "stalled", which is a stream that
+           is still open and quiet, and from "retrying", which claims nothing about the cause. */
+        else if (state === "failed") {
+          conn("warn", "the stream failed on the gateway"
+               + (incident ? " \u2014 incident " + incident : ""));
+        }
         if (window.__matrixarkLiveState) {
           window.__matrixarkLiveState(state === "live" ? "live"
             : (state === "retrying" ? "down" : "stale"));
@@ -1448,7 +1523,21 @@ function liveStream(options) {
               if (line.indexOf("event:") === 0) { name = line.slice(6).trim(); }
               else if (line.indexOf("data:") === 0) { payload = line.slice(5).trim(); }
             });
-            if (name === "bye") { planned = true; return; }
+            if (name === "bye") {
+              planned = true;
+              /* The strip has no message line, so the reason goes where a reader can still get at
+                 it: the dot's own title. A goodbye that is a fault leaves the dot down rather than
+                 letting the next keepalive clear it back to live. */
+              try {
+                var why = JSON.parse(payload || "{}");
+                if (why.reason && why.reason !== "stream_max_age") {
+                  dot.className = "live-dot down";
+                  dot.title = "the stream failed on the gateway"
+                    + (why.incident ? " \u2014 incident " + why.incident : "");
+                }
+              } catch (e) { /* an older gateway says goodbye with no body */ }
+              return;
+            }
             if (name !== "status" || !payload) { return; }
             try {
               var frame = JSON.parse(payload);
@@ -1520,6 +1609,76 @@ function liveStream(options) {
 
   reveal();
   if (window.addEventListener) { window.addEventListener("hashchange", reveal); }
+}());
+
+/* ---------- what this page asked, and what came back ----------
+ *
+ * Every panel here is drawn from a call, and the only evidence one was made was whether the panel
+ * filled in. When something is wrong the first question is which request failed and what it
+ * answered -- and the only way to find out was the browser's own developer tools, which is a fine
+ * answer for whoever wrote the page and no answer at all for an operator looking at a deployment
+ * they did not build.
+ *
+ * Folded away until asked for: this is a debugging surface, not part of the page's job. */
+(function () {
+  var button = document.getElementById("liveCalls");
+  var panel = document.getElementById("callLog");
+  var rows = document.getElementById("callLogRows");
+  if (!button || !panel || !rows || !window.__matrixarkTrace) { return; }
+
+  function esc(s) {
+    return String(s).replace(/[&<>"]/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c];
+    });
+  }
+
+  /* The path, not the whole URL. Every one of these is this deployment, so the origin is the same
+     on every row and spends the width that the query -- which is what differs -- needs. */
+  function shorten(url) {
+    try {
+      var parsed = new URL(String(url), location.href);
+      return parsed.pathname + (parsed.search || "");
+    } catch (e) { return String(url); }
+  }
+
+  function label(n) {
+    button.hidden = !n;
+    button.textContent = n === 1 ? "1 call" : n + " calls";
+  }
+
+  function render() {
+    var calls = window.__matrixarkTrace.calls();
+    if (!calls.length) {
+      rows.innerHTML = '<tr><td colspan="4">Nothing asked yet.</td></tr>';
+      return;
+    }
+    /* Newest first: the call somebody is trying to explain is the one they just made. */
+    rows.innerHTML = calls.slice().reverse().map(function (c) {
+      /* A status of 0 is "never answered", which is a different row from a 500 and reads as one.
+         The browser's own message is what separates a blocked request from a refused one. */
+      var answered = c.status ? String(c.status) : (c.detail || "never answered");
+      return '<tr class="' + (!c.status || c.status >= 400 ? "bad" : "") + '"><td>'
+        + esc(window.__matrixarkWhen ? window.__matrixarkWhen(c.at) : c.at)
+        + '</td><td class="mono">' + esc(c.method + " " + shorten(c.url))
+        + "</td><td>" + esc(answered)
+        + "</td><td>" + esc(c.ms + " ms") + "</td></tr>";
+    }).join("");
+  }
+
+  button.addEventListener("click", function () {
+    var show = panel.hidden;
+    panel.hidden = !show;
+    button.setAttribute("aria-expanded", show ? "true" : "false");
+    if (show) { render(); }
+  });
+
+  window.__matrixarkTrace.onChange(function (n) {
+    label(n);
+    /* Only while it is open. Rebuilding a hidden table on every request is work nobody asked for
+       on a page that is left open for days. */
+    if (!panel.hidden) { render(); }
+  });
+  label(window.__matrixarkTrace.calls().length);
 }());
 </script>
 </body>

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -186,6 +186,13 @@
   .live-seg.warn b{color:var(--warn)}
   .live-seg.busy b{color:var(--accent)}
   .live-dot{width:7px;height:7px;border-radius:50%;background:var(--ok);flex:0 0 auto}
+  .calllog{margin:0 0 18px;max-height:340px;overflow:auto;border:1px solid var(--line);
+           border-radius:8px}
+  .calllog table{width:100%;border-collapse:collapse;font-size:12.5px;
+                 font-variant-numeric:tabular-nums}
+  .calllog th,.calllog td{text-align:left;padding:5px 9px;border-bottom:1px solid var(--line)}
+  .calllog td.mono{font-family:"IBM Plex Mono",monospace;font-size:11.5px}
+  .calllog tr.bad td{color:var(--crit)}
   .live-dot.stale{background:var(--warn)}
   .live-dot.down{background:var(--crit)}
   @media (max-width:820px){ .livestrip{margin-left:0;width:100%;padding-top:6px} }
@@ -435,9 +442,15 @@
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
       <a class="live-seg warn" href="/v1/admin/setup#warnings" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup#awaitingRestart" id="liveWaiting" hidden></a>
+      <button class="live-seg" id="liveCalls" type="button" aria-expanded="false"
+              aria-controls="callLog" title="What this page has asked the gateway, and what came back"></button>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>
+  <div class="calllog" id="callLog" hidden>
+    <table class="inv"><thead><tr><th>When</th><th>Call</th><th>Answered</th><th>Took</th></tr>
+      </thead><tbody id="callLogRows"></tbody></table>
+  </div>
   <p class="lede">Point this deployment at the models it should use, confirm the endpoints actually
     answer, tune what it does with them, and see the traffic it is serving — without shell access
     to the server.</p>
@@ -836,6 +849,49 @@
     return "The gateway answered " + status + ".";
   };
 
+  window.__matrixarkTrace = (function () {
+    /* The last calls this page made, newest last. Bounded: a portal tab is left open for days and
+       an unbounded list of every request is a leak that only shows on the busiest deployment. */
+    var calls = [], LIMIT = 60;
+    var listeners = [];
+
+    function note(entry) {
+      calls.push(entry);
+      if (calls.length > LIMIT) { calls.shift(); }
+      for (var i = 0; i < listeners.length; i++) {
+        try { listeners[i](calls.length); } catch (e) { /* a listener must not break a request */ }
+      }
+    }
+
+    var original = typeof window.fetch === "function" ? window.fetch : null;
+    if (original) {
+      window.fetch = function (input, init) {
+        var at = Date.now();
+        var method = String((init && init.method) || (input && input.method) || "GET").toUpperCase();
+        var url = String((input && input.url) || input || "");
+        return original.apply(this, arguments).then(function (response) {
+          /* Untouched. Reading the body here to pull out an incident token would consume it and
+             hand the caller an empty one -- breaking the panels this exists to help diagnose. */
+          note({ at: at, ms: Date.now() - at, method: method, url: url, status: response.status });
+          return response;
+        }, function (err) {
+          /* Status 0 is "never answered", which is a different row from a 500 and has to read as
+             one. The message is the browser's own; it is what tells a blocked request from a
+             refused one. */
+          note({ at: at, ms: Date.now() - at, method: method, url: url, status: 0,
+                 detail: (err && err.message) ? String(err.message) : String(err) });
+          throw err;
+        });
+      };
+    }
+
+    return {
+      calls: function () { return calls.slice(); },
+      onChange: function (fn) { if (typeof fn === "function") { listeners.push(fn); } },
+      note: note
+    };
+  }());
+
   window.__matrixarkWhen = function (ms) {
     /* 0 is "no timestamp" here, not the epoch: the catalog site this replaces read
        `ms ? ... : dash`, and a record with no time would otherwise date to 1970. */
@@ -1061,7 +1117,20 @@ function liveStream(options) {
        that looks only for `data:` hands {"reason": "stream_max_age"} to the frame handler as
        though it were the deployment's state -- and a page rendering from an object with none of
        the fields blanks the traffic table, the failures panel and the strip, every ten minutes. */
-    if (name === "bye") { planned = true; return; }
+    if (name === "bye") {
+      /* A rotation and a fault are both a bye. Treating every bye as planned reconnected at once
+         into a gateway that had just said it was failing -- and `planned` is exactly what makes
+         that reconnect immediate, so a fault has to clear it and take the backoff instead. */
+      var why = null;
+      try { why = JSON.parse(payload || "{}"); } catch (e) { why = null; }
+      if (why && why.reason && why.reason !== "stream_max_age") {
+        planned = false;
+        onState("failed", 0, why.incident || "");
+        return;
+      }
+      planned = true;
+      return;
+    }
     if (name !== "status" || !payload) { return; }
     try {
       var frame = JSON.parse(payload);
@@ -2995,7 +3064,7 @@ function liveStream(options) {
     if (live) { live.restart(); return; }
     live = liveStream({
       headers: auth,
-      onState: function (state, seconds) {
+      onState: function (state, seconds, incident) {
         streamLive = (state === "live");
         if (state === "live") { conn("live", "live"); }
         else if (state === "denied") { conn("live", "connected"); }
@@ -3003,6 +3072,12 @@ function liveStream(options) {
         /* Connected and receiving nothing. Not "down" -- the socket is open and a reconnect would
            not help -- and not "live", which is what it said before. */
         else if (state === "stalled") { conn("warn", "no update for " + seconds + "s"); }
+        /* The gateway said it was going, and why. Distinct from "stalled", which is a stream that
+           is still open and quiet, and from "retrying", which claims nothing about the cause. */
+        else if (state === "failed") {
+          conn("warn", "the stream failed on the gateway"
+               + (incident ? " \u2014 incident " + incident : ""));
+        }
         if (window.__matrixarkLiveState) {
           window.__matrixarkLiveState(state === "live" ? "live"
             : (state === "retrying" ? "down" : "stale"));
@@ -3405,7 +3480,21 @@ function liveStream(options) {
               if (line.indexOf("event:") === 0) { name = line.slice(6).trim(); }
               else if (line.indexOf("data:") === 0) { payload = line.slice(5).trim(); }
             });
-            if (name === "bye") { planned = true; return; }
+            if (name === "bye") {
+              planned = true;
+              /* The strip has no message line, so the reason goes where a reader can still get at
+                 it: the dot's own title. A goodbye that is a fault leaves the dot down rather than
+                 letting the next keepalive clear it back to live. */
+              try {
+                var why = JSON.parse(payload || "{}");
+                if (why.reason && why.reason !== "stream_max_age") {
+                  dot.className = "live-dot down";
+                  dot.title = "the stream failed on the gateway"
+                    + (why.incident ? " \u2014 incident " + why.incident : "");
+                }
+              } catch (e) { /* an older gateway says goodbye with no body */ }
+              return;
+            }
             if (name !== "status" || !payload) { return; }
             try {
               var frame = JSON.parse(payload);
@@ -3477,6 +3566,76 @@ function liveStream(options) {
 
   reveal();
   if (window.addEventListener) { window.addEventListener("hashchange", reveal); }
+}());
+
+/* ---------- what this page asked, and what came back ----------
+ *
+ * Every panel here is drawn from a call, and the only evidence one was made was whether the panel
+ * filled in. When something is wrong the first question is which request failed and what it
+ * answered -- and the only way to find out was the browser's own developer tools, which is a fine
+ * answer for whoever wrote the page and no answer at all for an operator looking at a deployment
+ * they did not build.
+ *
+ * Folded away until asked for: this is a debugging surface, not part of the page's job. */
+(function () {
+  var button = document.getElementById("liveCalls");
+  var panel = document.getElementById("callLog");
+  var rows = document.getElementById("callLogRows");
+  if (!button || !panel || !rows || !window.__matrixarkTrace) { return; }
+
+  function esc(s) {
+    return String(s).replace(/[&<>"]/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c];
+    });
+  }
+
+  /* The path, not the whole URL. Every one of these is this deployment, so the origin is the same
+     on every row and spends the width that the query -- which is what differs -- needs. */
+  function shorten(url) {
+    try {
+      var parsed = new URL(String(url), location.href);
+      return parsed.pathname + (parsed.search || "");
+    } catch (e) { return String(url); }
+  }
+
+  function label(n) {
+    button.hidden = !n;
+    button.textContent = n === 1 ? "1 call" : n + " calls";
+  }
+
+  function render() {
+    var calls = window.__matrixarkTrace.calls();
+    if (!calls.length) {
+      rows.innerHTML = '<tr><td colspan="4">Nothing asked yet.</td></tr>';
+      return;
+    }
+    /* Newest first: the call somebody is trying to explain is the one they just made. */
+    rows.innerHTML = calls.slice().reverse().map(function (c) {
+      /* A status of 0 is "never answered", which is a different row from a 500 and reads as one.
+         The browser's own message is what separates a blocked request from a refused one. */
+      var answered = c.status ? String(c.status) : (c.detail || "never answered");
+      return '<tr class="' + (!c.status || c.status >= 400 ? "bad" : "") + '"><td>'
+        + esc(window.__matrixarkWhen ? window.__matrixarkWhen(c.at) : c.at)
+        + '</td><td class="mono">' + esc(c.method + " " + shorten(c.url))
+        + "</td><td>" + esc(answered)
+        + "</td><td>" + esc(c.ms + " ms") + "</td></tr>";
+    }).join("");
+  }
+
+  button.addEventListener("click", function () {
+    var show = panel.hidden;
+    panel.hidden = !show;
+    button.setAttribute("aria-expanded", show ? "true" : "false");
+    if (show) { render(); }
+  });
+
+  window.__matrixarkTrace.onChange(function (n) {
+    label(n);
+    /* Only while it is open. Rebuilding a hidden table on every request is work nobody asked for
+       on a page that is left open for days. */
+    if (!panel.hidden) { render(); }
+  });
+  label(window.__matrixarkTrace.calls().length);
 }());
 </script>
 </body>

--- a/tools/portal/trace_harness.js
+++ b/tools/portal/trace_harness.js
@@ -1,0 +1,84 @@
+/* Run the page's OWN call recorder against a fetch that answers, one that refuses, and one that
+ * never answers at all.
+ *
+ * The shared block is executed rather than copied: the recorder replaces window.fetch, and the one
+ * property that matters -- that it hands the response back untouched -- cannot be checked against
+ * a copy of the code.
+ *
+ * Usage: node trace_harness.js <page.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const at = page.indexOf("Helpers every page may call");
+if (at < 0) { console.log(JSON.stringify({ error: "no shared helper block" })); process.exit(2); }
+const from = page.lastIndexOf("<script>", at) + "<script>".length;
+const to = page.indexOf("</script>", from);
+
+/* A window with the fetch the page would have had. Bodies are real objects so "was it consumed"
+   is a question this harness can actually ask. */
+function response(status, body) {
+  let used = false;
+  return {
+    status: status,
+    ok: status >= 200 && status < 300,
+    text: function () { if (used) { return Promise.reject(new Error("body already used")); }
+                        used = true; return Promise.resolve(body); },
+    wasUsed: function () { return used; }
+  };
+}
+
+const answers = {
+  "/ok": () => Promise.resolve(response(200, "{\"fine\":true}")),
+  "/refused": () => Promise.resolve(response(403, "{\"error\":\"forbidden\"}")),
+  "/gone": () => Promise.reject(new TypeError("Failed to fetch"))
+};
+
+const win = {
+  fetch: function (input, init) {
+    const url = String((input && input.url) || input || "");
+    const make = answers[url];
+    return make ? make() : Promise.resolve(response(404, "{}"));
+  }
+};
+const original = win.fetch;
+
+new Function("window", page.slice(from, to))(win);
+
+const changes = [];
+win.__matrixarkTrace.onChange(function (n) { changes.push(n); });
+
+(async () => {
+  const okResponse = await win.fetch("/ok");
+  /* The whole point: the caller still gets a body. A recorder that read it to pull out an
+     incident token would hand back an empty one and break every panel on the portal. */
+  const bodyAfterRecording = await okResponse.text();
+
+  await win.fetch("/refused");
+  let refusedError = "";
+  try { await win.fetch("/gone"); } catch (e) { refusedError = e.message; }
+
+  /* Read the three before flooding the ring, or the assertions below describe whatever survived
+     the flood rather than the three calls they name. */
+  const three = win.__matrixarkTrace.calls();
+
+  /* The ring is bounded: a portal tab is left open for days. */
+  for (let i = 0; i < 80; i++) { await win.fetch("/ok"); }
+
+  const calls = win.__matrixarkTrace.calls();
+  console.log(JSON.stringify({
+    wrapped: win.fetch !== original,
+    bodyAfterRecording: bodyAfterRecording,
+    bodyWasNotConsumedByTheRecorder: bodyAfterRecording === "{\"fine\":true}",
+    refusedError: refusedError,
+    statuses: three.map((c) => c.status),
+    methods: three.map((c) => c.method),
+    urls: three.map((c) => c.url),
+    detailOnTheOneThatNeverAnswered: (three[2] || {}).detail || "",
+    bounded: calls.length,
+    listenerFired: changes.length,
+    everyEntryHasATime: calls.every((c) => typeof c.at === "number" && c.at > 0),
+    everyEntryHasADuration: calls.every((c) => typeof c.ms === "number" && c.ms >= 0)
+  }, null, 1));
+})();

--- a/tools/test_matrixark_a_goodbye_that_is_a_fault.py
+++ b/tools/test_matrixark_a_goodbye_that_is_a_fault.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A goodbye that is a fault is not a goodbye that is a rotation.
+
+The gateway closes a stream every ten minutes on purpose and says so, and it now says so when it
+breaks as well. Both are ``event: bye``. The client set ``planned`` for either -- and ``planned``
+is precisely what makes the next reconnect immediate, so a gateway that had just said it was
+failing got reconnected into at once, by a page showing nothing wrong.
+
+That is the hot loop the reason exists to make visible, driven from this end.
+
+A rotation still reconnects at once, because it is not a fault. A fault clears ``planned``, takes
+the backoff, and reports itself with the token that names the log entry -- the one string in the
+message that leads anywhere.
+
+Driven through the SHIPPED client. What a page does with a goodbye is the whole change, and a
+reading of the source cannot tell an immediate reconnect from a backed-off one.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+HARNESS = os.path.join(PORTAL, "bye_reason_harness.js")
+PAGE = os.path.join(PORTAL, "setup_portal.html")
+
+
+def drive(bye: dict, keep_open: bool = False) -> dict:
+    out = subprocess.run(
+        ["node", HARNESS, PAGE, json.dumps({"bye": bye, "keepOpen": keep_open})],
+        capture_output=True, text=True, timeout=300)
+    if out.returncode != 0:
+        raise AssertionError(out.stderr[-900:])
+    return json.loads(out.stdout)
+
+
+class AGoodbyeThatIsAFaultTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            self.skipTest("node is not available")
+
+    def test_a_rotation_is_not_reported_as_a_fault(self) -> None:
+        """It happens every ten minutes on every open tab. Reporting it would put a fault on the
+        screen of every healthy deployment, six times an hour."""
+        said = drive({"reason": "stream_max_age"}, keep_open=True)
+        self.assertFalse(said["reportedAFault"])
+
+    def test_a_fault_is_reported(self) -> None:
+        said = drive({"reason": "server_error", "incident": "fa9ce4d24331"})
+        self.assertTrue(said["reportedAFault"])
+
+    def test_the_fault_carries_the_token(self) -> None:
+        """Without it the page has a sentence and no way to get any further, and the operator has
+        a log they cannot tie to the report."""
+        self.assertEqual("fa9ce4d24331",
+                         drive({"reason": "server_error", "incident": "fa9ce4d24331"})["faultIncident"])
+
+    def test_a_fault_backs_off_instead_of_reconnecting_at_once(self) -> None:
+        """The behaviour, not the message. Reconnecting immediately into a gateway that has just
+        said it is failing is the loop the reason was added to expose."""
+        said = drive({"reason": "server_error", "incident": "abc"})
+        self.assertTrue(said["backedOff"])
+        self.assertFalse(said["reconnectedImmediately"])
+
+    def test_a_rotation_still_reconnects_at_once(self) -> None:
+        """The complement, and the reason a fault cannot simply be treated as one: a rotation is
+        expected and reconnecting immediately is right for it. Losing that would put every open
+        tab through a backoff every ten minutes for no reason."""
+        said = drive({"reason": "stream_max_age"})
+        self.assertTrue(said["reconnectedImmediately"])
+        self.assertFalse(said["reportedAFault"])
+
+    def test_a_goodbye_with_no_reason_is_still_a_rotation(self) -> None:
+        """An older gateway says goodbye with no body at all, and it is not faulty for that."""
+        self.assertFalse(drive({}, keep_open=True)["reportedAFault"])
+
+    def test_the_stream_gets_as_far_as_live(self) -> None:
+        """The floor. Every assertion above is satisfied by a client that never connects, and a
+        client that never connects reports no faults for the most boring reason there is."""
+        said = drive({"reason": "server_error", "incident": "abc"})
+        states = [entry["state"] for entry in said["states"]]
+        self.assertIn("live", states, "the harness never got a working stream: %s" % states)
+
+
+class BothClientsReadTheReasonTest(unittest.TestCase):
+    """The strip has its own reader, on every page, and it had the same bug. It has no message
+    line, so what it can say goes in the dot's title -- but it must still tell the two apart."""
+
+    def test_the_strip_tells_a_rotation_from_a_fault(self) -> None:
+        for name in sorted(f for f in os.listdir(PORTAL) if f.endswith("_portal.html")):
+            with io.open(os.path.join(PORTAL, name), encoding="utf-8") as handle:
+                text = handle.read()
+            with self.subTest(page=name):
+                self.assertIn("the stream failed on the gateway", text,
+                              "%s never says a stream failed" % name)
+                self.assertGreaterEqual(
+                    text.count("stream_max_age"), 1,
+                    "%s treats every goodbye the same" % name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_the_page_says_what_it_asked.py
+++ b/tools/test_matrixark_the_page_says_what_it_asked.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The page keeps a record of what it asked the gateway, and what came back.
+
+Every panel on this portal is drawn from a call, and the only evidence a call was made was whether
+the panel filled in. When something is wrong the first question is *which request failed and what
+did it answer*, and the only way to find out was the browser's own developer tools -- a fine answer
+for whoever wrote the page, and no answer at all for an operator looking at a deployment they did
+not build.
+
+So the last sixty calls are kept and can be shown: method, path, status, how long, and when.
+
+**The response is handed back untouched.** That is the property this whole thing lives or dies on:
+a recorder that read the body to pull an incident token out of it would hand the caller an empty
+one, and every panel on the portal would break in exactly the way this exists to help diagnose. It
+is checked by reading a body *after* the recorder has seen it.
+
+The three outcomes are kept apart, because they are three different problems. A 200 is fine, a 403
+is the deployment refusing, and a status of 0 with the browser's own message is a request that
+never got an answer -- which is a network or a CORS question, not a gateway one.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+HARNESS = os.path.join(PORTAL, "trace_harness.js")
+
+
+def pages() -> list:
+    return sorted(f for f in os.listdir(PORTAL) if f.endswith("_portal.html"))
+
+
+def read(name: str) -> str:
+    with io.open(os.path.join(PORTAL, name), encoding="utf-8") as handle:
+        return handle.read()
+
+
+class TheRecorderTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if subprocess.run(["node", "--version"], capture_output=True).returncode != 0:
+            raise unittest.SkipTest("node is not available")
+        out = subprocess.run(["node", HARNESS, os.path.join(PORTAL, "overview_portal.html")],
+                             capture_output=True, text=True, timeout=300)
+        if out.returncode != 0:
+            raise AssertionError(out.stderr[-900:])
+        cls.result = json.loads(out.stdout)
+
+    def test_the_body_is_still_there_after_it_is_recorded(self) -> None:
+        """The property everything else depends on. A recorder that consumed the body would break
+        every panel on the portal, and it would break them while looking like a debugging aid."""
+        self.assertTrue(self.result["bodyWasNotConsumedByTheRecorder"])
+        self.assertEqual('{"fine":true}', self.result["bodyAfterRecording"])
+
+    def test_the_caller_still_sees_the_failure(self) -> None:
+        """A recorder that swallowed a rejection would leave every catch on the portal unreached,
+        which is worse than not recording at all."""
+        self.assertEqual("Failed to fetch", self.result["refusedError"])
+
+    def test_the_three_outcomes_are_kept_apart(self) -> None:
+        self.assertEqual([200, 403, 0], self.result["statuses"])
+        self.assertEqual(["/ok", "/refused", "/gone"], self.result["urls"])
+
+    def test_a_request_that_never_answered_says_what_the_browser_said(self) -> None:
+        """A status of 0 is not a status. Without the message it is indistinguishable from any
+        other call that did not complete, and the message is what separates blocked from refused.
+        """
+        self.assertEqual("Failed to fetch", self.result["detailOnTheOneThatNeverAnswered"])
+
+    def test_it_is_bounded(self) -> None:
+        """A portal tab is left open for days, so an unbounded list of every request is a leak that
+        only shows up on the busiest deployment."""
+        self.assertEqual(60, self.result["bounded"])
+
+    def test_every_entry_can_be_placed_in_time(self) -> None:
+        self.assertTrue(self.result["everyEntryHasATime"])
+        self.assertTrue(self.result["everyEntryHasADuration"])
+
+    def test_it_actually_wrapped_fetch(self) -> None:
+        """The positive control: every assertion above is satisfied by a recorder that records
+        nothing, if the harness's own fetch answers the same way."""
+        self.assertTrue(self.result["wrapped"])
+        self.assertGreater(self.result["listenerFired"], 0)
+
+
+class EveryPageCarriesItTest(unittest.TestCase):
+    """Which call failed is asked on whichever page went wrong, so it is on all of them -- the two
+    the builder only injects a nav into included."""
+
+    def test_each_page_has_the_recorder_the_button_and_the_panel(self) -> None:
+        for name in pages():
+            text = read(name)
+            with self.subTest(page=name):
+                self.assertEqual(1, text.count("window.__matrixarkTrace = "))
+                self.assertEqual(1, text.count('id="liveCalls"'))
+                self.assertEqual(1, text.count('id="callLog"'))
+
+    def test_the_panel_starts_folded_away(self) -> None:
+        """It is a debugging surface, not part of what the page is for."""
+        for name in pages():
+            with self.subTest(page=name):
+                self.assertIn('<div class="calllog" id="callLog" hidden>', read(name))
+
+    def test_there_are_pages_to_check(self) -> None:
+        self.assertGreaterEqual(len(pages()), 5, "found %s" % pages())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two things an operator could not find out from the portal itself.

## What the page asked, and what came back

Every panel here is drawn from a call, and the only evidence a call was made was
whether the panel filled in. When something is wrong the first question is *which
request failed and what did it answer* — and the only way to find out was the
browser's own developer tools. That is a fine answer for whoever wrote the page and
no answer at all for an operator looking at a deployment they did not build.

The last sixty calls are kept and can be shown: **method, path, status, how long,
and when**. Folded away until asked for — it is a debugging surface, not part of
what the page is for — and present on **every** page, because "which call failed" is
asked on whichever page went wrong.

### The response is handed back untouched

That is the property the whole thing lives on. A recorder that read the body to pull
an incident token out of it would hand the caller an **empty** one, and every panel
on the portal would break in exactly the way this exists to help diagnose.

It is checked by reading a body *after* the recorder has seen it — not by reading
the code.

## Why the stream went

The gateway now says whether it is closing on a ten-minute rotation or a fault. Both
are `event: bye`, and both clients treated every one as **planned** — and `planned`
is precisely what makes the next reconnect immediate. So a gateway that had just said
it was failing got reconnected into at once, by a page showing nothing wrong.

A rotation still reconnects at once, because it is not a fault. A fault clears
`planned`, takes the backoff, and reports itself with the token that names the log
entry. Driven through the shipped client:

```
connecting -> live -> failed (incident fa9ce4d24331) -> retrying
```

The strip has no message line, so on every page it puts that in the dot's own title
and leaves the dot down rather than letting the next keepalive clear it back to live.

## Checks

**Ten mutations**, each reddening a distinct assertion. Both halves are driven
through the shipped code: a reading of the source cannot tell an immediate reconnect
from a backed-off one, and cannot tell a consumed body from an intact one.

Two notes for whoever edits the harnesses next:

* A planned goodbye reconnects at once, so a harness that serves a fresh stream every
  time is an infinite loop. It was — and it exhausted the heap twice before the second
  connection was made to *hang* instead of refuse, which bounds the run at one
  reconnect while still recording that one was attempted.
* The call log is emitted after the closing `</nav>`, which the nav substitution does
  not cover, so it is removed and re-placed on every build rather than replaced where
  it sits. The repo's own idempotency test caught the first version stacking a copy
  per build on the two hand-maintained pages.
