### PR TITLE
Two launchers source a file that was never in the repository

### DIFF
--- a/tools/temporalstore_runtime_env.sh
+++ b/tools/temporalstore_runtime_env.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Shared runtime environment for the launchers that run the Rust engine from a checkout.
+#
+# `tools/run_rust_unified_tests.sh` and `tools/run_temporalstore_rust_ubuntu22.sh` both source this
+# file and call `temporalstore_export_sdk_loader_path`. It was not in the repository, so both
+# scripts died on their own line 5 -- `set -euo pipefail` turns a missing `source` into an
+# immediate exit, before either script does anything, and the message names a path rather than a
+# cause.
+#
+# The body is the loader-path block that `tools/matrixark_codex_rust_hook.sh` already runs inline,
+# lifted into the function those two scripts expect rather than invented: the SDK builds a cdylib,
+# and a binary that links it needs the directory holding it on the loader path.
+
+# Put the built SDK's library directory on the dynamic loader path, if it exists.
+# Takes the repository root. Safe to call more than once and safe when nothing is built yet --
+# a directory that is not there is skipped rather than exported as an empty entry, because an
+# empty component in LD_LIBRARY_PATH means "the current directory" to the loader.
+temporalstore_export_sdk_loader_path() {
+  local root="${1:-}"
+  if [[ -z "${root}" ]]; then
+    echo "temporalstore_export_sdk_loader_path: repository root argument is required" >&2
+    return 2
+  fi
+
+  local libdir
+  for libdir in \
+    "${root}/output/sdk/lib" \
+    "${root}/sdk/lib"; do
+    if [[ -d "${libdir}" ]]; then
+      export LD_LIBRARY_PATH="${libdir}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+    fi
+  done
+}

--- a/tools/test_a_sourced_file_is_in_the_repository.py
+++ b/tools/test_a_sourced_file_is_in_the_repository.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A shell script may not source a file that is not here.
+
+With `set -euo pipefail` a missing `source` is not a degraded mode: the script exits on that line,
+before it has done anything, and the error names a path instead of a cause. Both scripts that
+source a fixed path in this repository were dead that way --
+`tools/temporalstore_runtime_env.sh` is documented in the crate README as the file launchers
+consume, and it had never been committed.
+
+Only statically resolvable targets are checked. A path still holding a shell variable other than
+the repository root depends on runtime state and cannot be decided here, so it is skipped rather
+than guessed at.
+"""
+import os
+import re
+import unittest
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SOURCE_LINE = re.compile(r"^\s*(?:source|\.)\s+[\"']?([^\"'\s;]+)", re.M)
+
+# A floor: if the walk stops finding scripts, every assertion below passes on an empty set.
+MIN_SHELL_SCRIPTS = 15
+
+
+def _shell_scripts():
+    found = []
+    for dirpath, dirs, files in os.walk(REPO):
+        dirs[:] = [d for d in dirs if d not in (".git", "target", "node_modules")]
+        for name in files:
+            if name.endswith(".sh"):
+                found.append(os.path.join(dirpath, name))
+    return sorted(found)
+
+
+def _resolvable_sources():
+    """(script, resolved target) for every source directive with no unresolved variable left."""
+    out = []
+    for path in _shell_scripts():
+        try:
+            with open(path, encoding="utf-8", errors="replace") as handle:
+                text = handle.read()
+        except OSError:
+            continue
+        for raw in SOURCE_LINE.findall(text):
+            resolved = raw
+            for token in ("${ROOT}", "$ROOT", "${REPO_ROOT}", "$REPO_ROOT"):
+                resolved = resolved.replace(token, REPO)
+            if "$" in resolved:
+                continue
+            if not os.path.isabs(resolved):
+                resolved = os.path.join(os.path.dirname(path), resolved)
+            out.append((path, resolved))
+    return out
+
+
+class ASourcedFileIsInTheRepository(unittest.TestCase):
+    def test_there_are_scripts_to_check(self):
+        """Non-vacuity: with no scripts found, the check below passes having examined nothing."""
+        scripts = _shell_scripts()
+        self.assertGreaterEqual(
+            len(scripts), MIN_SHELL_SCRIPTS,
+            "found %d shell scripts under %s, expected at least %d -- if the layout changed, the "
+            "assertion below runs on an empty set" % (len(scripts), REPO, MIN_SHELL_SCRIPTS))
+
+    def test_something_is_actually_resolvable(self):
+        """The second half of the floor: scripts exist, but do any of them source a fixed path?"""
+        self.assertTrue(
+            _resolvable_sources(),
+            "no source directive resolved to a fixed path, so the check below cannot fail")
+
+    def test_no_script_sources_a_file_that_is_missing(self):
+        missing = sorted(
+            "%s -> %s" % (os.path.relpath(script, REPO), os.path.relpath(target, REPO))
+            for script, target in _resolvable_sources()
+            if not os.path.isfile(target))
+        self.assertEqual(
+            [], missing,
+            "these scripts source a file that is not in the repository, so they exit on that line "
+            "before doing anything: %s" % missing)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two launchers source a file that was never in the repository

`tools/run_rust_unified_tests.sh` and `tools/run_temporalstore_rust_ubuntu22.sh` both begin:

    set -euo pipefail
    ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
    source "${ROOT}/tools/temporalstore_runtime_env.sh"
    temporalstore_export_sdk_loader_path "${ROOT}"

That file is not here, and `git log --all --diff-filter=AD` finds no commit that ever added it.
With `set -e` a missing `source` is not a degraded mode -- the script exits on that line, having
done nothing:

    tools/run_rust_unified_tests.sh: line 5: .../tools/temporalstore_runtime_env.sh:
    No such file or directory

So both launchers are unrunnable from a clean checkout, and one of them is the unified Rust test
entry point a contributor would reach for first. The crate README documents the file by name --
"launchers consume the same names through `tools/temporalstore_runtime_env.sh`" -- so the
documentation describes something no clone has ever had.

`temporalstore_export_sdk_loader_path` is defined nowhere either; those two calls are its only
mentions. Rather than invent a contract, the body is the loader-path block
`tools/matrixark_codex_rust_hook.sh` already runs inline, lifted into the function these scripts
ask for: the SDK builds a cdylib, and a binary linking it needs that directory on the loader path.

A directory that is not built is skipped rather than exported, because an empty component in
LD_LIBRARY_PATH means "the current directory" to the loader, and a missing root argument returns 2
instead of exporting a path rooted at nothing.

Verified by replicating each script's own `ROOT` computation and running its line 5 and line 6:
both succeed. Also verified in both directions -- with neither `output/sdk/lib` nor `sdk/lib`
present the variable is left alone, and against a root where one exists it is exported. The full
suites are not run here; they build, and what was broken was the ability to start at all.

The guard is the part that generalises. It resolves every `source` directive in every shell script
that names a fixed path, and fails naming the script and the target. It carries two floors -- that
scripts were found at all, and that at least one directive resolved -- so it cannot pass by
examining nothing. Both statically resolvable directives in this repository were the two above.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>
