### PR TITLE
A 32-wide vector did not come from a 3072-wide encoder

### DIFF
--- a/tools/matrixark_local_adapter_dashboard.py
+++ b/tools/matrixark_local_adapter_dashboard.py
@@ -728,6 +728,10 @@ class _LocalAdapterDashboardMixin:
         without_vector = 0
         models: dict[str, int] = {}
         dimensions: dict[int, int] = {}
+        # The pairing the other two throw away. Kept because the interesting question is not which
+        # names appear or which widths appear, but whether a name appears at a width it could not
+        # have written.
+        model_dimensions: dict[tuple, int] = {}
         oldest_pending_ms = 0
         newest_pending_ms = 0
         deferred_tasks = 0
@@ -790,6 +794,9 @@ class _LocalAdapterDashboardMixin:
                 dim = 0
             if dim:
                 dimensions[dim] = dimensions.get(dim, 0) + 1
+            if model and dim:
+                pair = (model, dim)
+                model_dimensions[pair] = model_dimensions.get(pair, 0) + 1
 
         return {
             "status": "ok",
@@ -804,6 +811,9 @@ class _LocalAdapterDashboardMixin:
             "dimensions": [{"dim": dim, "count": count}
                            for dim, count in sorted(dimensions.items(), key=lambda kv: -kv[1])],
             "mixed_dimensions": len(dimensions) > 1,
+            "model_dimensions": [{"model": name, "dim": dim, "count": count}
+                                 for (name, dim), count
+                                 in sorted(model_dimensions.items(), key=lambda kv: -kv[1])],
             "oldest_pending_ms": oldest_pending_ms,
             "newest_pending_ms": newest_pending_ms,
             "deferred_tasks": deferred_tasks,

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -3153,13 +3153,60 @@ async def _embedding_models_in_store(server: Any, cfg: GatewayConfig, key: Optio
                 "detail": "The backend could not be asked what the stored vectors were made with."}
     if not isinstance(result, dict):
         return {"known": False, "detail": "The backend gave no usable answer."}
+    paired = result.get("model_dimensions") or []
     return {
         "known": True,
         "models": result.get("models") or [],
         "dimensions": result.get("dimensions") or [],
         "mixed_dimensions": bool(result.get("mixed_dimensions")),
+        "model_dimensions": paired,
+        "impossible": _impossible_model_widths(paired),
         "total": result.get("total") or 0,
     }
+
+
+def _impossible_model_widths(paired: List[Json]) -> List[Json]:
+    """Stored vectors whose model name cannot be the encoder that produced them.
+
+    The deterministic fallback is `EMBEDDING_DIM` wide and every encoder in the catalogue is far
+    wider, so a vector of exactly that width carrying an encoder's name was written by the fallback
+    and labelled with whatever was configured at the time.
+
+    Reported rather than repaired. Rewriting the labels would make the store self-consistent and
+    still wrong; recording the encoder that actually ran is a change to the write path, with its
+    own migration. What this fixes is that the condition was invisible -- the store counted names
+    and widths in two separate tallies and never the pair, so nothing could notice.
+    """
+    try:
+        from matrixark_mcp_embeddings import EMBEDDING_DIM
+    except Exception:  # pragma: no cover - encoder module absent
+        return []
+    findings: List[Json] = []
+    for row in paired:
+        if not isinstance(row, dict):
+            continue
+        name = str(row.get("model") or "")
+        try:
+            dim = int(row.get("dim") or 0)
+        except (TypeError, ValueError):
+            continue
+        if dim != EMBEDDING_DIM or not name:
+            continue
+        # The fallback naming itself is the honest case, and the common one on a build with no
+        # encoder configured. It is the vectors wearing somebody else's name that are the finding.
+        if "hash" in name.lower() or "local" in name.lower() or "deterministic" in name.lower():
+            continue
+        findings.append({
+            "model": name,
+            "dim": dim,
+            "count": row.get("count") or 0,
+            "detail": ("%s vectors carry %r at %d dimensions, which is the deterministic "
+                       "fallback's width. They were written by the fallback and recorded under "
+                       "the configured name, so the store holds two vector spaces under one name "
+                       "and the model hash cannot tell them apart."
+                       % (row.get("count") or 0, name, dim)),
+        })
+    return findings
 
 
 def embedding_picker_catalogue() -> List[Json]:

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -3636,6 +3636,14 @@ ONEBOX_BODY = """
   </section>
 
   <section>
+    <h2>The vectors already in the store</h2>
+    <p class="hint" style="margin-top:0">Which encoder wrote what is in there, by width. The width
+      is the check: every encoder in the catalogue is 384 wide or more, so a narrower vector
+      carrying an encoder's name was not written by it.</p>
+    <div id="vectors"><div class="empty">Enter an admin key to read the store.</div></div>
+  </section>
+
+  <section>
     <h2>What decides recall</h2>
     <p class="hint" style="margin-top:0">The three caps that bound a retrieve, and which of them was
       doing the cutting. Raising the others changed nothing in that measurement.</p>
@@ -3703,6 +3711,33 @@ ONEBOX_JS = r"""<script>
       : '<div class="empty">This build offers none of them.</div>';
   }
 
