### PR TITLE
Four helpers read a flag, two of them dead and the live two identical

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -2983,7 +2983,7 @@ pub(crate) fn evict_sampler_config() -> eviction_sampler::EvictionSamplerConfig 
 /// Default-ON gate read: the fix is LIVE unless explicitly disabled with
 /// `=0|false|no|off`. Shipped write-path/raft fixes use this so production gets the
 /// fixed behavior by default; the env var remains only as an escape hatch.
-fn env_flag_default_on(name: &str) -> bool {
+pub(crate) fn env_flag_default_on(name: &str) -> bool {
     !matches!(
         std::env::var(name)
             .unwrap_or_default()

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -2933,31 +2933,6 @@ fn resolve_last_sequence_for_append(
     Ok((cached_last_sequence.max(disk_last_sequence), record_end))
 }
 
-fn wal_env_flag_on(name: &str) -> bool {
-    matches!(
-        std::env::var(name)
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "1" | "true" | "yes" | "on"
-    )
-}
-
-/// Default-ON gate read: the fix is LIVE unless explicitly disabled with
-/// `=0|false|no|off`. Shipped write-path/raft fixes use this so production gets the
-/// fixed behavior by default; the env var remains only as an escape hatch.
-fn wal_env_flag_default_on(name: &str) -> bool {
-    !matches!(
-        std::env::var(name)
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "0" | "false" | "no" | "off"
-    )
-}
-
 /// TS_WAL_RECLAIM_MAX_SEGMENTS_PER_PASS: how many sealed pieces one reclaim pass may unlink.
 ///
 /// The unlinking happens while the log's lock is held, and every append takes that lock, so an
@@ -2983,7 +2958,7 @@ fn wal_reclaim_max_segments_per_pass() -> usize {
 /// written either way reads back under the other, since the tail scan treats a zeros run as
 /// room and a plain file simply ends at its records).
 fn wal_preallocate_enabled() -> bool {
-    wal_env_flag_default_on("TS_WAL_PREALLOCATE")
+    crate::engine::env_flag_default_on("TS_WAL_PREALLOCATE")
 }
 
 /// TS_WAL_PREALLOCATE_CHUNK: how far past the write the file is grown when it runs out of room.


### PR DESCRIPTION
Four functions in the crate answer "is this flag on", in two shapes:

| function | shape | callers |
|---|---|---|
| `engine::env_flag_on` | on only for `1/true/yes/on` | 1 |
| `engine::env_flag_default_on` | on unless `0/false/no/off` | **0** |
| `wal::wal_env_flag_on` | identical to `env_flag_on` | **0** |
| `wal::wal_env_flag_default_on` | identical to `env_flag_default_on` | 1 |

The two `wal_` versions are byte-identical copies of the two in `engine`, down to the
`.trim().to_ascii_lowercase()` chain and the match arms. Nothing documents why a second pair
exists — `wal_env_flag_on` has no doc at all, and `wal_env_flag_default_on` carries a verbatim
copy of the other one's.

Two of the four are dead, and the compiler already says so:

```
warning: function `env_flag_default_on` is never used
warning: function `wal_env_flag_on` is never used
```

So the crate reads flags through **two** live functions that behave identically, while carrying
two more that nothing calls.

## What this changes

`env_flag_default_on` becomes `pub(crate)` and is the one default-ON reader. Both `wal_` copies
go, and `wal_preallocate_enabled` — the single caller — takes the shared one. `wal.rs` already
calls `crate::engine::bulk_ingest_mode()`, so this adds no dependency edge that was not there.

Net: four functions to two, both live, one definition each of what "on" and "off" mean.

## Why it is worth doing rather than leaving

Two copies of a value parser is how a variable ends up with two defaults — the exact failure
`test_flag_readers_agree` and `test_numeric_defaults_agree` exist to catch. Here the copies
agreed, so nothing was wrong yet; the point is that nothing was keeping them agreeing, and the
next edit to one of them had no reason to find the other.

It also removes a smaller trap: `flag_docs_state_the_default_the_code_actually_has` classifies
an accessor by which helper name its body contains, and it matches on substring. With
`wal_env_flag_default_on` present, that name contains `env_flag_default_on`, so the two helpers
were indistinguishable to the guard by construction.

## Checks

`flag_docs_state_the_default_the_code_actually_has` passes. Both preallocate tests pass,
including `the_preallocate_escape_hatch_restores_growing_appends` — the one that selects
`TS_WAL_PREALLOCATE`'s **off** position, which is the check that matters here: the shared reader
still honours `=0` for the one flag that goes through it.

Full `cargo test --release --lib --tests --no-fail-fast -- --test-threads=1`: no failure that
main does not already have. Both dead-code warnings are gone.
