### PR TITLE
Prove a WAL piece droppable from the next one, not by decoding it

### DIFF
--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -2337,18 +2337,38 @@ fn drop_covered_wal_segments(
     // Whatever is left is dropped by the next pass: pieces go from the front in order, so stopping
     // early leaves the rest exactly where the next pass would have looked anyway.
     let limit = wal_reclaim_max_segments_per_pass();
-    for path in wal_segment_paths(root, shard_id) {
+    let paths = wal_segment_paths(root, shard_id);
+    for (index, path) in paths.iter().enumerate() {
+        let path = path.clone();
         if limit > 0 && dropped >= limit {
             break;
         }
         if path == active || !path.exists() {
             continue;
         }
-        let (last, _) = last_wal_sequence_in(&path)?;
-        if last == 0 {
-            // Holds no record at all; nothing to keep and nothing to lose.
-        } else if last >= retain_from_sequence {
-            break;
+        // Prove it from the NEXT piece's first record when that is possible. Records ascend
+        // strictly, so `last(N) < first(N+1)`, and `first(N+1) <= retain_from` therefore puts all
+        // of piece N below the floor. That is one record read instead of decoding the whole file:
+        // the walk below costs 20-27 ms on a real ~500 KB piece, which is what makes this pass
+        // expensive enough to need a cap, and the cap is what stops a backlog draining.
+        //
+        // Only ever used to say YES. Anything unclear -- no next piece, an unreadable head, a
+        // bound that does not clear the floor -- falls through to the authoritative walk, because
+        // unlinking a piece that still holds a needed record cannot be undone.
+        let covered_by_next = match paths.get(index + 1) {
+            Some(next) => first_wal_sequence_in(next)
+                .ok()
+                .flatten()
+                .is_some_and(|first_next| first_next <= retain_from_sequence),
+            None => false,
+        };
+        if !covered_by_next {
+            let (last, _) = last_wal_sequence_in(&path)?;
+            if last == 0 {
+                // Holds no record at all; nothing to keep and nothing to lose.
+            } else if last >= retain_from_sequence {
+                break;
+            }
         }
         freed = freed.saturating_add(path.metadata().map(|meta| meta.len()).unwrap_or(0));
         fs::remove_file(&path)?;
@@ -3572,6 +3592,39 @@ fn skip_block_footer_if_due<R: std::io::BufRead + std::io::Seek>(
     let next = header_len + (index + 1) * WAL_BLOCK_BYTES;
     reader.seek(SeekFrom::Start(next))?;
     Ok(next)
+}
+
+/// The sequence of the FIRST record in a piece, or None when there is not one to read.
+///
+/// One record, where `last_wal_sequence_in` decodes the whole file. Used only to prove that an
+/// EARLIER piece is entirely below a retain floor: records are appended in strictly ascending
+/// sequence, so `last(N) < first(N+1)`.
+///
+/// None on anything unusual -- no header, no first record, a head that will not decode -- because
+/// every caller treats None as "cannot tell, go and look properly". It must never guess.
+fn first_wal_sequence_in(path: &Path) -> Result<Option<u64>, WriteAheadLogError> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let (_, header_len) = read_wal_base(path)?;
+    let file = File::open(path)?;
+    let len = file.metadata()?.len();
+    if len <= header_len {
+        return Ok(None);
+    }
+    let mut reader = BufReader::new(file);
+    reader.seek(SeekFrom::Start(header_len))?;
+    let record_end = skip_block_footer_if_due(&mut reader, header_len, header_len)?;
+    if record_end >= len {
+        return Ok(None);
+    }
+    let Some(raw) = read_raw_record(&mut reader)? else {
+        return Ok(None);
+    };
+    if raw.is_empty() || raw.iter().all(|byte| byte.is_ascii_whitespace()) {
+        return Ok(None);
+    }
+    Ok(decode_wal_line(&raw).ok().map(|record| record.sequence))
 }
 
 fn last_wal_sequence_forward(path: &Path) -> Result<(u64, u64), WriteAheadLogError> {
@@ -8473,6 +8526,144 @@ mod tests {
     }
 
     /// What reclaim costs with the log in one piece against many.
+    /// The cheap droppability test must drop exactly what the walk would, and nothing more.
+    #[test]
+    fn dropping_a_piece_from_the_next_ones_first_record_matches_the_walk() {
+        for retain_offset in [50u64, 500, 1200, 1900] {
+            set_wal_segment_bytes_for_test(Some(8 * 1024));
+            let dir = tempfile::tempdir().unwrap();
+            let store = LocalWriteAheadLogStore::new(dir.path());
+            let records = 2_000u64;
+            for index in 0..records {
+                store
+                    .append_with_sync(
+                        1,
+                        Command::StringSet {
+                            key: format!("k{index:06}"),
+                            value: vec![118u8; 128],
+                        },
+                        false,
+                    )
+                    .unwrap();
+            }
+
+            // What the AUTHORITY says about every piece, before anything is unlinked.
+            let before: Vec<(std::path::PathBuf, u64)> = wal_segment_paths(dir.path(), 1)
+                .into_iter()
+                .filter(|path| path.exists())
+                .map(|path| {
+                    let (last, _) = last_wal_sequence_in_for_test(&path).unwrap();
+                    (path, last)
+                })
+                .collect();
+
+            let retain_from = retain_offset;
+            let report = store.gc_before_sequence_unchecked(1, retain_from).unwrap();
+
+            let mut dropped_checked = 0usize;
+            for (path, last) in &before {
+                if path.exists() {
+                    continue;
+                }
+                dropped_checked += 1;
+                assert!(
+                    *last == 0 || *last < retain_from,
+                    "a piece was unlinked whose last sequence {last} is not below the retain floor \
+                     {retain_from}; the cheap test disagreed with the walk"
+                );
+            }
+            assert_eq!(
+                dropped_checked, report.dropped_segments,
+                "the pieces missing from disk should be exactly the ones reported dropped"
+            );
+            set_wal_segment_bytes_for_test(None);
+        }
+    }
+
+    /// The short circuit has to actually fire, or the equivalence above proves nothing.
+    #[test]
+    fn the_cheap_droppability_test_is_what_drops_the_pieces() {
+        set_wal_segment_bytes_for_test(Some(8 * 1024));
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalWriteAheadLogStore::new(dir.path());
+        for index in 0..2_000u64 {
+            store
+                .append_with_sync(
+                    1,
+                    Command::StringSet {
+                        key: format!("k{index:06}"),
+                        value: vec![118u8; 128],
+                    },
+                    false,
+                )
+                .unwrap();
+        }
+        // Every piece below this floor is covered by the next piece's first record, so the cheap
+        // path is the one that decides them.
+        let report = store.gc_before_sequence_unchecked(1, 1_500).unwrap();
+        assert!(
+            report.dropped_segments > 0,
+            "no piece was dropped, so nothing here exercises the decision: {report:?}"
+        );
+        set_wal_segment_bytes_for_test(None);
+    }
+
+    /// What each droppability probe costs, on segments from a real store.
+    ///
+    /// The pass holds the append lock while it probes, so this ratio is what decides how many
+    /// segments one pass may safely take.
+    #[test]
+    fn what_each_droppability_probe_costs_on_real_segments() {
+        let Ok(sample) = std::env::var("MATRIXARK_LIVE_WAL_SAMPLE") else {
+            println!("  set MATRIXARK_LIVE_WAL_SAMPLE to a directory of segments to measure");
+            return;
+        };
+        let mut paths: Vec<std::path::PathBuf> = std::fs::read_dir(&sample)
+            .expect("the sample directory")
+            .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+            .filter(|path| path.is_file())
+            .collect();
+        paths.sort();
+        if paths.is_empty() {
+            println!("  no segments in {sample}");
+            return;
+        }
+        let probed = paths.len();
+        let total_bytes: u64 = paths
+            .iter()
+            .map(|path| path.metadata().map(|meta| meta.len()).unwrap_or(0))
+            .sum();
+
+        let started = std::time::Instant::now();
+        for path in &paths {
+            let _ = last_wal_sequence_in_for_test(path);
+        }
+        let walk_us = started.elapsed().as_secs_f64() * 1e6;
+
+        let started = std::time::Instant::now();
+        for path in &paths {
+            let _ = first_wal_sequence_in(path);
+        }
+        let head_us = started.elapsed().as_secs_f64() * 1e6;
+
+        println!("  {probed} segment(s), {} MB total", total_bytes / 1_000_000);
+        println!(
+            "  walk  (last_wal_sequence_in) : {:>9.0} us -> {:>7.3} ms each -> {:>6.1} s for 721",
+            walk_us,
+            walk_us / 1000.0 / probed as f64,
+            walk_us / 1e6 / probed as f64 * 721.0
+        );
+        println!(
+            "  head (first_wal_sequence_in) : {:>9.0} us -> {:>7.3} ms each -> {:>6.1} s for 721",
+            head_us,
+            head_us / 1000.0 / probed as f64,
+            head_us / 1e6 / probed as f64 * 721.0
+        );
+        if head_us > 0.0 {
+            println!("  ratio: {:.0}x cheaper per segment", walk_us / head_us);
+        }
+    }
+
     #[test]
     fn what_reclaim_costs_in_one_piece_against_many() {
         for segment_bytes in [0u64, 8 * 1024] {


### PR DESCRIPTION
`drop_covered_wal_segments` calls `last_wal_sequence_in` on every candidate before unlinking it,
**under the append lock**. Measured against 40 segments taken from a live store, binary frame on and
no usable footer, that probe costs **24.9–72.2 ms each** — it is a full forward decode of a ~500 KB
file.

That is why the pass is capped at 64 segments: 64 × 25 ms is already seconds of held lock. And the
cap is why a backlog never drains. On the box these numbers come from, 721 segments had
accumulated; the six-hourly reclaim took 64 per round while new ones arrived, so the log sat at
~306 MB and restart stayed at **39.6 s** — about 0.13 s per MB, with peak RSS flat at 388 MB across
every open.

### The change

Records are appended in strictly ascending sequence — the live path increments under the append
lock, and replay refuses anything at or below the last sequence — so for consecutive pieces:

```
last(piece N)  <  first(piece N + 1)
```

which makes `first(N+1) <= retain_from` sufficient to prove every record in piece N is below the
floor. That is **one record read** instead of decoding the whole file.

| probe | per segment | projected for 721 segments |
|---|---|---|
| `last_wal_sequence_in` (decode the piece) | 24.9–72.2 ms | 18–52 s of held append lock |
| `first_wal_sequence_in` (read one record) | **0.354–0.546 ms** | **0.3–0.4 s** |

46–204x. The walk's cost varies with machine load; the head read stays sub-millisecond in every run.

### It is a short circuit, not a replacement

`last_wal_sequence_in` remains the authority and is still consulted whenever the cheap bound is not
conclusive: no next piece, an unreadable or empty head, or a bound that does not clear the floor.
**The cheap path may only say YES.** Unlinking a piece that still holds a needed record cannot be
undone and would surface later as an unrelated read failure, so the predicate is unchanged — drop
iff every record is below the retain floor — and only the cost of evaluating it moves.

This deliberately does **not** change `TS_WAL_RECLAIM_MAX_SEGMENTS_PER_PASS`. The cap now costs
~0.02 s per pass rather than ~1.6 s, so what it should be is a separate operational decision with a
different cost basis, and an operator can raise it without a code change.

### Tests

`dropping_a_piece_from_the_next_ones_first_record_matches_the_walk` checks the decision against the
authority it replaces, per piece and at four different retain floors: it records what
`last_wal_sequence_in` says about every piece before the pass, then asserts of every piece that was
unlinked that the walk agreed it was entirely below the floor, and that the pieces missing from disk
are exactly the ones reported dropped.

`the_cheap_droppability_test_is_what_drops_the_pieces` exists because all of that is vacuously true
of a pass that drops nothing — which is precisely what a short circuit that never fires would
produce.

`what_each_droppability_probe_costs_on_real_segments` times both probes over the same segments and
prints the ratio above. It skips unless `MATRIXARK_LIVE_WAL_SAMPLE` points at a directory of
segments, so it costs nothing in CI. It exists because the 8 KiB microbenchmark cannot settle this:
across three repeats it measured 11.3 / 67.8 / 20.1 ms for identical work, since walking an 8 KiB
piece is cheap either way and the noise swamps the difference.

### Suite

`cargo test -p temporalstore-rust --lib -- --test-threads=1`: **1706 passed, 2 failed**, and the
116 `reclaim`/`wal::` tests pass on this branch's exact base.

- `storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_flags` — verified
  pre-existing by reverting the change and running it alone; it fails identically.
- `raft::tests::part2::http_raft_transport_sends_append_vote_and_snapshot_over_tcp` — `io error:
  Resource temporarily unavailable (os error 11)`, a loaded-machine resource failure. Its sibling
  transport test failed in one run and passed in another, which is the same story.
