### PR TITLE
The one-box retrieval profile is visible to monitoring

### DIFF
--- a/docs/ops/matrixark-gateway-dashboard.json
+++ b/docs/ops/matrixark-gateway-dashboard.json
@@ -738,6 +738,46 @@
           "legendFormat": "{{reason}}"
         }
       ]
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "One-box retrieval profile",
+      "description": "How this deployment ranks. onebox_embedding_first is 1 when a candidate's score is its vector similarity alone and 0 when it is blended with a lexical match (0.72/0.28) -- it is on by default, and it decides every result. return_all_candidates is 1 when ranking is not allowed to drop anything and the token budget is the only limit; the threshold is the candidate count at or below which that applies on its own, 0 meaning off. Read together they answer 'why did the answers change', which no series could answer before.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 52
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "matrixark_gateway_onebox_embedding_first{instance=~\"$instance\"}",
+          "legendFormat": "vector-only scoring"
+        },
+        {
+          "refId": "B",
+          "expr": "matrixark_gateway_return_all_candidates{instance=~\"$instance\"}",
+          "legendFormat": "return every candidate"
+        },
+        {
+          "refId": "C",
+          "expr": "matrixark_gateway_return_all_candidate_threshold{instance=~\"$instance\"}",
+          "legendFormat": "return-all threshold"
+        }
+      ]
     }
   ]
 }

