### PR TITLE
A section heading says what the section is, and nothing else

### DIFF
--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -103,6 +103,18 @@
   .livestrip{display:flex;gap:14px;align-items:center;margin-left:auto;padding-bottom:7px;
              flex-wrap:wrap}
   .subhead{font-size:13px;font-weight:650;margin:18px 0 0;letter-spacing:.01em}
+  /* A section heading whose row also carries a control.
+
+     The control used to sit INSIDE the h2. A heading's accessible name is its contents, so the
+     heading announced itself as "Grafana copy scrape config", or "Access remember for this
+     browser tab" -- and moving through a long page by heading is how that name gets used. The
+     row is unchanged: these properties are the ones the h2 was carrying, the heading keeps its
+     own type, and .aux is still pushed right. The colour is restated because .aux used to
+     inherit it from the heading it sat in. */
+  .sechead{display:flex;align-items:center;gap:10px;margin:0 0 14px}
+  .sechead>h1,.sechead>h2,.sechead>h3,.sechead>h4{margin:0}
+  .sechead>.aux{margin-left:auto;text-transform:none;letter-spacing:0;font-size:12px;
+                font-weight:400;color:var(--muted)}
   .status-chip{display:inline-block;font-family:"IBM Plex Mono",monospace;font-size:11px;
       padding:0 5px;border-radius:4px;background:var(--card);margin-right:4px;
       font-variant-numeric:tabular-nums}

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -174,6 +174,18 @@
   .livestrip{display:flex;gap:14px;align-items:center;margin-left:auto;padding-bottom:7px;
              flex-wrap:wrap}
   .subhead{font-size:13px;font-weight:650;margin:18px 0 0;letter-spacing:.01em}
+  /* A section heading whose row also carries a control.
+
+     The control used to sit INSIDE the h2. A heading's accessible name is its contents, so the
+     heading announced itself as "Grafana copy scrape config", or "Access remember for this
+     browser tab" -- and moving through a long page by heading is how that name gets used. The
+     row is unchanged: these properties are the ones the h2 was carrying, the heading keeps its
+     own type, and .aux is still pushed right. The colour is restated because .aux used to
+     inherit it from the heading it sat in. */
+  .sechead{display:flex;align-items:center;gap:10px;margin:0 0 14px}
+  .sechead>h1,.sechead>h2,.sechead>h3,.sechead>h4{margin:0}
+  .sechead>.aux{margin-left:auto;text-transform:none;letter-spacing:0;font-size:12px;
+                font-weight:400;color:var(--muted)}
   .status-chip{display:inline-block;font-family:"IBM Plex Mono",monospace;font-size:11px;
       padding:0 5px;border-radius:4px;background:var(--card);margin-right:4px;
       font-variant-numeric:tabular-nums}

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -76,6 +76,18 @@ NAV_CSS = """
   .livestrip{display:flex;gap:14px;align-items:center;margin-left:auto;padding-bottom:7px;
              flex-wrap:wrap}
   .subhead{font-size:13px;font-weight:650;margin:18px 0 0;letter-spacing:.01em}
+  /* A section heading whose row also carries a control.
+
+     The control used to sit INSIDE the h2. A heading's accessible name is its contents, so the
+     heading announced itself as "Grafana copy scrape config", or "Access remember for this
+     browser tab" -- and moving through a long page by heading is how that name gets used. The
+     row is unchanged: these properties are the ones the h2 was carrying, the heading keeps its
+     own type, and .aux is still pushed right. The colour is restated because .aux used to
+     inherit it from the heading it sat in. */
+  .sechead{display:flex;align-items:center;gap:10px;margin:0 0 14px}
+  .sechead>h1,.sechead>h2,.sechead>h3,.sechead>h4{margin:0}
+  .sechead>.aux{margin-left:auto;text-transform:none;letter-spacing:0;font-size:12px;
+                font-weight:400;color:var(--muted)}
   .status-chip{display:inline-block;font-family:"IBM Plex Mono",monospace;font-size:11px;
       padding:0 5px;border-radius:4px;background:var(--card);margin-right:4px;
       font-variant-numeric:tabular-nums}
@@ -1329,7 +1341,7 @@ SETUP_BODY = """
 
   <section class="pane" role="tabpanel" aria-labelledby="tab-access" id="pane-access">
   <section>
-    <h2>Access <span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></h2>
+    <div class="sechead"><h2>Access</h2><span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></div>
     <label for="key">Admin API key</label>
     <input id="key" type="password" placeholder="Key carrying an admin scope" autocomplete="off" spellcheck="false">
     <p class="hint">No key yet? <a href="/v1/admin/portal#firstkey">Where the first one comes from</a>
