### PR TITLE
Take the next page id from the manifest that already records it

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -972,7 +972,6 @@ impl LocalBlockStore {
             .metadata()
             .map(|metadata| metadata.len())
             .unwrap_or_default();
-        let next_page_id = next_page_id_at(&root).unwrap_or_default();
         let manifest_exists =
             band_manifest_path(&root).exists() || legacy_zone_manifest_path(&root).exists();
         let (mut bands, mut manifest_rebuilt) = if manifest_exists {
@@ -983,6 +982,12 @@ impl LocalBlockStore {
         } else {
             (rebuild_band_manifest_at(&root).unwrap_or_default(), true)
         };
+        // Loaded BEFORE the page-id scan on purpose: the manifest already records `last_page_id`
+        // per slab, and reading it turns a walk over every page record header -- 90% of a
+        // steady-state open's reads -- into a few MB. Any slab the manifest cannot prove unchanged
+        // is still walked, and the active slab always is.
+        let next_page_id =
+            next_page_id_from_bands(&root, &bands, page_slab_id).unwrap_or_default();
         let band_manifest_reconciled_on_open =
             reconcile_band_manifest_with_disk(&root, &mut bands).unwrap_or_default();
         manifest_rebuilt |= band_manifest_reconciled_on_open;

--- a/crates/temporalstore-rust/src/block_store/slab_ids.rs
+++ b/crates/temporalstore-rust/src/block_store/slab_ids.rs
@@ -123,6 +123,68 @@ pub(crate) fn latest_slab_id_at(root: &Path) -> Result<u64, BlockStoreError> {
     Ok(slab_ids_at(root)?.into_iter().max().unwrap_or_default())
 }
 
+/// `next_page_id_at`, but taking each sealed slab's answer from the band manifest.
+///
+/// The walk in `next_page_id_at` reads every page record header in every slab. Attributed on a
+/// live-store copy, that is 1,723 MB of a 1,916 MB steady-state open -- 90% -- to compute one
+/// integer, because live records average 148 bytes and a header walk over records that small never
+/// leaves the read buffer.
+///
+/// The manifest already records `last_page_id` per slab. This uses it ONLY on evidence that the
+/// file has not changed since it was recorded, and falls back to walking any slab it cannot prove:
+///
+///   * the active slab is always walked -- it is being appended to, so the manifest lags it
+///   * a sealed band must not be corrupt, must record a `last_page_id`, and must still match the
+///     file's size AND its verified mtime
+///
+/// The direction of error matters here and only one direction is safe. A value that is too HIGH
+/// wastes page ids; a value that is too LOW re-uses them, which the open path calls out as leading
+/// to stale reads. Every check above can only remove a slab from the fast path, never lower an
+/// answer the walk would have given.
+pub(crate) fn next_page_id_from_bands(
+    root: &Path,
+    bands: &BTreeMap<u64, BlockStoreBandDescriptor>,
+    active_page_slab_id: u64,
+) -> Result<u64, BlockStoreError> {
+    let mut max_page_id: Option<u64> = None;
+    for page_slab_id in slab_ids_at(root)? {
+        let recorded = if page_slab_id == active_page_slab_id {
+            None
+        } else {
+            bands.get(&page_slab_id).and_then(|band| {
+                if band.has_corruption {
+                    return None;
+                }
+                let last_page_id = band.last_page_id?;
+                let verified_mtime = band.verified_source_mtime_unix_ms?;
+                let path = slab_path(root, page_slab_id);
+                let meta = fs::metadata(&path).ok()?;
+                if meta.len() != band.physical_bytes {
+                    return None;
+                }
+                if file_modified_unix_ms(&path) != Some(verified_mtime) {
+                    return None;
+                }
+                Some(last_page_id)
+            })
+        };
+        let slab_max = match recorded {
+            Some(last_page_id) => Some(last_page_id),
+            None => {
+                let file = File::open(slab_path(root, page_slab_id))?;
+                let slab_len = file.metadata()?.len();
+                max_page_id_in_slab_file(file, slab_len, page_slab_id)?
+            }
+        };
+        if let Some(slab_max) = slab_max {
+            max_page_id = Some(max_page_id.map_or(slab_max, |current: u64| current.max(slab_max)));
+        }
+    }
+    Ok(max_page_id
+        .map(|page_id| page_id.saturating_add(1))
+        .unwrap_or_default())
+}
+
 pub(crate) fn next_page_id_at(root: &Path) -> Result<u64, BlockStoreError> {
     let mut max_page_id = None;
     for page_slab_id in slab_ids_at(root)? {
@@ -140,6 +202,163 @@ pub(crate) fn next_page_id_at(root: &Path) -> Result<u64, BlockStoreError> {
     Ok(max_page_id
         .map(|page_id| page_id.saturating_add(1))
         .unwrap_or_default())
+}
+
+#[cfg(test)]
+mod next_page_id_from_bands_tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn payload(tag: u8) -> Vec<u8> {
+        vec![tag; 64]
+    }
+
+    fn write_slab(root: &Path, page_slab_id: u64, page_ids: &[u64]) {
+        let mut bytes = Vec::new();
+        for (index, page_id) in page_ids.iter().enumerate() {
+            let encoded = encode_page_record(
+                &payload(index as u8 + 1),
+                *page_id,
+                None,
+                None,
+                0,
+                BlockStoreOptions::default(),
+            )
+            .expect("encode page record");
+            bytes.extend_from_slice(&encoded.bytes);
+        }
+        fs::create_dir_all(root).expect("create slab root");
+        fs::write(slab_path(root, page_slab_id), &bytes).expect("write slab");
+    }
+
+    /// A band that claims to describe the slab exactly as it currently is on disk.
+    fn band_matching_disk(root: &Path, page_slab_id: u64, last_page_id: Option<u64>)
+        -> BlockStoreBandDescriptor
+    {
+        let path = slab_path(root, page_slab_id);
+        let meta = fs::metadata(&path).expect("slab metadata");
+        BlockStoreBandDescriptor {
+            band_id: page_slab_id,
+            page_slab_id,
+            state: BlockStoreBandState::Sealed,
+            physical_bytes: meta.len(),
+            logical_bytes: meta.len(),
+            created_unix_ms: None,
+            updated_unix_ms: None,
+            first_page_id: None,
+            last_page_id,
+            readable_prefix_physical_bytes: meta.len(),
+            verified_source_mtime_unix_ms: file_modified_unix_ms(&path),
+            has_corruption: false,
+            first_error_offset: None,
+            first_error: None,
+        }
+    }
+
+    #[test]
+    fn a_current_manifest_gives_the_same_answer_as_the_walk() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        write_slab(root, 0, &[0, 1, 2]);
+        write_slab(root, 1, &[3, 9, 4]);
+        let mut bands = BTreeMap::new();
+        bands.insert(0, band_matching_disk(root, 0, Some(2)));
+        bands.insert(1, band_matching_disk(root, 1, Some(9)));
+        // Active slab id 2 does not exist, so every slab here is sealed and provable.
+        assert_eq!(
+            next_page_id_from_bands(root, &bands, 2).expect("from bands"),
+            next_page_id_at(root).expect("walk"),
+            "the fast path disagreed with the walk it replaces"
+        );
+    }
+
+    #[test]
+    fn a_slab_appended_to_since_the_manifest_falls_back_to_the_walk() {
+        // The dangerous case: a stale manifest that under-reports. If it were trusted, the store
+        // would re-use page ids 3..9 and serve stale pages.
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        write_slab(root, 0, &[0, 1, 2]);
+        let stale = band_matching_disk(root, 0, Some(2));
+        write_slab(root, 0, &[0, 1, 2, 9]);
+        let mut bands = BTreeMap::new();
+        bands.insert(0, stale);
+        assert_eq!(
+            next_page_id_from_bands(root, &bands, 99).expect("from bands"),
+            10,
+            "a manifest describing an older, shorter slab was trusted"
+        );
+    }
+
+    #[test]
+    fn a_band_without_a_recorded_page_id_falls_back() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        write_slab(root, 0, &[0, 1, 7]);
+        let mut bands = BTreeMap::new();
+        bands.insert(0, band_matching_disk(root, 0, None));
+        assert_eq!(next_page_id_from_bands(root, &bands, 99).expect("from bands"), 8);
+    }
+
+    #[test]
+    fn the_active_slab_is_walked_even_when_the_manifest_describes_it() {
+        // Its entry cannot be current by construction: appends are landing in it.
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        write_slab(root, 0, &[0, 1, 2]);
+        let mut bands = BTreeMap::new();
+        bands.insert(0, band_matching_disk(root, 0, Some(0)));
+        assert_eq!(
+            next_page_id_from_bands(root, &bands, 0).expect("from bands"),
+            3,
+            "the active slab was answered from the manifest instead of being walked"
+        );
+    }
+
+    /// The two computations must agree on a real store's own manifest and slabs.
+    ///
+    /// A fixture only exercises the shapes I thought to build. A live manifest carries bands
+    /// written by older engines, bands with no `last_page_id`, and mtimes that moved for reasons
+    /// no fixture models -- and the failure this guards against (an answer that is too LOW) is
+    /// invisible in any read-path result.
+    #[test]
+    fn the_manifest_and_the_walk_agree_on_a_real_store() {
+        let Ok(pages) = std::env::var("MATRIXARK_LIVE_STORE_PAGES") else {
+            println!("  set MATRIXARK_LIVE_STORE_PAGES to a pages/ directory to check this");
+            return;
+        };
+        let root = Path::new(&pages);
+        if !root.exists() {
+            println!("  {pages} does not exist");
+            return;
+        }
+        let bands = crate::block_store::band_manifest::load_band_manifest_at(root)
+            .expect("load the band manifest");
+        let active = latest_slab_id_at(root).expect("latest slab id");
+        let walked = next_page_id_at(root).expect("walk");
+        let from_bands = next_page_id_from_bands(root, &bands, active).expect("from bands");
+        let provable = bands
+            .values()
+            .filter(|band| {
+                band.last_page_id.is_some() && band.verified_source_mtime_unix_ms.is_some()
+            })
+            .count();
+        println!(
+            "  {} bands, {provable} carry both fields; active slab {active}; walk={walked} manifest={from_bands}",
+            bands.len()
+        );
+        assert_eq!(
+            walked, from_bands,
+            "the manifest-backed answer disagrees with the walk on a real store"
+        );
+    }
+
+    #[test]
+    fn an_empty_root_is_zero_either_way() {
+        let dir = tempdir().unwrap();
+        let bands = BTreeMap::new();
+        assert_eq!(next_page_id_from_bands(dir.path(), &bands, 0).expect("from bands"), 0);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`next_page_id_at` wants **one integer** — `max(page_id) + 1` — and walks every page record header in
every slab to get it.

Its comment says the header walk means "the cost stops tracking the size of the pages". That holds
for large records. Live page records average **148 bytes**, and the widest header is ~64, so the
`seek_relative` skip never leaves the 256 KB `BufReader` and the walk streams every file end to end.

Attributed with `strace` (fd → path, bytes per path) over a **steady-state** open, with sealed-slab
verification already skipped:

```
total read 1,916.2 MB
  /pages/           1,723.3 MB   89.9%     ← one segment alone read 280.6 MB
  /indexes/wals/      148.0 MB    7.7%
  /indexes/slot-dumps/ 30.1 MB    1.6%
```

**90% of a restart's reads are this scan.**

### The change

`BlockStoreBandDescriptor` already persists `last_page_id` per slab, and the band manifest is loaded
a few lines further down the same function. This loads it first and takes the answer from there.

The manifest is used **only on evidence**, and every check can only remove a slab from the fast path:

- the **active** slab is always walked — it is being appended to, so the manifest necessarily lags it
- a sealed band is trusted only when it is not corrupt, records a `last_page_id`, and **both** its
  `physical_bytes` and its verified mtime still match the file

An append changes a file's size, so "size still matches" is exactly the check that catches a slab
written after the manifest was persisted.

### Why the checks are that strict

The direction of error is not symmetric. The truncation code a few lines below spells it out: a
regressed `next_page_id` gives page-id reuse and stale reads. Too high wastes ids; **too low
corrupts**. So the fast path may only ever answer when the file is provably unchanged, and anything
unrecorded, unreadable or mismatched walks.

### Result

Both binaries built `--release` from the **same worktree and base**, differing only by this change.
Same copy, page cache dropped before every open, three opens each:

| open | wall | read | rchar | cpu | records |
|---|---|---|---|---|---|
| old-3 | 12,392 ms | 1,891.4 MB | 2,012.9 MB | 7.9 s | 16,717 |
| **new-3** | **7,580 ms** | **294.9 MB** | **321.9 MB** | **4.8 s** | 16,717 |

**6.4x less disk I/O**, 1.65x less CPU, 1.63x wall. The record count is identical on all six rows.

### Equivalence, checked on a real store

A matching record count does **not** show this is correct — the record count is a read-path answer,
while `next_page_id` governs future allocation. A fast path that under-reported would look identical
today and re-use page ids tomorrow.

So `the_manifest_and_the_walk_agree_on_a_real_store` computes both ways over a copy of a production
store and asserts they match. Its first run reported `161 bands, 0 carry both fields` — the live
manifest predates the verified-mtime field, so the fast path never fired and the test passed on the
fallback alone. After one open populates the identities: **`161 bands, 161 carry both fields;
walk=5670474 manifest=5670474`**. The count is printed precisely so a pass on an inactive fast path
cannot be mistaken for a pass on an active one.

### Tests

`next_page_id_from_bands_tests`, each a way the manifest could be wrong rather than a way it could
be right:

- a current manifest agrees with the walk
- **a slab appended to since the manifest was persisted** — the dangerous case; trusting the stale
  entry would re-use ids 3..9. Asserts the fallback gives 10
- a band with no recorded `last_page_id` falls back
- the **active** slab is walked even when the manifest describes it
- an empty root is 0 either way

### On the harness

The A/B script predicts `new-1` should resemble `old-1`, since a first open cannot use the fast path.
That check did **not** hold here (new-1 read 261 MB) and the prediction was wrong, not the result:
all six opens share one copy, so `new-1` inherited the verified identities that `old-1..3` wrote. The
comparison that stands is `old-3` against `new-3` on identical state.
