### PR TITLE
A guard could not import the module it guards

### DIFF
--- a/tools/test_a_nested_function_that_captures_nothing_is_hoisted.py
+++ b/tools/test_a_nested_function_that_captures_nothing_is_hoisted.py
@@ -34,9 +34,21 @@ import unittest
 
 
 def _module():
+    """The module under guard, imported the only way it can be.
+
+    It and `matrixark_mcp_local_adapter` import each other -- the mixin split -- so neither can be
+    entered first. Asking for this one directly raises "cannot import name
+    _LocalAdapterRetrieveMixin from partially initialized module", on BOTH arms: the dotted form for
+    want of a `tools` package, the bare one on the cycle. That is why this guard errored rather than
+    checked anything.
+
+    Importing the adapter first resolves the pair, and this module is then complete in `sys.modules`.
+    """
     try:
+        importlib.import_module("tools.matrixark_mcp_local_adapter")
         return importlib.import_module("tools.matrixark_local_adapter_retrieve")
     except ImportError:
+        importlib.import_module("matrixark_mcp_local_adapter")
         return importlib.import_module("matrixark_local_adapter_retrieve")
 
 


### PR DESCRIPTION
`test_a_nested_function_that_captures_nothing_is_hoisted` errors on `main` -- all three of its tests,
in `setUp`. It has not been checking anything.

It guards `matrixark_local_adapter_retrieve`, and cannot import it:

    ImportError: cannot import name '_LocalAdapterRetrieveMixin' from partially initialized
    module 'matrixark_local_adapter_retrieve'

That module and `matrixark_mcp_local_adapter` import each other -- the mixin split -- so **neither
can be entered first**, and both arms of the guard's try/except fail: the dotted form for want of a
`tools` package, the bare fallback on the cycle.

Importing the adapter that owns the mixin first resolves the pair; by the time the retrieve module is
asked for, it is complete in `sys.modules`. That is the whole change.

## It works, and it discriminates

Revived, it **passes** -- the code it guards is currently compliant, which is worth knowing after it
spent that time silent.

And it is not passing vacuously. Planting exactly what it exists to catch -- a nested `def` inside
`retrieve` that closes over nothing:

    def _planted_free_function(value):
        return str(value).strip().lower()

makes it **fail**. So the guard is live again rather than merely green.

The test's own docstring already warned about a version of this: it says a static-only detector
"reported all twenty as capturing something and would have passed vacuously forever". Erroring in
`setUp` is the same failure one step earlier -- a guard that cannot reach its subject is not a weaker
guard, it is no guard.