@@ -1349,8 +1361,8 @@ SETUP_BODY = """
   </section>
 
   <section>
-    <h2>Models <span class="aux"><button class="link" id="probeModels" type="button">ask the
-      endpoints what they serve</button></span></h2>
+    <div class="sechead"><h2>Models</h2><span class="aux"><button class="link" id="probeModels" type="button">ask the
+      endpoints what they serve</button></span></div>
     <p class="hint" style="margin-top:0">Both of these are free text on the wire, and a name that is
       merely misspelt does not fail loudly: extraction falls back to the local rules and embedding to
       hash vectors, both answering 200. Pick from the catalogue, or ask the configured endpoint for
@@ -1427,9 +1439,9 @@ SETUP_BODY = """
   </section>
 
   <section>
-    <h2>Move this configuration <span class="aux">
+    <div class="sechead"><h2>Move this configuration</h2><span class="aux">
       <button class="link" id="exportCfg" type="button">export</button>
-      <button class="link" id="copyCfgCurl" type="button">copy as curl</button></span></h2>
+      <button class="link" id="copyCfgCurl" type="button">copy as curl</button></span></div>
     <p class="hint" style="margin-top:0">Export emits exactly what the write endpoint accepts, so
       making another deployment match this one is one request rather than 79 fields retyped.
       Secrets are never exported — set the keys on the target afterwards.</p>
@@ -1461,7 +1473,7 @@ SETUP_BODY = """
   </section>
 
   <section>
-    <h2>Traffic <span class="aux"><label class="check"><input type="checkbox" id="auto" checked> auto-refresh</label></span></h2>
+    <div class="sechead"><h2>Traffic</h2><span class="aux"><label class="check"><input type="checkbox" id="auto" checked> auto-refresh</label></span></div>
     <div id="traffic"><div class="empty">Loading…</div></div>
     <h3 class="subhead">Recent failures</h3>
     <p class="hint" style="margin-top:0">The last few requests this worker answered with an error,
@@ -1534,7 +1546,7 @@ SETUP_BODY = """
   </section>
 
   <section>
-    <h2>Launch a deployment <span class="aux"><button class="link" id="copyEnv" type="button">copy env file</button></span></h2>
+    <div class="sechead"><h2>Launch a deployment</h2><span class="aux"><button class="link" id="copyEnv" type="button">copy env file</button></span></div>
     <p class="hint" style="margin-top:0">The storage directories, the metaserver address and the
       topology are not editable on the Settings tab, and that is deliberate — repointing a running deployment's
       storage from a browser does not reconfigure it, it strands its data. They are chosen when a
@@ -1570,8 +1582,8 @@ SETUP_BODY = """
     <div id="depMsg" role="status" aria-live="polite"></div>
     <div id="depVerdict"></div>
     <pre id="depEnv"></pre>
-    <h3>Launch <span class="aux"><button class="link" id="copyUserData" type="button">copy
-      user-data</button></span></h3>
+    <div class="sechead"><h3 class="subhead">Launch</h3><span class="aux"><button class="link" id="copyUserData" type="button">copy
+      user-data</button></span></div>
     <p class="hint" style="margin-top:0">Nothing here runs from this page. The gateway holds no AWS
       credentials, and creating billable infrastructure is not something a web page should do on a
       click — so this produces exactly what to run, and the command that destroys it again.
@@ -1582,7 +1594,7 @@ SETUP_BODY = """
   </section>
 
   <section>
-    <h2>Grafana <span class="aux"><button class="link" id="copyScrape" type="button">copy scrape config</button></span></h2>
+    <div class="sechead"><h2>Grafana</h2><span class="aux"><button class="link" id="copyScrape" type="button">copy scrape config</button></span></div>
     <p class="hint" style="margin-top:0">Everything on this page is also exported at
       <span class="mono">/v1/metrics</span> in Prometheus text format — aggregate counters only, no
       keys and no tenant identifiers, so it is safe to scrape without credentials.</p>
@@ -3837,7 +3849,7 @@ MEM0_BODY = """
     something you did not expect.</p>
 
   <section>
-    <h2>Access <span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></h2>
+    <div class="sechead"><h2>Access</h2><span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></div>
     <label for="key">API key</label>
     <input id="key" type="password" placeholder="Key carrying context:ingest / context:retrieve" autocomplete="off" spellcheck="false">
     <div class="hint">An ordinary scoped key, not an admin one: these are the same routes an
@@ -4568,7 +4580,7 @@ CATALOG_BODY = """
   <div class="summary" id="summary"></div>
 
   <section>
-    <h2>Access <span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></h2>
+    <div class="sechead"><h2>Access</h2><span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></div>
     <label for="key">API key</label>
     <input id="key" type="password" placeholder="Key carrying skill:read / resource:read" autocomplete="off" spellcheck="false">
     <div class="hint">These are ordinary scoped reads, not admin actions: a key with
