### PR TITLE
A flag value is trimmed before it is parsed

### DIFF
--- a/crates/temporalstore-rust/src/bin/codex_context_hook.rs
+++ b/crates/temporalstore-rust/src/bin/codex_context_hook.rs
@@ -230,7 +230,7 @@ fn parse_args() -> Args {
         query: String::new(),
         max_context_tokens: std::env::var("MATRIXARK_HOOK_MAX_CONTEXT_TOKENS")
             .ok()
-            .and_then(|value| value.parse::<u32>().ok())
+            .and_then(|value| value.trim().parse::<u32>().ok())
             .unwrap_or(1024),
     };
     while let Some(arg) = args.next() {
@@ -435,7 +435,7 @@ fn env_bool(name: &str) -> bool {
 fn additional_context_char_limit() -> usize {
     std::env::var("MATRIXARK_HOOK_ADDITIONAL_CONTEXT_CHAR_LIMIT")
         .ok()
-        .and_then(|value| value.parse::<usize>().ok())
+        .and_then(|value| value.trim().parse::<usize>().ok())
         .filter(|value| *value > 0)
         .unwrap_or(40_000)
 }

--- a/crates/temporalstore-rust/src/bin/context_workflow_harness.rs
+++ b/crates/temporalstore-rust/src/bin/context_workflow_harness.rs
@@ -1198,7 +1198,7 @@ fn run_external_context_benchmark(engine: &TemporalEngine) -> ExternalContextBen
     let mut unsupported_benchmark_case_ids = Vec::<String>::new();
     let max_events = std::env::var("TEMPORALSTORE_CONTEXT_BENCHMARK_MAX_EVENTS")
         .ok()
-        .and_then(|value| value.parse::<usize>().ok())
+        .and_then(|value| value.trim().parse::<usize>().ok())
         .filter(|value| *value > 0)
         .unwrap_or(32);
     let all_source_replay = temporalstore_rust::env_flag::env_bool(
@@ -1207,7 +1207,7 @@ fn run_external_context_benchmark(engine: &TemporalEngine) -> ExternalContextBen
     );
     let selected_id_limit = std::env::var("TEMPORALSTORE_CONTEXT_BENCHMARK_SELECTED_ID_LIMIT")
         .ok()
-        .and_then(|value| value.parse::<usize>().ok())
+        .and_then(|value| value.trim().parse::<usize>().ok())
         .filter(|value| *value > 0)
         .unwrap_or(128);
     let direct_source_scoring =

--- a/crates/temporalstore-rust/src/bin/distributed_raft_harness.rs
+++ b/crates/temporalstore-rust/src/bin/distributed_raft_harness.rs
@@ -1215,7 +1215,7 @@ fn wait_for_replica_read(
 fn wait_for_key(node: &ProductionRaftNode, key: &str, expected: &[u8]) -> ReplicaReadSummary {
     let timeout_secs = std::env::var("TS_DISTRIBUTED_RAFT_CATCHUP_TIMEOUT_SECS")
         .ok()
-        .and_then(|raw| raw.parse::<u64>().ok())
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
         .unwrap_or(30);
     let deadline = Instant::now() + Duration::from_secs(timeout_secs);
     loop {

--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -1142,7 +1142,7 @@ fn failure_detector_options_from_env() -> FailureDetectorOptions {
         max_interval_ms: env_u64("TS_META_FD_MAX_INTERVAL_MS", defaults.max_interval_ms),
         phi_failure_threshold: std::env::var("TS_META_FD_PHI_THRESHOLD")
             .ok()
-            .and_then(|value| value.parse::<f64>().ok())
+            .and_then(|value| value.trim().parse::<f64>().ok())
             .filter(|value| value.is_finite() && *value > 0.0)
             .unwrap_or(defaults.phi_failure_threshold),
         max_round_pause_ms: env_u64("TS_META_FD_MAX_ROUND_PAUSE_MS", defaults.max_round_pause_ms),

--- a/crates/temporalstore-rust/src/engine/context.rs
+++ b/crates/temporalstore-rust/src/engine/context.rs
@@ -177,7 +177,7 @@ impl Default for ContextCompressionPolicy {
 pub(super) fn default_traversal_top_k() -> usize {
     std::env::var("MATRIXARK_RETRIEVAL_TRAVERSAL_TOP_K")
         .ok()
-        .and_then(|v| v.parse::<usize>().ok())
+        .and_then(|v| v.trim().parse::<usize>().ok())
         .filter(|v| *v > 0)
         .unwrap_or(CONTEXT_DEFAULT_TRAVERSAL_TOP_K)
 }
@@ -186,7 +186,7 @@ pub(super) fn default_traversal_top_k() -> usize {
 pub(super) fn default_traversal_candidates() -> usize {
     std::env::var("MATRIXARK_RETRIEVAL_MAX_CANDIDATES")
         .ok()
-        .and_then(|v| v.parse::<usize>().ok())
+        .and_then(|v| v.trim().parse::<usize>().ok())
         .filter(|v| *v > 0)
         .unwrap_or(CONTEXT_DEFAULT_TRAVERSAL_CANDIDATES)
 }

--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -355,12 +355,12 @@ impl TemporalEngine {
                     let default_anchor = self.wal_store.stats(shard_id).last_sequence;
                     let anchor = std::env::var("MATRIXARK_BULK_INGEST_REPLAY_FROM_SEQUENCE")
                         .ok()
-                        .and_then(|value| value.parse::<u64>().ok())
+                        .and_then(|value| value.trim().parse::<u64>().ok())
                         .map(|start_sequence| {
                             let expected_tail =
                                 std::env::var("MATRIXARK_BULK_INGEST_EXPECTED_WAL_COMMANDS")
                                     .ok()
-                                    .and_then(|value| value.parse::<u64>().ok())
+                                    .and_then(|value| value.trim().parse::<u64>().ok())
                                     .and_then(|written| start_sequence.checked_add(written));
                             if expected_tail == Some(default_anchor) {
                                 default_anchor

--- a/crates/temporalstore-rust/src/engine/tests/conformance.rs
+++ b/crates/temporalstore-rust/src/engine/tests/conformance.rs
@@ -820,11 +820,11 @@ fn run_one_oracle_sequence(seed: u64) -> Result<(), String> {
 fn conformance_oracle_matches_reference_model() {
     let count = std::env::var("CONFORMANCE_SEEDS")
         .ok()
-        .and_then(|value| value.parse::<u64>().ok())
+        .and_then(|value| value.trim().parse::<u64>().ok())
         .unwrap_or(64);
     let start = std::env::var("CONFORMANCE_START")
         .ok()
-        .and_then(|value| value.parse::<u64>().ok())
+        .and_then(|value| value.trim().parse::<u64>().ok())
         .unwrap_or(0);
     let outcome = (start..start.saturating_add(count))
         .map(|seed| match run_one_oracle_sequence(seed) {
@@ -897,11 +897,11 @@ fn conformance_random_sequences_never_panic_and_survive_reload() {
     // CONFORMANCE_SEEDS / CONFORMANCE_START (e.g. CONFORMANCE_SEEDS=4000 cargo test ...).
     let count = std::env::var("CONFORMANCE_SEEDS")
         .ok()
-        .and_then(|value| value.parse::<u64>().ok())
+        .and_then(|value| value.trim().parse::<u64>().ok())
         .unwrap_or(64);
     let start = std::env::var("CONFORMANCE_START")
         .ok()
-        .and_then(|value| value.parse::<u64>().ok())
+        .and_then(|value| value.trim().parse::<u64>().ok())
         .unwrap_or(0);
     let maintenance = std::env::var("CONFORMANCE_MAINTENANCE").is_ok();
     let outcome = (start..start.saturating_add(count))

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -4200,7 +4200,7 @@ fn open_engine(request: &RecordLogRequest) -> Result<RecordStore, String> {
     })?;
     let cache_bytes = env::var("MATRIXARK_RUST_PROXY_CACHE_BYTES")
         .ok()
-        .and_then(|value| value.parse::<usize>().ok())
+        .and_then(|value| value.trim().parse::<usize>().ok())
         .filter(|value| *value > 0)
         .unwrap_or_else(default_engine_cache_bytes);
     eprintln!(
@@ -4284,7 +4284,7 @@ fn open_engine(request: &RecordLogRequest) -> Result<RecordStore, String> {
             // explicit truthy MATRIXARK_RUST_PROXY_ASYNC_STORAGE.
             async_storage: env::var("MATRIXARK_RUST_PROXY_ASYNC_STORAGE")
                 .ok()
-                .and_then(|value| value.parse::<bool>().ok())
+                .and_then(|value| temporalstore_rust::env_flag::parse_bool(&value))
                 .unwrap_or(false),
             ..Config::default()
         },

--- a/tools/test_a_flag_value_is_trimmed_before_it_is_parsed.py
+++ b/tools/test_a_flag_value_is_trimmed_before_it_is_parsed.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A flag value is trimmed before it is parsed, and never handed to Rust's `bool` parser.
+
+The numeric twin of the defect `test_no_flag_reader_decides_by_case.py` records. A shell
+export, a systemd `Environment=` line and a heredoc all leave whitespace behind, and
+`" 64".parse::<usize>()` is an `Err` -- so the reader falls back to its default and the value
+the operator set is discarded with no message at all. Sixteen readers were in that state,
+including three on serving paths: `MATRIXARK_RUST_PROXY_CACHE_BYTES`,
+`MATRIXARK_RETRIEVAL_TRAVERSAL_TOP_K` and `MATRIXARK_RETRIEVAL_MAX_CANDIDATES`.
+
+`parse::<bool>()` is the same failure, at its worst. `bool::from_str` accepts exactly two
+strings, `"true"` and `"false"`. `MATRIXARK_RUST_PROXY_ASYNC_STORAGE` was read that way while
+the comment directly above it said the switch was "opt-in only, via an explicit **truthy**"
+value -- so `1`, `on`, `yes` and `TRUE` all read as false. Every launcher in the tree happens to
+write the literal `true`, which is why nothing ever noticed.
+
+Both rules are about the value, not the vocabulary, so neither dictates which words a flag
+accepts -- `crate::env_flag::parse_bool` decides that.
+"""
+from __future__ import annotations
+
+import io
+import os
+import re
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(TOOLS)
+SRC = os.path.join(REPO, "crates", "temporalstore-rust", "src")
+
+#: `env::var("NAME") ... .parse::<T>()`, with whatever the chain does in between. The window is
+#: bounded by `;` so it cannot run past the end of the statement into an unrelated parse.
+READ = re.compile(
+    r'env::var(?:_os)?\(\s*(?:&)?(?:"(?P<lit>[A-Z][A-Z0-9_]*)"|(?P<konst>[A-Za-z_:]+))\s*\)'
+    r'(?P<tail>(?:[^;]{0,400}?))\.parse::<(?P<ty>[a-z0-9]+)>\(\)',
+    re.S)
+
+#: A scan that finds nothing passes both rules below, so the corpus is floored.
+EXPECTED_READER_FLOOR = 15
+
+
+def _sources():
+    for base, dirs, files in os.walk(SRC):
+        dirs[:] = [d for d in dirs if d != "target"]
+        for name in sorted(files):
+            if name.endswith(".rs"):
+                yield os.path.join(base, name)
+
+
+def _read(path):
+    with io.open(path, encoding="utf-8", errors="replace") as handle:
+        return handle.read()
+
+
+def _parsed_flag_reads():
+    """(where, flag, type, trims) for every env value the crate parses."""
+    for path in _sources():
+        text = _read(path)
+        for match in READ.finditer(text):
+            line = text.count("\n", 0, match.start()) + 1
+            yield ("%s:%d" % (os.path.relpath(path, REPO).replace(os.sep, "/"), line),
+                   match.group("lit") or match.group("konst"),
+                   match.group("ty"),
+                   ".trim()" in match.group("tail"))
+
+
+class AFlagValueIsTrimmedBeforeItIsParsedTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.reads = list(_parsed_flag_reads())
+
+    def test_the_scan_still_finds_the_readers(self) -> None:
+        """Both rules pass on an empty scan, which would read exactly like compliance."""
+        self.assertGreaterEqual(
+            len(self.reads), EXPECTED_READER_FLOOR,
+            "found %d parsed flag reads, expected at least %d -- if the chain shape changed, "
+            "the rules below are deciding nothing" % (len(self.reads), EXPECTED_READER_FLOOR))
+
+    def test_every_parsed_flag_value_is_trimmed_first(self) -> None:
+        untrimmed = ["%s  %s (%s)" % (where, flag, ty)
+                     for where, flag, ty, trims in self.reads if not trims]
+        self.assertEqual(
+            [], untrimmed,
+            "these parse a flag value without trimming it, so a value with surrounding "
+            "whitespace is discarded silently and the default applies instead: %s" % untrimmed)
+
+    def test_no_flag_is_handed_to_the_rust_bool_parser(self) -> None:
+        """`bool::from_str` accepts `"true"` and `"false"` and nothing else -- not `1`, not `on`,
+        not `TRUE`. A flag wants `crate::env_flag::parse_bool`."""
+        offenders = []
+        for path in _sources():
+            text = _read(path)
+            for found in re.finditer(r"parse::<bool>\(\)", text):
+                line = text.count("\n", 0, found.start()) + 1
+                offenders.append("%s:%d" % (
+                    os.path.relpath(path, REPO).replace(os.sep, "/"), line))
+        self.assertEqual(
+            [], offenders,
+            "these ask rust's bool parser what a flag means, so only the exact strings true "
+            "and false do anything. Call crate::env_flag::parse_bool: %s" % offenders)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The numeric twin of the defect #1308 fixed for booleans, plus the worst single case of it.

## Sixteen readers parsed a flag value without trimming it

A shell export, a systemd `Environment=` line and a heredoc all leave whitespace behind.
`" 64".parse::<usize>()` is an `Err`, so the reader falls back to its default and the value the
operator set is discarded — with no message, no warning, and nothing in the logs.

Three of the sixteen are on serving paths:

- `MATRIXARK_RUST_PROXY_CACHE_BYTES` — the proxy's cache size.
- `MATRIXARK_RETRIEVAL_TRAVERSAL_TOP_K` and `MATRIXARK_RETRIEVAL_MAX_CANDIDATES` — the two
  retrieval ceilings.

The rest are the metaserver's failure-detector threshold, the raft catch-up timeout, two bulk
ingest sequence knobs, the hook's context char limit, two benchmark knobs and four conformance
harness seeds. All now `.trim()` first. Thirty readers parse a flag value; thirty trim.

## And one flag was handed to Rust's `bool` parser

```rust
// Async is opt-in only, via an explicit truthy MATRIXARK_RUST_PROXY_ASYNC_STORAGE.
async_storage: env::var("MATRIXARK_RUST_PROXY_ASYNC_STORAGE")
    .ok()
    .and_then(|value| value.parse::<bool>().ok())
    .unwrap_or(false),
```

`bool::from_str` accepts exactly two strings, `"true"` and `"false"`. Not `1`, not `on`, not
`yes`, not `TRUE`. So the comment directly above it — "an explicit **truthy**" value — described
something the code did not do.

Every launcher in the tree (`matrixark_codex_rust_hook.sh`, `matrixark_codex_dual_hook.sh`,
`matrixark_claude_hook.sh`, `matrixark_agent_config.py`) writes the literal `true`, which is the
one spelling that worked. That is why this never surfaced, and it is also why fixing it changes
nothing for any current deployment. It now reads through `crate::env_flag::parse_bool` like
every other boolean flag.

## Kept where they were: `env::var("NAME")` and `.unwrap_or(...)`

Deliberately. Those two are what the default derivations under `tools/` read — inserting
`.trim()` and swapping the parse leaves both exactly in place. #1312 was withdrawn for moving
them, so this change was checked against the derivations before anything else:
`test_matrixark_engine_flag_inventory`, `test_matrixark_engine_settings_match_the_engine`,
`test_matrixark_the_wal_compresses_a_record_by_default`,
`test_matrixark_every_live_claim_is_checked` and `test_numeric_defaults_agree` all pass.

## The guard

`tools/test_a_flag_value_is_trimmed_before_it_is_parsed.py` holds two rules — every parsed flag
value is trimmed first, and `parse::<bool>()` appears nowhere — with the reader count floored so
an empty scan cannot read as compliance. Verified to discriminate: a file containing both
offences makes it name six sites; removing the file makes it pass.

Neither rule dictates vocabulary. Which words a flag accepts is `crate::env_flag::parse_bool`'s
business, and `test_no_flag_reader_decides_by_case.py` guards that.

## Checks

`cargo check --release --lib --bins --tests` clean; 14 targeted tests around the changed readers
pass. Full `cargo test --release --lib --tests --no-fail-fast -- --test-threads=1`: no failure
that main does not already have.
