### PR TITLE
Nine flag readers spell the vocabulary; now they call the one that owns it

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -1873,14 +1873,7 @@ pub(crate) fn timestamp_range_bounds(
 /// themselves and gate their own half of the same decision; a copy that drifted would leave one
 /// subsystem in bulk mode and the rest on the live path.
 pub(crate) fn bulk_ingest_mode() -> bool {
-    matches!(
-        std::env::var("MATRIXARK_BULK_INGEST")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "1" | "true" | "yes" | "on"
-    )
+    crate::env_flag::env_bool("MATRIXARK_BULK_INGEST", false)
 }
 
 /// Whether the per-command model-map -> bucket-index promotion and first-index
@@ -1900,14 +1893,7 @@ fn defer_bucket_index_reconstruct() -> bool {
 /// store after reconstructing the index (disk->memory promotion on restart).
 /// Defaults ON; set MATRIXARK_EAGER_CACHE_WARM_ON_LOAD to 0/false/off/no to disable.
 pub(crate) fn eager_cache_warm_on_load() -> bool {
-    !matches!(
-        std::env::var("MATRIXARK_EAGER_CACHE_WARM_ON_LOAD")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "0" | "false" | "no" | "off"
-    )
+    crate::env_flag::env_bool("MATRIXARK_EAGER_CACHE_WARM_ON_LOAD", true)
 }
 
 /// Current on-disk shape of a shard index.

--- a/crates/temporalstore-rust/src/log_framing.rs
+++ b/crates/temporalstore-rust/src/log_framing.rs
@@ -95,14 +95,7 @@ pub(crate) const FRAME_MAGIC_V3: u8 = 0xB3;
 /// be thrown over an existing binary-framed log and it never was; what was wrong is the sentence
 /// that said it could be.
 pub(crate) fn binary_frame_enabled() -> bool {
-    !matches!(
-        std::env::var("TS_WAL_BINARY_FRAME")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "0" | "false" | "no" | "off"
-    )
+    crate::env_flag::env_bool("TS_WAL_BINARY_FRAME", true)
 }
 
 fn write_varint(value: u64, out: &mut Vec<u8>) {

--- a/crates/temporalstore-rust/src/memory_trim.rs
+++ b/crates/temporalstore-rust/src/memory_trim.rs
@@ -33,14 +33,7 @@ pub fn release_free_heap_to_os() -> bool {
 /// not using. The escape hatch exists because a trim costs a walk of the free lists, and an
 /// operator who measures that as expensive on their heap should not need a build to stop it.
 fn trim_enabled() -> bool {
-    !matches!(
-        std::env::var("TS_MALLOC_TRIM")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "0" | "false" | "no" | "off"
-    )
+    crate::env_flag::env_bool("TS_MALLOC_TRIM", true)
 }
 
 #[cfg(all(target_os = "linux", target_env = "gnu"))]

--- a/crates/temporalstore-rust/src/types.rs
+++ b/crates/temporalstore-rust/src/types.rs
@@ -2095,14 +2095,7 @@ fn pack_f32_vector(vector: &[f32]) -> Vec<u8> {
 /// Whether new writes store the quantized form. Default OFF; reading understands both regardless,
 /// so this can be turned on and off without stranding anything already written.
 fn vector_int8_enabled() -> bool {
-    matches!(
-        std::env::var("TS_VECTOR_INT8")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "1" | "true" | "yes" | "on"
-    )
+    crate::env_flag::env_bool("TS_VECTOR_INT8", false)
 }
 
 /// A vector as it will read back once it has been through a page.
@@ -2135,14 +2128,7 @@ pub(crate) fn context_vector_as_stored(vector: &[f32]) -> Vec<f32> {
 /// strands nothing already written, and turning it back on needs no backfill -- the copy reappears
 /// as each node's summary is next written.
 pub(crate) fn context_node_summary_vector_enabled() -> bool {
-    !matches!(
-        std::env::var("TS_NODE_SUMMARY_VECTOR")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "0" | "false" | "no" | "off"
-    )
+    crate::env_flag::env_bool("TS_NODE_SUMMARY_VECTOR", true)
 }
 
 /// Symmetric per-vector int8, scale first: `scale = max|v| / 127`, then `round(v / scale)`.
@@ -2208,14 +2194,7 @@ fn unpack_f32_vector(bytes: &[u8]) -> Vec<f32> {
 /// Reading never consults this -- a vector is decoded by the field carrying it -- so turning it
 /// off again strands nothing. `TS_VECTOR_SCALED` opts OUT.
 fn vector_scaled_enabled() -> bool {
-    !matches!(
-        std::env::var("TS_VECTOR_SCALED")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "0" | "false" | "no" | "off"
-    )
+    crate::env_flag::env_bool("TS_VECTOR_SCALED", true)
 }
 
 /// f32 vector -> zigzag varints of `round(v * VECTOR_SCALE)`.

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -363,14 +363,7 @@ pub fn wal_outcome_items_enabled() -> bool {
     // Default ON. Recording stopped costing the group-commit coalescing once results travelled
     // through the reserve-only append, and recovery prefers installing them over re-running an
     // operation wherever it has them. The variable now opts OUT.
-    !matches!(
-        std::env::var("TS_WAL_OUTCOME_ITEMS")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "0" | "false" | "no" | "off"
-    )
+    crate::env_flag::env_bool("TS_WAL_OUTCOME_ITEMS", true)
 }
 
 fn outcome_not_deleted(deleted: &bool) -> bool {

--- a/crates/temporalstore-rust/src/wal_proto.rs
+++ b/crates/temporalstore-rust/src/wal_proto.rs
@@ -111,14 +111,7 @@ const COMPRESSION_MIN_BYTES: usize = 256;
 /// property of the payload, not of this flag.
 ///
 pub(crate) fn compress_records_enabled() -> bool {
-    !matches!(
-        std::env::var("TS_WAL_COMPRESS_RECORDS")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "0" | "false" | "no" | "off"
-    )
+    crate::env_flag::env_bool("TS_WAL_COMPRESS_RECORDS", true)
 }
 
 thread_local! {


### PR DESCRIPTION
#1308 gave the crate one reader for boolean flags and a guard that no reader may decide by
case. Nine accessors were already correct — they just each restated the vocabulary instead of
calling it:

```rust
pub(crate) fn trim_enabled() -> bool {
    !matches!(
        std::env::var("TS_MALLOC_TRIM")
            .unwrap_or_default()
            .trim()
            .to_ascii_lowercase()
            .as_str(),
        "0" | "false" | "no" | "off"
    )
}
```

becomes

```rust
pub(crate) fn trim_enabled() -> bool {
    crate::env_flag::env_bool("TS_MALLOC_TRIM", true)
}
```

Nine bodies of nine lines become nine calls: `TS_MALLOC_TRIM`, `TS_WAL_BINARY_FRAME`,
`TS_WAL_COMPRESS_RECORDS`, `TS_WAL_OUTCOME_ITEMS`, `TS_VECTOR_INT8`, `TS_VECTOR_SCALED`,
`TS_NODE_SUMMARY_VECTOR`, `MATRIXARK_BULK_INGEST` and `MATRIXARK_EAGER_CACHE_WARM_ON_LOAD`.

## Why this is the same behaviour, not merely similar

Both inline shapes are `env_bool` with a fixed default, for every input:

| written | `!matches!(…, "0"\|"false"\|"no"\|"off")` | `env_bool(n, true)` |
|---|---|---|
| unset | `unwrap_or_default()` gives `""`, in neither list → `true` | default → `true` |
| `off` | in the list → `false` | `Some(false)` → `false` |
| `yes` | not in the list → `true` | `Some(true)` → `true` |
| `wat` | not in the list → `true` | unreadable → default → `true` |

and the mirror for the `"1" | "true" | "yes" | "on"` shape with `env_bool(n, false)`, where an
unset variable gives `""`, matches nothing, and comes back `false`. Trim and lowercase were
already being applied in both, by the same two calls the shared reader makes.

That equivalence is what makes this a rewrite rather than a change: the one case where an inline
deny-list and `env_bool` could differ is an unreadable value, and for these the flag's default
*is* the value the deny-list produced.

## Checks

The tests that select **both** positions of these flags pass unchanged — which is the point,
since a semantics change would land there first:

- `memory_trim::the_trim_switch_is_read_every_time`, which drives `"0"`, `"false"`, `"NO"`,
  `"Off"`, `" 0 "` and `"1"` — the case and whitespace spellings.
- `wal_proto::compression_is_on_when_nothing_says_otherwise`, and its sibling that drives every
  off spelling including `"OFF"`.
- The `log_framing` frame tests and the vector-encoding tests for the three `types.rs` knobs.

20 targeted tests pass. `cargo check --release --lib --bins --tests` clean. Full
`cargo test --release --lib --tests --no-fail-fast -- --test-threads=1`: no failure that main
does not already have.

Net −63 lines, and `crate::env_flag` is now the only place in the crate that spells the words.
