### PR TITLE
Regenerate the flag inventory, and say why the new flag has two paths

### DIFF
--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -8,7 +8,7 @@ within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 286 of them, read by 87 functions.
+There are 287 of them, read by 88 functions.
 
 Deleting unreachable code is not the lever. An earlier version of this document argued that
 by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
@@ -60,12 +60,12 @@ Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 286 |
-| booleans whose default this could read off the source | 46 |
+| total | 287 |
+| booleans whose default this could read off the source | 47 |
 | numbers whose default this could read off the source | 70 |
 | **defaulting on, and set by nothing** | 5 |
 | offered on the portal | 26 |
-| **that nothing in this repository sets** | 157 |
+| **that nothing in this repository sets** | 158 |
 | documented as keeping an older path alive | 3 |
 | reaching more than two files | 15 |
 | whose doc comment is really about another flag | 43 |
@@ -365,7 +365,7 @@ Read only by the benchmark harnesses. Never consulted on a serving path.
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_SELECTED_ID_LIMIT` | 128 | script | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_SOURCE_ORDER_RANKING` | off | script | 1 | — |
 
-## behaviour (61)
+## behaviour (62)
 
 Everything else that changes what the engine does.
 
@@ -418,6 +418,7 @@ Everything else that changes what the engine does.
 | `TS_RAFT_REPLICATION_DEADLINE_MS` | — | test | 1 | — |
 | `TS_RAFT_SECURITY_MODE` | — | nothing | 1 | — |
 | `TS_RAFT_TRANSPORT_SECURITY` | — | nothing | 1 | — |
+| `TS_REVERIFY_ALL_SLABS` | off | nothing | 1 | — |
 | `TS_SERVER_JOIN_EMPTY` | off | script | 1 | — |
 | `TS_SERVER_RAFT` | off | nothing | 1 | — |
 | `TS_SERVER_RAFT_READ_MODE` | — | nothing | 1 | — |

--- a/tools/test_a_two_path_flag_says_why.py
+++ b/tools/test_a_two_path_flag_says_why.py
@@ -112,6 +112,11 @@ KNOWN_TWO_PATH_FLAGS: Dict[str, str] = {
     "TS_META_SHARD_DIVERGENCE_CHECK":
         "compares the owner map against what each datanode reports serving and re-places the "
         "difference. Off because it moves shards",
+    "TS_REVERIFY_ALL_SLABS":
+        "re-verifies every slab on every open, as the store did before the check was made "
+        "skippable. Off because the skip is the whole saving; the engine calls this the "
+        "escape hatch for a deployment that suspects its slabs, and says it costs the full "
+        "cold-start CPU again, which is the point",
     "TS_SERVER_RAFT":
         "the gate on the whole per-shard raft path in the datanode; `start_server_raft_from_env` "
         "returns None without it",


### PR DESCRIPTION
`TS_REVERIFY_ALL_SLABS` landed in `block_store/band_manifest.rs` (#1316 era) without the generated inventory being regenerated. Two guards are red on main because of it, and on every branch cut from main:

- `test_every_flag_named_in_the_engine_is_listed` — the engine names a flag the document does not list.
- `test_regenerating_produces_the_same_document` — 286 flags read by 87 functions on paper, 287 by 88 in the tree.

Regenerating adds the row and takes the counts to 287 / 88 / 158-set-by-nothing, and moves `behaviour` from 61 to 62.

That surfaces the flag to `test_a_two_path_flag_says_why`, which then wants a recorded reason for its off side — so the second half of this change supplies one, taken from what the engine already says at the read:

> Re-verify every slab on every open, as before this was made skippable. The escape hatch for a deployment that suspects its slabs: it costs the full cold-start CPU again, which is the point.

I derived that from the code rather than from the author, so if the intent was different the wording is the part to correct.

Checked: `test_a_two_path_flag_says_why`, `test_matrixark_engine_flag_inventory`, `test_matrixark_engine_settings_match_the_engine`, `test_matrixark_every_live_claim_is_checked` and `test_no_flag_reader_decides_by_case` all pass. No engine code changes.