### PR TITLE
The recovery check and the serving path now agree on what a hot record is

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -104,20 +104,10 @@ try:
 except ModuleNotFoundError:  # Direct script execution from tools/.
     from matrixark_mcp_local_idempotency import build_idempotency_record as _build_idempotency_record
 
-RETRIEVAL_HOT_RECORD_TYPES = {
-    "context_compression_event",
-    "context_embedding",
-    "context_entity",
-    "context_event",
-    "context_index",
-    "context_segment",
-    "context_summary",
-    "matrixark_async_pipeline_task",
-    "resource_chunk",
-    "resource_manifest",
-    "skill_registry_update",
-    "skill_section",
-}
+try:  # the list lives with the retrieval records; this module re-exports it
+    from tools.matrixark_mcp_retrieval_records import RETRIEVAL_HOT_RECORD_TYPES  # noqa: F401
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_retrieval_records import RETRIEVAL_HOT_RECORD_TYPES  # noqa: F401
 
 RESOURCE_IMPORT_IGNORE_DIRS = {".git", "node_modules", "target", "build", "dist", ".venv", "__pycache__"}
 LOCAL_DURABLE_READ_CACHE_ENABLED = os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_CACHE_ENABLED", "1").strip().lower() not in {"0", "false", "no"}

--- a/tools/matrixark_mcp_retrieval_records.py
+++ b/tools/matrixark_mcp_retrieval_records.py
@@ -25,6 +25,9 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
     )
 
 
+#: One list, because matrixark_mcp_recovery uses it to decide whether a recovered store still
+#: serves, and the serving path uses its own copy. A type missing from one of them means the
+#: check and the thing it checks disagree.
 RETRIEVAL_HOT_RECORD_TYPES = {
     "context_compression_event",
     "context_embedding",
@@ -33,6 +36,7 @@ RETRIEVAL_HOT_RECORD_TYPES = {
     "context_index",
     "context_segment",
     "context_summary",
+    "matrixark_async_pipeline_task",
     "resource_chunk",
     "resource_manifest",
     "skill_registry_update",


### PR DESCRIPTION
`RETRIEVAL_HOT_RECORD_TYPES` was defined twice, with different members, and the module that checks
whether a recovered store still serves read the shorter one.

| | members | has `matrixark_async_pipeline_task` |
|---|---|---|
| `matrixark_mcp_local_adapter` | 12 | yes |
| `matrixark_mcp_retrieval_records` | 11 | **no** |

Five modules read this list. Four resolve the 12-member copy — the serving paths. The fifth,
`matrixark_mcp_recovery`, imports the 11-member copy by name and uses it in three places:

- `_retrieval_smoke_from_compacted_records`, the check that a recovered store can still be
  retrieved from,
- the `hot_counts` / `compacted_hot_counts` report,
- the guard that fires when a store comes back with no hot records in it at all.

**The live store holds 1,255 `matrixark_async_pipeline_task` records.** Recovery's answer to "does
this store still serve?" was computed over a set that excluded every one of them. A store whose
surviving records were mostly of that type would be reported as having recovered nothing, and the
hot counts under-report by that type in every case.

This is the failure mode the recovery rule exists to prevent: a recovery is verified by serving
reads, and here the verification used a different notion of what serving reads than serving does.

## What changed

One definition, in `matrixark_mcp_retrieval_records` — the module about retrieval records — with the
member that was missing. `matrixark_mcp_local_adapter` re-exports it rather than restating it.
Neither module imported the other before, so this adds one edge and no cycle.

Only `matrixark_mcp_recovery` reads the copy whose value changes, so the behaviour that moves is
exactly the intended one: recovery now counts and smoke-checks the same types the serving path does.

## Checked

- All seven modules that read the list now report 12 members including the missing type, asked of
  the module objects rather than the source.
- `test_matrixark_mcp_recovery` passes (6 tests).
- `tools.test_matrixark_python_module_boundaries` reports 11 failures and 17 errors — identical with
  the change and at HEAD, with `__pycache__` cleared between runs, so it is pre-existing and not
  something this introduces.
- Full suite name-diffed against a run on main.

## Noted while here, not changed

Three more constants are defined twice with different values. Unlike this one they have no
production reader outside their defining modules, so they are stale copies rather than live
disagreements, and deleting them is a separate tidy-up:

| constant | difference |
|---|---|
| `SECONDARY_INDEX_PRIORITY_PREFIXES` | `matrixark_mcp_indexing` lists three prefixes core does not |
| `SERVING_RESOURCE_METADATA_FIELDS` | `matrixark_mcp_resources` lists three fields core does not |
| `MATRIXARK_CONTEXT_SCOPES` | `matrixark_mcp_identity` is missing `context:forget` — its single reader resolves the complete copy, so no scope check is affected |
