### PR TITLE
Stop re-hashing sealed slabs that have not changed since they were verified

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -615,6 +615,16 @@ pub struct BlockStoreBandDescriptor {
     pub last_page_id: Option<u64>,
     #[serde(default)]
     pub readable_prefix_physical_bytes: u64,
+    /// The file mtime this descriptor was last verified against.
+    ///
+    /// Every open re-reads and re-hashes every page record in every slab; on a 1.4 GB store that is
+    /// ~30 s of CPU, and it is the same work every time for slabs nobody has touched. Recording the
+    /// identity the descriptor was verified against makes "has this file changed" answerable from
+    /// metadata instead of by decoding the slab again.
+    ///
+    /// None on a descriptor written before this existed, which simply verifies once and fills it in.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verified_source_mtime_unix_ms: Option<u64>,
     #[serde(default)]
     pub has_corruption: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1110,6 +1120,7 @@ impl LocalBlockStore {
                 first_page_id: None,
                 last_page_id: None,
                 readable_prefix_physical_bytes: 0,
+                verified_source_mtime_unix_ms: None,
                 has_corruption: false,
                 first_error_offset: None,
                 first_error: None,
@@ -1162,6 +1173,7 @@ impl LocalBlockStore {
                 first_page_id: band.first_page_id,
                 last_page_id: band.last_page_id,
                 readable_prefix_physical_bytes: band.physical_bytes,
+                verified_source_mtime_unix_ms: None,
                 has_corruption: false,
                 first_error_offset: None,
                 first_error: None,
@@ -1519,6 +1531,7 @@ fn roll_slab_inner(
         first_page_id: None,
         last_page_id: None,
         readable_prefix_physical_bytes: 0,
+        verified_source_mtime_unix_ms: None,
         has_corruption: false,
         first_error_offset: None,
         first_error: None,
@@ -2495,7 +2508,27 @@ mod tests {
         let reopened = LocalBlockStore::new(dir.path());
         let reopened_bands = reopened.band_descriptors();
         assert_eq!(reopened_bands.len(), bands.len());
-        assert_eq!(reopened_bands[0], bands[0]);
+        // The band must survive a reopen unchanged. `verified_source_mtime_unix_ms` is excluded
+        // because it is not part of the band: it records when the descriptor was last checked
+        // against the file, and the two sides differ on that for a good reason, asserted below.
+        let strip = |band: &BlockStoreBandDescriptor| {
+            let mut band = band.clone();
+            band.verified_source_mtime_unix_ms = None;
+            band
+        };
+        assert_eq!(strip(&reopened_bands[0]), strip(&bands[0]));
+        // The original store wrote and sealed this slab without ever inspecting it, so it has
+        // nothing verified to record; the reopen reconciled, which inspected it, so it does.
+        assert!(
+            bands[0].verified_source_mtime_unix_ms.is_none(),
+            "a slab this process only wrote has not been verified by inspection: {:?}",
+            bands[0]
+        );
+        assert!(
+            reopened_bands[0].verified_source_mtime_unix_ms.is_some(),
+            "reopening inspected this slab, so the identity it verified should be recorded: {:?}",
+            reopened_bands[0]
+        );
         assert_eq!(
             reopened_bands[1].page_slab_id,
             bands[1].page_slab_id

--- a/crates/temporalstore-rust/src/block_store/band_manifest.rs
+++ b/crates/temporalstore-rust/src/block_store/band_manifest.rs
@@ -64,6 +64,10 @@ pub(super) fn rebuild_band_manifest_at(
                 first_page_id: report.first_page_id,
                 last_page_id: report.last_page_id,
                 readable_prefix_physical_bytes: report.readable_prefix_physical_bytes,
+                // This path inspected the slab, so record the identity it was verified against;
+                // leaving it empty makes the next reconcile re-read a slab this one just proved.
+                verified_source_mtime_unix_ms: file_modified_unix_ms(&path)
+                    .or_else(|| file_created_unix_ms(&path)),
                 has_corruption: report.has_corruption,
                 first_error_offset: report.first_error_offset,
                 first_error: report.first_error,
@@ -89,12 +93,23 @@ pub(super) fn rebuild_band_manifest_at(
                 first_page_id: None,
                 last_page_id: None,
                 readable_prefix_physical_bytes: 0,
+                verified_source_mtime_unix_ms: None,
                 has_corruption: false,
                 first_error_offset: None,
                 first_error: None,
             });
     }
     Ok(bands)
+}
+
+/// Re-verify every slab on every open, as before this was made skippable.
+///
+/// The escape hatch for a deployment that suspects its slabs: it costs the full cold-start CPU
+/// again, which is the point.
+fn reverify_all_slabs() -> bool {
+    std::env::var("TS_REVERIFY_ALL_SLABS")
+        .map(|value| matches!(value.trim(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(false)
 }
 
 pub(super) fn reconcile_band_manifest_with_disk(
@@ -120,7 +135,40 @@ pub(super) fn reconcile_band_manifest_with_disk(
     // (13.5 MB/s, against hundreds of MB/s for sha256) with the process pinned at 99% of one core.
     // Only the reads and hashing are shared out; the update loop below is unchanged and still walks
     // `live_slab_ids` in order, so it makes the same decisions in the same sequence.
-    let ordered_slab_ids = live_slab_ids.iter().copied().collect::<Vec<_>>();
+    let mut ordered_slab_ids = live_slab_ids.iter().copied().collect::<Vec<_>>();
+    // Leave out the sealed slabs whose file is still exactly what their descriptor was verified
+    // against. Inspecting one re-reads it and re-hashes every record in it, which is the bulk of a
+    // cold open -- 30.7 s of CPU in a 32.0 s restart on this store, 96% CPU-bound -- and for a slab
+    // nobody has touched it recomputes an answer already on disk.
+    //
+    // Deliberately narrow. Only a SEALED slab already in the manifest, not marked corrupt, already
+    // in the state it should be in, whose size AND mtime both still match what was verified. The
+    // active slab is always inspected: it is the one being appended to. Anything unreadable or
+    // unrecorded falls through to a full inspection, so the skip can only ever be taken on evidence.
+    if !reverify_all_slabs() {
+        ordered_slab_ids.retain(|page_slab_id| {
+            if *page_slab_id == latest {
+                return true;
+            }
+            let Some(band) = bands.get(page_slab_id) else {
+                return true;
+            };
+            if band.has_corruption || band.state != BlockStoreBandState::Sealed {
+                return true;
+            }
+            let Some(verified_mtime) = band.verified_source_mtime_unix_ms else {
+                return true;
+            };
+            let path = slab_path(root, *page_slab_id);
+            let Ok(meta) = fs::metadata(&path) else {
+                return true;
+            };
+            if meta.len() != band.physical_bytes {
+                return true;
+            }
+            file_modified_unix_ms(&path) != Some(verified_mtime)
+        });
+    }
     let workers = std::thread::available_parallelism()
         .map(|value| value.get())
         .unwrap_or(1)
@@ -189,6 +237,9 @@ pub(super) fn reconcile_band_manifest_with_disk(
                 band.has_corruption = report.has_corruption;
                 band.first_error_offset = report.first_error_offset;
                 band.first_error = report.first_error;
+                // What this descriptor has now been verified against, so the next open can tell
+                // whether the file still matches without reading it.
+                band.verified_source_mtime_unix_ms = updated_unix_ms;
                 changed |= *band != old;
             }
             None => {
@@ -205,6 +256,9 @@ pub(super) fn reconcile_band_manifest_with_disk(
                         first_page_id: report.first_page_id,
                         last_page_id: report.last_page_id,
                         readable_prefix_physical_bytes: report.readable_prefix_physical_bytes,
+                        // Just inspected, so record what it was verified against; otherwise the
+                        // next open re-reads and re-hashes a slab this one already proved.
+                        verified_source_mtime_unix_ms: updated_unix_ms,
                         has_corruption: report.has_corruption,
                         first_error_offset: report.first_error_offset,
                         first_error: report.first_error,
@@ -234,6 +288,7 @@ pub(super) fn reconcile_band_manifest_with_disk(
                 first_page_id: old.as_ref().and_then(|band| band.first_page_id),
                 last_page_id: old.as_ref().and_then(|band| band.last_page_id),
                 readable_prefix_physical_bytes: 0,
+                verified_source_mtime_unix_ms: None,
                 has_corruption: false,
                 first_error_offset: None,
                 first_error: None,
@@ -392,6 +447,7 @@ pub(super) fn ensure_band_descriptor(
             first_page_id: None,
             last_page_id: None,
             readable_prefix_physical_bytes: physical_bytes,
+            verified_source_mtime_unix_ms: None,
             has_corruption: false,
             first_error_offset: None,
             first_error: None,
@@ -429,6 +485,7 @@ pub(super) fn upsert_band_after_append(
             first_page_id: Some(page_id),
             last_page_id: Some(page_id),
             readable_prefix_physical_bytes: 0,
+            verified_source_mtime_unix_ms: None,
             has_corruption: false,
             first_error_offset: None,
             first_error: None,
@@ -479,6 +536,7 @@ pub(super) fn set_band_state(
             first_page_id: None,
             last_page_id: None,
             readable_prefix_physical_bytes: 0,
+            verified_source_mtime_unix_ms: None,
             has_corruption: false,
             first_error_offset: None,
             first_error: None,

--- a/crates/temporalstore-rust/src/block_store/band_reports.rs
+++ b/crates/temporalstore-rust/src/block_store/band_reports.rs
@@ -115,6 +115,7 @@ impl LocalBlockStore {
                             first_page_id: zone.first_page_id,
                             last_page_id: zone.last_page_id,
                             readable_prefix_physical_bytes: zone.physical_bytes,
+                            verified_source_mtime_unix_ms: None,
                             has_corruption: false,
                             first_error_offset: None,
                             first_error: None,

--- a/crates/temporalstore-rust/src/block_store/read.rs
+++ b/crates/temporalstore-rust/src/block_store/read.rs
@@ -152,6 +152,7 @@ impl LocalBlockStore {
                 first_page_id: band_summary.first_page_id,
                 last_page_id: band_summary.last_page_id,
                 readable_prefix_physical_bytes: bytes.len() as u64,
+                verified_source_mtime_unix_ms: None,
                 has_corruption: false,
                 first_error_offset: None,
                 first_error: None,


### PR DESCRIPTION
Every engine open re-reads every slab and re-verifies the sha256 of every page record in it, whether
or not anything has touched the file since the last time it was checked.

Measured on a 2.9 GB store (1,490 MB of pages), page cache dropped before each open:

```
read_bytes  = 1,545.8 MB      (essentially the whole store)
rchar       = 3,077.3 MB      (traversed twice)
cpu         = 30.7 s of 32.0 s wall   →  96% CPU-bound
```

gdb stack sampling puts every sample under `LocalBlockStore::with_options`, with the hot frames being
`verify_page_record_checksum`, `inspect_slab`, `reconcile_band_manifest_with_disk` and
`decode_page_record`. The code already says as much: *"Inspecting a slab re-verifies the sha256 of
every page record in it, and this runs at EVERY engine open ... ~950 MB of slabs took about 70 s of a
cold start"*.

### The change

`BlockStoreBandDescriptor` gains `verified_source_mtime_unix_ms`: the mtime the slab had when the
descriptor was last verified against it. A sealed slab is skipped only when **all** of these hold:

- the descriptor exists and is not marked corrupt,
- its state already equals the state it should have (so a slab that has just sealed is inspected),
- the file's size still equals `physical_bytes`, and
- the file's mtime still equals `verified_source_mtime_unix_ms`.

Anything else — an absent field, a changed size, a changed mtime, unreadable metadata — inspects
exactly as before. The active slab is always inspected: it is the one being appended to.

The field is `#[serde(default)]`, so existing manifests start with `None`, verify once, and record
what they verified as they go. `TS_REVERIFY_ALL_SLABS=1` restores the old behaviour in full.

### Result

Both binaries built `--release` from the **same base**, run against the same copy, page cache dropped
before every open, three opens each so both reach steady state:

| open | binary | wall | CPU | records |
|---|---|---|---|---|
| old-3 | baseline | 17,000 ms | 29.3 s | 16,717 |
| new-1 | with skip | 14,076 ms | 24.3 s | 16,717 |
| new-2 | with skip | 10,458 ms | 6.2 s | 16,717 |
| new-3 | with skip | **9,726 ms** | **6.5 s** | 16,717 |

**4.5x less CPU per restart**, 1.75x wall. `new-1` still verifies everything — no descriptor carries
an identity yet — and lands at 24.3 CPU-s, next to the baseline's 29.3. That the first open does
*not* get faster is what shows the saving is coming from the skip rather than from the harness.

The record count is identical on every row. This change touches integrity checking, so an open that
served fewer records would be a failure and not a speedup.

### An earlier attempt, and why this one differs

Skipping unchanged sealed slabs was tried before and abandoned: it predicated on
`updated_unix_ms == the file's mtime`, but that field records when the *content* last changed, not
when the file was written, so it matched 3 of 127 slabs and bought nothing. The conclusion recorded
then was that doing it properly means storing the file's own identity in the descriptor. That is what
this does, rather than inferring it from a field that means something else.

### Tests

74 `block_store`/`band` tests pass. Two of them changed, and both changes are behavioural rather than
cosmetic:

`band_manifest_tracks_roll_reopen_gc_and_purge` asserted whole-descriptor equality across a reopen.
One field now legitimately differs: the original store *wrote and sealed* that slab without ever
inspecting it, so it has nothing verified to record, while the reopen reconciled and does. The
assertion is split rather than loosened — the band itself must still be identical, and each side's
verification field is asserted for what it means. That distinguishes "verified" from "never looked
at", which the equality could not.

`missing_band_manifest_rebuilds_from_existing_slabs` caught a real bug in an earlier draft: the
rebuild path inspects every slab but I had left its descriptor's identity empty, so the very next
reconcile re-inspected the lot and reported a change. The same mistake existed on the
created-descriptor path inside reconcile. Both now record what they verified; `upsert_band_after_append`
still records `None`, correctly, because it has not inspected anything.
