### PR TITLE
One vocabulary for boolean flags, and none of them decides by case

### DIFF
--- a/crates/temporalstore-rust/src/bin/codex_context_hook.rs
+++ b/crates/temporalstore-rust/src/bin/codex_context_hook.rs
@@ -429,14 +429,7 @@ fn agent_profile(agent_name: &str) -> &'static str {
 }
 
 fn env_bool(name: &str) -> bool {
-    matches!(
-        std::env::var(name)
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "1" | "true" | "yes" | "on"
-    )
+    temporalstore_rust::env_flag::env_bool(name, false)
 }
 
 fn additional_context_char_limit() -> usize {

--- a/crates/temporalstore-rust/src/bin/context_batch_ingest.rs
+++ b/crates/temporalstore-rust/src/bin/context_batch_ingest.rs
@@ -685,14 +685,7 @@ fn now_ms() -> u64 {
 }
 
 fn env_bool(name: &str) -> bool {
-    std::env::var(name)
-        .map(|value| {
-            matches!(
-                value.trim().to_ascii_lowercase().as_str(),
-                "1" | "true" | "yes" | "on"
-            )
-        })
-        .unwrap_or(false)
+    temporalstore_rust::env_flag::env_bool(name, false)
 }
 
 fn stable_hash64(value: &str) -> u64 {

--- a/crates/temporalstore-rust/src/bin/context_workflow_harness.rs
+++ b/crates/temporalstore-rust/src/bin/context_workflow_harness.rs
@@ -310,9 +310,10 @@ fn main() {
         root.join("indexes"),
     );
     engine.load_shard(1);
-    let external_only = std::env::var("TEMPORALSTORE_CONTEXT_BENCHMARK_EXTERNAL_ONLY")
-        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
-        .unwrap_or(false);
+    let external_only = temporalstore_rust::env_flag::env_bool(
+        "TEMPORALSTORE_CONTEXT_BENCHMARK_EXTERNAL_ONLY",
+        false,
+    );
     if external_only {
         let external_benchmark = run_external_context_benchmark(&engine);
         let state = context_workflow_state_report();
@@ -1200,22 +1201,25 @@ fn run_external_context_benchmark(engine: &TemporalEngine) -> ExternalContextBen
         .and_then(|value| value.parse::<usize>().ok())
         .filter(|value| *value > 0)
         .unwrap_or(32);
-    let all_source_replay = std::env::var("TEMPORALSTORE_CONTEXT_BENCHMARK_ALL_SOURCE_REPLAY")
-        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
-        .unwrap_or(false);
+    let all_source_replay = temporalstore_rust::env_flag::env_bool(
+        "TEMPORALSTORE_CONTEXT_BENCHMARK_ALL_SOURCE_REPLAY",
+        false,
+    );
     let selected_id_limit = std::env::var("TEMPORALSTORE_CONTEXT_BENCHMARK_SELECTED_ID_LIMIT")
         .ok()
         .and_then(|value| value.parse::<usize>().ok())
         .filter(|value| *value > 0)
         .unwrap_or(128);
     let direct_source_scoring =
-        std::env::var("TEMPORALSTORE_CONTEXT_BENCHMARK_DIRECT_SOURCE_SCORING")
-            .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
-            .unwrap_or(false);
+        temporalstore_rust::env_flag::env_bool(
+            "TEMPORALSTORE_CONTEXT_BENCHMARK_DIRECT_SOURCE_SCORING",
+            false,
+        );
     let source_order_ranking =
-        std::env::var("TEMPORALSTORE_CONTEXT_BENCHMARK_SOURCE_ORDER_RANKING")
-            .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
-            .unwrap_or(false);
+        temporalstore_rust::env_flag::env_bool(
+            "TEMPORALSTORE_CONTEXT_BENCHMARK_SOURCE_ORDER_RANKING",
+            false,
+        );
     let mut ingested_source_sets = BTreeMap::<u64, Vec<u64>>::new();
     let mut retrieved_source_sets = BTreeMap::<u64, Vec<temporalstore_rust::ContextBlock>>::new();
     for (_index, case) in cases.iter().enumerate() {

--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -6,6 +6,7 @@ use std::io::{self, Write};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
+use temporalstore_rust::env_flag::env_bool;
 use temporalstore_rust::http::{
     get_json_with_options, json_response, parse_json, post_json_with_options, serve,
     serve_with_stream_handler, HttpRequest, HttpRequestOptions, RequestHead, StreamAction,
@@ -2264,12 +2265,6 @@ fn env_u64(name: &str, default: u64) -> u64 {
         .unwrap_or(default)
 }
 
-fn env_bool(name: &str, default: bool) -> bool {
-    std::env::var(name)
-        .ok()
-        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
-        .unwrap_or(default)
-}
 
 fn runtime_options_from_env() -> ProductionMetaRaftRuntimeOptions {
     ProductionMetaRaftRuntimeOptions {

--- a/crates/temporalstore-rust/src/bin/proxy.rs
+++ b/crates/temporalstore-rust/src/bin/proxy.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 MatrixArkAI
 
+use temporalstore_rust::env_flag::env_bool;
 use temporalstore_rust::http::serve;
 use temporalstore_rust::{ProxyOptions, ProxyService, ProxyServingMode};
 use tracing::info;
@@ -90,16 +91,6 @@ fn env_usize(name: &str, default: usize) -> usize {
         .unwrap_or(default)
 }
 
-fn env_bool(name: &str, default: bool) -> bool {
-    std::env::var(name)
-        .ok()
-        .and_then(|value| match value.to_ascii_lowercase().as_str() {
-            "1" | "true" | "yes" | "on" => Some(true),
-            "0" | "false" | "no" | "off" => Some(false),
-            _ => None,
-        })
-        .unwrap_or(default)
-}
 
 fn env_u8(name: &str, default: u8) -> u8 {
     std::env::var(name)

--- a/crates/temporalstore-rust/src/bin/raft_node.rs
+++ b/crates/temporalstore-rust/src/bin/raft_node.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
+use temporalstore_rust::env_flag::env_bool;
 use temporalstore_rust::http::{json_response, parse_json, serve, HttpRequest};
 use temporalstore_rust::meta::ShardSnapshotRef;
 use temporalstore_rust::raft::{
@@ -1120,9 +1121,3 @@ mod tests {
     }
 }
 
-fn env_bool(name: &str, default: bool) -> bool {
-    std::env::var(name)
-        .ok()
-        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
-        .unwrap_or(default)
-}

--- a/crates/temporalstore-rust/src/bin/scale_harness.rs
+++ b/crates/temporalstore-rust/src/bin/scale_harness.rs
@@ -985,14 +985,10 @@ fn percentile(sorted: &[u128], pct: usize) -> u128 {
 }
 
 fn parse_bool(value: &str, key: &str) -> bool {
-    match value {
-        "1" | "true" | "TRUE" | "yes" | "YES" => true,
-        "0" | "false" | "FALSE" | "no" | "NO" => false,
-        _ => {
-            eprintln!("invalid {key} boolean value {value:?}");
-            std::process::exit(2);
-        }
-    }
+    temporalstore_rust::env_flag::parse_bool(value).unwrap_or_else(|| {
+        eprintln!("invalid {key} boolean value {value:?}");
+        std::process::exit(2);
+    })
 }
 
 fn now_ms() -> u128 {

--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
+use temporalstore_rust::env_flag::env_bool;
 use temporalstore_rust::context_workflow::{
     context_pipeline_manage_report, context_workflow_state_report, default_context_model_providers,
     embed_drainer_config_from_env, embed_drainer_enabled, extract_context, ingest_extract_context,
@@ -2255,12 +2256,6 @@ fn env_i32(name: &str, default: i32) -> i32 {
         .unwrap_or(default)
 }
 
-fn env_bool(name: &str, default: bool) -> bool {
-    std::env::var(name)
-        .ok()
-        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
-        .unwrap_or(default)
-}
 
 /// Build the datanode's `RaftConfig`, overlaying the write-path tuning knobs from env. Unset ->
 /// `RaftConfig::default()` verbatim (replication_deadline_ms 5000, max_inflights_replicate 128),

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -2952,14 +2952,7 @@ pub(super) fn wal_single_barrier() -> bool {
 // at once; it is read by nothing now, so setting it does nothing.
 
 fn env_flag_on(name: &str) -> bool {
-    matches!(
-        std::env::var(name)
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "1" | "true" | "yes" | "on"
-    )
+    crate::env_flag::env_bool(name, false)
 }
 
 /// Tuning for sampled eviction, read from the environment with defaults that mirror the
@@ -2984,14 +2977,7 @@ pub(crate) fn evict_sampler_config() -> eviction_sampler::EvictionSamplerConfig 
 /// `=0|false|no|off`. Shipped write-path/raft fixes use this so production gets the
 /// fixed behavior by default; the env var remains only as an escape hatch.
 pub(crate) fn env_flag_default_on(name: &str) -> bool {
-    !matches!(
-        std::env::var(name)
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "0" | "false" | "no" | "off"
-    )
+    crate::env_flag::env_bool(name, true)
 }
 
 /// One durable config-log entry: the shard config `config`, effective for every WAL write with

--- a/crates/temporalstore-rust/src/env_flag.rs
+++ b/crates/temporalstore-rust/src/env_flag.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! One vocabulary for boolean environment flags.
+//!
+//! Six hand-rolled readers disagreed about what an operator had written. Four of them
+//! (`metaserver`, `server`, `raft_node`, and `storage_backend::env_truthy`) matched the raw
+//! string against `"1" | "true" | "TRUE" | "yes" | "YES"` with no trim and no lowercasing, and
+//! treated everything else as `false` rather than as "not specified". For a flag whose default
+//! is `true` that is the dangerous direction, because the value an operator is most likely to
+//! write in order to KEEP it on turns it off:
+//!
+//! | written | that reader | this one |
+//! |---|---|---|
+//! | `on` / `On` / `ON` | `false` | `true` |
+//! | `True` | `false` | `true` |
+//! | `" 1"` (a stray space, as a unit file or heredoc leaves) | `false` | `true` |
+//! | `wat` (anything unrecognised) | `false` | the default |
+//! | `""` (set but empty) | `false` | the default |
+//!
+//! Every default-on flag in the tree reached one of those readers:
+//! `TS_META_AUTO_REBALANCE_BALANCE`, `TS_META_REBALANCE_LOCATION_SCOPED`,
+//! `TS_META_REBALANCE_PER_TABLE`, `TS_MATRIXOBJECT_CHECKPOINT_ON_START`,
+//! `TS_MATRIXOBJECT_NETWORKED_CHECKPOINT_ON_START` and `TS_RAFT_ALLOW_PLAINTEXT`.
+//!
+//! The python side of this repository already settled the same argument and wrote it down in
+//! `tools/test_env_flag_vocabulary.py`: "Boolean flags were parsed in six different
+//! vocabularies. They disagreed on the two words an operator is most likely to reach for."
+//! This is that vocabulary, for rust.
+
+/// The words a boolean flag understands, or `None` when the value is not one of them.
+///
+/// `None` is deliberately distinct from `Some(false)`: a value nobody can read is not a
+/// request to turn something off, and the caller falls back to the flag's own default.
+pub fn parse_bool(raw: &str) -> Option<bool> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+/// Read `name` as a boolean, falling back to `default` when it is unset, empty, or holds
+/// something outside the vocabulary.
+pub fn env_bool(name: &str, default: bool) -> bool {
+    std::env::var(name)
+        .ok()
+        .and_then(|raw| parse_bool(&raw))
+        .unwrap_or(default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn both_halves_of_the_vocabulary_are_understood() {
+        for on in ["1", "true", "yes", "on"] {
+            assert_eq!(Some(true), parse_bool(on), "{on} should read as on");
+        }
+        for off in ["0", "false", "no", "off"] {
+            assert_eq!(Some(false), parse_bool(off), "{off} should read as off");
+        }
+    }
+
+    #[test]
+    fn case_and_surrounding_space_do_not_change_the_answer() {
+        // A unit file, a heredoc and a shell export all leave these behind.
+        for written in ["On", "ON", "True", " 1", "1 ", "\tYES\n", "  on  "] {
+            assert_eq!(
+                Some(true),
+                parse_bool(written),
+                "{written:?} should read as on"
+            );
+        }
+        for written in ["Off", "OFF", "False", " 0 ", "\tNO\n"] {
+            assert_eq!(
+                Some(false),
+                parse_bool(written),
+                "{written:?} should read as off"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unreadable_value_is_not_a_request_to_turn_something_off() {
+        // The failure this module exists to prevent: a default-on flag whose value nobody can
+        // read used to come back false, so a typo silently disabled the behaviour instead of
+        // leaving it where the deployment had it.
+        for written in ["", "wat", "2", "enabled", "disable"] {
+            assert_eq!(None, parse_bool(written), "{written:?} should not parse");
+        }
+    }
+
+    #[test]
+    fn the_default_is_what_survives_an_unset_or_unreadable_variable() {
+        // A name no test sets, so this reads the unset path without racing a sibling.
+        let unset = "TS_ENV_FLAG_VOCABULARY_NAME_THAT_IS_NEVER_SET";
+        assert!(env_bool(unset, true), "unset must fall back to the default");
+        assert!(!env_bool(unset, false), "unset must fall back to the default");
+    }
+}

--- a/crates/temporalstore-rust/src/lib.rs
+++ b/crates/temporalstore-rust/src/lib.rs
@@ -32,6 +32,7 @@ pub mod durability_metrics;
 pub mod flush_gate;
 pub mod memory_trim;
 pub mod engine;
+pub mod env_flag;
 pub mod http;
 pub mod index_log;
 pub mod ingestion;

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -428,9 +428,7 @@ fn main() {
 
 fn single_shot_debug_enabled(args: &[String]) -> bool {
     args.iter().any(|arg| arg == "--debug-single-shot")
-        || env::var("MATRIXARK_RUST_PROXY_SINGLE_SHOT_DEBUG")
-            .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
-            .unwrap_or(false)
+        || temporalstore_rust::env_flag::env_bool("MATRIXARK_RUST_PROXY_SINGLE_SHOT_DEBUG", false)
 }
 
 fn response_from_result(
@@ -4443,12 +4441,7 @@ fn env_bool_any(names: &[&str], default: bool) -> bool {
     names
         .iter()
         .find_map(|name| env::var(name).ok())
-        .map(|value| {
-            matches!(
-                value.trim(),
-                "1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON"
-            )
-        })
+        .and_then(|value| temporalstore_rust::env_flag::parse_bool(&value))
         .unwrap_or(default)
 }
 

--- a/crates/temporalstore-rust/src/storage_backend.rs
+++ b/crates/temporalstore-rust/src/storage_backend.rs
@@ -116,16 +116,11 @@ impl StorageBackend {
     /// So: shared storage caches to disk; one-box and raft run memory + their own disk.
     /// `TS_CACHE_DISK_TIER` overrides either way for an operator who knows better.
     pub fn wants_disk_cache_tier(&self) -> bool {
-        if let Ok(value) = std::env::var("TS_CACHE_DISK_TIER") {
-            let value = value.trim().to_ascii_lowercase();
-            if !value.is_empty() {
-                return !matches!(value.as_str(), "0" | "false" | "no" | "off");
-            }
-        }
-        match self {
+        let backend_default = match self {
             StorageBackend::MatrixObject { .. } | StorageBackend::SharedPath { .. } => true,
             StorageBackend::RaftReplication => false,
-        }
+        };
+        crate::env_flag::env_bool("TS_CACHE_DISK_TIER", backend_default)
     }
 
     /// The cluster-level replication mode implied by this backend.
@@ -945,13 +940,6 @@ pub const TS_DISTRIBUTED: &str = "TS_DISTRIBUTED";
 const META_ADDR_SENTINELS: [&str; 5] = ["", "local", "none", "standalone", "off"];
 
 /// Truthy exactly as the datanode has always read these flags.
-fn env_truthy(name: &str) -> bool {
-    std::env::var(name)
-        .ok()
-        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
-        .unwrap_or(false)
-}
-
 /// Is this node running as a **single node** - no metaserver, no peers?
 ///
 /// This is the one implementation of that rule. The datanode decides whether to
@@ -974,7 +962,7 @@ pub fn single_node(meta_addr_raw: Option<&str>) -> bool {
     {
         Some("1") | Some("true") | Some("yes") | Some("on") => true,
         Some("0") | Some("false") | Some("no") | Some("off") => false,
-        _ => !(meta_addr_is_real || env_truthy(TS_DISTRIBUTED)),
+        _ => !(meta_addr_is_real || crate::env_flag::env_bool(TS_DISTRIBUTED, false)),
     }
 }
 

--- a/crates/temporalstore-rust/src/storage_config.rs
+++ b/crates/temporalstore-rust/src/storage_config.rs
@@ -184,11 +184,10 @@ fn parse_usize(value: Option<String>, default: usize) -> usize {
 }
 
 fn parse_bool(value: Option<String>, default: bool) -> bool {
-    match value.as_deref().map(str::trim).map(str::to_ascii_lowercase) {
-        Some(value) if matches!(value.as_str(), "1" | "true" | "yes" | "on") => true,
-        Some(value) if matches!(value.as_str(), "0" | "false" | "no" | "off") => false,
-        _ => default,
-    }
+    value
+        .as_deref()
+        .and_then(crate::env_flag::parse_bool)
+        .unwrap_or(default)
 }
 
 #[cfg(test)]

--- a/tools/test_no_flag_reader_decides_by_case.py
+++ b/tools/test_no_flag_reader_decides_by_case.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A flag reader that spells `"TRUE"` has forgotten to lowercase what it read.
+
+`tools/test_env_flag_vocabulary.py` settled this for the python side and recorded why: "Boolean
+flags were parsed in six different vocabularies. They disagreed on the two words an operator is
+most likely to reach for." The rust side had the same defect and no guard, so it kept it.
+
+Nine readers -- in `metaserver`, `server`, `raft_node`, `storage_backend`, the proxy's
+single-shot debug switch, `env_bool_any`, the scale harness and four benchmark knobs -- matched
+the value against `"1" | "true" | "TRUE" | "yes" | "YES"`. Spelling both cases of a word is only
+ever necessary because the value was never lowercased, and a list of cases is never complete.
+Measured, against a flag whose default is `true`:
+
+    "on" -> false      "On" -> false     "True" -> false
+    " 1" -> false      "wat" -> false      "" -> false
+
+Every default-on flag in the tree reached one of them, including
+`TS_META_AUTO_REBALANCE_BALANCE` and `TS_RAFT_ALLOW_PLAINTEXT`. Writing `on` to keep one of
+those on turned it off, and an unreadable value turned it off rather than leaving it at its
+default.
+
+This does not dictate which words a reader accepts -- `control.rs` deliberately also takes
+`enabled`, and `raft.rs` takes `y`/`n`. It says only that a reader must not decide by case,
+which `crate::env_flag::parse_bool` handles for anyone who calls it.
+"""
+from __future__ import annotations
+
+import io
+import os
+import re
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(TOOLS)
+SRC = os.path.join(REPO, "crates", "temporalstore-rust", "src")
+CANONICAL = os.path.join(SRC, "env_flag.rs")
+
+#: An upper-case spelling of a boolean word, as a string literal.
+UPPER_WORD = re.compile(r'"(?:TRUE|FALSE|YES|NO|ON|OFF)"')
+
+#: Both assertions below pass on an empty scan, so the corpus is floored.
+EXPECTED_SOURCE_FLOOR = 100
+
+
+def _sources():
+    for base, dirs, files in os.walk(SRC):
+        dirs[:] = [d for d in dirs if d != "target"]
+        for name in sorted(files):
+            if name.endswith(".rs"):
+                yield os.path.join(base, name)
+
+
+def _read(path):
+    with io.open(path, encoding="utf-8", errors="replace") as handle:
+        return handle.read()
+
+
+def _offenders():
+    found = []
+    for path in _sources():
+        if os.path.abspath(path) == os.path.abspath(CANONICAL):
+            continue
+        for number, line in enumerate(_read(path).split("\n"), 1):
+            # Only an ALTERNATION arm decides by case. A test naming the spellings it expects a
+            # reader to accept lists them in an array, with no `|` -- and is asserting the very
+            # property this guard exists to keep.
+            if "|" not in line:
+                continue
+            hit = UPPER_WORD.search(line)
+            if hit:
+                found.append("%s:%d %s" % (
+                    os.path.relpath(path, REPO).replace(os.sep, "/"), number, hit.group(0)))
+    return found
+
+
+class NoFlagReaderDecidesByCaseTest(unittest.TestCase):
+
+    def test_the_scan_still_sees_the_crate(self) -> None:
+        """The rule below passes on an empty corpus, which would read exactly like compliance."""
+        sources = list(_sources())
+        self.assertGreaterEqual(
+            len(sources), EXPECTED_SOURCE_FLOOR,
+            "found %d rust sources under %s, expected at least %d -- with an empty corpus the "
+            "rule below cannot fail" % (len(sources), SRC, EXPECTED_SOURCE_FLOOR))
+
+    def test_the_canonical_reader_is_where_the_vocabulary_lives(self) -> None:
+        self.assertTrue(os.path.exists(CANONICAL), "crates/.../src/env_flag.rs is gone")
+        text = _read(CANONICAL)
+        for name in ("pub fn parse_bool", "pub fn env_bool"):
+            self.assertIn(name, text, "env_flag.rs no longer offers %s" % name)
+
+    def test_no_reader_spells_an_upper_case_boolean_word(self) -> None:
+        self.assertEqual(
+            [], _offenders(),
+            "these decide a boolean by case, which is how the tree ended up with readers that "
+            "disagreed about `on`. Call crate::env_flag::parse_bool, which lowercases and trims "
+            "first: %s" % _offenders())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Nine places in the rust tree read a boolean flag by matching the raw value against
`"1" | "true" | "TRUE" | "yes" | "YES"` — no trim, no lowercasing — and treating everything else
as `false` rather than as "not specified". Compiled and run, against a flag whose default is
`true`:

```
  "on" -> false     "On" -> false     "ON" -> false
"True" -> false     " 1" -> false    "wat" -> false      "" -> false
```

Only `1`, `true`, `TRUE`, `yes`, `YES` did anything.

**Every default-on flag in the tree went through one of those readers**:
`TS_META_AUTO_REBALANCE_BALANCE`, `TS_META_REBALANCE_LOCATION_SCOPED`,
`TS_META_REBALANCE_PER_TABLE`, `TS_MATRIXOBJECT_CHECKPOINT_ON_START`,
`TS_MATRIXOBJECT_NETWORKED_CHECKPOINT_ON_START` and `TS_RAFT_ALLOW_PLAINTEXT`. So writing the
word an operator is most likely to reach for — `on`, to keep one of them on — turned it off. A
typo did the same thing, silently, instead of leaving the flag at its default.

## This repository already settled this argument once

`tools/test_env_flag_vocabulary.py` says so in its own words: *"Boolean flags were parsed in six
different vocabularies. They disagreed on the two words an operator is most likely to reach
for."* That work fixed the python side and left a guard behind. The guard only reads
`os.environ.get` shapes under `tools/`, so the rust side kept the defect and nothing said so.

## What this changes

`crate::env_flag` is now the one place that spells the words:

- `parse_bool(&str) -> Option<bool>` — trims, lowercases, `1/true/yes/on` and `0/false/no/off`.
  `None` is deliberately distinct from `Some(false)`: a value nobody can read is not a request
  to turn something off.
- `env_bool(name, default) -> bool` — reads the variable and falls back to `default` when unset,
  empty, or unreadable.

Reading through it now: `metaserver`, `server`, `raft_node`, `proxy`, `context_batch_ingest`,
`codex_context_hook`, the scale harness and four benchmark knobs, plus `storage_backend`,
`storage_config`, `matrixark_rust_proxy_impl` and the `engine` pair. `storage_config` already
had exactly this rule, privately, for one caller — it keeps its `Option`-taking shape and reads
the words from the shared place rather than restating them.

Two behaviour changes beyond accepting more spellings, both deliberate:

- An unreadable value now yields the flag's **default** instead of `false`.
- `TS_CACHE_DISK_TIER` treated anything not in `0/false/no/off` as *on*, so an unreadable value
  overrode the backend's own answer. It now falls back to that answer.

## The guard pins the property, not the vocabulary

`tools/test_no_flag_reader_decides_by_case.py` asserts that no reader spells an upper-case
boolean word in an alternation arm. Spelling both cases of a word is only ever necessary because
the value was never lowercased, and a list of cases is never complete.

It deliberately does **not** dictate which words a reader accepts — `control.rs` also takes
`enabled` and `raft.rs` also takes `y`/`n`, both intentional supersets that lowercase correctly.

Tests that *list* spellings they expect a reader to accept (`["false", "NO", "Off", " 0 "]` in
`memory_trim`, and the same in `wal_proto`) are not offenders — they assert the very property
this guard keeps — so the rule looks only at alternation arms, and the corpus is floored so an
empty scan cannot read as compliance.

Verified to discriminate: dropping a file containing
`matches!(value, "1" | "true" | "TRUE" | "yes" | "YES")` into `src/` makes it fail and name that
file; removing it makes it pass.

## Checks

`cargo check --release --lib --bins --tests` clean. Four new tests in `env_flag` cover both
halves of the vocabulary, case and surrounding whitespace, that an unreadable value does not
parse, and that the default is what survives. Full
`cargo test --release --lib --tests --no-fail-fast -- --test-threads=1`: no failure that main
does not already have.

The existing `TS_CACHE_DISK_TIER` test — which covers `"0"`, `"1"` and `""` — passes unchanged;
all three behave identically under the shared reader.
