### PR TITLE
The console says what forget does, and asks for what the call needs

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -2269,8 +2269,12 @@ MEM0_OPERATIONS: List[Json] = [
      "fields": [
          {"name": "memory_id", "in": "body", "kind": "text", "required": True,
           "label": "Memory id", "placeholder": "mem_7f21"},
-         {"name": "rating", "in": "body", "kind": "number", "default": 1, "label": "Rating",
-          "help": "1 useful, -1 not."},
+         {"name": "rating", "in": "body", "kind": "choice",
+          "choices": ["POSITIVE", "NEGATIVE", "VERY_NEGATIVE"], "default": "POSITIVE",
+          "label": "Rating",
+          "help": "The vocabulary is closed and the deployment refuses anything outside it. This "
+                  "field offered a number, and the sample value it carried -- 1 -- was refused on "
+                  "every call."},
      ]},
     {"id": "session_commit", "label": "commit a session", "group": "Write", "method": "POST",
      "path": "/v1/session/commit", "scope": "context:ingest", "destructive": False,
@@ -2280,10 +2284,15 @@ MEM0_OPERATIONS: List[Json] = [
      "fields": []},
     {"id": "forget", "label": "forget()", "group": "Forget", "method": "POST", "path": "/v1/forget",
      "scope": "context:forget", "destructive": True, "needs_scope": False,
-     "summary": "Stop returning one memory. The record stays, so history still explains it.",
+     "summary": "Delete EVERY memory for the subject in the scope above -- mem0's "
+                "delete_all(user_id=...). Not one memory: the whole subject. A tombstone and an "
+                "audit entry are kept; the memories are not.",
      "fields": [
-         {"name": "memory_id", "in": "body", "kind": "text", "required": True,
-          "label": "Memory id", "placeholder": "mem_7f21"},
+         {"name": "confirm", "in": "body", "kind": "text", "required": True,
+          "label": "Confirm the subject",
+          "placeholder": "the user this key resolves to",
+          "help": "Must equal the RESOLVED scope user, which is not necessarily the user_id you "
+                  "send: a key resolving to root needs root here. Run users() to see it."},
      ]},
     {"id": "delete", "label": "delete()", "group": "Forget", "method": "POST", "path": "/v1/delete",
      "scope": "context:forget", "destructive": True, "needs_scope": False,
@@ -2296,7 +2305,11 @@ MEM0_OPERATIONS: List[Json] = [
      "path": "/v1/reset", "scope": "context:forget", "destructive": True, "needs_scope": True,
      "summary": "Drop everything in the scope shown above. There is no undo, and an empty user "
                 "field means the default scope, not none of them.",
-     "fields": []},
+     "fields": [
+         {"name": "confirm", "in": "body", "kind": "text", "required": True, "label": "Confirm",
+          "placeholder": "RESET",
+          "help": "The tenant id, or the literal word RESET. The call is refused without it."},
+     ]},
 ]
 
 ROUTE_DOCS: List[Json] = [

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -3702,301 +3702,317 @@ MEM0_JS = r"""
   /* Generated from the gateway's own MEM0_OPERATIONS, so an operation that gains an argument gains
      a field here without anyone remembering to add one. */
   var MEM0_OPS = [
-  {
-    "id": "add",
-    "label": "add()",
-    "group": "Write",
-    "method": "POST",
-    "path": "/v1/ingest",
-    "scope": "context:ingest",
-    "destructive": false,
-    "needs_scope": true,
-    "summary": "Write a turn. Acknowledged at 202 with extraction running behind it, which is why a search issued immediately afterwards can legitimately not see it yet.",
-    "fields": [
-      {
-        "name": "content",
-        "in": "message",
-        "kind": "textarea",
-        "required": true,
-        "label": "Message",
-        "placeholder": "The team agreed to keep the coupon stacking rule for ACME until Q4.",
-        "help": "Sent as one user turn."
-      },
-      {
-        "name": "finalize",
-        "in": "body",
-        "kind": "bool",
-        "default": true,
-        "label": "Extract before answering",
-        "help": "Off is how production behaves: the write is acknowledged and extraction runs in the background."
-      },
-      {
-        "name": "metadata",
-        "in": "body",
-        "kind": "json",
-        "label": "Metadata",
-        "placeholder": "{\"source\": \"portal\"}",
-        "help": "Stored alongside the memory and returned with it."
-      }
-    ]
-  },
-  {
-    "id": "search",
-    "label": "search()",
-    "group": "Read",
-    "method": "POST",
-    "path": "/v1/retrieve",
-    "scope": "context:retrieve",
-    "destructive": false,
-    "needs_scope": true,
-    "summary": "The retrieval path an agent uses: ranked, then packed to fit a token budget.",
-    "fields": [
-      {
-        "name": "query",
-        "in": "body",
-        "kind": "text",
-        "required": true,
-        "label": "Query",
-        "placeholder": "when do we ship?"
-      },
-      {
-        "name": "max_budget_tokens",
-        "in": "body",
-        "kind": "number",
-        "default": 2048,
-        "label": "Token budget",
-        "help": "The pack is built to fit this. A budget far below what the answer needs is indistinguishable from poor retrieval."
-      }
-    ]
-  },
-  {
-    "id": "get_all",
-    "label": "get_all()",
-    "group": "Read",
-    "method": "POST",
-    "path": "/v1/memories",
-    "scope": "context:retrieve",
-    "destructive": false,
-    "needs_scope": true,
-    "summary": "The memories in the scope, unranked -- the listing, not the search. A limit does not make it a sample of the whole scope: it takes the NEWEST that many.",
-    "fields": [
-      {
-        "name": "limit",
-        "in": "body",
-        "kind": "number",
-        "default": 50,
-        "label": "Limit",
-        "help": "The NEWEST this many, listed oldest first. 0 or blank for the whole scope."
-      }
-    ]
-  },
-  {
-    "id": "get",
-    "label": "get()",
-    "group": "Read",
-    "method": "GET",
-    "path": "/v1/memory/{id}",
-    "scope": "context:retrieve",
-    "destructive": false,
-    "needs_scope": false,
-    "summary": "One memory's stored record, by id.",
-    "fields": [
-      {
-        "name": "id",
-        "in": "path",
-        "kind": "text",
-        "required": true,
-        "label": "Memory id",
-        "placeholder": "mem_7f21"
-      }
-    ]
-  },
-  {
-    "id": "history",
-    "label": "history()",
-    "group": "Read",
-    "method": "GET",
-    "path": "/v1/memory/{id}/history",
-    "scope": "context:retrieve",
-    "destructive": false,
-    "needs_scope": false,
-    "summary": "How that memory changed: each supersede, with what it said before.",
-    "fields": [
-      {
-        "name": "id",
-        "in": "path",
-        "kind": "text",
-        "required": true,
-        "label": "Memory id",
-        "placeholder": "mem_7f21"
-      }
-    ]
-  },
-  {
-    "id": "get_by_key",
-    "label": "by identity key",
-    "group": "Read",
-    "method": "GET",
-    "path": "/v1/memory/by-key",
-    "scope": "context:retrieve",
-    "destructive": false,
-    "needs_scope": false,
-    "summary": "The one live value for an identity key in a scope \u2014 the shape a profile field wants, where the answer is a value and not a ranked list.",
-    "fields": [
-      {
-        "name": "identity_key",
-        "in": "query",
-        "kind": "text",
-        "required": true,
-        "label": "Identity key",
-        "placeholder": "ship_date"
-      },
-      {
-        "name": "user_id",
-        "in": "query",
-        "kind": "text",
-        "label": "User",
-        "from_scope": "user"
-      }
-    ]
-  },
-  {
-    "id": "users",
-    "label": "users()",
-    "group": "Read",
-    "method": "POST",
-    "path": "/v1/users",
-    "scope": "context:retrieve",
-    "destructive": false,
-    "needs_scope": true,
-    "summary": "Which users, agents and runs hold memories in this tenant.",
-    "fields": []
-  },
-  {
-    "id": "update",
-    "label": "update()",
-    "group": "Write",
-    "method": "POST",
-    "path": "/v1/update",
-    "scope": "context:ingest",
-    "destructive": false,
-    "needs_scope": false,
-    "summary": "Supersede a memory: the amended text is ingested and the old id tombstoned, so history keeps both.",
-    "fields": [
-      {
-        "name": "memory_id",
-        "in": "body",
-        "kind": "text",
-        "required": true,
-        "label": "Memory id",
-        "placeholder": "mem_7f21"
-      },
-      {
-        "name": "text",
-        "in": "body",
-        "kind": "textarea",
-        "required": true,
-        "label": "New text",
-        "placeholder": "We ship on Friday."
-      }
-    ]
-  },
-  {
-    "id": "feedback",
-    "label": "feedback()",
-    "group": "Write",
-    "method": "POST",
-    "path": "/v1/memory/feedback",
-    "scope": "context:ingest",
-    "destructive": false,
-    "needs_scope": false,
-    "summary": "Rate a retrieved memory. A write about a memory, so it gates like a write.",
-    "fields": [
-      {
-        "name": "memory_id",
-        "in": "body",
-        "kind": "text",
-        "required": true,
-        "label": "Memory id",
-        "placeholder": "mem_7f21"
-      },
-      {
-        "name": "rating",
-        "in": "body",
-        "kind": "number",
-        "default": 1,
-        "label": "Rating",
-        "help": "1 useful, -1 not."
-      }
-    ]
-  },
-  {
-    "id": "session_commit",
-    "label": "commit a session",
-    "group": "Write",
-    "method": "POST",
-    "path": "/v1/session/commit",
-    "scope": "context:ingest",
-    "destructive": false,
-    "needs_scope": true,
-    "summary": "Close a session and roll its turns into summaries. Until this runs the turns are stored but not summarised.",
-    "fields": []
-  },
-  {
-    "id": "forget",
-    "label": "forget()",
-    "group": "Forget",
-    "method": "POST",
-    "path": "/v1/forget",
-    "scope": "context:forget",
-    "destructive": true,
-    "needs_scope": false,
-    "summary": "Stop returning one memory. The record stays, so history still explains it.",
-    "fields": [
-      {
-        "name": "memory_id",
-        "in": "body",
-        "kind": "text",
-        "required": true,
-        "label": "Memory id",
-        "placeholder": "mem_7f21"
-      }
-    ]
-  },
-  {
-    "id": "delete",
-    "label": "delete()",
-    "group": "Forget",
-    "method": "POST",
-    "path": "/v1/delete",
-    "scope": "context:forget",
-    "destructive": true,
-    "needs_scope": false,
-    "summary": "Delete one memory outright.",
-    "fields": [
-      {
-        "name": "memory_id",
-        "in": "body",
-        "kind": "text",
-        "required": true,
-        "label": "Memory id",
-        "placeholder": "mem_7f21"
-      }
-    ]
-  },
-  {
-    "id": "delete_all",
-    "label": "delete_all()",
-    "group": "Forget",
-    "method": "POST",
-    "path": "/v1/reset",
-    "scope": "context:forget",
-    "destructive": true,
-    "needs_scope": true,
-    "summary": "Drop everything in the scope shown above. There is no undo, and an empty user field means the default scope, not none of them.",
-    "fields": []
-  }
-];
+    {
+      "id": "add",
+      "label": "add()",
+      "group": "Write",
+      "method": "POST",
+      "path": "/v1/ingest",
+      "scope": "context:ingest",
+      "destructive": false,
+      "needs_scope": true,
+      "summary": "Write a turn. Acknowledged at 202 with extraction running behind it, which is why a search issued immediately afterwards can legitimately not see it yet.",
+      "fields": [
+        {
+          "name": "content",
+          "in": "message",
+          "kind": "textarea",
+          "required": true,
+          "label": "Message",
+          "placeholder": "The team agreed to keep the coupon stacking rule for ACME until Q4.",
+          "help": "Sent as one user turn."
+        },
+        {
+          "name": "finalize",
+          "in": "body",
+          "kind": "bool",
+          "default": true,
+          "label": "Extract before answering",
+          "help": "Off is how production behaves: the write is acknowledged and extraction runs in the background."
+        },
+        {
+          "name": "metadata",
+          "in": "body",
+          "kind": "json",
+          "label": "Metadata",
+          "placeholder": "{\"source\": \"portal\"}",
+          "help": "Stored alongside the memory and returned with it."
+        }
+      ]
+    },
+    {
+      "id": "search",
+      "label": "search()",
+      "group": "Read",
+      "method": "POST",
+      "path": "/v1/retrieve",
+      "scope": "context:retrieve",
+      "destructive": false,
+      "needs_scope": true,
+      "summary": "The retrieval path an agent uses: ranked, then packed to fit a token budget.",
+      "fields": [
+        {
+          "name": "query",
+          "in": "body",
+          "kind": "text",
+          "required": true,
+          "label": "Query",
+          "placeholder": "when do we ship?"
+        },
+        {
+          "name": "max_budget_tokens",
+          "in": "body",
+          "kind": "number",
+          "default": 2048,
+          "label": "Token budget",
+          "help": "The pack is built to fit this. A budget far below what the answer needs is indistinguishable from poor retrieval."
+        }
+      ]
+    },
+    {
+      "id": "get_all",
+      "label": "get_all()",
+      "group": "Read",
+      "method": "POST",
+      "path": "/v1/memories",
+      "scope": "context:retrieve",
+      "destructive": false,
+      "needs_scope": true,
+      "summary": "The memories in the scope, unranked -- the listing, not the search. A limit does not make it a sample of the whole scope: it takes the NEWEST that many.",
+      "fields": [
+        {
+          "name": "limit",
+          "in": "body",
+          "kind": "number",
+          "default": 50,
+          "label": "Limit",
+          "help": "The NEWEST this many, listed oldest first. 0 or blank for the whole scope."
+        }
+      ]
+    },
+    {
+      "id": "get",
+      "label": "get()",
+      "group": "Read",
+      "method": "GET",
+      "path": "/v1/memory/{id}",
+      "scope": "context:retrieve",
+      "destructive": false,
+      "needs_scope": false,
+      "summary": "One memory's stored record, by id.",
+      "fields": [
+        {
+          "name": "id",
+          "in": "path",
+          "kind": "text",
+          "required": true,
+          "label": "Memory id",
+          "placeholder": "mem_7f21"
+        }
+      ]
+    },
+    {
+      "id": "history",
+      "label": "history()",
+      "group": "Read",
+      "method": "GET",
+      "path": "/v1/memory/{id}/history",
+      "scope": "context:retrieve",
+      "destructive": false,
+      "needs_scope": false,
+      "summary": "How that memory changed: each supersede, with what it said before.",
+      "fields": [
+        {
+          "name": "id",
+          "in": "path",
+          "kind": "text",
+          "required": true,
+          "label": "Memory id",
+          "placeholder": "mem_7f21"
+        }
+      ]
+    },
+    {
+      "id": "get_by_key",
+      "label": "by identity key",
+      "group": "Read",
+      "method": "GET",
+      "path": "/v1/memory/by-key",
+      "scope": "context:retrieve",
+      "destructive": false,
+      "needs_scope": false,
+      "summary": "The one live value for an identity key in a scope — the shape a profile field wants, where the answer is a value and not a ranked list.",
+      "fields": [
+        {
+          "name": "identity_key",
+          "in": "query",
+          "kind": "text",
+          "required": true,
+          "label": "Identity key",
+          "placeholder": "ship_date"
+        },
+        {
+          "name": "user_id",
+          "in": "query",
+          "kind": "text",
+          "label": "User",
+          "from_scope": "user"
+        }
+      ]
+    },
+    {
+      "id": "users",
+      "label": "users()",
+      "group": "Read",
+      "method": "POST",
+      "path": "/v1/users",
+      "scope": "context:retrieve",
+      "destructive": false,
+      "needs_scope": true,
+      "summary": "Which users, agents and runs hold memories in this tenant.",
+      "fields": []
+    },
+    {
+      "id": "update",
+      "label": "update()",
+      "group": "Write",
+      "method": "POST",
+      "path": "/v1/update",
+      "scope": "context:ingest",
+      "destructive": false,
+      "needs_scope": false,
+      "summary": "Supersede a memory: the amended text is ingested and the old id tombstoned, so history keeps both.",
+      "fields": [
+        {
+          "name": "memory_id",
+          "in": "body",
+          "kind": "text",
+          "required": true,
+          "label": "Memory id",
+          "placeholder": "mem_7f21"
+        },
+        {
+          "name": "text",
+          "in": "body",
+          "kind": "textarea",
+          "required": true,
+          "label": "New text",
+          "placeholder": "We ship on Friday."
+        }
+      ]
+    },
+    {
+      "id": "feedback",
+      "label": "feedback()",
+      "group": "Write",
+      "method": "POST",
+      "path": "/v1/memory/feedback",
+      "scope": "context:ingest",
+      "destructive": false,
+      "needs_scope": false,
+      "summary": "Rate a retrieved memory. A write about a memory, so it gates like a write.",
+      "fields": [
+        {
+          "name": "memory_id",
+          "in": "body",
+          "kind": "text",
+          "required": true,
+          "label": "Memory id",
+          "placeholder": "mem_7f21"
+        },
+        {
+          "name": "rating",
+          "in": "body",
+          "kind": "choice",
+          "choices": [
+            "POSITIVE",
+            "NEGATIVE",
+            "VERY_NEGATIVE"
+          ],
+          "default": "POSITIVE",
+          "label": "Rating",
+          "help": "The vocabulary is closed and the deployment refuses anything outside it. This field offered a number, and the sample value it carried -- 1 -- was refused on every call."
+        }
+      ]
+    },
+    {
+      "id": "session_commit",
+      "label": "commit a session",
+      "group": "Write",
+      "method": "POST",
+      "path": "/v1/session/commit",
+      "scope": "context:ingest",
+      "destructive": false,
+      "needs_scope": true,
+      "summary": "Close a session and roll its turns into summaries. Until this runs the turns are stored but not summarised.",
+      "fields": []
+    },
+    {
+      "id": "forget",
+      "label": "forget()",
+      "group": "Forget",
+      "method": "POST",
+      "path": "/v1/forget",
+      "scope": "context:forget",
+      "destructive": true,
+      "needs_scope": false,
+      "summary": "Delete EVERY memory for the subject in the scope above -- mem0's delete_all(user_id=...). Not one memory: the whole subject. A tombstone and an audit entry are kept; the memories are not.",
+      "fields": [
+        {
+          "name": "confirm",
+          "in": "body",
+          "kind": "text",
+          "required": true,
+          "label": "Confirm the subject",
+          "placeholder": "the user this key resolves to",
+          "help": "Must equal the RESOLVED scope user, which is not necessarily the user_id you send: a key resolving to root needs root here. Run users() to see it."
+        }
+      ]
+    },
+    {
+      "id": "delete",
+      "label": "delete()",
+      "group": "Forget",
+      "method": "POST",
+      "path": "/v1/delete",
+      "scope": "context:forget",
+      "destructive": true,
+      "needs_scope": false,
+      "summary": "Delete one memory outright.",
+      "fields": [
+        {
+          "name": "memory_id",
+          "in": "body",
+          "kind": "text",
+          "required": true,
+          "label": "Memory id",
+          "placeholder": "mem_7f21"
+        }
+      ]
+    },
+    {
+      "id": "delete_all",
+      "label": "delete_all()",
+      "group": "Forget",
+      "method": "POST",
+      "path": "/v1/reset",
+      "scope": "context:forget",
+      "destructive": true,
+      "needs_scope": true,
+      "summary": "Drop everything in the scope shown above. There is no undo, and an empty user field means the default scope, not none of them.",
+      "fields": [
+        {
+          "name": "confirm",
+          "in": "body",
+          "kind": "text",
+          "required": true,
+          "label": "Confirm",
+          "placeholder": "RESET",
+          "help": "The tenant id, or the literal word RESET. The call is refused without it."
+        }
+      ]
+    }
+  ];
 
   var currentOp = null;
 
@@ -4021,6 +4037,10 @@ MEM0_JS = r"""
     }).join("");
   }
 
