### PR TITLE
A caller's mistake is a 400 that says what to fix

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -6660,9 +6660,9 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         user_id = str(scope.get("user_id") or "").strip()
         confirm = str(args.get("confirm") or "").strip()
         if not user_id:
-            raise MatrixArkError("forget requires scope.user_id (the subject to forget)")
+            raise MatrixArkInvalidRequestError("forget requires scope.user_id (the subject to forget)")
         if confirm != user_id:
-            raise MatrixArkError("forget requires confirm to equal scope.user_id (exact match, no wildcard)")
+            raise MatrixArkInvalidRequestError("forget requires confirm to equal scope.user_id (exact match, no wildcard)")
         tenant_hash, user_hash = self._resolve_subject_hashes(scope)
         if not tenant_hash or not user_hash:
             raise MatrixArkError("forget could not resolve the subject scope (tenant_hash/user_hash)")
@@ -6732,7 +6732,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         backward compatible with the pre-closure behavior."""
         memory_id = str(args.get("memory_id") or args.get("id") or "").strip()
         if not memory_id:
-            raise MatrixArkError("delete requires a memory_id")
+            raise MatrixArkInvalidRequestError("delete requires a memory_id")
         records = self.records_for_delete(memory_id)
         try:
             memory_id_int: int | None = int(memory_id)
@@ -7061,7 +7061,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         through the live view so superseded / expired / forgotten keyed records never surface."""
         identity_key = str(args.get("identity_key") or "").strip()
         if not identity_key:
-            raise MatrixArkError("get by key requires identity_key")
+            raise MatrixArkInvalidRequestError("get by key requires identity_key")
         scope = optional_object(args, "scope")
         tenant_hash, user_hash = self._resolve_subject_hashes(scope)
         candidates: list[Json] = []
@@ -7139,7 +7139,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         try:
             limit = int(args.get("limit") or 0)
         except (TypeError, ValueError):
-            raise MatrixArkError("limit must be an integer")
+            raise MatrixArkInvalidRequestError("limit must be an integer")
         # Select first, project second. Building the projected memory for every record and then
         # slicing threw most of that work away: a subject with thousands of memories paid for all
         # of them to answer `limit=10`. Order the cheap (time, record) pairs, cut, and build only
@@ -7188,9 +7188,9 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         tenant_id = str(scope.get("tenant_id") or "").strip()
         confirm = str(args.get("confirm") or "").strip()
         if not confirm:
-            raise MatrixArkError("reset requires an explicit confirm (the tenant_id or 'RESET')")
+            raise MatrixArkInvalidRequestError("reset requires an explicit confirm (the tenant_id or 'RESET')")
         if confirm != "RESET" and (not tenant_id or confirm != tenant_id):
-            raise MatrixArkError("reset requires confirm to equal the tenant_id or the literal 'RESET'")
+            raise MatrixArkInvalidRequestError("reset requires confirm to equal the tenant_id or the literal 'RESET'")
         tenant_hash, _ = self._resolve_subject_hashes(scope)
         if not tenant_hash:
             raise MatrixArkError("reset could not resolve the caller's tenant scope")
@@ -7297,7 +7297,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         forgotten/deleted memory returns ``{found: false}``."""
         memory_id = str(args.get("memory_id") or args.get("id") or "").strip()
         if not memory_id:
-            raise MatrixArkError("get requires a memory_id")
+            raise MatrixArkInvalidRequestError("get requires a memory_id")
         memory_id_int = _safe_int(memory_id)
         event: Json | None = None
         derived: list[Json] = []
@@ -7351,14 +7351,14 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         (cross-tenant update is refused)."""
         memory_id = str(args.get("memory_id") or args.get("id") or "").strip()
         if not memory_id:
-            raise MatrixArkError("update requires a memory_id")
+            raise MatrixArkInvalidRequestError("update requires a memory_id")
         new_text = args.get("data")
         if new_text in (None, ""):
             new_text = args.get("text")
         if new_text in (None, ""):
             new_text = args.get("content")
         if not isinstance(new_text, str) or not new_text.strip():
