### PR TITLE
Five copies of three definitions, reduced to one each

### DIFF
--- a/tools/matrixark_local_adapter_ingest.py
+++ b/tools/matrixark_local_adapter_ingest.py
@@ -2,6 +2,16 @@
 from __future__ import annotations
 
 try:  # package path
+    from tools.matrixark_mcp_native_pack_policy import (
+        native_context_pack_required_for_backend,
+    )
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_native_pack_policy import (
+        native_context_pack_required_for_backend,
+    )
+
+
+try:  # package path
     from tools.matrixark_mcp_core import *  # noqa: F401,F403
 except ImportError:
     from matrixark_mcp_core import *  # noqa: F401,F403
@@ -4317,10 +4327,11 @@ class _LocalAdapterIngestMixin:
         return False
 
     def native_context_pack_required(self) -> bool:
-        if MATRIXARK_REQUIRE_NATIVE_CONTEXT_PACK:
-            return MATRIXARK_REQUIRE_NATIVE_CONTEXT_PACK in {"1", "true", "yes"}
+        # One rule, in matrixark_mcp_native_pack_policy. This used to restate it, and a rule stated
+        # twice is a rule that can be changed once.
         backend_label = str(getattr(self, "_backend_label", lambda: "local")())
-        return backend_label != "local"
+        return native_context_pack_required_for_backend(
+            backend_label, require_flag=MATRIXARK_REQUIRE_NATIVE_CONTEXT_PACK)
 
     def native_context_pack(self, request: Json) -> Json | None:
         """Return a backend-assembled ContextPack when the native backend supports it.

--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -72,7 +72,14 @@ def _mcp_debug_log(message: str) -> None:
         pass
 MAX_PRIOR_MESSAGES = 8
 MAX_PRIOR_CHARS = 4096
-EMBEDDING_DIM = 32
+# EMBEDDING_DIM lives with the encoder that uses it. core carried its own copy of this
+# constant, left from when it also carried its own embedding_for_text -- and because the
+# serving modules pull core in with `import *`, a copy here is the one they would resolve.
+# One definition, imported, so widening the encoder reaches every reader.
+try:  # package path
+    from tools.matrixark_mcp_embeddings import EMBEDDING_DIM  # noqa: F401
+except ImportError:  # top-level path (direct tools/ execution)
+    from matrixark_mcp_embeddings import EMBEDDING_DIM  # noqa: F401
 DIRECT_RECORD_LOG_SHARD_SIZE = 256
 DIRECT_RECORD_BUNDLE_MAX_BYTES = int(os.environ.get("MATRIXARK_DIRECT_RECORD_BUNDLE_MAX_BYTES", "65536"))
 DIRECT_RECORD_HOT_CACHE_MAX_RECORDS = int(os.environ.get("MATRIXARK_DIRECT_RECORD_HOT_CACHE_MAX_RECORDS", "20000"))

--- a/tools/matrixark_mcp_embeddings.py
+++ b/tools/matrixark_mcp_embeddings.py
@@ -159,17 +159,9 @@ def embedding_for_text(text: str, role: str = "passage") -> list[float]:
         with _EMBEDDING_VECTOR_CACHE_LOCK:
             _cache_put(cache_key, vector)
         return vector
-    vector = [0.0] * EMBEDDING_DIM
-    for token in tokens(text):
-        digest = hashlib.sha256(token.encode("utf-8")).digest()
-        index = digest[0] % EMBEDDING_DIM
-        sign = 1.0 if digest[1] % 2 == 0 else -1.0
-        vector[index] += sign
-    norm = math.sqrt(sum(value * value for value in vector))
-    if norm == 0:
-        result = vector
-    else:
-        result = [round(value / norm, 6) for value in vector]
+    # The same token-hash encoder the api and oss paths fall back to; one copy, so widening or
+    # reweighting it cannot reach one caller and miss the other.
+    result = _deterministic_embedding_for_text(text)
     with _EMBEDDING_VECTOR_CACHE_LOCK:
         _cache_put(cache_key, result)
     return result

--- a/tools/matrixark_mcp_extraction_runtime.py
+++ b/tools/matrixark_mcp_extraction_runtime.py
@@ -229,13 +229,10 @@ except ImportError:  # Direct script execution from tools/.
 
 
 
-def resource_extraction_mode(envelope: Json) -> str:
-    provider = understanding_provider(envelope)
-    if provider == "oss_encoder":
-        return "matrixark_resource_schema_oss_encoder"
-    if provider in {"openai", "openai_compatible", "openai-compatible"}:
-        return "matrixark_resource_schema_openai_compatible"
-    return "matrixark_resource_schema"
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import resource_extraction_mode
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import resource_extraction_mode
 
 
 try:  # the implementation lives in matrixark_mcp_core; this module re-exports it

--- a/tools/matrixark_mcp_resources.py
+++ b/tools/matrixark_mcp_resources.py
@@ -470,11 +470,10 @@ RESOURCE_FACT_SCHEMAS: list[Json] = [
 ]
 
 
-def should_extract_resource_fact(text: str, metadata: Json) -> bool:
-    if RESOURCE_FACT_KEYWORDS.search(text):
-        return True
-    unit_kind = str(metadata.get("unit_kind", ""))
-    return unit_kind in {"table_row", "table_row_group", "xlsx_row", "xlsx_row_group", "json_document", "json_record", "json_record_group"}
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import should_extract_resource_fact
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import should_extract_resource_fact
 
 
 def matched_resource_fact_schemas(text: str, metadata: Json) -> list[Json]:


### PR DESCRIPTION
Five copies of three definitions, reduced to one each. All three sit on the path that produced
every vector currently in the store, or that decides whether Rust or Python assembles a
ContextPack.

## The token-hash encoder, twice in one file

`embedding_for_text` inlined the token-hash encoder. Eleven lines below it,
`_deterministic_embedding_for_text` is the same eleven lines — and is already what the api and oss
paths call when they fall back. Widening or reweighting the encoder had to be done twice, and
missing one would leave the configured hash provider and the fallback computing different vectors
under a single name.

## `EMBEDDING_DIM`, in core as well as in the encoder's module

core's copy is left over from when core also carried its own `embedding_for_text`. Those copies
turned out to be the ones production actually ran — the serving modules pull core in with
`import *` — so improvements made to the encoder module did nothing at all. core's own comments
record it. The functions were consolidated then; the constant was not.

Nothing outside the two modules reads it today, which is exactly why it is worth closing now: the
next reader resolves core's copy through a star import, and an edit made in the encoder's own module
would not reach it.

## `resource_extraction_mode` and `should_extract_resource_fact`

Defined in `matrixark_mcp_core` and again in the module that uses them, identical bodies. Both
modules already carry the re-export idiom for other core functions, with the same comment, so this
follows the convention already in the file. Neither gains a dependency — both already import core.

## The native-pack rule, restated in the adapter

`native_context_pack_required` decides whether the backend must assemble the ContextPack or whether
Python may pack it instead. About three quarters of `matrixark_local_adapter_retrieve` sits behind
that decision. The rule lives in `matrixark_mcp_native_pack_policy`; the local adapter restated it
inline. It now calls it.

## How each was checked

Not by the definition being gone from the file — a re-export that silently failed would leave the
name bound to something else and a text check would not notice.

- **encoder**: the old and new modules loaded side by side and compared on empty input, single
  characters, punctuation, unicode, a 4,000-character string, a 500-token repeat, both query and
  passage roles, and the batch path. Identical on every one. The comparison was then given a
  perturbation smaller than the stored rounding and reported the difference, so an equal result
  means agreement rather than a harness that cannot fail.
- **core functions**: object identity — `matrixark_mcp_extraction_runtime.resource_extraction_mode
  is matrixark_mcp_core.resource_extraction_mode`, and likewise for the other, both reporting
  `__module__ == "matrixark_mcp_core"`.
- **native-pack rule**: the method and the helper compared across every backend label the tree uses
  plus the empty and unrecognised cases — same answer everywhere. Also confirmed core does not
  export a name of the same spelling, since the new import sits above a `import *` that would
  otherwise shadow it.
- **imports**: every module under `tools/` still imports. The only two that do not are the pair
  naming a deliberately absent module, which failed the same way before.

## One thing found and deliberately left alone

`native_context_pack_required` is stated a third time, in `matrixark_mcp_server`. That copy uses an
explicit allowlist rather than "not local", so with the flag unset it permits Python packing for
`temporalstore`, `mem0`, `rust` and any unrecognised label, where the other two require native
assembly:

| backend | policy helper | adapter | server copy |
|---|---|---|---|
| `local` | False | False | False |
| `temporalstore` | True | True | **False** |
| `mem0` | True | True | **False** |
| `rust` | True | True | **False** |
| unrecognised | True | True | **False** |

That is two request paths enforcing different rules for one deployment, and reconciling them
changes what a deployment does. It is raised here rather than folded into a de-duplication.
