### PR TITLE
Two imports ran once per record instead of once per call

### DIFF
--- a/tools/matrixark_local_adapter_summaries.py
+++ b/tools/matrixark_local_adapter_summaries.py
@@ -592,6 +592,14 @@ class _LocalAdapterSummariesMixin:
         skip_dirty_reasons: set[str] | None = None,
         records: list[Json] | None = None,
     ) -> Json:
+        # Resolved once per call, not once per summary: this sat inside two nested loops, so
+        # the import machinery ran for every summary of every dirty node.
+        try:
+            from tools.matrixark_index_growth_bound import (
+                index_compact_on_summary_enabled, index_compaction_tombstone)
+        except ImportError:  # Direct script execution from tools/.
+            from matrixark_index_growth_bound import (
+                index_compact_on_summary_enabled, index_compaction_tombstone)
         refreshed_at_ms = refreshed_at_ms or now_ms()
         skip_dirty_reasons = skip_dirty_reasons or set()
         # `records` lets one caller's read serve a whole pass. Reading here is a full record-log
@@ -990,12 +998,6 @@ class _LocalAdapterSummariesMixin:
                 # `index_compaction_tombstone` returns None when there is nothing to compact, so a
                 # summary with no source events appends nothing and the log stays byte-identical to
                 # what it was before this.
-                try:
-                    from tools.matrixark_index_growth_bound import (
-                        index_compact_on_summary_enabled, index_compaction_tombstone)
-                except ImportError:  # Direct script execution from tools/.
-                    from matrixark_index_growth_bound import (
-                        index_compact_on_summary_enabled, index_compaction_tombstone)
                 summary_scope = summary_record.get("scope")
                 if index_compact_on_summary_enabled(summary_scope):
                     compaction = index_compaction_tombstone(

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -1422,15 +1422,17 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
                 return full
 
             def project(records: list[Json]) -> list[tuple]:
+                # Resolved once, not once per record: the name cannot change between iterations, and
+                # an import inside the loop runs the machinery for every context_event the backend
+                # returns. This seam is on the live serving path.
+                try:
+                    from tools.matrixark_mcp_local_adapter import _record_scope_hashes
+                except ModuleNotFoundError:
+                    from matrixark_mcp_local_adapter import _record_scope_hashes
                 out = []
                 for record in records:
                     if str(record.get("record_type") or "") != "context_event":
                         continue
-                    rec_tenant, rec_user = 0, 0
-                    try:
-                        from tools.matrixark_mcp_local_adapter import _record_scope_hashes
-                    except ModuleNotFoundError:
-                        from matrixark_mcp_local_adapter import _record_scope_hashes
                     rec_tenant, rec_user = _record_scope_hashes(record)
                     if rec_tenant != tenant_hash or rec_user != user_hash:
                         continue


### PR DESCRIPTION
Two imports sat **inside per-record loops**. An import in a function body runs once per call; inside
a loop it runs once per iteration.

`MatrixArkTemporalStoreDirectAdapter.records_for_get_all` is the one that matters, because it is on
the live serving path -- the live adapter is a `MatrixArkLocalAdapter` subclass and overrides this
seam, so this loop runs for every `context_event` the backend returns:

    def project(records):
        out = []
        for record in records:
            if str(record.get("record_type") or "") != "context_event":
                continue
            rec_tenant, rec_user = 0, 0
            try:
                from tools.matrixark_mcp_local_adapter import _record_scope_hashes   # per record
            except ModuleNotFoundError:
                from matrixark_mcp_local_adapter import _record_scope_hashes
            rec_tenant, rec_user = _record_scope_hashes(record)

The second is `refresh_dirty_node_summaries`, where the import sits inside **two nested loops** --
per summary, per dirty node -- and is now resolved once at the top of the function.

## What it costs, stated honestly

Where the dotted form **resolves** -- which is the live hook, because `load_matrixark` puts the repo
root on `sys.path` before importing anything -- a repeat import is served from `sys.modules` at
**1.47 us**. Per record. A `get_all` over 10,000 records pays ~14 ms for a name that cannot change
between iterations.

Where it does **not** resolve -- any process whose `sys.path` cannot reach `tools`, which includes
the test suite -- it is **134.98 us** per record, because Python does not cache a failed import.

So this is a small win in production and a large one in the suite. It is worth making either way: an
import inside a loop is not a trade-off, just repetition.

Sweeping `tools/` for imports inside loops finds **five**; these are the two on a serving path. The
third is a one-off script's `main()`, left alone.

## Test

Both modules import and the seam is still present on the class. 20 suites reach these two functions
or their modules: **155 tests, no failures** beyond `test_matrixark_access_governance`, which errors
identically on clean `main` (no extraction backend in this environment).

The removed `rec_tenant, rec_user = 0, 0` was dead: the next statement overwrote it unconditionally,
and an exception other than `ModuleNotFoundError` propagates rather than falling through to it.
