### PR TITLE
Filter the time-compression view once per refresh, not once per dirty node

### DIFF
--- a/tools/matrixark_local_adapter_summaries.py
+++ b/tools/matrixark_local_adapter_summaries.py
@@ -13,6 +13,7 @@ try:  # names owned by the parent module
     Any,
     async_summary_progress_records,
     summary_progress_source_records,
+    time_compression_source_records,
     compression_context_index_records,
     compression_profile_layer_values,
     pending_dirty_node_records,
@@ -23,6 +24,7 @@ except ImportError:
     Any,
     async_summary_progress_records,
     summary_progress_source_records,
+    time_compression_source_records,
     compression_context_index_records,
     compression_profile_layer_values,
     pending_dirty_node_records,
@@ -609,6 +611,8 @@ class _LocalAdapterSummariesMixin:
         records = self.read_all() if records is None else records
         # Filtered once, not once per dirty node -- see summary_progress_source_records.
         progress_source_records = summary_progress_source_records(records)
+        # Same reason, different reader: filtered once, not once per dirty node.
+        time_compression_source = time_compression_source_records(records)
         skipped_dirty_reasons: Json = {}
         pending_by_node = pending_dirty_node_records(
             records=records,
@@ -1065,7 +1069,7 @@ class _LocalAdapterSummariesMixin:
                     }
                 )
             compression_refresh = self.auto_time_compress_node_events(
-                records=records,
+                records=time_compression_source,
                 scope=dirty.get("scope", scope),
                 node_hash=node_hash,
                 node_path=node_path,

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -68,11 +68,13 @@ try:
     from tools.matrixark_mcp_summary_runtime import (
         async_summary_progress_records,
         summary_progress_source_records,
+        time_compression_source_records,
     )
 except ModuleNotFoundError:  # Direct script execution from tools/.
     from matrixark_mcp_summary_runtime import (
         async_summary_progress_records,
         summary_progress_source_records,
+        time_compression_source_records,
     )
 
 try:

--- a/tools/matrixark_mcp_summary_runtime.py
+++ b/tools/matrixark_mcp_summary_runtime.py
@@ -597,6 +597,33 @@ def append_node_summary_embeddings(
 SUMMARY_PROGRESS_RECORD_TYPES = frozenset({"context_entity", "matrixark_async_pipeline_task"})
 
 
+#: The record types `auto_time_compress_node_events` reads. Derived from that method, not guessed:
+#: its first loop tests one type in the guard and another INSIDE the body, and a reading that missed
+#: the nested one would build a filter silently dropping 1,886 reinforcement rows.
+#: `test_the_time_compression_filter_is_complete` re-derives it and fails if they drift.
+#:
+#: It lives here rather than beside the method: summaries already reaches this module through the
+#: parent, so defining it there and importing it back closes a cycle.
+TIME_COMPRESSION_RECORD_TYPES = frozenset({
+    "context_compression_event",
+    "context_debug_record",
+    "context_event",
+    "context_recall_reinforcement",
+})
+
+
+def time_compression_source_records(records: list[Json]) -> list[Json]:
+    """The subset of a live view `auto_time_compress_node_events` can act on.
+
+    Callers refreshing several nodes should filter ONCE and pass the result to every call: the
+    method runs per dirty node, and on a real store the types it reads are 2,078 of 7,085 records.
+    """
+    return [
+        record for record in records
+        if record.get("record_type") in TIME_COMPRESSION_RECORD_TYPES
+    ]
+
+
 def summary_progress_source_records(records: list[Json]) -> list[Json]:
     """The subset of a live view that `async_summary_progress_records` can act on.
 
@@ -783,6 +810,8 @@ def refresh_dirty_node_summaries(
     records = adapter.read_all()
     # Filtered once, not once per dirty node: the progress builder reads two record types.
     progress_source_records = summary_progress_source_records(records)
+    # Same reason, different reader: filtered once, not once per dirty node.
+    time_compression_source = time_compression_source_records(records)
     pending_by_node = pending_dirty_node_records(
         records=records,
         scope=scope,
@@ -841,7 +870,7 @@ def refresh_dirty_node_summaries(
         generated_summary_types = summary_refresh_records["generated_summary_types"]
         l1_policy = summary_refresh_records["summary_generation_policy"]
         compression_refresh = adapter.auto_time_compress_node_events(
-            records=records,
+            records=time_compression_source,
             scope=dirty.get("scope", scope),
             node_hash=node_hash,
             node_path=node_path,

--- a/tools/test_the_time_compression_filter_is_complete.py
+++ b/tools/test_the_time_compression_filter_is_complete.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The time-compression filter must name every record type the method it feeds actually reads.
+
+`refresh_dirty_node_summaries` calls `auto_time_compress_node_events` once per dirty node and used
+to hand it the whole live view each time. It now filters once with `time_compression_source_records`.
+
+This guard exists because the obvious reading of that method is WRONG. Its first loop tests one type
+in the loop guard and a second one INSIDE the body:
+
+    for record in records:
+        if record.get("record_type") != "context_compression_event":
+            if record.get("record_type") == "context_recall_reinforcement":
+                ...
+
+A filter built from the loop guards alone names two types and silently drops the 1,886
+`context_recall_reinforcement` rows -- no error, no failing assertion, just a quieter answer. That
+mistake was actually made while writing this change and caught by re-deriving the set from every
+comparison in the method, which is what the test below does.
+
+Derived, not listed: a test repeating the four names would pass unchanged after a fifth was added.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import unittest
+
+TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
+METHOD_FILE = os.path.join(TOOLS_DIR, "matrixark_local_adapter_summaries.py")
+FILTER_FILE = os.path.join(TOOLS_DIR, "matrixark_mcp_summary_runtime.py")
+METHOD = "auto_time_compress_node_events"
+FILTER = "time_compression_source_records"
+CONSTANT = "TIME_COMPRESSION_RECORD_TYPES"
+
+
+def _parse(path):
+    with open(path, encoding="utf-8") as handle:
+        return ast.parse(handle.read())
+
+
+def _named(tree, name):
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    return None
+
+
+def _record_types_compared(fn):
+    """Every string compared against a record_type lookup, ANYWHERE in the function.
+
+    Walking the whole body, not just each loop's leading guard -- the nested comparison is the one
+    that makes this method easy to read wrongly.
+    """
+    found = set()
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Compare):
+            continue
+        if "record_type" not in ast.unparse(node):
+            continue
+        for part in ast.walk(node):
+            if isinstance(part, ast.Constant) and isinstance(part.value, str) \
+                    and part.value != "record_type":
+                found.add(part.value)
+    return found
+
+
+def _constant_value(tree):
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+                isinstance(t, ast.Name) and t.id == CONSTANT for t in node.targets):
+            for sub in ast.walk(node.value):
+                if isinstance(sub, ast.Set):
+                    return {e.value for e in sub.elts
+                            if isinstance(e, ast.Constant) and isinstance(e.value, str)}
+    return None
+
+
+class TheTimeCompressionFilterIsCompleteTest(unittest.TestCase):
+
+    def test_the_scan_finds_the_method_and_its_comparisons(self):
+        """A scan matching nothing would report the filter complete."""
+        fn = _named(_parse(METHOD_FILE), METHOD)
+        self.assertIsNotNone(fn, "%s is gone; the filter it protects has no owner" % METHOD)
+        compared = _record_types_compared(fn)
+        self.assertGreaterEqual(
+            len(compared), 3,
+            "found %d record_type comparisons in %s, expected at least 3 -- the scan stopped "
+            "matching, so the check below proves nothing" % (len(compared), METHOD))
+
+    def test_the_nested_comparison_is_seen(self):
+        """Pin the specific reading error this guard exists for."""
+        compared = _record_types_compared(_named(_parse(METHOD_FILE), METHOD))
+        self.assertIn(
+            "context_recall_reinforcement", compared,
+            "the scan missed the type tested INSIDE the first loop's body -- that is precisely the "
+            "reading that produces a filter dropping every reinforcement row")
+
+    def test_the_filter_names_every_type_the_method_reads(self):
+        declared = _constant_value(_parse(FILTER_FILE))
+        self.assertIsNotNone(declared, "%s is not a set literal any more" % CONSTANT)
+        compared = _record_types_compared(_named(_parse(METHOD_FILE), METHOD))
+        missing = compared - declared
+        self.assertEqual(
+            set(), missing,
+            "%s reads record types %s does not pass through: %s. A caller filtering with it would "
+            "hand the method a view with none of those rows in it, and the only symptom would be a "
+            "quieter answer." % (METHOD, FILTER, sorted(missing)))
+
+    def test_the_filter_passes_exactly_those_types(self):
+        try:  # package path
+            from tools.matrixark_mcp_summary_runtime import (
+                TIME_COMPRESSION_RECORD_TYPES,
+                time_compression_source_records,
+            )
+        except ImportError:  # Direct script execution from tools/.
+            from matrixark_mcp_summary_runtime import (
+                TIME_COMPRESSION_RECORD_TYPES,
+                time_compression_source_records,
+            )
+        wanted = sorted(TIME_COMPRESSION_RECORD_TYPES)
+        rows = [{"record_type": t} for t in wanted]
+        rows += [{"record_type": "context_segment"}, {"record_type": "context_summary"}, {}]
+        kept = time_compression_source_records(rows)
+        self.assertEqual(wanted, sorted(r["record_type"] for r in kept))
+
+    def test_the_callers_filter_before_the_loop_not_inside_it(self):
+        """Filtering inside the per-node loop would cost exactly what this saves."""
+        for name in ("matrixark_mcp_summary_runtime.py", "matrixark_local_adapter_summaries.py"):
+            tree = _parse(os.path.join(TOOLS_DIR, name))
+            calls = [n for n in ast.walk(tree)
+                     if isinstance(n, ast.Call)
+                     and (getattr(n.func, "id", None) or getattr(n.func, "attr", None)) == FILTER]
+            self.assertTrue(calls, "%s no longer filters at all" % name)
+            for call in calls:
+                inside = [lp for lp in ast.walk(tree)
+                          if isinstance(lp, (ast.For, ast.While))
+                          and lp.lineno < call.lineno <= (lp.end_lineno or call.lineno)]
+                self.assertEqual(
+                    [], inside,
+                    "%s:%d calls %s inside a loop -- it is meant to run once per refresh"
+                    % (name, call.lineno, FILTER))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`refresh_dirty_node_summaries` calls `auto_time_compress_node_events` once per dirty node and handed
it the whole live view each time. The method reads four record types, which on a real store are
**2,078 of 7,085 records**; the other 5,007 were walked and discarded per node.

The view is now filtered once, before the loop, beside the filter added for the progress builder.

## Measured

Counting records walked rather than milliseconds — counts do not move with machine load, and this
box has been at load average 80:

| | calls | records walked |
|---|---|---|
| before | 3 | 21,255 |
| after | 3 | **6,234** |

**3.4x**, scaling with the number of dirty nodes. The refresh result is identical: `status: ok`,
`refreshed_count: 3`, `compression_created_count: 0`, `skipped_dirty_count: 0`,
`pass_budget_exhausted: false`.

## The type set is derived, and the obvious reading of it is wrong

The method's first loop tests one type in the loop guard and a **second one inside the body**:

```python
for record in records:
    if record.get("record_type") != "context_compression_event":
        if record.get("record_type") == "context_recall_reinforcement":
```

A filter built from the loop guards alone names two types and silently drops the 1,886
`context_recall_reinforcement` rows — no error, no failing assertion, just a quieter answer. That
mistake was made while writing this change: the first sizing reported "36.9x" from a two-type set,
which was wrong on both the number and the safety.

So the guard re-derives the set from **every** `record_type` comparison anywhere in the method, and
one test pins that specific reading error by asserting the nested type is seen. Listing the four
names instead would pass unchanged after a fifth was added.

The guard is shown to discriminate: drop one type from the constant and it fails with

```
FAIL: test_the_filter_names_every_type_the_method_reads
    does not pass through: ['context_recall_reinforcement']
```

and passes again when restored.

## Placement, and the cycle it avoids

The filter lives in `matrixark_mcp_summary_runtime`, beside the one added for the progress builder,
rather than next to the method it serves in `matrixark_local_adapter_summaries`.

Putting it beside the method was the first attempt, and it closed an import cycle — summaries
already reaches the runtime through the parent module, so importing the filter back broke five
modules with `cannot import name ... from partially initialized module`. Placed in the runtime it
travels by the route the sibling filter already uses, and the import sweep is back to its baseline
two failures (the pair naming a deliberately absent module).

## Tests

`test_the_time_compression_filter_is_complete` (5, new), `test_the_summary_progress_filter_is_complete`
(4), `test_refresh_one_read` (6), `test_refresh_pass_budget` (6), `test_matrixark_summary_worker` (6),
`test_native_backends_reach_temporalstore` (3) — all pass. The `codex_pipeline` errors and the
codex-hook cluster were failing before this change.