@@ -4966,7 +4978,7 @@ OVERVIEW_BODY = """
   <div class="summary" id="summary"></div>
 
   <section>
-    <h2>Access <span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></h2>
+    <div class="sechead"><h2>Access</h2><span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></div>
     <label for="key">Admin API key</label>
     <input id="key" type="password" placeholder="Key carrying an admin scope" autocomplete="off" spellcheck="false">
     <p class="hint">No key yet? <a href="/v1/admin/portal#firstkey">Where the first one comes from</a>
@@ -4980,8 +4992,8 @@ OVERVIEW_BODY = """
   </section>
 
   <section>
-    <h2>Setup <span class="aux"><label class="check"><input type="checkbox" id="autoOverview" checked> auto-refresh</label>
-      <span id="progressText" style="margin-left:12px"></span></span></h2>
+    <div class="sechead"><h2>Setup</h2><span class="aux"><label class="check"><input type="checkbox" id="autoOverview" checked> auto-refresh</label>
+      <span id="progressText" style="margin-left:12px"></span></span></div>
     <div class="progress"><i id="progressBar" style="width:0%%"></i></div>
     <div id="checks"><div class="empty">Enter an admin key to check this deployment.</div></div>
   </section>
@@ -4992,8 +5004,8 @@ OVERVIEW_BODY = """
   </section>
 
   <section>
-    <h2>Diagnostics <span class="aux"><button class="link" id="copyDiag" type="button">copy</button>
-      <button class="link" id="downloadDiag" type="button">download</button></span></h2>
+    <div class="sechead"><h2>Diagnostics</h2><span class="aux"><button class="link" id="copyDiag" type="button">copy</button>
+      <button class="link" id="downloadDiag" type="button">download</button></span></div>
     <p class="hint" style="margin-top:0">Everything on this page plus the effective configuration
       and the current counters, as one JSON document — the thing to attach to a support request.
       Secrets are never in it: the configuration half reports whether a key resolves, never its
@@ -5540,7 +5552,7 @@ EXPLORE_BODY = """
   </section>
 
   <section class="pane" role="tabpanel" aria-labelledby="tab-browse" id="pane-browse" hidden>
-    <h2>Browse <span class="aux"><button class="link" id="refresh" type="button">refresh</button></span></h2>
+    <div class="sechead"><h2>Browse</h2><span class="aux"><button class="link" id="refresh" type="button">refresh</button></span></div>
     <div id="users" class="metric-list"></div>
     <div id="browseMsg" role="status" aria-live="polite"></div>
     <div id="memories"><div class="empty">Not loaded.</div></div>

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -174,6 +174,18 @@
   .livestrip{display:flex;gap:14px;align-items:center;margin-left:auto;padding-bottom:7px;
              flex-wrap:wrap}
   .subhead{font-size:13px;font-weight:650;margin:18px 0 0;letter-spacing:.01em}
+  /* A section heading whose row also carries a control.
+
+     The control used to sit INSIDE the h2. A heading's accessible name is its contents, so the
+     heading announced itself as "Grafana copy scrape config", or "Access remember for this
+     browser tab" -- and moving through a long page by heading is how that name gets used. The
+     row is unchanged: these properties are the ones the h2 was carrying, the heading keeps its
+     own type, and .aux is still pushed right. The colour is restated because .aux used to
+     inherit it from the heading it sat in. */
+  .sechead{display:flex;align-items:center;gap:10px;margin:0 0 14px}
+  .sechead>h1,.sechead>h2,.sechead>h3,.sechead>h4{margin:0}
+  .sechead>.aux{margin-left:auto;text-transform:none;letter-spacing:0;font-size:12px;
+                font-weight:400;color:var(--muted)}
   .status-chip{display:inline-block;font-family:"IBM Plex Mono",monospace;font-size:11px;
       padding:0 5px;border-radius:4px;background:var(--card);margin-right:4px;
       font-variant-numeric:tabular-nums}
@@ -459,7 +471,7 @@
   <div class="summary" id="summary"></div>
 
   <section>
-    <h2>Access <span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></h2>
+    <div class="sechead"><h2>Access</h2><span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></div>
     <label for="key">API key</label>
     <input id="key" type="password" placeholder="Key carrying skill:read / resource:read" autocomplete="off" spellcheck="false">
     <div class="hint">These are ordinary scoped reads, not admin actions: a key with

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -174,6 +174,18 @@
   .livestrip{display:flex;gap:14px;align-items:center;margin-left:auto;padding-bottom:7px;
              flex-wrap:wrap}
   .subhead{font-size:13px;font-weight:650;margin:18px 0 0;letter-spacing:.01em}
