### PR TITLE
A posting-fold give-up returned None and crashed the read path

### DIFF
--- a/tools/matrixark_mcp_indexing.py
+++ b/tools/matrixark_mcp_indexing.py
@@ -502,7 +502,9 @@ def _identity_values(record: Json, singular: str, plural: str) -> list:
     return values
 
 
-def compact_context_index_postings(records: list[Json]) -> list[Json]:
+def compact_context_index_postings(
+    records: list[Json], *, allow_adopt: bool = True
+) -> list[Json]:
     """Group ContextIndex writes into Feature-style timestamped posting rows."""
     unchanged = _already_folded_postings(records)
     if unchanged is not None:
@@ -553,7 +555,7 @@ def compact_context_index_postings(records: list[Json]) -> list[Json]:
             str(record.get("ref_type") or ""),
             bucket_ms,
         )
-        if key not in grouped and is_fold_output(
+        if allow_adopt and key not in grouped and is_fold_output(
             record, POSTING_POLICY_BUCKETED,
             ("index_hash", "storage_record_kind", "storage_part")
         ):
@@ -613,7 +615,11 @@ def compact_context_index_postings(records: list[Json]) -> list[Json]:
                 if value not in (None, "", [], {}):
                     grouped_scalar_values[key][field].add(str(value))
                 elif record.get(field) not in (None, "", [], {}):
-                    return None
+                    # Give up on adoption and let the full pass run, which is what this branch
+                    # always meant to do. It returned None, and the caller
+                    # (compact_latest_context_state_records) iterates the result -- so every read
+                    # reaching this condition raised TypeError instead of falling back.
+                    return compact_context_index_postings(records, allow_adopt=False)
             for field in list_lineage_fields:
                 values = source.get(field)
                 if isinstance(values, list):


### PR DESCRIPTION
`compact_context_index_postings` is annotated `-> list[Json]` and returned `None` from one branch.
Its caller does:

```python
records = compact_context_index_postings(records)
for index, record in enumerate(records):
```

so any read reaching that branch raised `TypeError: 'NoneType' object is not iterable`, taking the
whole Python read path with it.

## The branch

It is the give-up of an adoption optimisation. A row that already carries the fold's own output for
its bucket is adopted whole rather than rebuilt field by field. A later row that would **add** a
value to a field the adopted row omits cannot be merged safely, because an absent field on an
adopted row is indistinguishable from "this bucket saw several values". The comment there says such
a row "gives up and lets the full pass run".

Returning `None` does not run a full pass. It returns `None` to a caller that iterates it.

## Reproduced

On a copy of a real store, `read_all()` raised on every attempt — three out of three. With the
change it returns 7,085 records. A/B against the parent commit, `__pycache__` cleared between runs,
with a sanity count of the changed token in each state so two identical runs could not read as
agreement:

```
WITH the fix     (allow_adopt mentions = 3):  read_all -> 7085 records
WITHOUT the fix  (allow_adopt mentions = 0):  read_all RAISED TypeError
```

## The change

An `allow_adopt` switch, off in the give-up, so the function re-runs itself with adoption disabled —
which *is* the full pass, exactly as the comment says. No recursion risk: with adoption off, the
branch that gives up cannot be reached.

Both settings agree. On the same 24,036 records, `allow_adopt=True` and `allow_adopt=False` each
return 18,646 records, identical lists — so the give-up returns the right answer, not merely a
non-`None` one.

## It is also why the read cache never worked

Measured on the same store by counting decode calls rather than milliseconds, so the numbers do not
move with machine load:

| | before | after |
|---|---|---|
| record decodes in one retrieve | 48,072 — two full passes | 25,419 on the first read, then **0** |
| read-cache source reported | `empty` on every read | `jsonl` once, then `instance` |
| a second retrieve with no write between | 5,727 ms | **9 ms, 0 decodes** |

The cache is keyed on the log's size and mtime, and the store did not change between those reads —
it was never populated because every read raised before it could be. So each retrieve re-decoded the
whole store twice, and every repeat retrieve paid it again.

That also corrects the diagnosis this investigation started from: the second decode looked like the
pre-retrieval write flush invalidating the cache. The store's signature never moved. The crash was
the whole of it.

## Why it survived

The same function exists twice. `matrixark_mcp_core` holds an older 168-line form with **no**
`None`-return at all. The 240-line copy in `matrixark_mcp_indexing` carries the adoption
optimisation and its broken give-up — and that is the copy `matrixark_mcp_serving_records`
resolves. The optimisation landed in the copy serving actually uses; the copy that cannot crash is
the one nothing on this path reads.

The condition depends on store content, which is why it was not caught earlier: the comment records
that over 334 folds on a real corpus it never fired, 123 of 123 bucket-fields having exactly one
value. It fires on the current store.

## Scope

This is the Python read path. A deployment whose backend assembles ContextPacks natively returns
before reaching it, which is why serving is unaffected there — but every other caller of
`read_all()` runs straight into it.
