### PR TITLE
An acknowledged write is recoverable from the log alone

### DIFF
--- a/crates/temporalstore-rust/src/bin/wal_single_barrier_crash_harness.rs
+++ b/crates/temporalstore-rust/src/bin/wal_single_barrier_crash_harness.rs
@@ -28,6 +28,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 use temporalstore_rust::{
+    LoadShardRequest,
     Command, CommandResponse, Config, ExecuteRequest, FeaturePoint, SetConfigRequest,
     TemporalEngine,
 };
@@ -214,7 +215,36 @@ struct RecoverReport {
 
 fn recover(root: PathBuf, keys: u64) {
     let engine = open_engine(&root);
-    engine.load_shard(1); // forces WAL replay from the durable watermark
+    // Load through the checked entry point and SAY what it answered.
+    //
+    // `load_shard` discards the status. Replay refuses a load it cannot honour -- a recorded
+    // outcome that will not install returns an error rather than serving a shard missing it --
+    // and discarding that turns a refusal into a shard that reads as empty. Every key then
+    // reports missing, which is the report a log that never held them would produce too, so the
+    // one number this harness exists to produce could not tell "lost" from "refused".
+    let load = engine.load_shard_with(LoadShardRequest {
+        shard_id: 1,
+        load_version: 0,
+        local_node_id: None,
+        shard_uri: String::new(),
+        start_routing_bucket: 0,
+        end_routing_bucket: u32::MAX,
+        readonly: false,
+        table_name: String::new(),
+    });
+    if !load.status.ok {
+        eprintln!(
+            "load refused: code={} message={}",
+            load.status.code, load.status.message
+        );
+    }
+    // What replay actually did, so "recovered 0" can be told apart from "replayed nothing".
+    let stats = engine.write_ahead_log_store().stats(1);
+    eprintln!(
+        "log: last_sequence={} | recovery: {:?}",
+        stats.last_sequence,
+        engine.storage_recovery_report(1)
+    );
     let mut missing = Vec::new();
     let mut mismatched = Vec::new();
     let mut recovered = 0u64;

--- a/crates/temporalstore-rust/src/data_node/runtime_storage.rs
+++ b/crates/temporalstore-rust/src/data_node/runtime_storage.rs
@@ -230,7 +230,11 @@ impl DataNodeRuntime {
             if resident > 0 {
                 let moved = self.inner.engine.materialize_oldest_resident_pages(
                     shard_id,
-                    resident.saturating_sub(options.max_dump_buckets_per_round.max(1)),
+                    resident.saturating_sub(if options.max_dump_buckets_per_round == 0 {
+                        usize::MAX
+                    } else {
+                        options.max_dump_buckets_per_round
+                    }),
                 );
                 tracing::debug!(
                     shard_id,

--- a/crates/temporalstore-rust/src/data_node/runtime_storage.rs
+++ b/crates/temporalstore-rust/src/data_node/runtime_storage.rs
@@ -215,6 +215,30 @@ impl DataNodeRuntime {
                 stats.storage_manager_reclaim_wal_runs += 1;
             }
             lifecycle_report = Some(response.report);
+            // Move the oldest pages that live only inside a WAL record into the block store,
+            // before anything tries to reclaim the log. `min_registered_sequence` pins retention
+            // to the LOWEST registration, so one resident page holds the floor down whatever the
+            // retention policy says. The dump this stage just took does NOT do it: measured on 48
+            // async writes, a flush left all 48 registered and so did a full eight-stage cycle,
+            // with the log floor still at sequence 1.
+            //
+            // Same bound and same order as the one-shot cycle in `engine::storage_manager_cycle`,
+            // which is the other implementation of these stages -- at most
+            // `max_dump_buckets_per_round` per pass, oldest first. This is the copy that runs on a
+            // timer, so it is the one that decides whether an IDLE shard ever becomes reclaimable.
+            let resident = self.inner.engine.wal_resident_page_count(shard_id);
+            if resident > 0 {
+                let moved = self.inner.engine.materialize_oldest_resident_pages(
+                    shard_id,
+                    resident.saturating_sub(options.max_dump_buckets_per_round.max(1)),
+                );
+                tracing::debug!(
+                    shard_id,
+                    moved,
+                    resident,
+                    "storage manager moved log-resident pages into the block store"
+                );
+            }
             executed_stages.push("reclaim_wal".to_string());
         } else if !options.enable_wal_reclaim {
             skipped_stages.push("reclaim_wal_disabled".to_string());

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -3788,9 +3788,35 @@ fn read_page_bytes(
             }
         }
     }
-    let bytes = page_store.read(address).ok()?;
-    let _ = cache.put(cache_key, bytes.clone());
-    Some(bytes)
+    if let Ok(bytes) = page_store.read(address) {
+        let _ = cache.put(cache_key, bytes.clone());
+        return Some(bytes);
+    }
+    // The block store could not answer, so try the record that carries this page.
+    //
+    // This is the same fallback the synthetic-address branch above performs, which until now was
+    // the ONLY way to reach it: the branch is entered on `is_wal_resident(address.page_slab_id)`.
+    // A synchronous write stores the real address its block-store append returned, so a read for
+    // one never entered that branch, and the copy carried in its record was registered, kept
+    // addressable, and never consulted.
+    //
+    // That is exactly the case the single barrier creates. It acks on the log fsync and defers
+    // the block fsync, so a crash can lose a block the index already names. Recovery then rebuilt
+    // the index, resolved a real address into a block that was never written, and answered None
+    // for a durably acknowledged write -- with the value sitting in the log the whole time.
+    //
+    // Ordered after the block-store read, not before it: the durable copy is the common case and
+    // a direct read, while this one resolves a log id and parses a record.
+    if page_store.block_in_wal() {
+        if let Some(bytes) = address
+            .object_id()
+            .and_then(|object_id| block_in_wal::read_page(page_store, shard_id, object_id))
+        {
+            let _ = cache.put(cache_key, bytes.clone());
+            return Some(bytes);
+        }
+    }
+    None
 }
 
 /// The page's bytes, shared rather than copied.

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -3530,6 +3530,24 @@ fn append_value(
     async_storage: bool,
 ) -> Result<BlockAddress, BlockStoreError> {
     if !async_storage {
+        // Carry the page in this write's record, the same as the asynchronous arm below.
+        //
+        // The record is allowed to state its results and drop the operation only when the blocks
+        // those results name survive a crash. A carried block does -- it IS the record. A
+        // synchronous write's block used to be assumed durable instead, but the single barrier
+        // acks on the WAL fsync and defers the block fsync (`defer_data_sync` in the block
+        // store's append), so at that moment the block store holds it in buffers and nowhere
+        // else. Wiping everything but the log then lost every acked write, which is what the
+        // recovery suite has been reporting.
+        //
+        // Carrying it costs the bytes twice for as long as the record lives, and no longer: the
+        // storage manager's reclaim stage moves carried pages into the block store and drops the
+        // registration that pins the log floor.
+        if page_store.block_in_wal() {
+            if let Some(object_id) = object_id {
+                block_in_wal::stage(object_id, bytes);
+            }
+        }
         return page_store.append_with_page_metadata(bytes, object_id, routing_bucket);
     }
     let address = BlockAddress::from_parts(HOT_PAGE_SLAB_ID, HOT_PAGE_OFFSET.fetch_add(1, Ordering::Relaxed), bytes.len() as u64, None, object_id, routing_bucket, object_id, None);

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -917,6 +917,18 @@ impl TemporalEngine {
                             request.shard_id,
                             command,
                             std::mem::take(&mut staged_outcomes),
+                            if carried_pages.is_empty() {
+                                if self.page_store.block_in_wal() {
+                                    block_in_wal::take_staged()
+                                } else {
+                                    Vec::new()
+                                }
+                            } else {
+                                if self.page_store.block_in_wal() {
+                                    let _ = block_in_wal::take_staged();
+                                }
+                                std::mem::take(&mut carried_pages)
+                            },
                         )
                         .map(|record| Some(record.sequence))
                 } else {

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -1463,7 +1463,7 @@ impl TemporalEngine {
     ///
     /// The point of the map is that it is part of the index rather than process state, so a
     /// test needs to be able to look at it to say anything about that.
-    pub(super) fn wal_resident_page_count(&self, shard_id: ShardId) -> usize {
+    pub(crate) fn wal_resident_page_count(&self, shard_id: ShardId) -> usize {
         self.shards
             .read()
             .expect("engine lock poisoned")

--- a/crates/temporalstore-rust/src/engine/reports.rs
+++ b/crates/temporalstore-rust/src/engine/reports.rs
@@ -3228,6 +3228,13 @@ pub struct StorageManagerStageReport {
     pub wal_records_removed: usize,
     #[serde(default)]
     pub index_log_records_removed: usize,
+    /// How many pages this stage moved out of the log and into the block store.
+    ///
+    /// Separate from `wal_records_removed`: this counts what had to become durable ELSEWHERE
+    /// before any record could be removed at all, because a page still living only inside a
+    /// record pins the retention floor to that record's sequence.
+    #[serde(default)]
+    pub wal_resident_pages_materialised: usize,
     #[serde(default)]
     pub retain_from_wal_sequence: u64,
     #[serde(default)]

--- a/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
+++ b/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
@@ -394,6 +394,36 @@ impl TemporalEngine {
         } else {
             None
         };
+        // Pages whose only durable copy is a WAL record leave the log HERE, before the reclaim
+        // plan is computed, because `min_registered_sequence` pins retention to the LOWEST
+        // registration: a page still resident holds the floor down and no retention policy can
+        // pass it. That is the order this stage's counterpart uses in the design this
+        // follows -- dump the dirty slots, advance the dumped-log id, and only then reclaim.
+        //
+        // Until this ran, the only caller that moved a page out of the log was the write path,
+        // which sweeps once registrations pass `TS_WAL_RESIDENT_PAGES` and therefore stops the
+        // moment writes stop. An idle shard kept every page it had ever written that way.
+        // Measured on 48 async writes: a flush left all 48 registered, and so did a full
+        // eight-stage cycle, with the log floor still at sequence 1.
+        //
+        // Bounded per cycle at `max_dump_buckets_per_round`, so a shard sitting at the write
+        // path's ceiling drains over several cycles instead of turning one into a long pause.
+        // Oldest first, because the oldest registration is the one holding the floor down. The
+        // bytes are already durable in the log, so this moves a copy that is safe either way.
+        let wal_resident_pages_before = self.wal_resident_page_count(request.shard_id);
+        let wal_resident_pages_materialised = if request.enable_wal_reclaim
+            && !request.dry_run
+            && wal_resident_pages_before > 0
+        {
+            let per_round = request.max_dump_buckets_per_round.max(1);
+            self.materialize_oldest_resident_pages(
+                request.shard_id,
+                wal_resident_pages_before.saturating_sub(per_round),
+            )
+        } else {
+            0
+        };
+
         let wal_reclaim_plan = self.storage_wal_reclaim_plan(
             request.shard_id,
             request.follower_replay_cursors.clone(),
@@ -426,6 +456,7 @@ impl TemporalEngine {
                 elapsed
             },
             stage: "reclaim_wal".to_string(),
+            wal_resident_pages_materialised,
             enabled: request.enable_wal_reclaim,
             applied: wal_reclaim_report
                 .as_ref()

--- a/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
+++ b/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
@@ -415,7 +415,14 @@ impl TemporalEngine {
             && !request.dry_run
             && wal_resident_pages_before > 0
         {
-            let per_round = request.max_dump_buckets_per_round.max(1);
+            // Zero is how this request spells "no bound" -- its own default is 0 while the
+            // scheduler's is 64 -- so a cycle asked for no bound drains the shard rather than
+            // one page per pass.
+            let per_round = if request.max_dump_buckets_per_round == 0 {
+                usize::MAX
+            } else {
+                request.max_dump_buckets_per_round
+            };
             self.materialize_oldest_resident_pages(
                 request.shard_id,
                 wal_resident_pages_before.saturating_sub(per_round),

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -1124,26 +1124,7 @@ impl LocalWriteAheadLogStore {
                 // What still cannot: an ASYNCHRONOUS write with nothing carried. Its result names
                 // an address in the block store that a crash may leave unwritten, and no amount
                 // of registering helps a block that was never stored.
-                command: record_command(
-                    command,
-                    &outcomes,
-                    // A record may drop the operation and keep only its results when the blocks
-                    // those results name can still be found after a crash. Carrying the blocks
-                    // qualifies -- they are IN this record. A synchronous write used to qualify
-                    // too, on the grounds that its blocks were already in the block store.
-                    //
-                    // That second clause was written for the barrier that fsynced the blocks
-                    // before acking. The single barrier acks on the WAL fsync and DEFERS the block
-                    // fsync, so at the moment this record is written a synchronous write's blocks
-                    // are in the block store's buffers and nowhere durable. A power cut then
-                    // leaves a record that names an address whose bytes were never stored, which
-                    // is the same hole the asynchronous case below was already excluded for.
-                    //
-                    // So the clause holds only where the block fsync still precedes the ack, which
-                    // is the legacy barrier. Under the single barrier a synchronous write keeps
-                    // its operation, and the log can rebuild what it acked from itself alone.
-                    (sync && !crate::engine::wal_single_barrier()) || !staged_pages.is_empty(),
-                ),
+                command: record_command(command, &outcomes, sync || !staged_pages.is_empty()),
                 staged_pages,
                 outcomes,
             };

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -9649,6 +9649,7 @@ mod tests {
                         value: vec![118u8; 64],
                     },
                     Vec::new(),
+                    Vec::new(),
                 )
                 .unwrap()
                 .sequence;

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -1124,7 +1124,26 @@ impl LocalWriteAheadLogStore {
                 // What still cannot: an ASYNCHRONOUS write with nothing carried. Its result names
                 // an address in the block store that a crash may leave unwritten, and no amount
                 // of registering helps a block that was never stored.
-                command: record_command(command, &outcomes, sync || !staged_pages.is_empty()),
+                command: record_command(
+                    command,
+                    &outcomes,
+                    // A record may drop the operation and keep only its results when the blocks
+                    // those results name can still be found after a crash. Carrying the blocks
+                    // qualifies -- they are IN this record. A synchronous write used to qualify
+                    // too, on the grounds that its blocks were already in the block store.
+                    //
+                    // That second clause was written for the barrier that fsynced the blocks
+                    // before acking. The single barrier acks on the WAL fsync and DEFERS the block
+                    // fsync, so at the moment this record is written a synchronous write's blocks
+                    // are in the block store's buffers and nowhere durable. A power cut then
+                    // leaves a record that names an address whose bytes were never stored, which
+                    // is the same hole the asynchronous case below was already excluded for.
+                    //
+                    // So the clause holds only where the block fsync still precedes the ack, which
+                    // is the legacy barrier. Under the single barrier a synchronous write keeps
+                    // its operation, and the log can rebuild what it acked from itself alone.
+                    (sync && !crate::engine::wal_single_barrier()) || !staged_pages.is_empty(),
+                ),
                 staged_pages,
                 outcomes,
             };

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -1185,6 +1185,7 @@ impl LocalWriteAheadLogStore {
         shard_id: ShardId,
         command: Command,
         outcomes: Vec<WalOutcomeItem>,
+        staged_pages: Vec<StagedPage>,
     ) -> Result<WriteAheadLogRecord, WriteAheadLogError> {
         let mut inner = self.inner.lock().expect("write-ahead log lock poisoned");
         // Acquiring the append lock creates the directory the first time it opens the lock
@@ -1201,10 +1202,17 @@ impl LocalWriteAheadLogStore {
             shard_id,
             sequence: seq,
             metadata: Some(WriteAheadLogRecordMetadata::single_command(&command)),
-            // This path exists to coalesce the fsync of a SYNCHRONOUS write, so the blocks behind
-            // these results are durable by the time the barrier this record waits on returns.
-            command: record_command(command, &outcomes, true),
-            staged_pages: Vec::new(),
+            // This path coalesces the fsync of a SYNCHRONOUS write. It used to assert that the
+            // blocks behind these results were therefore durable by the time the barrier returned,
+            // and drop the operation on that basis. They are not: the barrier this record waits on
+            // is the LOG's, and the block fsync is deferred past it, so a power cut can leave these
+            // results naming blocks that were never written. That is what makes a log carrying only
+            // results unable to rebuild what it acked.
+            //
+            // So this path asks the same question every other one does -- can these blocks be found
+            // again? -- and answers it from what the record actually carries.
+            command: record_command(command, &outcomes, !staged_pages.is_empty()),
+            staged_pages,
             outcomes,
         };
         // sync=false: write the bytes, defer the fdatasync to `commit_barrier`. Same as the


### PR DESCRIPTION
An acknowledged write could be lost by a crash, and the value was in the log the whole time.

The single barrier acks on the log fsync and defers the block fsync -- `defer_data_sync` in the
block store's append is `bulk_relaxed_durability() || page_wal_single_barrier()`. So when a record
is written, its blocks are in the block store's buffers and nowhere durable. Losing them is
permitted; the log is what makes the write recoverable. The crash harness has been reporting the
result: wipe everything but the log, and all 300 acked keys read as missing. Five of its eight
cases fail on main, and the step that runs them carries `continue-on-error: true`.

Four things had to be true for the log to be able to answer, and three of them were not.

**A synchronous write did not carry its page.** `append_value` staged the page into the record on
the asynchronous arm only. The synchronous arm went straight to the block store, so its record
named an address and carried nothing.

**The group-commit path asserted durability rather than checking it.** It called
`record_command(command, &outcomes, true)` while passing `staged_pages: Vec::new()` -- claiming the
blocks behind its results survive a crash, on the strength of a barrier that covers the log and not
them. That is the path a concurrent synchronous write actually takes, so the assertion was made
exactly where it was least true. It now carries its pages and answers from what it holds.

**A read could not reach a carried page unless the address was synthetic.** This is the one that
made the others look pointless. The fallback that reads a page back out of its record sits inside
`if is_wal_resident(address.page_slab_id)`. A synchronous write stores the real address its append
returned, so a read for one never entered that branch: the page was carried, replay registered it,
the registry held it, and nothing ever asked. A real address that the block store cannot answer now
falls through to the carried copy, ordered after the durable read so the common path is unchanged.

**Nothing moved a carried page back out.** `materialize_oldest_resident_pages` had one caller, the
write path, which sweeps only once registrations pass `TS_WAL_RESIDENT_PAGES` and so stops when
writes stop. An idle shard kept every page it had written that way, and because
`min_registered_sequence` pins retention to the LOWEST registration, those pages held the log floor
down and no retention policy could pass them. Measured on 48 writes: 48 registrations after the
writes, 48 after a flush, 48 after a full eight-stage cycle, with the floor still at sequence 1.

The storage manager now drains them in its reclaim stage, before the reclaim plan is computed --
make the pages durable elsewhere, then let retention advance past them. Bounded per pass by
`max_dump_buckets_per_round`, oldest first, since the oldest registration holds the floor. A bound
of zero means no bound: the cycle request defaults to 0 while the scheduler defaults to 64, so a
cycle asked for no bound drained one page per pass. It went into both cycle implementations,
because both are scheduled and would otherwise drift.

Carrying a page costs its bytes twice for as long as its record lives, and no longer -- the drain is
what ends that, which is why these land together.

The harness also stopped discarding the load status. Replay refuses a load it cannot honour, and
`load_shard` drops that answer, so a refusal and an empty log produced the same report.

Recovery suite: 3 passed / 5 failed on main, 7 passed / 1 failed here.
`single_barrier_evict_then_crash_before_dump_does_not_resurrect` still fails, as it does on main: a
carried copy can be stale with respect to a later trim, and serving it brings back points the trim
removed. That one is not addressed here.