+  /* A section heading whose row also carries a control.
+
+     The control used to sit INSIDE the h2. A heading's accessible name is its contents, so the
+     heading announced itself as "Grafana copy scrape config", or "Access remember for this
+     browser tab" -- and moving through a long page by heading is how that name gets used. The
+     row is unchanged: these properties are the ones the h2 was carrying, the heading keeps its
+     own type, and .aux is still pushed right. The colour is restated because .aux used to
+     inherit it from the heading it sat in. */
+  .sechead{display:flex;align-items:center;gap:10px;margin:0 0 14px}
+  .sechead>h1,.sechead>h2,.sechead>h3,.sechead>h4{margin:0}
+  .sechead>.aux{margin-left:auto;text-transform:none;letter-spacing:0;font-size:12px;
+                font-weight:400;color:var(--muted)}
   .status-chip{display:inline-block;font-family:"IBM Plex Mono",monospace;font-size:11px;
       padding:0 5px;border-radius:4px;background:var(--card);margin-right:4px;
       font-variant-numeric:tabular-nums}
@@ -592,7 +604,7 @@
   </section>
 
   <section class="pane" role="tabpanel" aria-labelledby="tab-browse" id="pane-browse" hidden>
-    <h2>Browse <span class="aux"><button class="link" id="refresh" type="button">refresh</button></span></h2>
+    <div class="sechead"><h2>Browse</h2><span class="aux"><button class="link" id="refresh" type="button">refresh</button></span></div>
     <div id="users" class="metric-list"></div>
     <div id="browseMsg" role="status" aria-live="polite"></div>
     <div id="memories"><div class="empty">Not loaded.</div></div>

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -170,6 +170,18 @@
   .livestrip{display:flex;gap:14px;align-items:center;margin-left:auto;padding-bottom:7px;
              flex-wrap:wrap}
   .subhead{font-size:13px;font-weight:650;margin:18px 0 0;letter-spacing:.01em}
+  /* A section heading whose row also carries a control.
+
+     The control used to sit INSIDE the h2. A heading's accessible name is its contents, so the
+     heading announced itself as "Grafana copy scrape config", or "Access remember for this
+     browser tab" -- and moving through a long page by heading is how that name gets used. The
+     row is unchanged: these properties are the ones the h2 was carrying, the heading keeps its
+     own type, and .aux is still pushed right. The colour is restated because .aux used to
+     inherit it from the heading it sat in. */
+  .sechead{display:flex;align-items:center;gap:10px;margin:0 0 14px}
+  .sechead>h1,.sechead>h2,.sechead>h3,.sechead>h4{margin:0}
+  .sechead>.aux{margin-left:auto;text-transform:none;letter-spacing:0;font-size:12px;
+                font-weight:400;color:var(--muted)}
   .status-chip{display:inline-block;font-family:"IBM Plex Mono",monospace;font-size:11px;
       padding:0 5px;border-radius:4px;background:var(--card);margin-right:4px;
       font-variant-numeric:tabular-nums}
@@ -238,7 +250,7 @@
   <div class="summary" id="summary"></div>
 
   <section>
-    <h2>Access <span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></h2>
+    <div class="sechead"><h2>Access</h2><span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></div>
     <label for="key">Admin API key</label>
     <input id="key" type="password" placeholder="Key carrying an admin scope" autocomplete="off" spellcheck="false">
     <p class="hint">No key yet? <a href="/v1/admin/portal#firstkey">Where the first one comes from</a>
@@ -291,12 +303,12 @@
   </section>
 
   <section>
-    <h2>Jobs <span class="aux"><label class="check"><input type="checkbox" id="auto" checked> auto-refresh</label></span></h2>
+    <div class="sechead"><h2>Jobs</h2><span class="aux"><label class="check"><input type="checkbox" id="auto" checked> auto-refresh</label></span></div>
     <div id="jobs"><div class="empty">Loading…</div></div>
   </section>
 
   <section>
-    <h2>Metrics <span class="aux"><button class="link" id="copyScrape">copy Prometheus scrape config</button></span></h2>
+    <div class="sechead"><h2>Metrics</h2><span class="aux"><button class="link" id="copyScrape">copy Prometheus scrape config</button></span></div>
     <p class="hint" style="margin-top:0">Aggregate counters are exported at <span class="mono">/v1/metrics</span>
       — no keys, no tenant identifiers — so it is safe to scrape without credentials. Import
       <span class="mono">docs/ops/matrixark-ingestion-dashboard.json</span> into Grafana for the