+  function opHasConfirmField(op) {
+    return (op.fields || []).some(function (f) { return f.name === "confirm"; });
+  }
+
   function fieldControl(op, f) {
     var id = "op_" + op.id + "_" + f.name;
     var value = f["default"] == null ? "" : String(f["default"]);
@@ -4030,7 +4050,18 @@ MEM0_JS = r"""
         (f.help ? '<div class="hint">' + esc(f.help) + "</div>" : "");
     }
     var control;
-    if (f.kind === "textarea" || f.kind === "json") {
+    if (f.kind === "choice") {
+      /* A closed vocabulary is offered as a closed control. This one was a number box whose sample
+         value the deployment refuses -- "feedback must be one of POSITIVE, NEGATIVE, VERY_NEGATIVE
+         (got '1')" -- so the form asked for something that could never be accepted. */
+      control = '<select id="' + id + '" data-f="' + esc(f.name) + '">'
+        + (f.choices || []).map(function (choice) {
+            return '<option value="' + esc(choice) + '"'
+              + (String(f["default"]) === String(choice) ? " selected" : "") + ">"
+              + esc(choice) + "</option>";
+          }).join("")
+        + "</select>";
+    } else if (f.kind === "textarea" || f.kind === "json") {
       control = '<textarea id="' + id + '" data-f="' + esc(f.name) + '" spellcheck="false"' +
         (f.placeholder ? ' placeholder="' + esc(f.placeholder) + '"' : "") + ">" +
         esc(f.kind === "json" ? "" : value) + "</textarea>";
@@ -4058,11 +4089,17 @@ MEM0_JS = r"""
       '<span class="scope"> · needs ' + esc(op.scope) + esc(scopeLine) + "</span></div>" +
       '<p class="hint" style="margin-top:0">' + esc(op.summary) + "</p>" +
       op.fields.map(function (f) { return fieldControl(op, f); }).join("") +
-      (op.destructive
+      /* An operation whose own field IS a confirmation does not get a second box. Two controls
+         both labelled Confirm, one of which the request never carries, is how this came to look
+         guarded while sending a call the deployment always refused. */
+      (op.destructive && !opHasConfirmField(op)
         ? '<div class="mwarn"><b>This cannot be undone</b>Type <span class="mono">' + esc(op.id) +
           '</span> to confirm, then run.</div><label for="opConfirm">Confirm</label>' +
           '<input id="opConfirm" type="text" spellcheck="false" autocomplete="off">'
-        : "") +
+        : (op.destructive
+           ? '<div class="mwarn"><b>This cannot be undone</b>The confirm field above is the '
+             + 'guard, and the deployment checks it.</div>'
+           : "")) +
       '<div class="actions"><button id="opRun" type="button">Run</button>' +
       '<button id="opCurl" class="ghost" type="button">Copy as curl</button></div>' +
       '<pre id="opPreview"></pre></div>';
@@ -4175,7 +4212,7 @@ MEM0_JS = r"""
       say($("opMsg"), request.problems.join(" "), "warn");
       return;
     }
-    if (op.destructive) {
+    if (op.destructive && !opHasConfirmField(op)) {
       var confirmEl = $("opConfirm");
       if (!confirmEl || confirmEl.value.trim() !== op.id) {
         say($("opMsg"), "Type " + op.id + " in the confirm box to run this.", "warn");

--- a/tools/portal/mem0_portal.html
+++ b/tools/portal/mem0_portal.html
@@ -691,301 +691,317 @@
   /* Generated from the gateway's own MEM0_OPERATIONS, so an operation that gains an argument gains
      a field here without anyone remembering to add one. */
   var MEM0_OPS = [
-  {
-    "id": "add",
-    "label": "add()",
-    "group": "Write",
-    "method": "POST",
-    "path": "/v1/ingest",
-    "scope": "context:ingest",
-    "destructive": false,
-    "needs_scope": true,
-    "summary": "Write a turn. Acknowledged at 202 with extraction running behind it, which is why a search issued immediately afterwards can legitimately not see it yet.",
-    "fields": [
-      {
-        "name": "content",
-        "in": "message",
-        "kind": "textarea",
-        "required": true,
-        "label": "Message",
-        "placeholder": "The team agreed to keep the coupon stacking rule for ACME until Q4.",
-        "help": "Sent as one user turn."
-      },
-      {
-        "name": "finalize",
-        "in": "body",
-        "kind": "bool",
-        "default": true,
-        "label": "Extract before answering",
-        "help": "Off is how production behaves: the write is acknowledged and extraction runs in the background."
-      },
-      {
-        "name": "metadata",
-        "in": "body",
-        "kind": "json",
-        "label": "Metadata",
-        "placeholder": "{\"source\": \"portal\"}",
-        "help": "Stored alongside the memory and returned with it."
-      }
-    ]
-  },
-  {
-    "id": "search",
-    "label": "search()",
-    "group": "Read",
-    "method": "POST",
-    "path": "/v1/retrieve",
-    "scope": "context:retrieve",
-    "destructive": false,
-    "needs_scope": true,
-    "summary": "The retrieval path an agent uses: ranked, then packed to fit a token budget.",
-    "fields": [
-      {
-        "name": "query",
-        "in": "body",
-        "kind": "text",
-        "required": true,
-        "label": "Query",
-        "placeholder": "when do we ship?"
-      },
-      {
-        "name": "max_budget_tokens",
-        "in": "body",
-        "kind": "number",
-        "default": 2048,
-        "label": "Token budget",
-        "help": "The pack is built to fit this. A budget far below what the answer needs is indistinguishable from poor retrieval."
-      }
-    ]
-  },
-  {
-    "id": "get_all",
-    "label": "get_all()",
-    "group": "Read",
-    "method": "POST",
-    "path": "/v1/memories",
-    "scope": "context:retrieve",
-    "destructive": false,
-    "needs_scope": true,
-    "summary": "The memories in the scope, unranked -- the listing, not the search. A limit does not make it a sample of the whole scope: it takes the NEWEST that many.",
-    "fields": [
-      {
-        "name": "limit",
-        "in": "body",
-        "kind": "number",
-        "default": 50,
-        "label": "Limit",
-        "help": "The NEWEST this many, listed oldest first. 0 or blank for the whole scope."
-      }
-    ]
-  },
-  {
-    "id": "get",
-    "label": "get()",
-    "group": "Read",
-    "method": "GET",
-    "path": "/v1/memory/{id}",
-    "scope": "context:retrieve",
-    "destructive": false,
-    "needs_scope": false,
-    "summary": "One memory's stored record, by id.",
-    "fields": [
-      {
-        "name": "id",
-        "in": "path",
-        "kind": "text",
-        "required": true,
-        "label": "Memory id",
-        "placeholder": "mem_7f21"
-      }
-    ]
-  },
-  {
-    "id": "history",
-    "label": "history()",
-    "group": "Read",
-    "method": "GET",
-    "path": "/v1/memory/{id}/history",
-    "scope": "context:retrieve",
-    "destructive": false,
-    "needs_scope": false,
-    "summary": "How that memory changed: each supersede, with what it said before.",
-    "fields": [
-      {
-        "name": "id",
-        "in": "path",
-        "kind": "text",
-        "required": true,
-        "label": "Memory id",
-        "placeholder": "mem_7f21"
-      }
-    ]
-  },
-  {
-    "id": "get_by_key",
-    "label": "by identity key",
-    "group": "Read",
-    "method": "GET",
-    "path": "/v1/memory/by-key",
-    "scope": "context:retrieve",
-    "destructive": false,
-    "needs_scope": false,
-    "summary": "The one live value for an identity key in a scope \u2014 the shape a profile field wants, where the answer is a value and not a ranked list.",
-    "fields": [
-      {
-        "name": "identity_key",
-        "in": "query",
-        "kind": "text",
-        "required": true,
-        "label": "Identity key",
-        "placeholder": "ship_date"
-      },
-      {
-        "name": "user_id",
-        "in": "query",
-        "kind": "text",
-        "label": "User",
-        "from_scope": "user"
-      }
-    ]
-  },
-  {
-    "id": "users",
-    "label": "users()",
-    "group": "Read",
-    "method": "POST",
-    "path": "/v1/users",
-    "scope": "context:retrieve",
-    "destructive": false,
-    "needs_scope": true,
-    "summary": "Which users, agents and runs hold memories in this tenant.",
-    "fields": []
-  },
-  {
-    "id": "update",
-    "label": "update()",
-    "group": "Write",
-    "method": "POST",
-    "path": "/v1/update",
-    "scope": "context:ingest",
-    "destructive": false,
-    "needs_scope": false,
-    "summary": "Supersede a memory: the amended text is ingested and the old id tombstoned, so history keeps both.",
-    "fields": [
-      {
-        "name": "memory_id",
-        "in": "body",
-        "kind": "text",
-        "required": true,
-        "label": "Memory id",
-        "placeholder": "mem_7f21"
-      },
-      {
-        "name": "text",
-        "in": "body",
-        "kind": "textarea",
-        "required": true,
-        "label": "New text",
-        "placeholder": "We ship on Friday."
-      }
-    ]
-  },
-  {
-    "id": "feedback",
-    "label": "feedback()",
-    "group": "Write",
-    "method": "POST",
-    "path": "/v1/memory/feedback",
-    "scope": "context:ingest",
-    "destructive": false,
-    "needs_scope": false,
-    "summary": "Rate a retrieved memory. A write about a memory, so it gates like a write.",
-    "fields": [
-      {
-        "name": "memory_id",
-        "in": "body",
-        "kind": "text",
-        "required": true,
-        "label": "Memory id",
-        "placeholder": "mem_7f21"
-      },
-      {
-        "name": "rating",
-        "in": "body",
-        "kind": "number",
-        "default": 1,
-        "label": "Rating",
-        "help": "1 useful, -1 not."
-      }
-    ]
-  },
-  {
-    "id": "session_commit",
-    "label": "commit a session",
-    "group": "Write",
-    "method": "POST",
-    "path": "/v1/session/commit",
-    "scope": "context:ingest",
-    "destructive": false,
-    "needs_scope": true,
-    "summary": "Close a session and roll its turns into summaries. Until this runs the turns are stored but not summarised.",
-    "fields": []
-  },
-  {
-    "id": "forget",
-    "label": "forget()",
-    "group": "Forget",
-    "method": "POST",
-    "path": "/v1/forget",
-    "scope": "context:forget",
-    "destructive": true,
-    "needs_scope": false,
-    "summary": "Stop returning one memory. The record stays, so history still explains it.",
-    "fields": [
-      {
-        "name": "memory_id",
-        "in": "body",
-        "kind": "text",
-        "required": true,
-        "label": "Memory id",
-        "placeholder": "mem_7f21"
-      }
-    ]
-  },
-  {
-    "id": "delete",
-    "label": "delete()",
-    "group": "Forget",
-    "method": "POST",
-    "path": "/v1/delete",
-    "scope": "context:forget",
-    "destructive": true,
-    "needs_scope": false,
-    "summary": "Delete one memory outright.",
-    "fields": [
-      {
-        "name": "memory_id",
-        "in": "body",
-        "kind": "text",
-        "required": true,
-        "label": "Memory id",
-        "placeholder": "mem_7f21"
-      }
-    ]
-  },
-  {
-    "id": "delete_all",
-    "label": "delete_all()",
-    "group": "Forget",
-    "method": "POST",
-    "path": "/v1/reset",
-    "scope": "context:forget",
-    "destructive": true,
-    "needs_scope": true,
-    "summary": "Drop everything in the scope shown above. There is no undo, and an empty user field means the default scope, not none of them.",
-    "fields": []
-  }
-];
+    {
+      "id": "add",
+      "label": "add()",
+      "group": "Write",
+      "method": "POST",
+      "path": "/v1/ingest",
+      "scope": "context:ingest",
+      "destructive": false,
+      "needs_scope": true,
+      "summary": "Write a turn. Acknowledged at 202 with extraction running behind it, which is why a search issued immediately afterwards can legitimately not see it yet.",
+      "fields": [
+        {
+          "name": "content",
+          "in": "message",
+          "kind": "textarea",
+          "required": true,
+          "label": "Message",
+          "placeholder": "The team agreed to keep the coupon stacking rule for ACME until Q4.",
+          "help": "Sent as one user turn."
+        },
+        {
+          "name": "finalize",
+          "in": "body",
+          "kind": "bool",
+          "default": true,
+          "label": "Extract before answering",
+          "help": "Off is how production behaves: the write is acknowledged and extraction runs in the background."
+        },
+        {
+          "name": "metadata",
+          "in": "body",
+          "kind": "json",
+          "label": "Metadata",
+          "placeholder": "{\"source\": \"portal\"}",
+          "help": "Stored alongside the memory and returned with it."
+        }
+      ]
+    },
+    {
+      "id": "search",
+      "label": "search()",
+      "group": "Read",
+      "method": "POST",
+      "path": "/v1/retrieve",
+      "scope": "context:retrieve",
+      "destructive": false,
+      "needs_scope": true,
+      "summary": "The retrieval path an agent uses: ranked, then packed to fit a token budget.",
+      "fields": [
+        {
+          "name": "query",
+          "in": "body",
+          "kind": "text",
+          "required": true,
+          "label": "Query",
+          "placeholder": "when do we ship?"
+        },
+        {
+          "name": "max_budget_tokens",
+          "in": "body",
+          "kind": "number",
+          "default": 2048,
+          "label": "Token budget",
+          "help": "The pack is built to fit this. A budget far below what the answer needs is indistinguishable from poor retrieval."
+        }
+      ]
+    },
+    {
+      "id": "get_all",
+      "label": "get_all()",
+      "group": "Read",
+      "method": "POST",
+      "path": "/v1/memories",
+      "scope": "context:retrieve",
+      "destructive": false,
+      "needs_scope": true,
+      "summary": "The memories in the scope, unranked -- the listing, not the search. A limit does not make it a sample of the whole scope: it takes the NEWEST that many.",
+      "fields": [
+        {
+          "name": "limit",
+          "in": "body",
+          "kind": "number",
+          "default": 50,
+          "label": "Limit",
+          "help": "The NEWEST this many, listed oldest first. 0 or blank for the whole scope."
+        }
+      ]
+    },
+    {
+      "id": "get",
+      "label": "get()",
+      "group": "Read",
+      "method": "GET",
+      "path": "/v1/memory/{id}",
+      "scope": "context:retrieve",
+      "destructive": false,
+      "needs_scope": false,
+      "summary": "One memory's stored record, by id.",
+      "fields": [
+        {
+          "name": "id",
+          "in": "path",
+          "kind": "text",
+          "required": true,
+          "label": "Memory id",
+          "placeholder": "mem_7f21"
+        }
+      ]
+    },
+    {
+      "id": "history",
+      "label": "history()",
+      "group": "Read",
+      "method": "GET",
+      "path": "/v1/memory/{id}/history",
+      "scope": "context:retrieve",
+      "destructive": false,
+      "needs_scope": false,
+      "summary": "How that memory changed: each supersede, with what it said before.",
+      "fields": [
+        {
+          "name": "id",
+          "in": "path",
+          "kind": "text",
+          "required": true,
+          "label": "Memory id",
+          "placeholder": "mem_7f21"
+        }
+      ]
+    },
+    {
+      "id": "get_by_key",
+      "label": "by identity key",
+      "group": "Read",
+      "method": "GET",
+      "path": "/v1/memory/by-key",
+      "scope": "context:retrieve",
+      "destructive": false,
+      "needs_scope": false,
+      "summary": "The one live value for an identity key in a scope — the shape a profile field wants, where the answer is a value and not a ranked list.",
+      "fields": [
+        {
+          "name": "identity_key",
+          "in": "query",
+          "kind": "text",
+          "required": true,
+          "label": "Identity key",
+          "placeholder": "ship_date"
+        },
+        {
+          "name": "user_id",
+          "in": "query",
+          "kind": "text",
+          "label": "User",
+          "from_scope": "user"
+        }
+      ]
+    },
+    {
+      "id": "users",
+      "label": "users()",
+      "group": "Read",
+      "method": "POST",
+      "path": "/v1/users",
+      "scope": "context:retrieve",
+      "destructive": false,
+      "needs_scope": true,
+      "summary": "Which users, agents and runs hold memories in this tenant.",
+      "fields": []
+    },
+    {
+      "id": "update",
+      "label": "update()",
+      "group": "Write",
+      "method": "POST",
+      "path": "/v1/update",
+      "scope": "context:ingest",
+      "destructive": false,
+      "needs_scope": false,
+      "summary": "Supersede a memory: the amended text is ingested and the old id tombstoned, so history keeps both.",
+      "fields": [
+        {
+          "name": "memory_id",
+          "in": "body",
+          "kind": "text",
+          "required": true,
+          "label": "Memory id",
+          "placeholder": "mem_7f21"
+        },
+        {
+          "name": "text",
+          "in": "body",
+          "kind": "textarea",
+          "required": true,
+          "label": "New text",
+          "placeholder": "We ship on Friday."
+        }
+      ]
+    },
+    {
+      "id": "feedback",
+      "label": "feedback()",
+      "group": "Write",
+      "method": "POST",
+      "path": "/v1/memory/feedback",
+      "scope": "context:ingest",
+      "destructive": false,
+      "needs_scope": false,
+      "summary": "Rate a retrieved memory. A write about a memory, so it gates like a write.",
+      "fields": [
+        {
+          "name": "memory_id",
+          "in": "body",
+          "kind": "text",
+          "required": true,
+          "label": "Memory id",
+          "placeholder": "mem_7f21"
+        },
+        {
+          "name": "rating",
+          "in": "body",
+          "kind": "choice",
+          "choices": [
+            "POSITIVE",
+            "NEGATIVE",
+            "VERY_NEGATIVE"
+          ],
+          "default": "POSITIVE",
+          "label": "Rating",
+          "help": "The vocabulary is closed and the deployment refuses anything outside it. This field offered a number, and the sample value it carried -- 1 -- was refused on every call."
+        }
+      ]
+    },
+    {
+      "id": "session_commit",
+      "label": "commit a session",
+      "group": "Write",
+      "method": "POST",
+      "path": "/v1/session/commit",
+      "scope": "context:ingest",
+      "destructive": false,
+      "needs_scope": true,
+      "summary": "Close a session and roll its turns into summaries. Until this runs the turns are stored but not summarised.",
+      "fields": []
+    },
+    {
+      "id": "forget",
+      "label": "forget()",
+      "group": "Forget",
+      "method": "POST",
+      "path": "/v1/forget",
+      "scope": "context:forget",
+      "destructive": true,
+      "needs_scope": false,
+      "summary": "Delete EVERY memory for the subject in the scope above -- mem0's delete_all(user_id=...). Not one memory: the whole subject. A tombstone and an audit entry are kept; the memories are not.",
+      "fields": [
+        {
+          "name": "confirm",
+          "in": "body",
+          "kind": "text",
+          "required": true,
+          "label": "Confirm the subject",
+          "placeholder": "the user this key resolves to",
+          "help": "Must equal the RESOLVED scope user, which is not necessarily the user_id you send: a key resolving to root needs root here. Run users() to see it."
+        }
+      ]
+    },
+    {
+      "id": "delete",
+      "label": "delete()",
+      "group": "Forget",
+      "method": "POST",
+      "path": "/v1/delete",
+      "scope": "context:forget",
+      "destructive": true,
+      "needs_scope": false,
+      "summary": "Delete one memory outright.",
+      "fields": [
+        {
+          "name": "memory_id",
+          "in": "body",
+          "kind": "text",
+          "required": true,
+          "label": "Memory id",
+          "placeholder": "mem_7f21"
+        }
+      ]
+    },
+    {
+      "id": "delete_all",
+      "label": "delete_all()",
+      "group": "Forget",
+      "method": "POST",
+      "path": "/v1/reset",
+      "scope": "context:forget",
+      "destructive": true,
+      "needs_scope": true,
+      "summary": "Drop everything in the scope shown above. There is no undo, and an empty user field means the default scope, not none of them.",
+      "fields": [
+        {
+          "name": "confirm",
+          "in": "body",
+          "kind": "text",
+          "required": true,
+          "label": "Confirm",
+          "placeholder": "RESET",
+          "help": "The tenant id, or the literal word RESET. The call is refused without it."
+        }
+      ]
+    }
+  ];
 
   var currentOp = null;
 
@@ -1010,6 +1026,10 @@
     }).join("");
   }
 
+  function opHasConfirmField(op) {
+    return (op.fields || []).some(function (f) { return f.name === "confirm"; });
+  }
+
   function fieldControl(op, f) {
     var id = "op_" + op.id + "_" + f.name;
     var value = f["default"] == null ? "" : String(f["default"]);
@@ -1019,7 +1039,18 @@
         (f.help ? '<div class="hint">' + esc(f.help) + "</div>" : "");
     }
     var control;
-    if (f.kind === "textarea" || f.kind === "json") {
+    if (f.kind === "choice") {
+      /* A closed vocabulary is offered as a closed control. This one was a number box whose sample
+         value the deployment refuses -- "feedback must be one of POSITIVE, NEGATIVE, VERY_NEGATIVE
+         (got '1')" -- so the form asked for something that could never be accepted. */
+      control = '<select id="' + id + '" data-f="' + esc(f.name) + '">'
+        + (f.choices || []).map(function (choice) {
+            return '<option value="' + esc(choice) + '"'
+              + (String(f["default"]) === String(choice) ? " selected" : "") + ">"
+              + esc(choice) + "</option>";
+          }).join("")
+        + "</select>";
+    } else if (f.kind === "textarea" || f.kind === "json") {
       control = '<textarea id="' + id + '" data-f="' + esc(f.name) + '" spellcheck="false"' +
         (f.placeholder ? ' placeholder="' + esc(f.placeholder) + '"' : "") + ">" +
         esc(f.kind === "json" ? "" : value) + "</textarea>";
@@ -1047,11 +1078,17 @@
       '<span class="scope"> · needs ' + esc(op.scope) + esc(scopeLine) + "</span></div>" +
       '<p class="hint" style="margin-top:0">' + esc(op.summary) + "</p>" +
       op.fields.map(function (f) { return fieldControl(op, f); }).join("") +
-      (op.destructive
+      /* An operation whose own field IS a confirmation does not get a second box. Two controls
+         both labelled Confirm, one of which the request never carries, is how this came to look
+         guarded while sending a call the deployment always refused. */
+      (op.destructive && !opHasConfirmField(op)
         ? '<div class="mwarn"><b>This cannot be undone</b>Type <span class="mono">' + esc(op.id) +
           '</span> to confirm, then run.</div><label for="opConfirm">Confirm</label>' +
           '<input id="opConfirm" type="text" spellcheck="false" autocomplete="off">'
-        : "") +
+        : (op.destructive
+           ? '<div class="mwarn"><b>This cannot be undone</b>The confirm field above is the '
+             + 'guard, and the deployment checks it.</div>'
+           : "")) +
       '<div class="actions"><button id="opRun" type="button">Run</button>' +
       '<button id="opCurl" class="ghost" type="button">Copy as curl</button></div>' +
       '<pre id="opPreview"></pre></div>';
@@ -1164,7 +1201,7 @@
       say($("opMsg"), request.problems.join(" "), "warn");
       return;
     }
-    if (op.destructive) {
+    if (op.destructive && !opHasConfirmField(op)) {
       var confirmEl = $("opConfirm");
       if (!confirmEl || confirmEl.value.trim() !== op.id) {
         say($("opMsg"), "Type " + op.id + " in the confirm box to run this.", "warn");

--- a/tools/test_matrixark_mem0_console.py
+++ b/tools/test_matrixark_mem0_console.py
@@ -27,7 +27,7 @@ ADMIN = {"Authorization": "Bearer k-acme"}
 HERE = os.path.dirname(os.path.abspath(__file__))
 
 FIELD_PLACES = {"body", "scope", "query", "path", "message"}
-FIELD_KINDS = {"text", "textarea", "number", "bool", "json"}
+FIELD_KINDS = {"text", "textarea", "number", "bool", "json", "choice"}
 
 
 def _read_text(path: str) -> str:
@@ -65,6 +65,22 @@ class OperationTableTest(unittest.TestCase):
     def test_operation_ids_are_unique(self) -> None:
         ids = [op["id"] for op in gw.MEM0_OPERATIONS]
         self.assertEqual(sorted(set(ids)), sorted(ids))
+
+    def test_a_choice_offers_choices_and_defaults_to_one_of_them(self) -> None:
+        """A closed vocabulary rendered as a closed control, and a default the deployment will
+        accept. The rating field was a number whose sample value -- 1 -- the deployment refuses:
+        `feedback must be one of POSITIVE, NEGATIVE, VERY_NEGATIVE (got '1')`. A choice whose
+        default is not among its own options would put the same call back, wearing a select.
+        """
+        for op in gw.MEM0_OPERATIONS:
+            for field in op.get("fields") or []:
+                if field.get("kind") != "choice":
+                    continue
+                with self.subTest(op=op["id"], field=field["name"]):
+                    choices = field.get("choices") or []
+                    self.assertTrue(choices, "a choice with nothing to choose from")
+                    if field.get("default") is not None:
+                        self.assertIn(field["default"], choices)
 
     def test_every_field_is_well_formed(self) -> None:
         for op in gw.MEM0_OPERATIONS:

--- a/tools/test_matrixark_the_console_asks_for_what_the_call_needs.py
+++ b/tools/test_matrixark_the_console_asks_for_what_the_call_needs.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A form's declared fields are enough to make the call.
+
+Found by driving every mem0 API one at a time. Two of them could not succeed with what the console
+offers, and one of those is destructive:
+
+* ``forget`` offered ``memory_id``. The call ignores it and requires ``confirm`` equal to the
+  RESOLVED scope user, so the form could never complete -- and the description said "Stop returning
+  one memory. The record stays", while one call removed 200 of 200 memories and left the scope
+  empty.
+* ``delete_all`` offered no ``confirm`` at all, and the deployment refuses the call without one.
+
+Both were invisible to every existing check, because each of those checks compares the console with
+the gateway's own list -- and the list was wrong in exactly the same way. Two copies of a mistake
+agree with each other perfectly.
+
+So this asks the deployment instead. For each operation, a request is built from the fields the
+console declares, and the answer must not be the deployment saying a required argument is missing.
+That is the only assertion that could have caught it.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_v1_gateway as gw  # noqa: E402
+
+
+def _adapter(tmp):
+    from matrixark_mcp_backends import add_backend_arguments, build_mcp_adapter
+    from matrixark_mcp_server import MatrixArkMcpServer
+
+    parser = argparse.ArgumentParser(add_help=False)
+    add_backend_arguments(parser)
+    ns = parser.parse_args([])
+    ns.backend = "local"
+    from pathlib import Path
+    # A Path, not a string: the adapter reads `.parent` off it to place its sidecar files.
+    ns.event_log = Path(tmp) / "events.jsonl"
+    ns.local_store = os.path.join(tmp, "store.jsonl")
+    # The defaults are the live files on a developer box. A test that writes into them is not a
+    # test, so this refuses rather than trusting that the assignment above took.
+    for field in ("event_log", "local_store"):
+        assert str(getattr(ns, field)).startswith(tmp), "%s is not isolated" % field
+    return MatrixArkMcpServer(build_mcp_adapter(ns), access_mode="dev")
+
+
+class TheFormAsksForWhatTheCallNeedsTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.tmp = tempfile.mkdtemp(prefix="mem0form")
+        cls.app = gw.make_v1_app(_adapter(cls.tmp), gw.GatewayConfig.from_env())
+        cls.call("POST", "/v1/ingest",
+                 {"messages": [{"role": "user", "content": "we ship on Friday"}],
+                  "finalize": True})
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        shutil.rmtree(cls.tmp, ignore_errors=True)
+
+    @classmethod
+    def call(cls, method, path, body=None):
+        payload = json.dumps(body or {}).encode("utf-8")
+        scope = {"type": "http", "method": method, "path": path, "query_string": b"",
+                 "headers": [(b"content-type", b"application/json")]}
+        got = {"status": 0, "body": b""}
+        sent = [False]
+
+        async def receive():
+            if not sent[0]:
+                sent[0] = True
+                return {"type": "http.request", "body": payload, "more_body": False}
+            return {"type": "http.disconnect"}
+
+        async def send(message):
+            if message["type"] == "http.response.start":
+                got["status"] = message["status"]
+            elif message["type"] == "http.response.body":
+                got["body"] += message.get("body", b"")
+
+        asyncio.run(asyncio.wait_for(cls.app(scope, receive, send), timeout=120))
+        try:
+            return got["status"], json.loads(got["body"])
+        except Exception:
+            return got["status"], {}
+
+    @staticmethod
+    def _op(op_id):
+        return next(op for op in gw.MEM0_OPERATIONS if op["id"] == op_id)
+
+    def _resolved_user(self):
+        _, users = self.call("POST", "/v1/users", {})
+        return ((users or {}).get("access") or {}).get("user_id") or "root"
+
+    def test_forget_offers_the_argument_the_call_requires(self) -> None:
+        """It offered memory_id, which forget ignores, and not confirm, which it demands."""
+        names = [f["name"] for f in self._op("forget")["fields"]]
+        self.assertIn("confirm", names)
+        self.assertNotIn("memory_id", names,
+                         "forget does not address one memory, so offering an id says it does")
+
+    def test_forget_completes_with_what_the_form_asks_for(self) -> None:
+        status, body = self.call("POST", "/v1/forget", {"confirm": self._resolved_user()})
+        self.assertEqual(200, status, json.dumps(body)[:200])
+
+    def test_delete_all_offers_a_confirm(self) -> None:
+        self.assertIn("confirm", [f["name"] for f in self._op("delete_all")["fields"]])
+
+    def test_delete_all_completes_with_what_the_form_asks_for(self) -> None:
+        field = next(f for f in self._op("delete_all")["fields"] if f["name"] == "confirm")
+        status, body = self.call("POST", "/v1/reset", {"confirm": field["placeholder"]})
+        self.assertEqual(200, status, json.dumps(body)[:200])
+
+    def test_the_rating_the_form_offers_is_one_the_call_accepts(self) -> None:
+        """The field was a number and its sample value was 1, which the deployment refuses on every
+        call: `feedback must be one of POSITIVE, NEGATIVE, VERY_NEGATIVE (got '1')`."""
+        self.call("POST", "/v1/ingest", {"messages": [{"role": "user", "content": "a memory"}],
+                                         "finalize": True})
+        _, listed = self.call("POST", "/v1/memories", {"limit": 1})
+        rows = (listed or {}).get("memories") or []
+        if not rows:
+            self.skipTest("nothing stored to rate")
+        field = next(f for f in self._op("feedback")["fields"] if f["name"] == "rating")
+        status, body = self.call("POST", "/v1/memory/feedback",
+                                 {"memory_id": str(rows[0].get("id")),
+                                  "rating": field["default"]})
+        self.assertEqual(200, status, json.dumps(body)[:200])
+
+    def test_the_deployment_really_does_refuse_a_missing_argument(self) -> None:
+        """The floor. Every assertion above passes against a deployment that accepts anything, and
+        that deployment would have accepted the broken forms too."""
+        status, _ = self.call("POST", "/v1/reset", {})
+        self.assertGreaterEqual(status, 400,
+                                "the deployment accepted a call with its required argument "
+                                "missing, so nothing above proves anything")
+        # WHICH refusal it is -- a 400 naming the argument rather than a 500 blaming the backend --
+        # belongs to the change that classifies it, and is asserted there. Pinning it here would
+        # make this suite depend on the order those two land in.
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Found by driving every mem0 API one at a time against an isolated store.

## `forget()` is not what the console says it is

| | |
|---|---|
| **the console said** | “Stop returning one memory. The record stays, so history still explains it.” |
| **the backend says** | “Delete ALL memory for a scope (mem0 `delete_all(user_id=…)`) — the primary, complete deletion primitive.” |
| **measured** | one call removed **200 of 200** memories and left the scope empty |

## And it could not run

The call **ignores** the `memory_id` the form sends, and requires `confirm` equal to
the **resolved** scope user — not the `user_id` in the request. A key resolving to
`root` needs `root`, whatever `user_id` was sent:

```
confirm: "alice"  ->  500     (the user_id the request carried)
confirm: "root"   ->  200     (the identity it resolved to)
```

The form has no field for it, and the Confirm box beside it is a **client-side gate**
that checks you typed the operation's name — it is never put in the request. So the
destructive operation with the reassuring description was the one that could never
complete, and had it completed it would have emptied the subject.

## Three corrections

* **forget** — the description, and `confirm` instead of `memory_id`, with help
  saying it must be the resolved scope user and how to find it.
* **delete_all** — a `confirm` field at all. The deployment refuses the call without
  one, and the form had nowhere to put it.
* **feedback** — a choice, not a number. The vocabulary is closed —
  `POSITIVE`, `NEGATIVE`, `VERY_NEGATIVE` — and the form's own sample value, `1`, is
  refused on every call: *“feedback must be one of POSITIVE, NEGATIVE, VERY_NEGATIVE
  (got '1')”*.

An operation whose own field **is** a confirmation no longer gets a second box. Two
controls both labelled Confirm, one of which the request never carried, is how this
came to look guarded while sending a call the backend always refused.

## The suite that could have caught it

Every existing check compares the console against the gateway's own list — and the
list was wrong in exactly the same way. **Two copies of a mistake agree with each other
perfectly.**

So the new one asks the deployment instead: a request built from the fields the form
declares must not be refused for a missing argument, with the floor that the deployment
*does* refuse one — or nothing above proves anything.

The two copies of the operation list are held identical field for field by a test, and
they drifted **twice inside ten minutes** while making this change — once on a help
string, once on an ellipsis. The builder's copy is now written *from* the gateway's
list rather than typed beside it.

Full ratchet run on the branch: no new failures.