-            raise MatrixArkError("update requires new content (data / text)")
+            raise MatrixArkInvalidRequestError("update requires new content (data / text)")
         # The id's own records, not the store's. An update reasons over exactly what a delete
         # does -- the addressed event plus everything pointing at it -- and the same subset serves
         # both the lookup here and the supersede closure below, so one id-scoped fetch replaces
@@ -7632,7 +7632,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         when the id is the NEW version produced by an update. Ordered oldest-first by log position."""
         memory_id = str(args.get("memory_id") or args.get("id") or "").strip()
         if not memory_id:
-            raise MatrixArkError("history requires a memory_id")
+            raise MatrixArkInvalidRequestError("history requires a memory_id")
         events: list[Json] = []
         seen_ingested = False
         for record in self.raw_records_for_history(memory_id):

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -3724,6 +3724,26 @@ def _ok_body(result: Any) -> Json:
     return result if isinstance(result, dict) else {"result": result}
 
 
+def _failure_body(scope: Json, exc: Exception) -> Tuple[int, Json]:
+    """The status AND the body for a failed backend call, in the words that fit whose fault it was.
+
+    A request the caller can fix is not a backend error, and answering it with one throws away the
+    only sentence that would fix it. Measured before this existed: omitting a memory_id answered
+    500 "The backend could not complete this call." with an incident token -- for a mistake the
+    caller made and could have corrected from the message the backend had already written.
+
+    The message is echoed only for the statuses where it is ABOUT THE REQUEST. A 500 keeps the
+    deliberately incurious sentence and the token, because that one is about the inside of the
+    deployment and the reader is not told it.
+    """
+    status = _classify_backend_error(exc)
+    if status == 400:
+        return status, {"error": "invalid_request", "detail": str(exc)[:400]}
+    if status == 404:
+        return status, {"error": "not_found", "detail": str(exc)[:400]}
+    return status, _failure(scope, "backend_error", exc)
+
+
 def _classify_backend_error(exc: Exception) -> int:
     name = exc.__class__.__name__
     if name in _STORAGE_QUOTA_ERRORS:
@@ -4510,8 +4530,8 @@ async def _dispatch_direct(client: "DirectBackendClient", cfg: GatewayConfig, to
         return await _json(send, 504, {"error": "backend_timeout",
                            "detail": f"backend did not respond within {cfg.backend_timeout}s"}, rl_headers)
     except Exception as exc:
-        return await _json(send, _classify_backend_error(exc),
-                           _failure(scope, "backend_error", exc), rl_headers)
+        _status, _body = _failure_body(scope, exc)
+        return await _json(send, _status, _body, rl_headers)
 
     if status >= 400:
         return await _json(send, status if status in (429, 507) else 502,
@@ -5223,8 +5243,8 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
             except Exception as exc:
                 # A backend that cannot answer this must not read as "nothing is pending" -- the
                 # honest answer is that the state is unknown.
-                return await _json(send, _classify_backend_error(exc),
-                                   _failure(scope, "backend_error", exc))
+                _status, _body = _failure_body(scope, exc)
+                return await _json(send, _status, _body)
             body = _ok_body(result)
             body["encoder"] = _encoder_summary()
             return await _json(send, 200, body)
@@ -5523,8 +5543,8 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                 return await _json(send, 504, {"error": "backend_timeout",
                                    "detail": f"backend did not respond within {cfg.backend_timeout}s"})
             except Exception as exc:
-                return await _json(send, _classify_backend_error(exc),
-                                   _failure(scope, "backend_error", exc))
+                _status, _body = _failure_body(scope, exc)
+                return await _json(send, _status, _body)
             return await _json(send, 200, _ok_body(result))
 
         # ---- who holds memories: GET /v1/users (auth + context:retrieve) ---------------------
@@ -5559,8 +5579,8 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                 return await _json(send, 504, {"error": "backend_timeout",
                                    "detail": f"backend did not respond within {cfg.backend_timeout}s"})
             except Exception as exc:
-                return await _json(send, _classify_backend_error(exc),
-                                   _failure(scope, "backend_error", exc))
+                _status, _body = _failure_body(scope, exc)
+                return await _json(send, _status, _body)
             return await _json(send, 200, _ok_body(result))
 
         # ---- skill / resource catalog (auth + resource:read / skill:read) --------------------
@@ -5610,8 +5630,8 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                 return await _json(send, 504, {"error": "backend_timeout",
                                    "detail": f"backend did not respond within {cfg.backend_timeout}s"})
             except Exception as exc:
-                return await _json(send, _classify_backend_error(exc),
-                                   _failure(scope, "backend_error", exc))
+                _status, _body = _failure_body(scope, exc)
+                return await _json(send, _status, _body)
             body = _ok_body(result)
             # What was actually applied, not what was asked for. A caller asking for 5,000 gets 500
             # rows and, without this, no way to tell that from a catalogue holding exactly 500 -- so
@@ -5658,8 +5678,8 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                 return await _json(send, 504, {"error": "backend_timeout",
                                    "detail": f"backend did not respond within {cfg.backend_timeout}s"})
             except Exception as exc:
-                return await _json(send, _classify_backend_error(exc),
-                                   _failure(scope, "backend_error", exc))
+                _status, _body = _failure_body(scope, exc)
+                return await _json(send, _status, _body)
             return await _json(send, 200, _ok_body(result))
 
         # ---- keyed recall via GET /v1/memory/by-key?identity_key=... (auth + context:retrieve) --
@@ -5698,8 +5718,8 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                 return await _json(send, 504, {"error": "backend_timeout",
                                    "detail": f"backend did not respond within {cfg.backend_timeout}s"})
             except Exception as exc:
-                return await _json(send, _classify_backend_error(exc),
-                                   _failure(scope, "backend_error", exc))
+                _status, _body = _failure_body(scope, exc)
+                return await _json(send, _status, _body)
             if result.get("found") is False:
                 return await _json(send, 404, _ok_body(result))
             return await _json(send, 200, _ok_body(result))
@@ -5734,8 +5754,8 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                 return await _json(send, 504, {"error": "backend_timeout",
                                    "detail": f"backend did not respond within {cfg.backend_timeout}s"})
             except Exception as exc:
-                return await _json(send, _classify_backend_error(exc),
-                                   _failure(scope, "backend_error", exc))
+                _status, _body = _failure_body(scope, exc)
+                return await _json(send, _status, _body)
             if tool == "matrixark_get_memory" and result.get("found") is False:
                 return await _json(send, 404, _ok_body(result))
             return await _json(send, 200, _ok_body(result))
@@ -5847,8 +5867,8 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                 return await _json(send, 504, {"error": "backend_timeout",
                                    "detail": f"backend did not respond within {cfg.backend_timeout}s"}, rl_headers)
             except Exception as exc:
-                return await _json(send, _classify_backend_error(exc),
-                                   _failure(scope, "backend_error", exc), rl_headers)
+                _status, _body = _failure_body(scope, exc)
+                return await _json(send, _status, _body, rl_headers)
             return await _json(send, 200, resp, rl_headers)
 
         args = parsed.get("arguments") if isinstance(parsed.get("arguments"), dict) else parsed
@@ -5919,9 +5939,15 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                                "detail": f"backend did not respond within {cfg.backend_timeout}s"}, rl_headers)
         except Exception as exc:
             status = _classify_backend_error(exc)
-            body = {"error": "rate_limited"} if status == 429 else (
-                _failure(scope, "storage_quota_exceeded", exc) if status == 507
-                else _failure(scope, "backend_error", exc))
+            if status == 429:
+                body = {"error": "rate_limited"}
+            elif status == 507:
+                body = _failure(scope, "storage_quota_exceeded", exc)
+            else:
+                # Every mem0 route is served from here, so this is where a caller's mistake was
+                # being answered as the deployment's. _failure_body re-reads the same
+                # classification and says whose fault it was in the words that fit.
+                status, body = _failure_body(scope, exc)
             headers = rl_headers + ([(b"retry-after", b"1")] if status == 429 else [])
             return await _json(send, status, body, headers)
 

--- a/tools/test_matrixark_a_callers_mistake_is_not_a_backend_error.py
+++ b/tools/test_matrixark_a_callers_mistake_is_not_a_backend_error.py
@@ -30,9 +30,19 @@ import unittest
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import matrixark_v1_gateway as gw  # noqa: E402
+
+
+def _cfg():
+    """Imported inside the call, not at module import time.
+
+    A test module that imports another one at import time reorders `unittest discover`, and can
+    fail tests it has nothing to do with -- in CI, while passing locally.
+    """
+    from test_matrixark_v1_gateway import _cfg as build
+    return build()
 from matrixark_mcp_core_identity import MatrixArkInvalidRequestError  # noqa: E402
 from matrixark_mcp_errors import MatrixArkError  # noqa: E402
-from test_matrixark_v1_gateway import _cfg  # noqa: E402
+
 
 ADMIN = {"Authorization": "Bearer k-acme"}
 

--- a/tools/test_matrixark_a_callers_mistake_is_not_a_backend_error.py
+++ b/tools/test_matrixark_a_callers_mistake_is_not_a_backend_error.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A caller's mistake is a 400 that says what to fix.
+
+Measured by driving every mem0 API one at a time. Omit a ``memory_id`` and the answer was:
+
+    500 {"error": "backend_error",
+         "detail": "The backend could not complete this call.",
+         "incident": "cd35add2689f"}
+
+The sentence that fixes it -- ``delete requires a memory_id`` -- was discarded, and the caller was
+handed a token to take to an operator, for a mistake they made themselves and could have corrected
+in one read. Eleven of the sixteen generic raises in the local adapter are request validation like
+that; the gateway has a 400 class and almost nothing reached it.
+
+**The floor matters more than the change.** A 500 is still deliberately incurious: it keeps the
+sentence that says nothing about the inside of the deployment, and the token that names the log
+entry which does. The message is echoed only where it is ABOUT THE REQUEST. Widening that would
+turn a debugging improvement into a disclosure, so it is asserted in both directions here.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_v1_gateway as gw  # noqa: E402
+from matrixark_mcp_core_identity import MatrixArkInvalidRequestError  # noqa: E402
+from matrixark_mcp_errors import MatrixArkError  # noqa: E402
+from test_matrixark_v1_gateway import _cfg  # noqa: E402
+
+ADMIN = {"Authorization": "Bearer k-acme"}
+
+
+class _RaisingServer:
+    """A backend that fails the way the local adapter fails."""
+
+    def __init__(self, exc):
+        self.exc = exc
+
+    def call_tool(self, name, args):
+        raise self.exc
+
+    def handle(self, body):
+        raise self.exc
+
+
+def call(exc, path="/v1/delete", body=None):
+    app = gw.make_v1_app(_RaisingServer(exc), _cfg())
+    payload = json.dumps(body or {}).encode("utf-8")
+    scope = {"type": "http", "method": "POST", "path": path, "query_string": b"",
+             "headers": [(b"content-type", b"application/json")]
+                        + [(k.lower().encode(), v.encode()) for k, v in ADMIN.items()]}
+    got = {"status": 0, "body": b""}
+    sent = [False]
+
+    async def receive():
+        if not sent[0]:
+            sent[0] = True
+            return {"type": "http.request", "body": payload, "more_body": False}
+        return {"type": "http.disconnect"}
+
+    async def send(message):
+        if message["type"] == "http.response.start":
+            got["status"] = message["status"]
+        elif message["type"] == "http.response.body":
+            got["body"] += message.get("body", b"")
+
+    asyncio.run(asyncio.wait_for(app(scope, receive, send), timeout=60))
+    try:
+        return got["status"], json.loads(got["body"])
+    except Exception:
+        return got["status"], {}
+
+
+class ACallersMistakeTest(unittest.TestCase):
+
+    def test_it_is_a_400(self) -> None:
+        status, _ = call(MatrixArkInvalidRequestError("delete requires a memory_id"))
+        self.assertEqual(400, status)
+
+    def test_it_says_what_to_fix(self) -> None:
+        """The whole point. A status alone tells a caller they were wrong and not how."""
+        _, body = call(MatrixArkInvalidRequestError("delete requires a memory_id"))
+        self.assertEqual("delete requires a memory_id", body.get("detail"))
+
+    def test_it_is_not_called_a_backend_error(self) -> None:
+        """400 with `backend_error` in the body says two contradictory things about whose fault it
+        was, and the reader has to pick one."""
+        _, body = call(MatrixArkInvalidRequestError("delete requires a memory_id"))
+        self.assertEqual("invalid_request", body.get("error"))
+
+    def test_a_caller_is_not_handed_a_token_for_their_own_mistake(self) -> None:
+        """An incident token is a handle for asking an operator about the deployment. Offering one
+        for a missing parameter sends somebody to ask about a fault that is not there."""
+        _, body = call(MatrixArkInvalidRequestError("delete requires a memory_id"))
+        self.assertNotIn("incident", body)
+
+
+class TheDeploymentsFaultIsStillItsOwnTest(unittest.TestCase):
+    """The floor. Every assertion above is satisfied by a gateway that echoes every exception it
+    catches, and that gateway leaks the inside of the deployment to anyone who can make it fail."""
+
+    def test_an_unexpected_failure_is_still_a_500(self) -> None:
+        status, _ = call(RuntimeError("psycopg2 connection to 10.4.2.9:5432 refused"))
+        self.assertEqual(500, status)
+
+    def test_and_still_says_nothing_about_the_inside(self) -> None:
+        _, body = call(RuntimeError("psycopg2 connection to 10.4.2.9:5432 refused"))
+        self.assertNotIn("psycopg2", json.dumps(body))
+        self.assertNotIn("10.4.2.9", json.dumps(body))
+        self.assertEqual("The backend could not complete this call.", body.get("detail"))
+
+    def test_and_still_carries_the_token(self) -> None:
+        """It is the one string that ties the caller's report to the operator's log."""
+        _, body = call(RuntimeError("psycopg2 connection refused"))
+        self.assertTrue(body.get("incident"))
+
+    def test_a_generic_error_from_the_backend_is_not_the_callers(self) -> None:
+        """`MatrixArkError` is the base class, raised for deployment-side trouble as well -- so it
+        must NOT be swept into 400 along with its invalid-request subclass."""
+        status, body = call(MatrixArkError("forget could not resolve the subject scope"))
+        self.assertEqual(500, status)
+        self.assertEqual("backend_error", body.get("error"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Measured by driving every mem0 API one at a time against an isolated store. Omit a
`memory_id` and the answer was:

```
500 {"error": "backend_error",
     "detail": "The backend could not complete this call.",
     "incident": "cd35add2689f"}
```

The sentence that fixes it — **`delete requires a memory_id`** — was discarded, and
the caller was handed a token to take to an operator, for a mistake they made
themselves and could have corrected in one read.

## The scale of it

**Eleven of the sixteen** generic raises in the local adapter are request validation
like that:

| | |
|---|---|
| `delete` / `get` / `update` / `history` | requires a memory_id |
| `get_all` | limit must be an integer |
| `get_by_key` | requires identity_key |
| `forget` / `reset` | the confirm checks |

The gateway has a 400 class and almost nothing reached it. Those eleven now raise the
invalid-request class, and every mem0 route is served from one dispatcher — which is
where the answer was being written.

```
400 {"error": "invalid_request",
     "detail": "reset requires an explicit confirm (the tenant_id or 'RESET')"}
```

## Left alone deliberately

* `could not resolve the subject scope`, `could not resolve the caller's tenant scope`
  and the telemetry write-mode check are the **deployment** failing or misconfigured,
  not the request. 500 is right for those.
* `refused: the memory belongs to another tenant` is an **authorisation boundary**.
  Whether that is 403 or 404 decides whether a caller can probe for the existence of
  another tenant's records — a security question, and not one to settle inside a
  wording change.

## The floor matters more than the change

It is asserted in both directions. A 500 still keeps the deliberately incurious
sentence and the token that names the log entry, and the message is echoed **only**
where it is about the request. Widening that would turn a debugging improvement into a
disclosure.

Five mutations, each reddening a distinct assertion — including *echo the message on a
500 too*, which the leak assertions catch, and *sweep the base class into 400*, which
would take deployment-side failures with it.