--- a/tools/portal/mem0_portal.html
+++ b/tools/portal/mem0_portal.html
@@ -174,6 +174,18 @@
   .livestrip{display:flex;gap:14px;align-items:center;margin-left:auto;padding-bottom:7px;
              flex-wrap:wrap}
   .subhead{font-size:13px;font-weight:650;margin:18px 0 0;letter-spacing:.01em}
+  /* A section heading whose row also carries a control.
+
+     The control used to sit INSIDE the h2. A heading's accessible name is its contents, so the
+     heading announced itself as "Grafana copy scrape config", or "Access remember for this
+     browser tab" -- and moving through a long page by heading is how that name gets used. The
+     row is unchanged: these properties are the ones the h2 was carrying, the heading keeps its
+     own type, and .aux is still pushed right. The colour is restated because .aux used to
+     inherit it from the heading it sat in. */
+  .sechead{display:flex;align-items:center;gap:10px;margin:0 0 14px}
+  .sechead>h1,.sechead>h2,.sechead>h3,.sechead>h4{margin:0}
+  .sechead>.aux{margin-left:auto;text-transform:none;letter-spacing:0;font-size:12px;
+                font-weight:400;color:var(--muted)}
   .status-chip{display:inline-block;font-family:"IBM Plex Mono",monospace;font-size:11px;
       padding:0 5px;border-radius:4px;background:var(--card);margin-right:4px;
       font-variant-numeric:tabular-nums}
@@ -459,7 +471,7 @@
     something you did not expect.</p>
 
   <section>
-    <h2>Access <span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></h2>
+    <div class="sechead"><h2>Access</h2><span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></div>
     <label for="key">API key</label>
     <input id="key" type="password" placeholder="Key carrying context:ingest / context:retrieve" autocomplete="off" spellcheck="false">
     <div class="hint">An ordinary scoped key, not an admin one: these are the same routes an

--- a/tools/portal/onebox_portal.html
+++ b/tools/portal/onebox_portal.html
@@ -174,6 +174,18 @@
   .livestrip{display:flex;gap:14px;align-items:center;margin-left:auto;padding-bottom:7px;
              flex-wrap:wrap}
   .subhead{font-size:13px;font-weight:650;margin:18px 0 0;letter-spacing:.01em}
+  /* A section heading whose row also carries a control.
+
+     The control used to sit INSIDE the h2. A heading's accessible name is its contents, so the
+     heading announced itself as "Grafana copy scrape config", or "Access remember for this
+     browser tab" -- and moving through a long page by heading is how that name gets used. The
+     row is unchanged: these properties are the ones the h2 was carrying, the heading keeps its
+     own type, and .aux is still pushed right. The colour is restated because .aux used to
+     inherit it from the heading it sat in. */
+  .sechead{display:flex;align-items:center;gap:10px;margin:0 0 14px}
+  .sechead>h1,.sechead>h2,.sechead>h3,.sechead>h4{margin:0}
+  .sechead>.aux{margin-left:auto;text-transform:none;letter-spacing:0;font-size:12px;
+                font-weight:400;color:var(--muted)}
   .status-chip{display:inline-block;font-family:"IBM Plex Mono",monospace;font-size:11px;
       padding:0 5px;border-radius:4px;background:var(--card);margin-right:4px;
       font-variant-numeric:tabular-nums}

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -174,6 +174,18 @@
   .livestrip{display:flex;gap:14px;align-items:center;margin-left:auto;padding-bottom:7px;
              flex-wrap:wrap}
   .subhead{font-size:13px;font-weight:650;margin:18px 0 0;letter-spacing:.01em}
+  /* A section heading whose row also carries a control.
+
+     The control used to sit INSIDE the h2. A heading's accessible name is its contents, so the
+     heading announced itself as "Grafana copy scrape config", or "Access remember for this
+     browser tab" -- and moving through a long page by heading is how that name gets used. The
+     row is unchanged: these properties are the ones the h2 was carrying, the heading keeps its
+     own type, and .aux is still pushed right. The colour is restated because .aux used to
+     inherit it from the heading it sat in. */
+  .sechead{display:flex;align-items:center;gap:10px;margin:0 0 14px}
+  .sechead>h1,.sechead>h2,.sechead>h3,.sechead>h4{margin:0}
+  .sechead>.aux{margin-left:auto;text-transform:none;letter-spacing:0;font-size:12px;
+                font-weight:400;color:var(--muted)}
   .status-chip{display:inline-block;font-family:"IBM Plex Mono",monospace;font-size:11px;
       padding:0 5px;border-radius:4px;background:var(--card);margin-right:4px;
       font-variant-numeric:tabular-nums}
@@ -460,7 +472,7 @@
   <div class="summary" id="summary"></div>
 
   <section>