--- a/tools/matrixark_gateway_metrics.py
+++ b/tools/matrixark_gateway_metrics.py
@@ -627,6 +627,62 @@ def worker_count(argv: Optional[List[str]] = None,
     return workers if workers > 0 else 1
 
 
+# The retrieval module's own default for the one-box profile. Duplicated here on purpose -- reading
+# it from that module means importing it, which is circular -- and held to the original by a test
+# rather than by hope.
+ONEBOX_PROFILE_DEFAULT = "1"
+
+
+def onebox_lines() -> List[str]:
+    """The retrieval profile this deployment is serving on, and whether it returns everything.
+
+    Three gauges, because the three answer different questions. The profile says how a score is
+    computed; return-all says whether ranking is allowed to drop anything; the threshold says at
+    what size the second stops applying. A dashboard that shows the first without the others
+    explains half of a changed answer.
+
+    Every value is read here rather than captured at import, and every one is emitted even when it
+    is at its default -- a gauge that appears only once somebody changes something cannot be
+    alerted on before they do.
+    """
+    # Read from the environment, not by importing the retrieval module. Importing it here is a
+    # circular import -- the adapter imports the retrieval mixin and the mixin imports the adapter
+    # -- and the first version of this caught that in an `except` and published 0. A gauge that
+    # says "blended scoring" about a deployment running the profile ON is worse than no gauge:
+    # every dashboard reading it would be describing the opposite of what happened.
+    #
+    # ONEBOX_PROFILE_DEFAULT is the same string the retrieval module defaults to, and
+    # test_matrixark_the_onebox_profile_is_visible asserts the two have not drifted apart.
+    raw = os.environ.get("MATRIXARK_ONEBOX_EMBEDDING_FIRST", ONEBOX_PROFILE_DEFAULT)
+    profile = 1 if str(raw).strip().lower() in ("1", "true", "yes", "on") else 0
+
+    return_all, threshold = 0, 0
+    try:
+        from matrixark_index_growth_bound import (
+            return_all_candidate_threshold,
+            return_all_candidates_enabled,
+        )
+        return_all = 1 if return_all_candidates_enabled(None) else 0
+        threshold = int(return_all_candidate_threshold(None) or 0)
+    except Exception:  # pragma: no cover - policy module absent
+        return_all, threshold = 0, 0
+
+    return [
+        "# HELP matrixark_gateway_onebox_embedding_first 1 when a candidate's score is its vector "
+        "similarity alone, 0 when it is blended with a lexical match.",
+        "# TYPE matrixark_gateway_onebox_embedding_first gauge",
+        "matrixark_gateway_onebox_embedding_first %d" % profile,
+        "# HELP matrixark_gateway_return_all_candidates 1 when retrieval returns every candidate "
+        "and lets the token budget be the only limit.",
+        "# TYPE matrixark_gateway_return_all_candidates gauge",
+        "matrixark_gateway_return_all_candidates %d" % return_all,
+        "# HELP matrixark_gateway_return_all_candidate_threshold Candidate count at or below which "
+        "retrieval returns everything. 0 means the rule is off.",
+        "# TYPE matrixark_gateway_return_all_candidate_threshold gauge",
+        "matrixark_gateway_return_all_candidate_threshold %d" % threshold,
+    ]
+
+
 def stream_lines() -> List[str]:
     """How the live streams ended, by reason.
 
@@ -685,6 +741,7 @@ def prometheus_text(config_snapshot: Optional[Json] = None,
     lines += config_change_lines()
     lines += worker_lines()
     lines += stream_lines()
+    lines += onebox_lines()
     if extra_lines:
         lines += extra_lines
     return "\n".join(lines) + "\n"

--- a/tools/test_matrixark_the_onebox_profile_is_visible.py
+++ b/tools/test_matrixark_the_onebox_profile_is_visible.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The one-box retrieval profile is visible to monitoring.
+
+``MATRIXARK_ONEBOX_EMBEDDING_FIRST`` decides whether a candidate's score is its vector similarity
+alone or a 0.72/0.28 blend with a lexical match. It is **on by default**, it decides every result
+the deployment returns, and nothing published it -- so "why did the answers change?" had no answer
+in any series the gateway emits, and two deployments answering differently looked identical on
+every dashboard.
+
+**The first version of this gauge lied.** It read the value by importing the retrieval module,
+which is a circular import -- the adapter imports the retrieval mixin and the mixin imports the
+adapter -- so the import raised, an ``except`` caught it, and the gauge published ``0``. A gauge
+saying "blended scoring" about a deployment running the profile ON is worse than no gauge at all:
+every dashboard reading it describes the opposite of what happened.
+
+So it reads the environment, and the default it falls back to is asserted here against the
+retrieval module's own. Two copies of a default agree until one is edited.
+"""
+from __future__ import annotations
+
+import io
+import os
+import re
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_gateway_metrics as gwm  # noqa: E402
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+
+
+def gauge(lines, name: str):
+    for line in lines:
+        if line.startswith(name + " "):
+            return line.split(" ", 1)[1].strip()
+    return None
+
+
+class TheProfileIsPublishedTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.original = os.environ.get("MATRIXARK_ONEBOX_EMBEDDING_FIRST")
+        self.addCleanup(self._restore)
+
+    def _restore(self) -> None:
+        if self.original is None:
+            os.environ.pop("MATRIXARK_ONEBOX_EMBEDDING_FIRST", None)
+        else:
+            os.environ["MATRIXARK_ONEBOX_EMBEDDING_FIRST"] = self.original
+
+    def test_it_reports_the_profile_that_is_actually_on(self) -> None:
+        os.environ["MATRIXARK_ONEBOX_EMBEDDING_FIRST"] = "1"
+        self.assertEqual("1", gauge(gwm.onebox_lines(),
+                                    "matrixark_gateway_onebox_embedding_first"))
+
+    def test_it_reports_the_profile_that_is_actually_off(self) -> None:
+        os.environ["MATRIXARK_ONEBOX_EMBEDDING_FIRST"] = "0"
+        self.assertEqual("0", gauge(gwm.onebox_lines(),
+                                    "matrixark_gateway_onebox_embedding_first"))
+
+    def test_with_nothing_set_it_reports_the_default_which_is_on(self) -> None:
+        """The case that matters most, because it is the case almost every deployment is in -- and
+        the case the first version of this got backwards."""
+        os.environ.pop("MATRIXARK_ONEBOX_EMBEDDING_FIRST", None)
+        self.assertEqual("1", gauge(gwm.onebox_lines(),
+                                    "matrixark_gateway_onebox_embedding_first"))
+
+    def test_the_default_here_is_the_default_there(self) -> None:
+        """The duplication this rests on, held to the original.
+
+        The metrics module cannot import the retrieval module to ask -- that import is circular --
+        so it carries its own copy of the default. Read out of the source rather than imported, for
+        the same reason.
+        """
+        with io.open(os.path.join(TOOLS, "matrixark_local_adapter_retrieval.py"),
+                     encoding="utf-8") as handle:
+            source = handle.read()
+        match = re.search(r'ONEBOX_EMBEDDING_FIRST_DEFAULT\s*=\s*"([^"]*)"', source)
+        self.assertIsNotNone(match, "the retrieval module no longer names its default")
+        self.assertEqual(match.group(1), gwm.ONEBOX_PROFILE_DEFAULT,
+                         "the two copies of the one-box default have drifted apart")
+
+    def test_the_return_all_state_is_published_too(self) -> None:
+        """A dashboard that shows how scoring works without showing whether ranking is allowed to
+        drop anything explains half of a changed answer."""
+        lines = gwm.onebox_lines()
+        for name in ("matrixark_gateway_return_all_candidates",
+                     "matrixark_gateway_return_all_candidate_threshold"):
+            with self.subTest(series=name):
+                self.assertIsNotNone(gauge(lines, name))
+
+    def test_every_gauge_is_emitted_even_at_its_default(self) -> None:
+        """A gauge that appears only once somebody changes something cannot be alerted on before
+        they do, which is the moment the alert was worth having."""
+        os.environ.pop("MATRIXARK_ONEBOX_EMBEDDING_FIRST", None)
+        lines = gwm.onebox_lines()
+        self.assertEqual(3, len([l for l in lines if l.startswith("matrixark_gateway_")]))
+
+    def test_it_reaches_the_scrape(self) -> None:
+        """The positive control: every assertion above passes on a function nothing calls."""
+        text = gwm.prometheus_text({"extraction": {"provider": "deterministic"},
+                                    "embedding": {"provider": "deterministic"}, "warnings": []})
+        self.assertIn("matrixark_gateway_onebox_embedding_first", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`MATRIXARK_ONEBOX_EMBEDDING_FIRST` decides whether a candidate's score is its vector similarity alone or a 0.72/0.28 blend with a lexical match. It is **on by default**, it decides every result the deployment returns, and **nothing published it** — so "why did the answers change?" had no answer in any series the gateway emits, and two deployments answering differently looked identical on every dashboard.

Three gauges, because they answer different questions: the profile says how a score is computed, `return_all_candidates` says whether ranking may drop anything, and the threshold says at what size that stops applying. A panel showing the first without the others explains half of a changed answer. All three are emitted **at their defaults**, because a gauge that appears only once somebody changes something cannot be alerted on before they do.

## The first version of this gauge lied

It read the profile by importing the retrieval module — which is a **circular import**, the adapter imports the retrieval mixin and the mixin imports the adapter — so the import raised, an `except` caught it, and the gauge published `0`.

A gauge saying "blended scoring" about a deployment running the profile **on** is worse than no gauge: every dashboard reading it describes the opposite of what happened.

It reads the environment now. The default it falls back to is a second copy of the retrieval module's own, and is asserted against it — two copies of a default agree until one is edited.

Seven tests, including the case almost every deployment is in (nothing set, profile on) which is exactly the case the first version got backwards, and the positive control that the series reaches the scrape at all.