### PR TITLE
A batch of fifty updates opened fifty connections

### DIFF
--- a/tools/matrixark_ingest_client.py
+++ b/tools/matrixark_ingest_client.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 import http.client
 import json
 import os
+import threading
 from typing import Any, Optional
 from urllib.parse import quote, urlsplit
 
@@ -148,23 +149,8 @@ def _put_blob(base_url: str, api_key: Optional[str], key: str, data: bytes,
     Content-addressed and idempotent: re-PUTting the same key replaces byte-identical
     content (no dup). When ``api_key`` is None/empty no ``Authorization`` header is
     sent (anonymous)."""
-    conn = _connect(base_url, timeout)
-    try:
-        conn.putrequest("PUT", f"/v1/blob/{key.lstrip('/')}")
-        if api_key:
-            conn.putheader("Authorization", f"Bearer {api_key}")
-        conn.putheader("Content-Length", str(len(data)))
-        conn.putheader("Content-Type", content_type)
-        conn.endheaders()
-        conn.send(data)
-        resp = conn.getresponse()
-        raw = resp.read()
-        status = int(getattr(resp, "status", 0) or 0)
-    finally:
-        try:
-            conn.close()
-        except Exception:
-            pass
+    status, raw = _exchange(base_url, api_key, "PUT", f"/v1/blob/{key.lstrip('/')}",
+                            data, timeout, content_type)
     if status >= 400:
         raise RuntimeError(
             f"blob upload PUT /v1/blob/{key} failed: HTTP {status}: {raw[:256]!r} "
@@ -175,25 +161,106 @@ def _put_blob(base_url: str, api_key: Optional[str], key: str, data: bytes,
         return {}
 
 
+_POOL = threading.local()
+
+
+def _pool_key(base_url: str, timeout: float) -> tuple:
+    parsed = urlsplit(base_url)
+    scheme = parsed.scheme or "http"
+    return (scheme, parsed.hostname or "127.0.0.1",
+            parsed.port or (443 if scheme == "https" else 80), float(timeout))
+
+
+def _take_connection(base_url: str, timeout: float):
+    """A pooled connection for this thread, or a new one. Returns ``(conn, reused)``.
+
+    Pooled per thread because an ``http.client`` connection carries one exchange at a time; sharing
+    one between threads interleaves two requests on the same socket. ``reused`` is what tells the
+    caller whether a failure is worth another try: a server may close an idle keep-alive connection
+    at any moment, and that close is indistinguishable from a real fault until a fresh socket says
+    otherwise.
+    """
+    cache = getattr(_POOL, "connections", None)
+    if cache is None:
+        cache = {}
+        _POOL.connections = cache
+    conn = cache.pop(_pool_key(base_url, timeout), None)
+    if conn is not None:
+        return conn, True
+    return _connect(base_url, timeout), False
+
+
+def _keep_connection(base_url: str, timeout: float, conn, response) -> None:
+    """Put a connection back, or close it when the exchange ended it.
+
+    ``will_close`` is the server's answer, not a guess: it is set while the response headers are
+    parsed, and it is True for HTTP/1.0, for ``Connection: close``, and for a response whose length
+    is delimited by the close itself. Keeping such a socket would hand the next call a dead one.
+    """
+    if conn is None:
+        return
+    if response is None or getattr(response, "will_close", True):
+        _discard_connection(conn)
+        return
+    cache = getattr(_POOL, "connections", None)
+    if cache is None:
+        cache = {}
+        _POOL.connections = cache
+    key = _pool_key(base_url, timeout)
+    previous = cache.get(key)
+    if previous is not None and previous is not conn:
+        _discard_connection(previous)
+    cache[key] = conn
+
+
+def _discard_connection(conn) -> None:
+    try:
+        conn.close()
+    except Exception:  # noqa: BLE001 - closing is best effort; the socket is going away regardless.
+        pass
+
+
+def _exchange(base_url: str, api_key: Optional[str], method: str, path: str,
+              data: Optional[bytes], timeout: float,
+              content_type: str = "application/json") -> tuple:
+    """One request and its response, on a pooled connection, tried again once if a REUSED one died.
+
+    Only a reused connection earns the second try. A fresh connection that fails has met something
+    real -- nothing listening, a wrong address -- and trying again only doubles the wait before the
+    caller learns that. A reused one that fails has most likely met the server's idle timeout, which
+    is not a fault at all and cannot be seen until the write goes out.
+    """
+    failure = None
+    for attempt in (0, 1):
+        conn, reused = _take_connection(base_url, timeout)
+        response = None
+        try:
+            conn.putrequest(method, path)
+            if api_key:
+                conn.putheader("Authorization", f"Bearer {api_key}")
+            if data is not None:
+                conn.putheader("Content-Type", content_type)
+                conn.putheader("Content-Length", str(len(data)))
+            conn.endheaders()
+            if data is not None:
+                conn.send(data)
+            response = conn.getresponse()
+            raw = response.read()
+            status = int(getattr(response, "status", 0) or 0)
+        except Exception as exc:  # noqa: BLE001 - a dead pooled socket looks like any other error.
+            _discard_connection(conn)
+            failure = exc
+            if reused and attempt == 0:
+                continue
+            raise
+        _keep_connection(base_url, timeout, conn, response)
+        return status, raw
+    raise failure
+
+
 def _post_json(base_url: str, api_key: Optional[str], path: str, body: Json, timeout: float) -> Json:
     data = json.dumps(body).encode("utf-8")
-    conn = _connect(base_url, timeout)
-    try:
-        conn.putrequest("POST", path)
-        if api_key:
-            conn.putheader("Authorization", f"Bearer {api_key}")
-        conn.putheader("Content-Type", "application/json")
-        conn.putheader("Content-Length", str(len(data)))
-        conn.endheaders()
-        conn.send(data)
-        resp = conn.getresponse()
-        raw = resp.read()
-        status = int(getattr(resp, "status", 0) or 0)
-    finally:
-        try:
-            conn.close()
-        except Exception:
-            pass
+    status, raw = _exchange(base_url, api_key, "POST", path, data, timeout)
     if status >= 400:
         raise RuntimeError(
             f"ingest POST {path} failed: HTTP {status}: {raw[:256]!r} "
@@ -207,20 +274,7 @@ def _post_json(base_url: str, api_key: Optional[str], path: str, body: Json, tim
 def _get_json(base_url: str, api_key: Optional[str], path: str, timeout: float) -> Json:
     """GET ``{base_url}{path}`` with an optional Bearer token; parse the JSON response. A 404 returns
     the parsed body (callers inspect ``found``); other >=400 statuses raise."""
-    conn = _connect(base_url, timeout)
-    try:
-        conn.putrequest("GET", path)
-        if api_key:
-            conn.putheader("Authorization", f"Bearer {api_key}")
-        conn.endheaders()
-        resp = conn.getresponse()
-        raw = resp.read()
-        status = int(getattr(resp, "status", 0) or 0)
-    finally:
-        try:
-            conn.close()
-        except Exception:
-            pass
+    status, raw = _exchange(base_url, api_key, "GET", path, None, timeout)
     if status >= 400 and status != 404:
         raise RuntimeError(f"GET {path} failed: HTTP {status}: {raw[:256]!r}")
     try:

--- a/tools/test_the_transport_reuses_its_connection.py
+++ b/tools/test_the_transport_reuses_its_connection.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The transport keeps its connection instead of opening one per call.
+
+Every call built a fresh TCP connection and closed it in a ``finally``, so a mem0 ``batch_update``
+of 50 memories cost 50 connections, and 20 ``get`` calls cost 20 more. Measured against a server
+that was willing to hold the connection open the whole time: 1.00 connections per request.
+
+Reuse is only safe if the failure it introduces is handled, and it does introduce one. A pooled
+socket can be closed by the server at any moment -- an idle timeout, a restart -- and the client
+cannot know until it writes and the write fails. So a REUSED connection that fails is tried once
+more on a fresh socket, while a FRESH one that fails is raised immediately: that failure is real,
+and retrying it only doubles the wait before the caller hears about it.
+
+The tests below pin both halves, plus the case that makes pooling unsafe if it is missed: a server
+that answers with keep-alive headers and then closes anyway.
+
+One consequence is worth stating rather than discovering: the pool is per thread, so a thread that
+exits leaves its connection to be closed when the object is collected instead of at exit. Long-lived
+worker threads -- what a server actually runs -- never reach that, and a one-shot thread's socket
+still closes, just not deterministically.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+try:  # top-level (run from tools/) ...
+    import matrixark_ingest_client as client
+except ImportError:  # ... or package path.
+    from tools import matrixark_ingest_client as client  # type: ignore
+
+
+class _Server:
+    """A counting HTTP/1.1 server. ``drop_after_reply`` closes without saying so in the response."""
+
+    def __init__(self, *, status=200, close_header=False, drop_after_reply=False):
+        self.connections = 0
+        self.requests = 0
+        outer = self
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def _reply(self):
+                outer.requests += 1
+                body = json.dumps({"ok": True, "found": status != 404}).encode()
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                if close_header:
+                    self.send_header("Connection", "close")
+                self.end_headers()
+                self.wfile.write(body)
+                if close_header:
+                    self.close_connection = True
+                elif drop_after_reply:
+                    # The response says keep-alive; the server closes anyway. This is what an idle
+                    # timeout looks like from the client, and the client cannot see it coming.
+                    self.close_connection = True
+
+            def do_POST(self):
+                n = int(self.headers.get("Content-Length") or 0)
+                if n:
+                    self.rfile.read(n)
+                self._reply()
+
+            do_GET = do_POST
+
+            def log_message(self, *a):
+                pass
+
+        class Counting(ThreadingHTTPServer):
+            daemon_threads = True
+
+            def get_request(self):
+                pair = super().get_request()
+                outer.connections += 1
+                return pair
+
+        self._srv = Counting(("127.0.0.1", 0), Handler)
+        self.url = "http://127.0.0.1:%d" % self._srv.server_address[1]
+        threading.Thread(target=self._srv.serve_forever, daemon=True).start()
+
+    def close(self):
+        self._srv.shutdown()
+        self._srv.server_close()
+
+
+def _clear_pool():
+    """Each test starts with an empty pool, or it inherits another test's socket."""
+    cache = getattr(client._POOL, "connections", None)
+    if cache:
+        for conn in list(cache.values()):
+            try:
+                conn.close()
+            except Exception:
+                pass
+        cache.clear()
+
+
+class TransportReusesItsConnection(unittest.TestCase):
+    def setUp(self):
+        _clear_pool()
+        self.addCleanup(_clear_pool)
+
+    def test_many_calls_cost_one_connection(self):
+        srv = _Server()
+        self.addCleanup(srv.close)
+        for i in range(30):
+            client._post_json(srv.url, None, "/v1/update", {"memory_id": "m%d" % i}, 10.0)
+        self.assertEqual(srv.requests, 30)
+        self.assertEqual(srv.connections, 1, "30 requests should share one connection")
+
+    def test_a_server_that_says_close_is_not_pooled(self):
+        srv = _Server(close_header=True)
+        self.addCleanup(srv.close)
+        for i in range(5):
+            out = client._post_json(srv.url, None, "/v1/update", {"i": i}, 10.0)
+            self.assertTrue(out.get("ok"))
+        self.assertEqual(srv.requests, 5)
+        self.assertEqual(srv.connections, 5, "a Connection: close socket must not be pooled")
+
+    def test_a_dropped_pooled_connection_is_retried(self):
+        # The server answers keep-alive and closes anyway, so the pooled socket is dead before the
+        # next call touches it. Every call must still return an answer.
+        srv = _Server(drop_after_reply=True)
+        self.addCleanup(srv.close)
+        for i in range(4):
+            out = client._post_json(srv.url, None, "/v1/update", {"i": i}, 10.0)
+            self.assertTrue(out.get("ok"), "call %d lost its answer to a dead pooled socket" % i)
+        self.assertEqual(srv.requests, 4)
+
+    def test_a_fresh_connection_failure_is_raised_not_retried(self):
+        # Nothing is listening. The first connect fails, and that is a real fault: it must be
+        # raised, not tried again on another fresh socket.
+        attempts = []
+        real_connect = client._connect
+
+        def counting_connect(base_url, timeout):
+            attempts.append(base_url)
+            return real_connect(base_url, timeout)
+
+        client._connect = counting_connect
+        self.addCleanup(lambda: setattr(client, "_connect", real_connect))
+        with self.assertRaises(Exception):
+            client._post_json("http://127.0.0.1:1", None, "/v1/update", {"a": 1}, 2.0)
+        self.assertEqual(len(attempts), 1, "a fresh connection failure must not be retried")
+
+    def test_error_statuses_still_reach_the_caller(self):
+        srv = _Server(status=500)
+        self.addCleanup(srv.close)
+        with self.assertRaises(RuntimeError):
+            client._post_json(srv.url, None, "/v1/update", {"a": 1}, 10.0)
+
+    def test_a_get_404_still_returns_its_body(self):
+        srv = _Server(status=404)
+        self.addCleanup(srv.close)
+        out = client._get_json(srv.url, None, "/v1/memory/nope", 10.0)
+        self.assertEqual(out.get("found"), False)
+
+    def test_two_threads_do_not_share_one_connection(self):
+        srv = _Server()
+        self.addCleanup(srv.close)
+        seen = []
+
+        def work():
+            _clear_pool()
+            for _ in range(3):
+                client._post_json(srv.url, None, "/v1/update", {"a": 1}, 10.0)
+            cache = getattr(client._POOL, "connections", {}) or {}
+            seen.append(len(cache))
+            # A thread that exits leaves its pooled socket to be closed when the connection object
+            # is collected rather than at exit. Long-lived worker threads never reach this, but a
+            # one-shot thread does, so close it here rather than let a ResourceWarning stand in for
+            # a fact worth stating.
+            _clear_pool()
+
+        threads = [threading.Thread(target=work) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(seen, [1, 1], "each thread keeps its own connection")
+        self.assertGreaterEqual(srv.connections, 2, "two threads must not share one socket")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Every call through the ingest transport built a fresh TCP connection and closed it in a `finally`.
Measured against a server that was willing to hold the connection open the whole time: **1.00
connections per request**, so the client was the one insisting.

That makes a batch cost a connection per entry, and a session cost one per call:

| operation | requests | connections before | after |
|---|---|---|---|
| single `get` / `history` / `update` | 1 | 1 | 1 |
| `batch_update` of 10 | 10 | 10 | **1** |
| `batch_delete` of 10 | 10 | 10 | **1** |
| a session of 15 mixed calls | 15 | 15 | **1** |

The request count is unchanged; only the connection count moves. On loopback that setup is nearly
free, which is why it never showed up in the in-process numbers. Over a network it is an extra round
trip per call, and over TLS a handshake of two or more — so the further the deployment is from the
caller, the more this was costing.

`_post_json`, `_get_json` and the blob `PUT` now share one pooled exchange, so the file has a single
connection policy rather than two behaviours.

## The failure this introduces, and how it is handled

A pooled socket can be closed by the server at any moment — an idle timeout, a restart — and the
client cannot know until it writes and the write fails. So:

- a **reused** connection that fails is tried once more on a fresh socket. That failure is expected
  and is not a fault.
- a **fresh** connection that fails is raised immediately. Nothing is listening, or the address is
  wrong; trying again only doubles the wait before the caller hears about it.

The pool is per thread, because an `http.client` connection carries one exchange at a time and
sharing one between threads interleaves two requests on the same socket. A connection is only kept
when the response says it may be: `will_close` is set while the headers are parsed and is true for
HTTP/1.0, for `Connection: close`, and for a close-delimited body.

One consequence is stated rather than left to be discovered: a thread that exits leaves its
connection to be closed when the object is collected instead of at exit. Long-lived worker threads —
what a server actually runs — never reach that.

## Tests

`test_the_transport_reuses_its_connection.py` pins both halves and the case that makes pooling
unsafe if it is missed: a server that answers with keep-alive headers and then closes anyway. Also
covered: `Connection: close` is not pooled, a fresh-connection failure is raised without a second
attempt, error statuses still reach the caller, a GET 404 still returns its body, and two threads do
not share a socket.

92 suites reach this transport; all pass except `test_matrixark_v1_gateway.py`, which fails
identically with the change reverted.