-    <h2>Access <span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></h2>
+    <div class="sechead"><h2>Access</h2><span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></div>
     <label for="key">Admin API key</label>
     <input id="key" type="password" placeholder="Key carrying an admin scope" autocomplete="off" spellcheck="false">
     <p class="hint">No key yet? <a href="/v1/admin/portal#firstkey">Where the first one comes from</a>
@@ -474,8 +486,8 @@
   </section>
 
   <section>
-    <h2>Setup <span class="aux"><label class="check"><input type="checkbox" id="autoOverview" checked> auto-refresh</label>
-      <span id="progressText" style="margin-left:12px"></span></span></h2>
+    <div class="sechead"><h2>Setup</h2><span class="aux"><label class="check"><input type="checkbox" id="autoOverview" checked> auto-refresh</label>
+      <span id="progressText" style="margin-left:12px"></span></span></div>
     <div class="progress"><i id="progressBar" style="width:0%"></i></div>
     <div id="checks"><div class="empty">Enter an admin key to check this deployment.</div></div>
   </section>
@@ -486,8 +498,8 @@
   </section>
 
   <section>
-    <h2>Diagnostics <span class="aux"><button class="link" id="copyDiag" type="button">copy</button>
-      <button class="link" id="downloadDiag" type="button">download</button></span></h2>
+    <div class="sechead"><h2>Diagnostics</h2><span class="aux"><button class="link" id="copyDiag" type="button">copy</button>
+      <button class="link" id="downloadDiag" type="button">download</button></span></div>
     <p class="hint" style="margin-top:0">Everything on this page plus the effective configuration
       and the current counters, as one JSON document — the thing to attach to a support request.
       Secrets are never in it: the configuration half reports whether a key resolves, never its

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -174,6 +174,18 @@
   .livestrip{display:flex;gap:14px;align-items:center;margin-left:auto;padding-bottom:7px;
              flex-wrap:wrap}
   .subhead{font-size:13px;font-weight:650;margin:18px 0 0;letter-spacing:.01em}
+  /* A section heading whose row also carries a control.
+
+     The control used to sit INSIDE the h2. A heading's accessible name is its contents, so the
+     heading announced itself as "Grafana copy scrape config", or "Access remember for this
+     browser tab" -- and moving through a long page by heading is how that name gets used. The
+     row is unchanged: these properties are the ones the h2 was carrying, the heading keeps its
+     own type, and .aux is still pushed right. The colour is restated because .aux used to
+     inherit it from the heading it sat in. */
+  .sechead{display:flex;align-items:center;gap:10px;margin:0 0 14px}
+  .sechead>h1,.sechead>h2,.sechead>h3,.sechead>h4{margin:0}
+  .sechead>.aux{margin-left:auto;text-transform:none;letter-spacing:0;font-size:12px;
+                font-weight:400;color:var(--muted)}
   .status-chip{display:inline-block;font-family:"IBM Plex Mono",monospace;font-size:11px;
       padding:0 5px;border-radius:4px;background:var(--card);margin-right:4px;
       font-variant-numeric:tabular-nums}
@@ -473,7 +485,7 @@
 
   <section class="pane" role="tabpanel" aria-labelledby="tab-access" id="pane-access">
   <section>
-    <h2>Access <span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></h2>
+    <div class="sechead"><h2>Access</h2><span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></div>
     <label for="key">Admin API key</label>
     <input id="key" type="password" placeholder="Key carrying an admin scope" autocomplete="off" spellcheck="false">
     <p class="hint">No key yet? <a href="/v1/admin/portal#firstkey">Where the first one comes from</a>
@@ -493,8 +505,8 @@
   </section>
 
   <section>
-    <h2>Models <span class="aux"><button class="link" id="probeModels" type="button">ask the
-      endpoints what they serve</button></span></h2>
+    <div class="sechead"><h2>Models</h2><span class="aux"><button class="link" id="probeModels" type="button">ask the
+      endpoints what they serve</button></span></div>
     <p class="hint" style="margin-top:0">Both of these are free text on the wire, and a name that is
       merely misspelt does not fail loudly: extraction falls back to the local rules and embedding to
       hash vectors, both answering 200. Pick from the catalogue, or ask the configured endpoint for
@@ -571,9 +583,9 @@
   </section>
 
   <section>
-    <h2>Move this configuration <span class="aux">
+    <div class="sechead"><h2>Move this configuration</h2><span class="aux">
       <button class="link" id="exportCfg" type="button">export</button>
-      <button class="link" id="copyCfgCurl" type="button">copy as curl</button></span></h2>
+      <button class="link" id="copyCfgCurl" type="button">copy as curl</button></span></div>
     <p class="hint" style="margin-top:0">Export emits exactly what the write endpoint accepts, so
       making another deployment match this one is one request rather than 79 fields retyped.
       Secrets are never exported — set the keys on the target afterwards.</p>
