### PR TITLE
The idle-commit flush scanned its input twice to apply the same filter

### DIFF
--- a/tools/matrixark_mcp_retrieve_request.py
+++ b/tools/matrixark_mcp_retrieve_request.py
@@ -253,11 +253,15 @@ def pre_retrieval_idle_commit_flush(target: Any, args: Json, ranking: Json, *, s
     current_time_ms = now_ms()
     due_tasks: list[Json] = []
     resolved_task_hashes: set[int] = set()
-    for record in records:
-        if not isinstance(record, dict):
-            continue
-        if record.get("record_type") != "matrixark_async_pipeline_task":
-            continue
+    # Filter once. Both phases below want the same rows, and on the fallback path `records` is the
+    # whole live view rather than the task index, so the filter was walking every record twice to
+    # find rows that number in the hundreds.
+    task_records = [
+        record for record in records
+        if isinstance(record, dict)
+        and record.get("record_type") == "matrixark_async_pipeline_task"
+    ]
+    for record in task_records:
         status = str(record.get("status") or "")
         if status in IDLE_COMMIT_RESOLVED_STATUSES:
             try:
@@ -265,11 +269,7 @@ def pre_retrieval_idle_commit_flush(target: Any, args: Json, ranking: Json, *, s
             except (TypeError, ValueError):
                 pass
             continue
-    for record in records:
-        if not isinstance(record, dict):
-            continue
-        if record.get("record_type") != "matrixark_async_pipeline_task":
-            continue
+    for record in task_records:
         status = str(record.get("status") or "")
         if status != "idle_commit_scheduled":
             continue


### PR DESCRIPTION
`pre_retrieval_idle_commit_flush` runs before every retrieve, and it walked its input twice to
apply the same filter:

```python
for record in records:      # collect resolved task hashes
    if not isinstance(record, dict): continue
    if record.get("record_type") != "matrixark_async_pipeline_task": continue
    ...
for record in records:      # find the scheduled ones
    if not isinstance(record, dict): continue
    if record.get("record_type") != "matrixark_async_pipeline_task": continue
```

Filtering once and walking the filtered list twice does the same work in one scan.

It matters on the **fallback path**. When a backend offers `idle_commit_task_records` the flush gets
a pre-filtered list of task rows — a few hundred. When it does not, the flush falls back to
`read_all()` and is handed the entire live view, then scans all of it twice to find those same few
hundred rows.

## Measured

Seven rounds per arm on a real store, result compared before timing:

| input | before | after |
|---|---|---|
| indexed path, 572 rows | 0.74 ms median, min 0.65, max 2.10 | 1.31 ms median, min 0.60, max 2.05 |
| fallback path, 7,085 rows | 65.92 ms median, min 29.13, max 116.00 | **9.14 ms median, min 4.14, max 22.92** |

On the fallback path that is **7.2x**, and the ranges do not overlap — the slowest run after the
change (22.92 ms) is faster than the fastest run before it (29.13 ms). That separation is the reason
to trust it: this box is under load and medians alone would not settle it.

On the indexed path the ranges overlap completely and the minima are within noise of each other
(0.60 against 0.65), so it is a wash there rather than a cost. The change adds one pass over an
already-filtered list and removes two type tests per row from the passes that follow.

**Identical output in all four runs**: sha `4baf9a26df0f`.

## Checked

- `test_idle_commit_candidates` (6), `test_matrixark_the_idle_commit_scan_is_indexed` (5),
  `test_the_resolved_set_covers_what_the_flush_writes` (4),
  `test_the_schema_names_what_the_route_reads` (6),
  `test_matrixark_one_audit_policy_two_declared_defaults` (14) — all pass.
- `test_codex_pipeline_part3` and `test_python_module_boundaries_part2` fail identically with and
  without the change, so they are pre-existing; both are the standalone-part-module import error,
  not a behaviour.

## Not changed

`IDLE_COMMIT_RESOLVED_STATUSES` still excludes `idle_commit_skipped`, and the comment above it
explains why that is an open question rather than an oversight: a skip is written with
`remaining_stages` set and `completed_stages` empty, i.e. as work still outstanding, so marking it
resolved would be indistinguishable from dropping live work. That is a decision about what a skip
means, not a scan to tighten, and it is left alone here.
