### PR TITLE
The summary progress scan selected the same rows twice, once per dirty node

### DIFF
--- a/tools/matrixark_mcp_summary_runtime.py
+++ b/tools/matrixark_mcp_summary_runtime.py
@@ -666,10 +666,16 @@ def async_summary_progress_records(
     # still costs a round trip and permanent growth, and on a record-log backend that growth
     # is what turns a busy store into one where a retrieve cannot finish. Skip the write when
     # nothing about the task actually changed; a genuinely new state still lands.
+    # Select the task rows once. The two loops below want the same rows and differ only in the
+    # status they look for, and both callers hand this the whole live view from `read_all()` and
+    # call it once per dirty node -- so selecting twice was paid per node.
+    task_records = [
+        record for record in records
+        if record.get("record_type") == "matrixark_async_pipeline_task"
+    ]
+
     already_recorded: set[tuple] = set()
-    for record in records:
-        if record.get("record_type") != "matrixark_async_pipeline_task":
-            continue
+    for record in task_records:
         if str(record.get("status") or "") != "summary_completed":
             continue
         if not compatible_scope(candidate_access_scope(record), scope):
@@ -686,9 +692,7 @@ def async_summary_progress_records(
         already_recorded.add(progress_identity(record.get("task_hash"), existing_completed))
 
     progress_records: list[Json] = []
-    for record in records:
-        if record.get("record_type") != "matrixark_async_pipeline_task":
-            continue
+    for record in task_records:
         if str(record.get("status") or "") != "extraction_committed":
             continue
         try:


### PR DESCRIPTION
`async_summary_progress_records` walks `records` three times:

| pass | filter |
|---|---|
| 1 | `context_entity` — a different type, left alone |
| 2 | `matrixark_async_pipeline_task`, status `summary_completed` |
| 3 | `matrixark_async_pipeline_task`, status `extraction_committed` |

Passes 2 and 3 select the same rows and differ only in the status they look for, so the type filter
ran over every record twice. Selecting once and walking the selection twice does the same work in
one pass.

## Why it is worth doing here

Both callers — `matrixark_local_adapter_summaries` and `matrixark_mcp_summary_runtime` — do
`records = read_all()` and then call this **once per dirty node**, inside `for dirty in ...`. The
repeated selection was paid per node, over the whole live view.

## Measured

On a real store, 7,085 records, seven rounds each, output compared before timing:

```
before   39.65 ms median    min 33.52    max 49.26
after    16.24 ms median    min 12.15    max 25.83
```

**2.4x**, and the ranges do not overlap — the slowest run after is faster than the fastest run
before, which is the part worth trusting on a box under load.

## Output is identical, and non-empty

179 progress records either way, `sha256=351140a26c6a`. An empty result would have compared equal
while proving nothing, so the inputs were built from the store's own committed task rows to make the
function actually select something.

## Scope

The `context_entity` pass is untouched: it reads a different record type, so folding it into the
same selection would change what it sees. A static check confirms exactly one loop over `records`
remains after the change.

Tests closest to the path pass: `test_refresh_one_read` (6), `test_refresh_pass_budget` (6),
`test_matrixark_summary_worker` (6), `test_native_backends_reach_temporalstore` (3).