+  function renderVectors(store) {
+    if (!store || store.known === false) {
+      return '<div class="empty">' + esc((store && store.detail)
+        || "The backend could not be asked what the stored vectors were made with.") + "</div>";
+    }
+    var paired = store.model_dimensions || [];
+    var rows = paired.map(function (row) {
+      return "<tr><th class='mono'>" + esc(row.model) + "</th><td class='mono'>" + esc(row.dim)
+        + "</td><td class='mono'>" + esc(row.count) + "</td></tr>";
+    }).join("");
+    var table = rows
+      ? "<table class='inv'><thead><tr><th>Written by</th><th>Width</th><th>Vectors</th></tr>"
+        + "</thead><tbody>" + rows + "</tbody></table>"
+      : '<div class="empty">Nothing is encoded in this scope yet.</div>';
+    /* The finding, above the table rather than below it: a reader who stops at the first thing
+       they see should stop at the one that says the names cannot be right. */
+    var bad = (store.impossible || []).map(function (f) {
+      return '<div class="msg err"><b>' + esc(f.model) + " at " + esc(f.dim)
+        + " dimensions</b><br>" + esc(f.detail) + "</div>";
+    }).join("");
+    return bad + table
+      + (store.mixed_dimensions
+         ? '<div class="hint">This store holds more than one width. Vectors of different widths '
+           + 'cannot be compared, so some memories can never match a query.</div>'
+         : "");
+  }
+
   function renderPolicy(knobs) {
     var names = ["return_all_candidates", "return_all_candidate_threshold"];
     var rows = names.map(function (name) {
@@ -3745,6 +3780,16 @@ ONEBOX_JS = r"""<script>
         var said = '<div class="msg err">' + esc(window.__matrixarkWhyFailed(e)) + "</div>";
         $("profile").innerHTML = said;
         $("caps").innerHTML = said;
+      });
+
+    /* probe=0: this asks the STORE what it holds, which needs no call to any provider. Probing
+       the endpoint is a separate button on Setup and can be slow. */
+    fetch("/v1/admin/models?target=embedding&probe=0", { headers: auth() })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+      .then(function (d) { $("vectors").innerHTML = renderVectors(d.in_store); })
+      .catch(function (e) {
+        $("vectors").innerHTML = '<div class="msg err">'
+          + esc(window.__matrixarkWhyFailed(e)) + "</div>";
       });
 
     fetch("/v1/admin/policy", { headers: auth() })

--- a/tools/portal/onebox_portal.html
+++ b/tools/portal/onebox_portal.html
@@ -485,6 +485,14 @@
   </section>
 
   <section>
+    <h2>The vectors already in the store</h2>
+    <p class="hint" style="margin-top:0">Which encoder wrote what is in there, by width. The width
+      is the check: every encoder in the catalogue is 384 wide or more, so a narrower vector
+      carrying an encoder's name was not written by it.</p>
+    <div id="vectors"><div class="empty">Enter an admin key to read the store.</div></div>
+  </section>
+
+  <section>
     <h2>What decides recall</h2>
     <p class="hint" style="margin-top:0">The three caps that bound a retrieve, and which of them was
       doing the cutting. Raising the others changed nothing in that measurement.</p>
@@ -693,6 +701,33 @@
       : '<div class="empty">This build offers none of them.</div>';
   }
 
+  function renderVectors(store) {
+    if (!store || store.known === false) {
+      return '<div class="empty">' + esc((store && store.detail)
+        || "The backend could not be asked what the stored vectors were made with.") + "</div>";
+    }
+    var paired = store.model_dimensions || [];
+    var rows = paired.map(function (row) {
+      return "<tr><th class='mono'>" + esc(row.model) + "</th><td class='mono'>" + esc(row.dim)
+        + "</td><td class='mono'>" + esc(row.count) + "</td></tr>";
+    }).join("");
+    var table = rows
+      ? "<table class='inv'><thead><tr><th>Written by</th><th>Width</th><th>Vectors</th></tr>"
+        + "</thead><tbody>" + rows + "</tbody></table>"
+      : '<div class="empty">Nothing is encoded in this scope yet.</div>';
+    /* The finding, above the table rather than below it: a reader who stops at the first thing
+       they see should stop at the one that says the names cannot be right. */
+    var bad = (store.impossible || []).map(function (f) {
+      return '<div class="msg err"><b>' + esc(f.model) + " at " + esc(f.dim)
+        + " dimensions</b><br>" + esc(f.detail) + "</div>";
+    }).join("");
+    return bad + table
+      + (store.mixed_dimensions
+         ? '<div class="hint">This store holds more than one width. Vectors of different widths '
+           + 'cannot be compared, so some memories can never match a query.</div>'
+         : "");
+  }
+
   function renderPolicy(knobs) {
     var names = ["return_all_candidates", "return_all_candidate_threshold"];
     var rows = names.map(function (name) {
@@ -735,6 +770,16 @@
         var said = '<div class="msg err">' + esc(window.__matrixarkWhyFailed(e)) + "</div>";
         $("profile").innerHTML = said;
         $("caps").innerHTML = said;
+      });
+
+    /* probe=0: this asks the STORE what it holds, which needs no call to any provider. Probing
+       the endpoint is a separate button on Setup and can be slow. */
+    fetch("/v1/admin/models?target=embedding&probe=0", { headers: auth() })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+      .then(function (d) { $("vectors").innerHTML = renderVectors(d.in_store); })
+      .catch(function (e) {
+        $("vectors").innerHTML = '<div class="msg err">'
+          + esc(window.__matrixarkWhyFailed(e)) + "</div>";
       });
 
     fetch("/v1/admin/policy", { headers: auth() })

--- a/tools/test_matrixark_a_narrow_vector_did_not_come_from_that_encoder.py
+++ b/tools/test_matrixark_a_narrow_vector_did_not_come_from_that_encoder.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A stored vector whose width cannot match its model name is called out.
+
+Measured on the live store while writing this: **9,098 vectors carrying
+``text-embedding-3-large`` at 32 dimensions.** That model is 3072 wide. 32 is the width of the
+deterministic fallback, and every encoder in the catalogue is 384 or more -- so those vectors were
+produced by the fallback and recorded under whatever name happened to be configured.
+
+**Why it was invisible.** ``embedding_status`` computed each record's model and its width in the
+same pass and then put them in two separate tallies -- one of names, one of widths. The store could
+say "these models appear" and "these widths appear", and never "this model wrote this width", which
+is the only form in which the contradiction exists.
+
+The consequence is not cosmetic: two vector spaces sit in one store under one name, so nothing
+downstream can separate them. The model hash cannot, because both were hashed from the same
+configured string, and a backfill that trusted the name would skip exactly the records that need
+redoing.
+
+**This reports; it does not repair.** Rewriting the labels would make the store self-consistent and
+still wrong. Recording the encoder that actually ran is a change to the write path with its own
+migration.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_v1_gateway as gw  # noqa: E402
+from matrixark_mcp_embeddings import EMBEDDING_DIM  # noqa: E402
+
+# The shape the live store is in, as measured.
+LIVE = [{"model": "text-embedding-3-large", "dim": EMBEDDING_DIM, "count": 9098}]
+
+
+class ANarrowVectorIsCalledOutTest(unittest.TestCase):
+
+    def test_the_live_shape_is_reported(self) -> None:
+        found = gw._impossible_model_widths(LIVE)
+        self.assertEqual(1, len(found))
+        self.assertEqual("text-embedding-3-large", found[0]["model"])
+        self.assertEqual(9098, found[0]["count"])
+
+    def test_it_says_what_is_wrong_and_why_it_matters(self) -> None:
+        """A finding that names a row without saying what it costs gets read as a warning about
+        tidiness. The cost is that the two spaces cannot be told apart afterwards."""
+        detail = gw._impossible_model_widths(LIVE)[0]["detail"]
+        self.assertIn("fallback", detail)
+        self.assertIn("model hash", detail)
+
+    def test_the_fallback_naming_itself_is_not_a_finding(self) -> None:
+        """The honest case, and the common one on a build with no encoder configured. Reporting it
+        would bury the real finding under a row that is behaving correctly."""
+        honest = [{"model": "matrixark-local-token-hash-v1", "dim": EMBEDDING_DIM, "count": 8}]
+        self.assertEqual([], gw._impossible_model_widths(honest))
+
+    def test_a_real_encoder_at_its_real_width_is_not_a_finding(self) -> None:
+        wide = [{"model": "intfloat/multilingual-e5-small", "dim": 384, "count": 500}]
+        self.assertEqual([], gw._impossible_model_widths(wide))
+
+    def test_it_is_keyed_on_the_encoders_own_width_not_a_literal(self) -> None:
+        """The floor under the whole check. If the fallback's width ever changes and this still
+        looked for 32, it would report nothing and keep passing."""
+        at_width = [{"model": "some-api-model", "dim": EMBEDDING_DIM, "count": 1}]
+        beside_it = [{"model": "some-api-model", "dim": EMBEDDING_DIM + 1, "count": 1}]
+        self.assertEqual(1, len(gw._impossible_model_widths(at_width)))
+        self.assertEqual([], gw._impossible_model_widths(beside_it))
+
+    def test_nothing_stored_is_not_a_finding(self) -> None:
+        self.assertEqual([], gw._impossible_model_widths([]))
+
+
+class TheStoreCanAnswerTheQuestionTest(unittest.TestCase):
+    """The pairing this rests on. Without it the check has nothing to read, and every assertion
+    above would pass against a store that could not answer."""
+
+    def test_embedding_status_reports_which_model_wrote_which_width(self) -> None:
+        import io
+        import re
+        with io.open(os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                  "matrixark_local_adapter_dashboard.py"), encoding="utf-8") as h:
+            source = h.read()
+        body = source[source.index("def embedding_status"):]
+        body = body[:body.index("\n    def ")]
+        self.assertIn("model_dimensions", body,
+                      "the store counts names and widths separately again, so the contradiction "
+                      "this file reports cannot be seen")
+        self.assertTrue(re.search(r"model_dimensions\[pair\]", body),
+                        "model_dimensions is returned but nothing fills it")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Measured on the live store: **9,098 vectors carrying `text-embedding-3-large` at 32 dimensions.**

That model is 3072 wide. 32 is the width of the deterministic fallback, and every encoder in the catalogue is 384 or more — so those vectors were produced by the fallback and recorded under whatever name was configured. There is exactly one such pair in that store, so every embedded record is in this state, and the count is still growing.

## Why it was invisible

`embedding_status` computed each record's model and its width **in the same pass**, then put them in two separate tallies — one of names, one of widths. The store could say *"these models appear"* and *"these widths appear"*, and never *"this model wrote this width"*, which is the only form in which the contradiction exists.

Pairing them is three lines. The check falls out of it.

## Why it is not cosmetic

Two vector spaces sit in one store under one name, so nothing downstream can separate them. The **model hash cannot** — both were hashed from the same configured string — and a backfill that trusted the name would skip exactly the records that need redoing.

## It reports; it does not repair

Rewriting the labels would make the store self-consistent and still wrong. Recording the encoder that actually ran is a change to the **write path**, with its own migration, and belongs in its own change.

The one-box page shows the finding **above** the table rather than below it: a reader who stops at the first thing they see should stop at the one saying the names cannot be right.

## Checks

Five mutations, each reddening a distinct assertion — including removing the pairing in the adapter, which leaves the check with nothing to read and is the floor the rest stands on.

The threshold is the encoder's own `EMBEDDING_DIM`, not the literal 32, so a fallback that changes width cannot silently turn the check off. Verified against three shapes: the live pairing (1 finding), the fallback naming itself honestly (0), and a real encoder at its real width (0).