### PR TITLE
Filter the progress view once per refresh, not once per dirty node

### DIFF
--- a/tools/matrixark_local_adapter_summaries.py
+++ b/tools/matrixark_local_adapter_summaries.py
@@ -12,6 +12,7 @@ try:  # names owned by the parent module
     from tools.matrixark_mcp_local_adapter import (
     Any,
     async_summary_progress_records,
+    summary_progress_source_records,
     compression_context_index_records,
     compression_profile_layer_values,
     pending_dirty_node_records,
@@ -21,6 +22,7 @@ except ImportError:
     from matrixark_mcp_local_adapter import (
     Any,
     async_summary_progress_records,
+    summary_progress_source_records,
     compression_context_index_records,
     compression_profile_layer_values,
     pending_dirty_node_records,
@@ -605,6 +607,8 @@ class _LocalAdapterSummariesMixin:
         # `records` lets one caller's read serve a whole pass. Reading here is a full record-log
         # read, and on a native backend it holds the single shared proxy lane while it runs.
         records = self.read_all() if records is None else records
+        # Filtered once, not once per dirty node -- see summary_progress_source_records.
+        progress_source_records = summary_progress_source_records(records)
         skipped_dirty_reasons: Json = {}
         pending_by_node = pending_dirty_node_records(
             records=records,
@@ -1137,7 +1141,7 @@ class _LocalAdapterSummariesMixin:
                 )
             generated_summary_types = [spec[0] for spec in summary_specs]
             summary_progress_records = async_summary_progress_records(
-                records=records,
+                records=progress_source_records,
                 scope=dirty.get("scope", scope),
                 source_event_ids=source_event_ids,
                 source_entity_hashes=source_entity_hashes,

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -65,9 +65,15 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
     )
 
 try:
-    from tools.matrixark_mcp_summary_runtime import async_summary_progress_records
+    from tools.matrixark_mcp_summary_runtime import (
+        async_summary_progress_records,
+        summary_progress_source_records,
+    )
 except ModuleNotFoundError:  # Direct script execution from tools/.
-    from matrixark_mcp_summary_runtime import async_summary_progress_records
+    from matrixark_mcp_summary_runtime import (
+        async_summary_progress_records,
+        summary_progress_source_records,
+    )
 
 try:
     from tools.matrixark_mcp_summary_dirty import pending_dirty_node_records

--- a/tools/matrixark_mcp_summary_runtime.py
+++ b/tools/matrixark_mcp_summary_runtime.py
@@ -591,6 +591,25 @@ def append_node_summary_embeddings(
     }
 
 
+#: The only record types `async_summary_progress_records` reads. Kept beside it so a future read of
+#: a third type has this in view; `test_the_summary_progress_filter_is_complete` derives the set
+#: from the function itself and fails if the two drift apart.
+SUMMARY_PROGRESS_RECORD_TYPES = frozenset({"context_entity", "matrixark_async_pipeline_task"})
+
+
+def summary_progress_source_records(records: list[Json]) -> list[Json]:
+    """The subset of a live view that `async_summary_progress_records` can act on.
+
+    Callers that refresh several nodes should filter ONCE and pass the result to every call: the
+    function is called per dirty node, and on a real store the types it reads are 951 of 7,085
+    records, so the rest was being walked and discarded once per node.
+    """
+    return [
+        record for record in records
+        if record.get("record_type") in SUMMARY_PROGRESS_RECORD_TYPES
+    ]
+
+
 def async_summary_progress_records(
     *,
     records: list[Json],
@@ -762,6 +781,8 @@ def refresh_dirty_node_summaries(
 ) -> Json:
     refreshed_at_ms = refreshed_at_ms or now_ms()
     records = adapter.read_all()
+    # Filtered once, not once per dirty node: the progress builder reads two record types.
+    progress_source_records = summary_progress_source_records(records)
     pending_by_node = pending_dirty_node_records(
         records=records,
         scope=scope,
@@ -900,7 +921,7 @@ def refresh_dirty_node_summaries(
                 }
             )
         summary_progress_records = async_summary_progress_records(
-            records=records,
+            records=progress_source_records,
             scope=dirty.get("scope", scope),
             source_event_ids=source_event_ids,
             source_entity_hashes=source_entity_hashes,

--- a/tools/test_the_summary_progress_filter_is_complete.py
+++ b/tools/test_the_summary_progress_filter_is_complete.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The caller-side filter must name every record type the function it feeds actually reads.
+
+`refresh_dirty_node_summaries` calls `async_summary_progress_records` once per dirty node, and used
+to hand it the whole live view each time -- 7,085 records to reach the 951 it can act on, per node.
+It now filters once with `summary_progress_source_records`.
+
+That is only correct while the filter's type set is COMPLETE. If someone teaches the function to
+read a third record type, the filter silently removes those rows and the function sees none of
+them: no error, no failing assertion anywhere else, just a quieter answer. So the set is derived
+here from the function's own source and compared with the constant.
+
+Deriving rather than listing is the point. A test that repeats the two names would pass unchanged
+after a third was added -- it would be checking its own copy, not the code.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import unittest
+
+TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
+RUNTIME = os.path.join(TOOLS_DIR, "matrixark_mcp_summary_runtime.py")
+FUNCTION = "async_summary_progress_records"
+FILTER = "summary_progress_source_records"
+CONSTANT = "SUMMARY_PROGRESS_RECORD_TYPES"
+
+
+def _module():
+    with open(RUNTIME, encoding="utf-8") as handle:
+        return ast.parse(handle.read())
+
+
+def _function(tree, name):
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    return None
+
+
+def _record_types_compared(fn):
+    """Every string a `record_type` lookup is compared against, inside `fn`."""
+    found = set()
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Compare):
+            continue
+        text = ast.unparse(node)
+        if "record_type" not in text:
+            continue
+        for part in ast.walk(node):
+            if isinstance(part, ast.Constant) and isinstance(part.value, str):
+                if part.value != "record_type":
+                    found.add(part.value)
+    return found
+
+
+def _constant_value(tree):
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+                isinstance(t, ast.Name) and t.id == CONSTANT for t in node.targets):
+            for sub in ast.walk(node.value):
+                if isinstance(sub, ast.Set):
+                    return {e.value for e in sub.elts
+                            if isinstance(e, ast.Constant) and isinstance(e.value, str)}
+    return None
+
+
+class TheSummaryProgressFilterIsCompleteTest(unittest.TestCase):
+
+    def test_the_scan_finds_the_function_and_its_comparisons(self):
+        """Without this, a scan that matched nothing would report the filter complete."""
+        fn = _function(_module(), FUNCTION)
+        self.assertIsNotNone(fn, "%s is gone; the filter it protects has no owner" % FUNCTION)
+        compared = _record_types_compared(fn)
+        self.assertGreaterEqual(
+            len(compared), 2,
+            "found %d record_type comparisons in %s, expected at least 2 -- the scan stopped "
+            "matching, so the check below proves nothing" % (len(compared), FUNCTION))
+
+    def test_the_filter_names_every_type_the_function_reads(self):
+        tree = _module()
+        declared = _constant_value(tree)
+        self.assertIsNotNone(declared, "%s is not a set literal any more" % CONSTANT)
+        compared = _record_types_compared(_function(tree, FUNCTION))
+        missing = compared - declared
+        self.assertEqual(
+            set(), missing,
+            "%s reads record types the filter does not pass through: %s. A caller filtering with "
+            "%s would hand it a view with none of those rows in it, and the only symptom would be "
+            "a quieter answer." % (FUNCTION, sorted(missing), FILTER))
+
+    def test_the_filter_passes_exactly_those_types(self):
+        """The behaviour, not the spelling -- the filter could be right and do something else."""
+        try:  # package path
+            from tools.matrixark_mcp_summary_runtime import (
+                SUMMARY_PROGRESS_RECORD_TYPES,
+                summary_progress_source_records,
+            )
+        except ImportError:  # Direct script execution from tools/.
+            from matrixark_mcp_summary_runtime import (
+                SUMMARY_PROGRESS_RECORD_TYPES,
+                summary_progress_source_records,
+            )
+
+        wanted = sorted(SUMMARY_PROGRESS_RECORD_TYPES)
+        rows = [{"record_type": t} for t in wanted]
+        rows += [{"record_type": "context_segment"}, {"record_type": "context_index"}, {}]
+        kept = summary_progress_source_records(rows)
+        self.assertEqual(wanted, sorted(r["record_type"] for r in kept))
+        self.assertEqual(len(SUMMARY_PROGRESS_RECORD_TYPES), len(kept),
+                         "the filter dropped or duplicated a type it declares")
+
+    def test_the_callers_filter_before_the_loop_not_inside_it(self):
+        """Filtering inside the per-node loop would cost what it was meant to save."""
+        for name in ("matrixark_mcp_summary_runtime.py", "matrixark_local_adapter_summaries.py"):
+            path = os.path.join(TOOLS_DIR, name)
+            with open(path, encoding="utf-8") as handle:
+                tree = ast.parse(handle.read())
+            calls = [n for n in ast.walk(tree)
+                     if isinstance(n, ast.Call)
+                     and (getattr(n.func, "id", None) or getattr(n.func, "attr", None)) == FILTER]
+            self.assertTrue(calls, "%s no longer filters at all" % name)
+            for call in calls:
+                inside = [lp for lp in ast.walk(tree)
+                          if isinstance(lp, (ast.For, ast.While))
+                          and lp.lineno < call.lineno <= (lp.end_lineno or call.lineno)]
+                self.assertEqual(
+                    [], inside,
+                    "%s:%d calls %s inside a loop -- it is meant to run once per refresh, not "
+                    "once per node" % (name, call.lineno, FILTER))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`refresh_dirty_node_summaries` calls `async_summary_progress_records` once per dirty node and
handed it the whole live view each time. The function reads exactly two record types —
`context_entity` and `matrixark_async_pipeline_task` — which on a real store are **951 of 7,085
records**. The other 6,134 were walked and discarded, per node.

The view is now filtered once, before the loop, by a named helper that lives beside the function it
feeds.

## Measured

Counting records walked rather than milliseconds, because counts do not move with machine load and
this box is at load average 80:

| | calls | records walked |
|---|---|---|
| before | 3 | 21,255 |
| after | 3 | **2,853** |

**7.5x**, and it scales with the number of dirty nodes, since the discarded work was per node.

The refresh result is identical — `status: ok`, `refreshed_count: 3`,
`compression_created_count: 0`, `skipped_dirty_count: 0`, `pass_budget_exhausted: false`, every
field the same either way.

## Why the type set is derived, not listed

A caller-side filter is only correct while its type set is complete. Teach the function a third
record type and the filter silently removes those rows: no error, no failing assertion anywhere
else, just a quieter answer.

So the guard derives the set from the function's own source and compares it with the declared
constant. A test that repeated the two names would pass unchanged after a third was added — it
would be checking its own copy rather than the code. The guard also asserts the callers filter
*outside* the loop, since filtering inside it would cost exactly what this saves, and it carries a
positive control so a scan that stopped matching cannot report the filter complete.

## The guard is shown to discriminate

With one compared type changed to a value the filter omits, it fails with exactly one failure:

```
FAIL: test_the_filter_names_every_type_the_function_reads
    reads record types the filter does not pass through: ['context_compression_event']
```

and passes again when restored. An earlier attempt at that control injected a malformed block and
the tests errored on `IndentationError` — red for the wrong reason, which proves nothing, so it was
redone with a mutation that keeps the file valid.

## Tests

`test_the_summary_progress_filter_is_complete` (4, new), `test_refresh_one_read` (6),
`test_refresh_pass_budget` (6), `test_matrixark_summary_worker` (6),
`test_native_backends_reach_temporalstore` (3) — all pass. The `codex_pipeline` errors and the
codex-hook cluster were failing before this change.
