### PR TITLE
A delegation re-ran a failing import on every call

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -2300,11 +2300,24 @@ def non_default_classification(value: Any) -> str:
     return "" if classification in {"", "NEW_EVENT"} else classification
 
 
+#: Resolved on first use and remembered. The import below is deferred on purpose -- doing it at
+#: module scope closes a cycle -- but the DOTTED form raises ModuleNotFoundError whenever there is no
+#: `tools` package on the path, which is how the adapter runs, and Python does not cache the fact
+#: that a module could not be found. So the whole finder ran on every call: sys.path walk, directory
+#: stats, the exception, then the fallback. Sampling a post-write retrieve put 65.2% of it here, with
+#: 66.8% of all samples inside importlib.
+_shared_benchmark_quality_index_terms: Any = None
+
+
 def benchmark_quality_index_terms(*values: Any) -> list[str]:
-    try:
-        from tools.matrixark_mcp_indexing import benchmark_quality_index_terms as shared_benchmark_quality_index_terms
-    except ModuleNotFoundError:  # Direct script execution from tools/.
-        from matrixark_mcp_indexing import benchmark_quality_index_terms as shared_benchmark_quality_index_terms
+    global _shared_benchmark_quality_index_terms
+    shared_benchmark_quality_index_terms = _shared_benchmark_quality_index_terms
+    if shared_benchmark_quality_index_terms is None:
+        try:
+            from tools.matrixark_mcp_indexing import benchmark_quality_index_terms as shared_benchmark_quality_index_terms
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_indexing import benchmark_quality_index_terms as shared_benchmark_quality_index_terms
+        _shared_benchmark_quality_index_terms = shared_benchmark_quality_index_terms
     return shared_benchmark_quality_index_terms(*values)
 
 

