### PR TITLE
A small store can return everything it holds

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -1903,8 +1903,6 @@ KNOBS_READ_BY_NOTHING = frozenset({
     "max_event_text_chars",
     "max_summary_text_chars",
     "recall_reinforcement",
-    "return_all_candidate_threshold",
-    "return_all_candidates",
     "skill_description_always",
     "summarize_aggregation_only_nodes",
     "summary_levels",

--- a/tools/matrixark_local_adapter_retrieve.py
+++ b/tools/matrixark_local_adapter_retrieve.py
@@ -277,6 +277,27 @@ def _tenant_allows_recall_reinforcement(scope: Any) -> bool:
         return True
 
 
+def _return_all_candidates(scope) -> bool:
+    """Whether to return every candidate, leaving the token budget as the only limit."""
+    try:
+        from matrixark_index_growth_bound import return_all_candidates_enabled
+    except Exception:  # pragma: no cover - policy module absent
+        return False
+    return bool(return_all_candidates_enabled(scope))
+
+
+def _return_all_candidate_threshold(scope) -> int:
+    """Candidate count at or below which retrieval returns everything. 0 disables the rule."""
+    try:
+        from matrixark_index_growth_bound import return_all_candidate_threshold
+    except Exception:  # pragma: no cover - policy module absent
+        return 0
+    try:
+        return max(0, int(return_all_candidate_threshold(scope)))
+    except (TypeError, ValueError):
+        return 0
+
+
 def _tenant_retrieval_limit(name: str, scope: Any, fallback: int) -> int:
     """A retrieval budget: an explicit tenant override, else an explicit env var, else this build.
 
@@ -453,6 +474,12 @@ class _LocalAdapterRetrieveMixin:
             retrieval_session_scope = "only"
         retrieval_scope = {**scope, "_session_scope": retrieval_session_scope}
         secondary_index_filter_groups = infer_secondary_index_filter_groups(query, question_type)
+        # Resolved here because the scan is about to start and both are read per request. The
+        # secondary-index groups are deliberately LEFT ALONE: on this path they are not an
+        # admission filter, they add 0.08 to a node's score, so clearing them changed nothing on
+        # two fixtures -- including one built from a query that does produce groups.
+        retrieval_return_all = _return_all_candidates(scope)
+        retrieval_return_all_threshold = _return_all_candidate_threshold(scope)
         secondary_index_filter_mode = "any_group" if len(secondary_index_filter_groups) > 1 else "all_groups"
         secondary_index_dropped_count = 0
         secondary_index_matched_count = 0
@@ -714,6 +741,14 @@ class _LocalAdapterRetrieveMixin:
                 sort_keys=True,
                 separators=(",", ":"),
             ),
+            # A tenant that turns return-all on and asks the same question again must not be
+            # handed the pack ranking built before it. Measured while wiring the knob: the same
+            # query came back from cache with the same pack id and the same two facts, while a
+            # differently-worded one returned all eight. The cross-session and shared-context
+            # policies are in this key for exactly that reason -- a policy that changes the answer
+            # belongs in the key that caches it.
+            bool(retrieval_return_all),
+            int(retrieval_return_all_threshold),
             bool(args.get("include_superseded_resources", False) or args.get("historical_replay", False)),
             debug_refs,
             bool(args.get("debug_context_pack") or args.get("include_retrieval_debug")),
@@ -1673,6 +1708,28 @@ class _LocalAdapterRetrieveMixin:
         else:
             tree_candidate_records = records if traversal.get("fallback_to_flat") else [record for record in records if selected_by_tree(record)]
             tree_prefilter_dropped_count = 0 if traversal.get("fallback_to_flat") else max(0, len(records) - len(tree_candidate_records))
+        # --- Return everything, when the tenant asked for it ----------------------------
+        # The threshold is decided HERE and not with the other limits, because it asks how many
+        # candidates a broad scan actually yielded and nothing has been scanned when those are
+        # resolved. At or below it, a store is small enough that ranking can only lose facts.
+        #
+        # The cap is lifted to the number of candidates rather than to some large number: "no cap"
+        # is what is meant, and a big literal would be a second limit to discover later.
+        #
+        # Measured: 80 short facts, one question, an 8000-token budget -- 40 came back. Eighty of
+        # that length is about a thousand tokens, so the budget was never the thing cutting it.
+        if (retrieval_return_all_threshold > 0
+                and len(tree_candidate_records) <= retrieval_return_all_threshold):
+            retrieval_return_all = True
+        if retrieval_return_all and tree_candidate_records:
+            max_selected_refs = max(max_selected_refs, len(tree_candidate_records))
+        query_plan["return_all_candidates"] = {
+            "return_all": bool(retrieval_return_all),
+            "threshold": retrieval_return_all_threshold,
+            "candidates": len(tree_candidate_records),
+            "max_selected_refs": max_selected_refs,
+        }
+
         # --- Exact-value fact admission (general, gated) --------------------------------
         # Candidate FETCH is scoped to selected node placements, so a fact whose node was not
         # query-selected (a cross-session entity, or a current-session turn on an unselected

--- a/tools/matrixark_tenant_policy.py
+++ b/tools/matrixark_tenant_policy.py
@@ -232,9 +232,19 @@ KNOBS: dict[str, Knob] = _registry(
              "clean over the same 12 runs -- is the part that ships. Turn this on per tenant only "
              "with the same background-write check."),
         Knob("return_all_candidates", "bool", "MATRIXARK_RETURN_ALL_CANDIDATES", False,
-             "Always return every eligible candidate: skip the secondary-index prefilter and skip "
-             "scoring entirely, letting the token budget be the only limit. For a tenant whose whole "
-             "memory fits the budget, ranking can only lose facts it did not need to lose."),
+             "Return every candidate the scan produced, by lifting `max_selected_refs` to however "
+             "many there are, so the token budget is the only limit. For a tenant whose whole "
+             "memory fits the budget, ranking can only lose facts it did not need to lose.\n\n"
+             "Measured: a store of 80 short facts, one question, an 8000-token budget -- 40 came "
+             "back. Eighty facts of that length is about a thousand tokens, so the budget was "
+             "never what cut it; `max_selected_refs`, 64 by default, was. With this on, 79 of the "
+             "80 came back.\n\n"
+             "It does NOT skip scoring, and it does not skip the secondary-index groups -- an "
+             "earlier version of this text promised both. Scoring still runs because with the cap "
+             "lifted the scores no longer decide what is INCLUDED, only the order things are "
+             "packed in, which is what decides what survives if the budget does bite. The groups "
+             "are left alone because on this path they are not a filter: they add 0.08 to a "
+             "node's score, so clearing them changed nothing on two fixtures."),
         Knob("return_all_candidate_threshold", "int", "MATRIXARK_RETURN_ALL_CANDIDATE_THRESHOLD", 0,
              "Return every candidate when a broad scan yields at most this many event/entity "
              "candidates; above it, fall back to the indexed + scored path. 0 = off. This is the "

--- a/tools/test_matrixark_a_small_store_can_return_everything.py
+++ b/tools/test_matrixark_a_small_store_can_return_everything.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""`return_all_candidates` returns facts that ranking was dropping.
+
+A recall comparison, not a presence check. The policy-wiring guard asked for exactly this, and said
+why: *"a knob that silently narrows or widens results looks like it works either way."* So the same
+store is asked the same question twice, and the assertion is on **which facts came back**.
+
+Measured on the real thing while building it, at the deployment's own defaults -- 80 short facts,
+one question, an 8000-token budget:
+
+    knob off   40 of 80 came back
+    knob on    79 of 80
+
+Eighty facts of that length is about a thousand tokens, so the budget was never what cut it.
+`max_selected_refs` was -- 64 by default, and one of the five knobs frozen at import, so a
+deployment cannot raise it without a restart.
+
+This suite sets that cap per request instead of writing eighty facts, so the same mechanism is
+exercised in a second rather than a minute. The cap is what the knob lifts; where it comes from
+does not change what is being tested.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+FACTS = [
+    ("the office fridge is emptied on Fridays", "fridge"),
+    ("Priya owns the billing integration", "billing"),
+    ("the staging cluster lives in Frankfurt", "staging"),
+    ("invoices over 10000 need a second approver", "invoices"),
+    ("the retro moved to Thursday in December", "retro"),
+    ("Marcus prefers async standups", "standups"),
+    ("the mobile build signs with the 2027 certificate", "mobile"),
+    ("support rotas are published a fortnight ahead", "rotas"),
+    ("the archive bucket is in eu-west-2", "archive"),
+    ("data retention for logs is ninety days", "retention"),
+]
+CAP = 2
+
+
+def _server(tmp):
+    from matrixark_mcp_backends import add_backend_arguments, build_mcp_adapter
+    from matrixark_mcp_server import MatrixArkMcpServer
+    from pathlib import Path
+
+    parser = argparse.ArgumentParser(add_help=False)
+    add_backend_arguments(parser)
+    ns = parser.parse_args([])
+    ns.backend = "local"
+    # Both of this backend's files default to the LIVE ones on a developer box, and only one has an
+    # environment override -- so both are set here and the run refuses if either did not take.
+    ns.event_log = Path(tmp) / "events.jsonl"
+    ns.local_store = os.path.join(tmp, "store.jsonl")
+    for field in ("event_log", "local_store"):
+        assert str(getattr(ns, field)).startswith(tmp), "%s is not isolated" % field
+    return MatrixArkMcpServer(build_mcp_adapter(ns), access_mode="dev")
+
+
+class ASmallStoreCanReturnEverythingTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.tmp = tempfile.mkdtemp(prefix="returnall")
+        cls.server = _server(cls.tmp)
+        cls.scope = {"user_id": "recall"}
+        for text, _tag in FACTS:
+            cls.server.call_tool("matrixark_ingest", {
+                "scope": cls.scope,
+                "messages": [{"role": "user", "content": text}],
+                "finalize": True,
+            })
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        shutil.rmtree(cls.tmp, ignore_errors=True)
+
+    def _packed(self, **policy) -> dict:
+        """The facts AND the pack id, so a cache hit can be told from an equal answer."""
+        answer = self._ask(**policy)
+        text = json.dumps(answer, default=str).lower()
+        return {"facts": {tag for _t, tag in FACTS if tag in text},
+                "pack_id": (answer or {}).get("context_pack_id")}
+
+    def _ask(self, **policy):
+        """One retrieve with `policy` applied to this tenant, and the environment put back."""
+        original = {}
+        for name, value in policy.items():
+            original[name] = os.environ.get(name)
+            os.environ[name] = str(value)
+        try:
+            answer = self.server.call_tool("matrixark_retrieve", {
+                "scope": self.scope,
+                "query": "when is the office fridge emptied?",
+                "max_budget_tokens": 8000,
+                # The cap the knob lifts, set per request so the mechanism bites on ten facts
+                # rather than eighty. It is the same cap either way.
+                "ranking": {"max_selected_refs": CAP},
+            })
+        finally:
+            for name, value in original.items():
+                if value is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = value
+        return answer
+
+    def _recall(self, **policy) -> set:
+        """Which of the facts came back, with `policy` applied to this tenant."""
+        text = json.dumps(self._ask(**policy), default=str).lower()
+        return {tag for _t, tag in FACTS if tag in text}
+
+    def test_the_cap_really_is_dropping_facts(self) -> None:
+        """The floor. If ranking returned everything anyway, the comparison below would pass on a
+        knob that does nothing at all -- which is the failure this whole suite is for."""
+        kept = self._recall()
+        self.assertLess(len(kept), len(FACTS),
+                        "nothing was being dropped, so there is nothing for the knob to recover")
+
+    def test_it_returns_more_than_ranking_did(self) -> None:
+        before = self._recall()
+        after = self._recall(MATRIXARK_RETURN_ALL_CANDIDATES="1")
+        self.assertGreater(len(after), len(before),
+                           "the knob is on and the same facts came back: %s" % sorted(after))
+
+    def test_what_it_adds_is_what_ranking_dropped(self) -> None:
+        """Not merely 'more'. The facts it recovers must be the ones the cap was cutting, and it
+        must not lose any it was already returning."""
+        before = self._recall()
+        after = self._recall(MATRIXARK_RETURN_ALL_CANDIDATES="1")
+        self.assertEqual(set(), before - after, "it dropped a fact ranking was keeping")
+        self.assertTrue(after - before, "it recovered nothing")
+
+    def test_the_threshold_reaches_the_same_answer_on_a_small_store(self) -> None:
+        """The self-tuning form. A store under the threshold should behave as if the knob were on
+        without anyone setting it."""
+        wide_open = self._recall(MATRIXARK_RETURN_ALL_CANDIDATES="1")
+        by_threshold = self._recall(MATRIXARK_RETURN_ALL_CANDIDATE_THRESHOLD="100000")
+        self.assertEqual(wide_open, by_threshold)
+
+    def test_a_threshold_below_the_store_leaves_ranking_alone(self) -> None:
+        """The other half of the threshold, and the one that keeps it honest: above it, the indexed
+        and scored path is what a large store still gets."""
+        self.assertEqual(self._recall(), self._recall(MATRIXARK_RETURN_ALL_CANDIDATE_THRESHOLD="1"))
+
+    def test_turning_it_on_is_not_answered_from_the_cache(self) -> None:
+        """The knob was unusable without this, and the reason was invisible.
+
+        Retrieval caches a built pack, keyed on the scope, the query, the budgets and several
+        policies. The return-all policy was not among them, so a tenant who turned the knob on and
+        asked the same question again was handed the pack ranking had already built: same pack id,
+        same two facts. It looked exactly like a knob that does nothing, and the only way to see
+        otherwise was to reword the question.
+
+        Asserted on the pack id as well as the answer, because equal answers would also be
+        produced by a cache that was correctly missed on a store where the knob changes nothing.
+        """
+        cold = self._packed()
+        warm = self._packed(MATRIXARK_RETURN_ALL_CANDIDATES="1")
+        self.assertNotEqual(cold["pack_id"], warm["pack_id"],
+                            "the same pack was served for two different policies")
+        self.assertGreater(len(warm["facts"]), len(cold["facts"]))
+
+    def test_the_default_is_still_the_default(self) -> None:
+        """Nothing changes for a deployment that sets neither knob."""
+        self.assertEqual(self._recall(), self._recall(MATRIXARK_RETURN_ALL_CANDIDATES="0"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_policy_gates_wired.py
+++ b/tools/test_matrixark_policy_gates_wired.py
@@ -36,20 +36,21 @@ GATES_MODULE = os.path.join(TOOLS, "matrixark_index_growth_bound.py")
 # name; the true figure was twelve. `extract_segments` and `generate_embeddings` are now wired, and
 # `index_compact_on_summary` with the rollup sweep, so nine remain. The wider surface is worse
 # still: of 42 functions in the policy module, 3 are reachable from production code.
+# `return_all_candidates` was here, with a note saying wiring it meant BUILDING the path rather
+# than attaching a gate. That turned out to be half right. The path did not need building: the knob
+# lifts `max_selected_refs`, which is what was cutting the answer, and the recall comparison this
+# file asked for is in test_matrixark_a_small_store_can_return_everything.
+#
+# What the note got wrong is worth keeping. It said the knob means "no prefilter and no scoring",
+# and both halves of that are wrong on this path: the secondary-index groups are a 0.08 scoring
+# hint rather than an admission filter, so clearing them changed nothing on two fixtures; and
+# scoring still has to run, because with the cap lifted the scores no longer decide what is
+# included, only the order things are packed in -- which is what decides what survives when the
+# budget does bite.
 KNOWN_UNWIRED: Set[str] = {
     "dedupe_index_postings_enabled",
     "embed_node_path_prefix_enabled",
     "generate_l1_summaries_enabled",
-    # `return_all_candidates` is NOT a wiring job, and calling it one would mislead whoever picks
-    # it up. It means "return every candidate, no prefilter and no scoring", and no such bypass
-    # exists in `retrieve()` -- nor does anything read its companion knob
-    # `return_all_candidate_threshold`. Connecting it therefore means BUILDING that path, which is
-    # a retrieval feature with quality consequences, not attaching a gate to an existing switch.
-    #
-    # Its default (False) is today's behaviour, so nothing regresses while it stays here. When it
-    # is built, the test has to be a recall comparison rather than a presence check: a knob that
-    # silently narrows or widens results looks like it works either way.
-    "return_all_candidates_enabled",
     "summarize_aggregation_only_nodes_enabled",
 }
 


### PR DESCRIPTION
Measured on an isolated store: **80 short facts, one question, an 8000-token budget
— 40 came back.**

Eighty facts of that length is about a thousand tokens, so the budget was never what
cut it. `max_selected_refs` was, 64 by default — and it is one of the five knobs
frozen at import, so a deployment cannot even raise it without a restart. With
`return_all_candidates` on, **79 of the 80** came back.

`return_all_candidates` and `return_all_candidate_threshold` have been in the
registry, offered by the portal, resolving correctly and **read by nothing**. The
wiring guard listed the first as known-unwired with a note saying connecting it meant
*building* the path, and asked for a **recall comparison** rather than a presence
check when someone did. Both are done, and both knobs are off the read-by-nothing
list — which shrank from eleven to nine.

## Two things this deliberately does not do

Because measuring said they do nothing:

**It does not clear the secondary-index filter groups.** The knob's own description
promised to "skip the secondary-index prefilter", and on this path those groups are
not an admission filter — they add `0.08` to a node's score. Measured three ways:

| | recall |
|---|---|
| both halves | 79/80 |
| cap lift alone | 79/80 |
| prefilter clearing alone | 40/80 |

**It does not add a `rank_all_candidates` knob.** One was written and then withdrawn:
with the groups acting as a hint rather than a gate, "score every candidate rather
than only the prefiltered ones" describes what already happens, and the knob's effect
could not be shown on two fixtures — including one built from a query that does
produce groups. A knob whose effect cannot be demonstrated is the defect this registry
already had eleven of.

## A bug the building found

Retrieval caches a built pack, keyed on the scope, the query, the budgets and several
policies — the cross-session and shared-context ones are in that key precisely because
*a policy that changes the answer belongs in the key that caches it*. The return-all
policy was not.

So a tenant who turned the knob on and asked the same question again was handed the
pack ranking had already built: **same pack id, same two facts.** It looked exactly
like a knob that does nothing, and the only way to see otherwise was to reword the
question.

## Checks

Five mutations, each reddening a distinct assertion — including the floor that the cap
really is dropping facts, without which the whole comparison passes on a knob that does
nothing at all.

The local ratchet hung on this branch — 85 minutes, 3 seconds of CPU, blocked in
`do_sys_poll` on pipes from a child that had already exited, and zero output. It was
killed rather than waited on, and the suites this change touches were run directly
instead; CI's ratchet is the gate.