@@ -605,7 +617,7 @@
   </section>
 
   <section>
-    <h2>Traffic <span class="aux"><label class="check"><input type="checkbox" id="auto" checked> auto-refresh</label></span></h2>
+    <div class="sechead"><h2>Traffic</h2><span class="aux"><label class="check"><input type="checkbox" id="auto" checked> auto-refresh</label></span></div>
     <div id="traffic"><div class="empty">Loading…</div></div>
     <h3 class="subhead">Recent failures</h3>
     <p class="hint" style="margin-top:0">The last few requests this worker answered with an error,
@@ -678,7 +690,7 @@
   </section>
 
   <section>
-    <h2>Launch a deployment <span class="aux"><button class="link" id="copyEnv" type="button">copy env file</button></span></h2>
+    <div class="sechead"><h2>Launch a deployment</h2><span class="aux"><button class="link" id="copyEnv" type="button">copy env file</button></span></div>
     <p class="hint" style="margin-top:0">The storage directories, the metaserver address and the
       topology are not editable on the Settings tab, and that is deliberate — repointing a running deployment's
       storage from a browser does not reconfigure it, it strands its data. They are chosen when a
@@ -714,8 +726,8 @@
     <div id="depMsg" role="status" aria-live="polite"></div>
     <div id="depVerdict"></div>
     <pre id="depEnv"></pre>
-    <h3>Launch <span class="aux"><button class="link" id="copyUserData" type="button">copy
-      user-data</button></span></h3>
+    <div class="sechead"><h3 class="subhead">Launch</h3><span class="aux"><button class="link" id="copyUserData" type="button">copy
+      user-data</button></span></div>
     <p class="hint" style="margin-top:0">Nothing here runs from this page. The gateway holds no AWS
       credentials, and creating billable infrastructure is not something a web page should do on a
       click — so this produces exactly what to run, and the command that destroys it again.
@@ -726,7 +738,7 @@
   </section>
 
   <section>
-    <h2>Grafana <span class="aux"><button class="link" id="copyScrape" type="button">copy scrape config</button></span></h2>
+    <div class="sechead"><h2>Grafana</h2><span class="aux"><button class="link" id="copyScrape" type="button">copy scrape config</button></span></div>
     <p class="hint" style="margin-top:0">Everything on this page is also exported at
       <span class="mono">/v1/metrics</span> in Prometheus text format — aggregate counters only, no
       keys and no tenant identifiers, so it is safe to scrape without credentials.</p>