--- a/tools/test_a_deferred_delegation_resolves_once.py
+++ b/tools/test_a_deferred_delegation_resolves_once.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A deferred delegation resolves once, not on every call.
+
+``benchmark_quality_index_terms`` forwards to ``matrixark_mcp_indexing``. The import is deferred on
+purpose -- doing it at module scope closes a cycle -- but it was inside the function body, and the
+DOTTED form raises ``ModuleNotFoundError`` whenever there is no ``tools`` package on the path, which
+is how the adapter runs.
+
+**Python does not cache the fact that a module could not be found.** So every call re-ran the whole
+finder: a ``sys.path`` walk, a directory stat per entry, the exception, and only then the fallback
+that succeeds out of ``sys.modules``. Measured: a failing ``from tools.X import y`` costs 238.49 us
+against 1.45 us for the fallback -- **165x** -- and one post-write retrieve made 307 of them, 75.6 ms
+of a 563 ms call.
+
+Counting ATTEMPTS is the test, not timing: the cost is per attempt and the wall clock on a shared
+box is not stable enough to see 13% reliably.
+"""
+from __future__ import annotations
+
+import builtins
+import os
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS)
+
+import matrixark_mcp_server  # noqa: F401,E402  -- core <-> core_packing only resolves this way
+import matrixark_mcp_core as core  # noqa: E402
+import matrixark_mcp_indexing as indexing  # noqa: E402
+
+
+class ADeferredDelegationResolvesOnceTest(unittest.TestCase):
+
+    def _attempts(self, fn, *, prefix="tools.") -> int:
+        """How many imports naming `prefix` are attempted while `fn` runs."""
+        count = 0
+        real = builtins.__import__
+
+        def counting(name, globals=None, locals=None, fromlist=(), level=0):
+            nonlocal count
+            if name.startswith(prefix):
+                count += 1
+            return real(name, globals, locals, fromlist, level)
+
+        builtins.__import__ = counting
+        try:
+            fn()
+        finally:
+            builtins.__import__ = real
+        return count
+
+    def test_repeated_calls_do_not_re_attempt_the_import(self) -> None:
+        """The whole point. One resolution, however many calls follow."""
+        core.benchmark_quality_index_terms("warm")          # resolve first
+        attempts = self._attempts(
+            lambda: [core.benchmark_quality_index_terms(f"value {i}") for i in range(50)])
+        self.assertEqual(attempts, 0,
+                         "a resolved delegation re-attempted the import that already failed once")
+
+    def test_the_wrapper_answers_what_the_implementation_answers(self) -> None:
+        """Memoising a delegate is only correct if it is the same delegate."""
+        for args in ((), ("alpha",), ("alpha", "beta"), ("Alpha Beta", "gamma"), (None,), ("",)):
+            self.assertEqual(core.benchmark_quality_index_terms(*args),
+                             indexing.benchmark_quality_index_terms(*args),
+                             f"the wrapper and the implementation disagree on {args!r}")
+
+    def test_it_still_resolves_from_a_cold_module_state(self) -> None:
+        """Clearing what it remembered must send it back to the import, not to None."""
+        remembered = core._shared_benchmark_quality_index_terms
+        try:
+            core._shared_benchmark_quality_index_terms = None
+            first = self._attempts(lambda: core.benchmark_quality_index_terms("cold"))
+            self.assertGreaterEqual(first, 0)          # it may resolve by either arm
+            self.assertIsNotNone(core._shared_benchmark_quality_index_terms,
+                                 "the delegate was not remembered after a cold resolve")
+            again = self._attempts(lambda: core.benchmark_quality_index_terms("warm again"))
+            self.assertEqual(again, 0, "the second call re-attempted the import")
+        finally:
+            core._shared_benchmark_quality_index_terms = remembered
+
+    def test_a_failing_dotted_import_really_is_not_cached(self) -> None:
+        """The premise, asserted rather than assumed: this is why the fix is needed at all.
+
+        If Python ever started remembering a failed import, this test would fail and the whole
+        change would be unnecessary -- which is worth knowing.
+        """
+        def attempt():
+            try:
+                from tools.matrixark_mcp_indexing import benchmark_quality_index_terms  # noqa: F401
+            except ModuleNotFoundError:
+                pass
+        first = self._attempts(attempt)
+        second = self._attempts(attempt)
+        if first == 0:
+            self.skipTest("a `tools` package is importable here, so the dotted form succeeds")
+        self.assertEqual(second, first,
+                         "a failed import appears to be cached; the deferred shims cost nothing")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
`benchmark_quality_index_terms` forwards to `matrixark_mcp_indexing`, and resolved that delegate on
**every call**:

    def benchmark_quality_index_terms(*values):
        try:
            from tools.matrixark_mcp_indexing import benchmark_quality_index_terms as shared
        except ModuleNotFoundError:  # Direct script execution from tools/.
            from matrixark_mcp_indexing import benchmark_quality_index_terms as shared
        return shared(*values)

The dotted form raises `ModuleNotFoundError` whenever there is no `tools` package on the path, which
is how the adapter runs. **Python does not cache the fact that a module could not be found**, so
every call re-ran the whole finder: a `sys.path` walk, a directory stat per entry, the exception,
and only then the fallback that succeeds out of `sys.modules`.

| | |
|---|---|
| a failing `from tools.X import y` | **238.49 us** |
| the fallback that succeeds | 1.45 us (**165x** cheaper) |
| dotted imports attempted per post-write retrieve | **317 -> 10** |
| of which this function | **307 -> 0** |
| that cost | **75.6 ms -> 2.4 ms**, 13.4% of the retrieve -> 0.5% |

The deferral is kept -- the import still happens on first use rather than at module scope, which is
what avoids the cycle it was written for. It just happens once.

## How this was found, because the first two answers were wrong

cProfile put 41% of the same retrieve on `candidate_memory_layer_name`. Removing 19,391 of its
20,401 calls moved the wall clock by **zero**: cProfile charges per call, so a cheap function called
20,000 times reads as a hotspot it is not. Before that, it put 96% on `retrieval_records`, which on
real data is 11.55 ms of a 400 ms call -- that one was a bad fixture.

A **sampling** profiler found this in one run: 65.2% of the retrieve in this function, and 66.8% of
all samples inside `importlib`, which named the cause rather than the location.

## Test

Timing is not the test -- a shared box moved this retrieve between 372 ms and 968 ms while measuring.
The cost is per import ATTEMPT, so the tests **count attempts** by wrapping `__import__`:

* 50 calls after the first resolve attempt **0** imports;
* the wrapper answers exactly what the implementation answers, on six inputs;
* clearing what it remembered sends it back to the import, and the call after that is free again;
* and the premise itself is asserted -- a failing dotted import really is re-attempted every time. If
  Python ever cached it, that test fails and this change becomes unnecessary, which is worth knowing.

| mutation | result |
|---|---|
| the original, importing on every call | **1 failure, 1 error** |
| resolve but never remember | **2 failures** |

## There are more of these

Sweeping `tools/` finds **73 functions** with an in-body `from tools.X import ...`, **11 of them on
the retrieve path**. This PR fixes the one that measurement showed is 98% of the cost on this path
(307 of 317 attempts). The remaining 10 attempts per retrieve are 2.4 ms across three functions and
are left for a change that can show its own number.

The largest cluster is not on this path at all: **`matrixark_mcp_temporal_adapters` holds 23**,
among them `_read_all_compacted`, `_read_raw_records` and `append_idempotency_record` -- the native
backend's hot reads and writes. `matrixark_mcp_local_adapter.compact_and_apply_tombstones` carries
three. None of those are measured here, because exercising them needs a live store rather than a
local fixture, and a number I have not taken does not belong in a PR body.

For contrast, the write path barely pays this: one full ingest through the server attempts **6**
dotted imports (1.4 ms, 1.9% of it), a delete **5**, and a plain append **0**. The tax is
concentrated on retrieve, which is why this PR is scoped to it.

---

## CORRECTION, and a correction to that correction

The numbers above were taken by a harness where `from tools.X import y` **fails**. In the live hook
it **succeeds**, and the change therefore buys far less there than the body implies.

I first attributed this to the working directory. That is wrong, and the real rule is worth stating
because it is easy to get backwards:

* `python3 /path/to/script.py` puts the **script's own directory** on `sys.path[0]` -- *not* the
  working directory. So a harness in `/root/goal` run from the repository root does **not** see
  `tools`, and every dotted attempt fails.
* `python3 -c ...` and `python3 -m ...` put the **working directory** on `sys.path`. Run from the
  repository root, the same import succeeds.

`tools/__init__.py` exists, so `tools` is a real package whenever its parent is reachable. Measured,
separating the one-time import from the steady state:

| `sys.path` includes the repository root | first attempt | steady state |
|---|---|---|
| yes | 36,197 us (**succeeds**) | **1.47 us** |
| no | 1,206 us (fails) | **134.98 us** |

**The live hook is in the first row**, and not by accident: `matrixark_codex_hook.load_matrixark`
does `sys.path.insert(0, str(root))` at line 2267 before it imports the server, so by the time any of
these shims runs the root is on the path and the dotted form resolves out of `sys.modules`.

So this change buys about a microsecond in the hook, and 135 us per call in the test suite and every
measurement harness in this repository -- which is where the body's figures came from. It is still
right, because resolving once is never worse than resolving repeatedly, but I measured it in the
wrong environment and stated the benefit too broadly.
