### PR TITLE
Three functions re-ran the same failing import for the same helper

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -2499,6 +2499,25 @@ def _chunked_refs(refs: list[Any], *, limit: int) -> list[list[Any]]:
 _CORE_POSTING_POLICY = "bucketed_by_scope_data_model_index_time"
 _ALREADY_FOLDED_POSTINGS = None
 
+#: The same shape as _ALREADY_FOLDED_POSTINGS below, for the same reason and the same helper: three
+#: functions import `strip_default_debug_lineage_fields` in their bodies, the dotted form raises
+#: ModuleNotFoundError when there is no `tools` package on the path, and Python does not cache that.
+#: Six attempts per retrieve at 238.49 us each, for one resolution that never changes.
+_STRIP_DEFAULT_DEBUG_LINEAGE_FIELDS = None
+
+
+def _strip_default_debug_lineage_fields(value: Any) -> Any:
+    """Resolved once. See _STRIP_DEFAULT_DEBUG_LINEAGE_FIELDS above."""
+    global _STRIP_DEFAULT_DEBUG_LINEAGE_FIELDS
+    helper = _STRIP_DEFAULT_DEBUG_LINEAGE_FIELDS
+    if helper is None:
+        try:
+            from tools.matrixark_mcp_context_pack import strip_default_debug_lineage_fields as helper
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_context_pack import strip_default_debug_lineage_fields as helper
+        _STRIP_DEFAULT_DEBUG_LINEAGE_FIELDS = helper
+    return helper(value)
+
 
 def _core_posting_bucket_key(record: Json):
     index_name = str(record.get("index_name") or "")
@@ -3959,11 +3978,7 @@ def serving_memory_layer_budget(memory_layer_budget: Any, *, include_debug: bool
         "source_codex_event_counts_by_event",
     ]:
         normalized.pop(field, None)
-    try:
-        from tools.matrixark_mcp_context_pack import strip_default_debug_lineage_fields
-    except ModuleNotFoundError:  # Direct script execution from tools/.
-        from matrixark_mcp_context_pack import strip_default_debug_lineage_fields
-    normalized = strip_default_debug_lineage_fields(normalized)
+    normalized = _strip_default_debug_lineage_fields(normalized)
     for field in list(normalized):
         if isinstance(normalized.get(field), dict) and not normalized[field]:
             normalized.pop(field, None)
@@ -4008,11 +4023,7 @@ def serving_memory_layer_pressure(memory_layer_pressure: Any, *, include_debug: 
         "post_tool_use_source_pressure",
     ]:
         compact.pop(field, None)
-    try:
-        from tools.matrixark_mcp_context_pack import strip_default_debug_lineage_fields
-    except ModuleNotFoundError:  # Direct script execution from tools/.
-        from matrixark_mcp_context_pack import strip_default_debug_lineage_fields
-    compact = strip_default_debug_lineage_fields(compact)
+    compact = _strip_default_debug_lineage_fields(compact)
     by_dimension = compact.get("by_dimension")
     if isinstance(by_dimension, dict):
         compact["by_dimension"] = {
@@ -4432,11 +4443,7 @@ def compact_context_pack_audit_record(record: Json, *, include_debug: bool = Fal
             if compact_pushdown:
                 compact["backend_retrieval_pushdown"] = compact_pushdown
     compact = {key: value for key, value in compact.items() if value not in (None, "", [], {})}
-    try:
-        from tools.matrixark_mcp_context_pack import strip_default_debug_lineage_fields
-    except ModuleNotFoundError:  # Direct script execution from tools/.
-        from matrixark_mcp_context_pack import strip_default_debug_lineage_fields
-    return strip_default_debug_lineage_fields(compact)
+    return _strip_default_debug_lineage_fields(compact)
 
 
 def compact_refs_for_audit(refs: list[Json], *, preview_chars: int = 160) -> list[Json]:


### PR DESCRIPTION
`serving_memory_layer_budget`, `serving_memory_layer_pressure` and
`compact_context_pack_audit_record` each import `strip_default_debug_lineage_fields` in their
bodies -- the same helper, three times:

    try:
        from tools.matrixark_mcp_context_pack import strip_default_debug_lineage_fields
    except ModuleNotFoundError:  # Direct script execution from tools/.
        from matrixark_mcp_context_pack import strip_default_debug_lineage_fields

The dotted form raises whenever there is no `tools` package on the path, which is how the adapter
runs, and **Python does not cache the fact that a module could not be found** -- so each call re-ran
the finder: a `sys.path` walk, a directory stat per entry, the exception, then the fallback. A failing
attempt costs **238.49 us** against 1.45 us for the one that succeeds.

They now share one resolver, in the shape this file already uses a thousand lines above:
`_ALREADY_FOLDED_POSTINGS`, whose own docstring records the same finding -- "an import per call was
already measured as 82.9% of what keying a record costs". The deferral is kept; only the repetition
goes.

## Measured, by counting attempts

Timing is useless here -- this box moved the same retrieve between 293 ms and 968 ms while measuring
-- so the tests and the numbers count import ATTEMPTS, which is what the cost is per.

| | before | after |
|---|---|---|
| dotted `tools.*` attempts per post-write retrieve | **10** | **4** |
| of them, `tools.matrixark_mcp_context_pack` | **7** | **1** |
| that cost | 2.4 ms | **1.0 ms** |

**This is a small change and worth saying so: 1.4 ms, about 0.4% of a post-write retrieve.** It is
here because the antipattern is proportional to call frequency rather than fixed, the fix is
mechanical, and the file already documents both the problem and this exact remedy -- leaving three
instances of it in a file that carries the cure is the part that reads wrong.

## Test

The resolver answers exactly what the implementation answers on four inputs, is remembered after the
first call, and all three functions return what they returned before.

The one remaining `tools.matrixark_mcp_context_pack` attempt is from a different function and is left
alone; so are the two for `tools.matrixark_mcp_identity` and one for
`tools.matrixark_local_adapter_retrieval`. Together they are 1.0 ms and I have no reason yet to
prefer fixing them over leaving them.

---

## CORRECTION, and a correction to that correction

The numbers above were taken by a harness where `from tools.X import y` **fails**. In the live hook
it **succeeds**, and the change therefore buys far less there than the body implies.

I first attributed this to the working directory. That is wrong, and the real rule is worth stating
because it is easy to get backwards:

* `python3 /path/to/script.py` puts the **script's own directory** on `sys.path[0]` -- *not* the
  working directory. So a harness in `/root/goal` run from the repository root does **not** see
  `tools`, and every dotted attempt fails.
* `python3 -c ...` and `python3 -m ...` put the **working directory** on `sys.path`. Run from the
  repository root, the same import succeeds.

`tools/__init__.py` exists, so `tools` is a real package whenever its parent is reachable. Measured,
separating the one-time import from the steady state:

| `sys.path` includes the repository root | first attempt | steady state |
|---|---|---|
| yes | 36,197 us (**succeeds**) | **1.47 us** |
| no | 1,206 us (fails) | **134.98 us** |

**The live hook is in the first row**, and not by accident: `matrixark_codex_hook.load_matrixark`
does `sys.path.insert(0, str(root))` at line 2267 before it imports the server, so by the time any of
these shims runs the root is on the path and the dotted form resolves out of `sys.modules`.

So this change buys about a microsecond in the hook, and 135 us per call in the test suite and every
measurement harness in this repository -- which is where the body's figures came from. It is still
right, because resolving once is never worse than resolving repeatedly, but I measured it in the
wrong environment and stated the benefit too broadly.
