### PR TITLE
Three closures re-derived every candidate's layer on every step

### DIFF
--- a/tools/matrixark_mcp_core_ref_selection.py
+++ b/tools/matrixark_mcp_core_ref_selection.py
@@ -361,6 +361,11 @@ def select_token_budgeted_refs(
     candidates = prefer_profile_entities_for_current_state(candidates, question_type)
     candidates.sort(key=lambda item: packing_sort_key(item, question_type), reverse=True)
     candidates = diversify_for_question_type(candidates, question_type, total_limit=candidate_pool_limit)
+    # `candidates` is final here -- nothing below reassigns it, and no candidate dict is written to
+    # -- so each one's memory layer is settled and worth deriving once. The three "remaining floor"
+    # closures below each re-scan the tail on every selection step and asked for it every time:
+    # 19,698 of a retrieve's 20,401 calls to candidate_memory_layer_name, 6,566 apiece.
+    candidate_layer_names = [candidate_memory_layer_name(candidate) for candidate in candidates]
     selected: list[Json] = []
     used_tokens = 0
     cross_session_policy = cross_session_policy or {"enabled": False, "budget_tokens": 0, "max_sessions": 0, "max_candidates": 0, "min_entity_bridge_refs": 0}
@@ -497,8 +502,9 @@ def select_token_budgeted_refs(
         )
 
     def remaining_profile_overview_floor_layer(start_index: int) -> str:
-        for remaining in candidates[start_index:]:
-            remaining_layer = candidate_memory_layer_name(remaining)
+        for index in range(start_index, len(candidates)):
+            remaining = candidates[index]
+            remaining_layer = candidate_layer_names[index]
             if remaining_layer not in high_level_profile_memory_layers:
                 continue
             try:
@@ -518,8 +524,9 @@ def select_token_budgeted_refs(
         return ""
 
     def remaining_profile_entity_floor_layer(start_index: int) -> str:
-        for remaining in candidates[start_index:]:
-            remaining_layer = candidate_memory_layer_name(remaining)
+        for index in range(start_index, len(candidates)):
+            remaining = candidates[index]
+            remaining_layer = candidate_layer_names[index]
             if remaining_layer not in profile_entity_bridge_layers:
                 continue
             try:
@@ -545,8 +552,9 @@ def select_token_budgeted_refs(
         )
 
     def remaining_codex_outcome_evidence_floor_layer(start_index: int) -> str:
-        for remaining in candidates[start_index:]:
-            remaining_layer = candidate_memory_layer_name(remaining)
+        for index in range(start_index, len(candidates)):
+            remaining = candidates[index]
+            remaining_layer = candidate_layer_names[index]
             if remaining_layer not in codex_outcome_evidence_layers:
                 continue
             try:


### PR DESCRIPTION
Three closures in `select_token_budgeted_refs` -- `remaining_profile_overview_floor_layer`,
`remaining_profile_entity_floor_layer` and `remaining_codex_outcome_evidence_floor_layer` -- each
scan `candidates[start_index:]` and ask `candidate_memory_layer_name` for every candidate. They run
once per selection step, so the same answer is re-derived for the same candidate on every step.

Over one retrieve that is **19,698 of 20,401 calls to that function -- 96.6%** -- 6,566 apiece.

A candidate's layer is settled by then: nothing reassigns `candidates` after
`diversify_for_question_type`, and no candidate dict is written to anywhere in the function (checked
from the AST, not by reading). So it is derived once, per candidate, and indexed. Iterating by index
also stops `candidates[start_index:]` copying the tail of the list on every call.

**20,401 calls -> 1,010.**

## I first measured this as "no win", and that was wrong

A wall-clock A/B said 472 ms before and 483 ms after, so I reverted it. That conclusion was not
supported: this box moved the *same* retrieve between 372 ms and 968 ms while measuring, and an
effect this size is under that spread. "No measurable win" and "no win" are different findings and I
reported the wrong one.

A **sampling** profiler reports SHARES, and a share is a ratio inside one run, so load cancels out.
Two pairs, alternating:

| | `candidate_memory_layer_name` share of the retrieve |
|---|---|
| before | **20.13%**, **15.38%** |
| after | **1.97%**, **1.23%** |

## The answer does not change, and the one difference is the point

Twelve packs across four subjects and three queries, compared field for field against the same store
served by the unchanged code: **identical**, once `pack_id` (a per-pack unique id) is excluded.

One pack differed on a single entry, and it is worth stating rather than scrubbing quietly: the
**unchanged** code emitted `stage_budget_exceeded:pack` and the changed code did not. That warning is
derived from elapsed time, not from what was selected -- the slow path missed its stage budget and
the fast path met it. It is the change working, not a behaviour difference.

## Test

136 suites reach ref selection, memory layers or the floors: **117 ran, 1,225 tests, no failures.**