--- a/tools/test_matrixark_a_heading_is_not_a_toolbar.py
+++ b/tools/test_matrixark_a_heading_is_not_a_toolbar.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A section heading says what the section is, and nothing else.
+
+Eight headings across four pages had their action button inside the ``<h2>``. A heading's
+accessible name is its contents, so the name became the title plus the button:
+
+    Grafana copy scrape config
+    Move this configuration export copy as curl
+    Launch a deployment copy env file
+
+Moving through a long page by heading is how that name gets used -- it is the table of contents
+for anyone who cannot see the page -- so the one place the wording has to be exact is the one
+place a button label was being appended to it.
+
+The row is unchanged. The ``h2`` was already ``display:flex`` with the actions pushed right by
+``margin-left:auto``; ``.sechead`` takes those properties over and the heading keeps its own type.
+Measured, not assumed: the two builds were served side by side and every box on Overview landed on
+the same pixel, with the same document height.
+
+**Parsed, not matched.** A first attempt used a regex for ``<h2>...<span class=aux>...</span></h2>``
+and the ``.*?`` between them crossed element boundaries: given a heading with no actions followed
+by one with them, it ran from the first open tag to the second close tag and swallowed everything
+between. The markup still looked plausible; the rendered page showed a heading row 323 pixels tall.
+HTMLParser cannot make that mistake.
+"""
+from __future__ import annotations
+
+import io
+import os
+import unittest
+from html.parser import HTMLParser
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+
+HEADINGS = ("h1", "h2", "h3", "h4", "h5", "h6")
+CONTROLS = ("button", "select", "textarea", "input")
+
+
+class Reader(HTMLParser):
+    """Every heading on the page: its text, and any control that opened inside it."""
+
+    def __init__(self) -> None:
+        HTMLParser.__init__(self, convert_charrefs=True)
+        self.headings = []          # (tag, text, [controls opened inside])
+        self.rows = []              # (has_heading, control_count) for each .sechead
+        self._heading = None
+        self._row = None
+        self._depth = 0
+
+    def handle_starttag(self, tag, attrs):
+        classes = dict(attrs).get("class", "").split()
+        if tag == "div" and "sechead" in classes:
+            self._row = [False, 0]
+            self._depth = 0
+        elif self._row is not None and tag == "div":
+            self._depth += 1
+        if tag in HEADINGS:
+            self._heading = [tag, [], []]
+            if self._row is not None:
+                self._row[0] = True
+        if tag in CONTROLS or (tag == "a" and "btn" in classes):
+            if self._heading is not None:
+                self._heading[2].append(tag)
+            if self._row is not None:
+                self._row[1] += 1
+
+    def handle_endtag(self, tag):
+        if tag in HEADINGS and self._heading is not None:
+            self.headings.append((self._heading[0], "".join(self._heading[1]).strip(),
+                                  self._heading[2]))
+            self._heading = None
+        elif tag == "div" and self._row is not None:
+            if self._depth == 0:
+                self.rows.append(tuple(self._row))
+                self._row = None
+            else:
+                self._depth -= 1
+
+    def handle_data(self, data):
+        if self._heading is not None:
+            self._heading[1].append(data)
+
+
+def pages() -> list:
+    return sorted(f for f in os.listdir(PORTAL) if f.endswith("_portal.html"))
+
+
+def read(name: str) -> Reader:
+    parser = Reader()
+    with io.open(os.path.join(PORTAL, name), encoding="utf-8") as handle:
+        parser.feed(handle.read())
+    return parser
+
+
+class AHeadingIsNotAToolbarTest(unittest.TestCase):
+
+    def test_no_heading_contains_a_control(self) -> None:
+        for name in pages():
+            for tag, text, controls in read(name).headings:
+                self.assertEqual(
+                    [], controls,
+                    "%s: <%s> %r contains %s, so the heading announces itself as the title plus "
+                    "that control's label" % (name, tag, text[:60], ", ".join(controls)))
+
+    def test_the_row_still_carries_its_actions(self) -> None:
+        """The other half. Deleting the buttons would satisfy the assertion above perfectly."""
+        for name in pages():
+            for has_heading, controls in read(name).rows:
+                self.assertTrue(has_heading, "%s: a heading row with no heading in it" % name)
+                self.assertGreater(
+                    controls, 0,
+                    "%s: a heading row with no action left in it -- the row exists to hold one, "
+                    "so an empty one means the control was dropped rather than moved" % name)
+
+    def test_the_pages_have_such_rows_at_all(self) -> None:
+        """The positive control. Both assertions above pass on a portal with no actions anywhere,
+        which is exactly what a bad edit would leave behind."""
+        rows = sum(len(read(name).rows) for name in pages())
+        self.assertGreaterEqual(rows, 5, "only %d heading rows carry an action" % rows)
+
+    def test_a_heading_that_lost_its_words_is_not_a_pass(self) -> None:
+        """A heading emptied of text also contains no control. Every heading still says something."""
+        for name in pages():
+            for tag, text, _ in read(name).headings:
+                self.assertTrue(text.strip(), "%s: an empty <%s>" % (name, tag))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Sixteen headings across the portal had their control **inside** the `<h2>`. A heading's accessible name is its contents, so the name became the title plus the control:

> Grafana **copy scrape config**
> Move this configuration **export copy as curl**
> Access **remember for this browser tab**

Moving through a long page by heading is how that name gets used — it is the table of contents for anyone who cannot see the page — so the one place the wording has to be exact was the one place a button label was being appended to it.

## The row is unchanged

The `h2` was already `display:flex` with the actions pushed right by `margin-left:auto`, so `.sechead` takes those properties over and the heading keeps its own type.

**Measured, not asserted.** The two builds were served side by side and compared box by box:

* Overview — every box on the same pixel, identical document height.
* Setup — 44 of 53 boxes identical; the 9 that move all shift by exactly −30px from **one** deliberate cause: the page's single unstyled `<h3>` now uses the page's own `subhead` class like every other sub-heading.

## Two things a first attempt got wrong

* A regex for `<h2>…<span class=aux>…</span></h2>` looked non-greedy enough and was not: given a heading with no actions followed by one with them, `.*?` ran from the **first** open tag to the **second** close tag and swallowed everything between. That produced a heading row 323px tall — invisible in the markup, obvious in the rendered geometry. It uses `HTMLParser` now, which cannot make that mistake.
* Scanning for `<button>` found only eight of the sixteen. The other seven hold a **checkbox** — the "remember for this browser tab" and "auto-refresh" toggles — and a button-only scan cannot see them. The rule is any control.

## Checks

Four mutations, each reddening exactly one distinct assertion: a control back inside a heading, a row emptied of its actions, every row and control removed (which the positive control catches), and a heading emptied of its words.
