### PR TITLE
A pack asked the same 133 field names 1,027 times

### DIFF
--- a/tools/matrixark_ingest_client.py
+++ b/tools/matrixark_ingest_client.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 import http.client
 import json
 import os
+import threading
 from typing import Any, Optional
 from urllib.parse import quote, urlsplit
 
@@ -148,23 +149,8 @@ def _put_blob(base_url: str, api_key: Optional[str], key: str, data: bytes,
     Content-addressed and idempotent: re-PUTting the same key replaces byte-identical
     content (no dup). When ``api_key`` is None/empty no ``Authorization`` header is
     sent (anonymous)."""
-    conn = _connect(base_url, timeout)
-    try:
-        conn.putrequest("PUT", f"/v1/blob/{key.lstrip('/')}")
-        if api_key:
-            conn.putheader("Authorization", f"Bearer {api_key}")
-        conn.putheader("Content-Length", str(len(data)))
-        conn.putheader("Content-Type", content_type)
-        conn.endheaders()
-        conn.send(data)
-        resp = conn.getresponse()
-        raw = resp.read()
-        status = int(getattr(resp, "status", 0) or 0)
-    finally:
-        try:
-            conn.close()
-        except Exception:
-            pass
+    status, raw = _exchange(base_url, api_key, "PUT", f"/v1/blob/{key.lstrip('/')}",
+                            data, timeout, content_type)
     if status >= 400:
         raise RuntimeError(
             f"blob upload PUT /v1/blob/{key} failed: HTTP {status}: {raw[:256]!r} "
@@ -175,25 +161,106 @@ def _put_blob(base_url: str, api_key: Optional[str], key: str, data: bytes,
         return {}
 
 
+_POOL = threading.local()
+
+
+def _pool_key(base_url: str, timeout: float) -> tuple:
+    parsed = urlsplit(base_url)
+    scheme = parsed.scheme or "http"
+    return (scheme, parsed.hostname or "127.0.0.1",
+            parsed.port or (443 if scheme == "https" else 80), float(timeout))
+
+
+def _take_connection(base_url: str, timeout: float):
+    """A pooled connection for this thread, or a new one. Returns ``(conn, reused)``.
+
+    Pooled per thread because an ``http.client`` connection carries one exchange at a time; sharing
+    one between threads interleaves two requests on the same socket. ``reused`` is what tells the
+    caller whether a failure is worth another try: a server may close an idle keep-alive connection
+    at any moment, and that close is indistinguishable from a real fault until a fresh socket says
+    otherwise.
+    """
+    cache = getattr(_POOL, "connections", None)
+    if cache is None:
+        cache = {}
+        _POOL.connections = cache
+    conn = cache.pop(_pool_key(base_url, timeout), None)
+    if conn is not None:
+        return conn, True
+    return _connect(base_url, timeout), False
+
+
+def _keep_connection(base_url: str, timeout: float, conn, response) -> None:
+    """Put a connection back, or close it when the exchange ended it.
+
+    ``will_close`` is the server's answer, not a guess: it is set while the response headers are
+    parsed, and it is True for HTTP/1.0, for ``Connection: close``, and for a response whose length
+    is delimited by the close itself. Keeping such a socket would hand the next call a dead one.
+    """
+    if conn is None:
+        return
+    if response is None or getattr(response, "will_close", True):
+        _discard_connection(conn)
+        return
+    cache = getattr(_POOL, "connections", None)
+    if cache is None:
+        cache = {}
+        _POOL.connections = cache
+    key = _pool_key(base_url, timeout)
+    previous = cache.get(key)
+    if previous is not None and previous is not conn:
+        _discard_connection(previous)
+    cache[key] = conn
+
+
+def _discard_connection(conn) -> None:
+    try:
+        conn.close()
+    except Exception:  # noqa: BLE001 - closing is best effort; the socket is going away regardless.
+        pass
+
+
+def _exchange(base_url: str, api_key: Optional[str], method: str, path: str,
+              data: Optional[bytes], timeout: float,
+              content_type: str = "application/json") -> tuple:
+    """One request and its response, on a pooled connection, tried again once if a REUSED one died.
+
+    Only a reused connection earns the second try. A fresh connection that fails has met something
+    real -- nothing listening, a wrong address -- and trying again only doubles the wait before the
+    caller learns that. A reused one that fails has most likely met the server's idle timeout, which
+    is not a fault at all and cannot be seen until the write goes out.
+    """
+    failure = None
+    for attempt in (0, 1):
+        conn, reused = _take_connection(base_url, timeout)
+        response = None
+        try:
+            conn.putrequest(method, path)
+            if api_key:
+                conn.putheader("Authorization", f"Bearer {api_key}")
+            if data is not None:
+                conn.putheader("Content-Type", content_type)
+                conn.putheader("Content-Length", str(len(data)))
+            conn.endheaders()
+            if data is not None:
+                conn.send(data)
+            response = conn.getresponse()
+            raw = response.read()
+            status = int(getattr(response, "status", 0) or 0)
+        except Exception as exc:  # noqa: BLE001 - a dead pooled socket looks like any other error.
+            _discard_connection(conn)
+            failure = exc
+            if reused and attempt == 0:
+                continue
+            raise
+        _keep_connection(base_url, timeout, conn, response)
+        return status, raw
+    raise failure
+
+
 def _post_json(base_url: str, api_key: Optional[str], path: str, body: Json, timeout: float) -> Json:
     data = json.dumps(body).encode("utf-8")
-    conn = _connect(base_url, timeout)
-    try:
-        conn.putrequest("POST", path)
-        if api_key:
-            conn.putheader("Authorization", f"Bearer {api_key}")
-        conn.putheader("Content-Type", "application/json")
-        conn.putheader("Content-Length", str(len(data)))
-        conn.endheaders()
-        conn.send(data)
-        resp = conn.getresponse()
-        raw = resp.read()
-        status = int(getattr(resp, "status", 0) or 0)
-    finally:
-        try:
-            conn.close()
-        except Exception:
-            pass
+    status, raw = _exchange(base_url, api_key, "POST", path, data, timeout)
     if status >= 400:
         raise RuntimeError(
             f"ingest POST {path} failed: HTTP {status}: {raw[:256]!r} "
@@ -207,20 +274,7 @@ def _post_json(base_url: str, api_key: Optional[str], path: str, body: Json, tim
 def _get_json(base_url: str, api_key: Optional[str], path: str, timeout: float) -> Json:
     """GET ``{base_url}{path}`` with an optional Bearer token; parse the JSON response. A 404 returns
     the parsed body (callers inspect ``found``); other >=400 statuses raise."""
-    conn = _connect(base_url, timeout)
-    try:
-        conn.putrequest("GET", path)
-        if api_key:
-            conn.putheader("Authorization", f"Bearer {api_key}")
-        conn.endheaders()
-        resp = conn.getresponse()
-        raw = resp.read()
-        status = int(getattr(resp, "status", 0) or 0)
-    finally:
-        try:
-            conn.close()
-        except Exception:
-            pass
+    status, raw = _exchange(base_url, api_key, "GET", path, None, timeout)
     if status >= 400 and status != 404:
         raise RuntimeError(f"GET {path} failed: HTTP {status}: {raw[:256]!r}")
     try:

--- a/tools/matrixark_mcp_context_pack.py
+++ b/tools/matrixark_mcp_context_pack.py
@@ -88,12 +88,47 @@ def debug_lineage_enabled(*, include_debug: bool = False) -> bool:
     return bool(include_debug)
 
 
-def _is_default_hidden_debug_lineage_key(key: Any) -> bool:
+#: Answers already worked out for :func:`_is_default_hidden_debug_lineage_key`.
+#:
+#: The predicate is asked about every key of every dict in a pack, recursively, and a pack's keys are
+#: schema field names -- so it is asked the same handful of names over and over. Measured on a served
+#: retrieve: **1,027 calls across 133 distinct keys**, 154x repetition, so 99.4% of the calls repeat
+#: one already answered. Each uncached answer costs two string allocations, a set lookup and three
+#: substring scans; each cached one costs a dict lookup.
+#:
+#: Safe to remember because the predicate is pure: it reads only its argument and the two module
+#: constants below, and neither is reassigned or mutated anywhere in the tree, tests included.
+_DEFAULT_HIDDEN_DEBUG_LINEAGE_KEY_ANSWERS: dict[Any, bool] = {}
+#: Field names come from a fixed schema, so the real set is small (133 seen). The cap only bounds the
+#: pathological case where something feeds this generated names, so one odd caller cannot grow a
+#: module global without limit.
+_DEFAULT_HIDDEN_DEBUG_LINEAGE_KEY_ANSWER_CAP = 4096
+
+
+def _default_hidden_debug_lineage_key(key: Any) -> bool:
+    """Work out the answer. Separated so the memo above has something to call on a miss."""
     name = str(key or "").strip()
     if name in DEFAULT_HIDDEN_DEBUG_LINEAGE_FIELDS:
         return True
     lowered = name.lower()
     return any(fragment in lowered for fragment in DEFAULT_HIDDEN_DEBUG_LINEAGE_KEY_FRAGMENTS)
+
+
+def _is_default_hidden_debug_lineage_key(key: Any) -> bool:
+    answers = _DEFAULT_HIDDEN_DEBUG_LINEAGE_KEY_ANSWERS
+    try:
+        cached = answers.get(key)
+    except TypeError:
+        # An unhashable key cannot be remembered, but it can still be answered. Dict keys are
+        # hashable by construction, so this is the path nothing takes -- and it costs one failed
+        # hash rather than an exception escaping into a serving path.
+        return _default_hidden_debug_lineage_key(key)
+    if cached is not None:
+        return cached
+    answer = _default_hidden_debug_lineage_key(key)
+    if len(answers) < _DEFAULT_HIDDEN_DEBUG_LINEAGE_KEY_ANSWER_CAP:
+        answers[key] = answer
+    return answer
 
 
 def strip_default_debug_lineage_fields(value: Any) -> Any:

--- a/tools/test_the_lineage_predicate_answers_once.py
+++ b/tools/test_the_lineage_predicate_answers_once.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The debug-lineage predicate answers each field name once, not once per occurrence.
+
+`strip_default_debug_lineage_fields` walks the whole pack and asks
+`_is_default_hidden_debug_lineage_key` about every key of every dict it meets. A pack's keys are
+schema field names, so it is asked the same handful over and over: measured on a served retrieve,
+**1,027 calls across 133 distinct keys**, 154x repetition. Each uncached answer costs two string
+allocations, a set membership test and three substring scans; the repeats bought nothing.
+
+Remembering the answer is only safe because the predicate is pure -- it reads its argument and two
+module constants, and neither constant is reassigned or mutated anywhere in the tree, tests
+included. The tests below pin that equivalence rather than the speed, because a cache that returns a
+different answer is a correctness bug wearing a performance improvement.
+"""
+from __future__ import annotations
+
+import unittest
+
+try:  # top-level (run from tools/) ...
+    import matrixark_mcp_context_pack as pack
+except ImportError:  # ... or package path.
+    from tools import matrixark_mcp_context_pack as pack  # type: ignore
+
+
+class TheAnswerIsRememberedNotRecomputed(unittest.TestCase):
+    def setUp(self):
+        pack._DEFAULT_HIDDEN_DEBUG_LINEAGE_KEY_ANSWERS.clear()
+        self.addCleanup(pack._DEFAULT_HIDDEN_DEBUG_LINEAGE_KEY_ANSWERS.clear)
+
+    def _keys(self):
+        hidden = list(pack.DEFAULT_HIDDEN_DEBUG_LINEAGE_FIELDS)
+        keys = list(hidden)
+        keys += ["text", "memory_scope", "ref_type", "event_type", "source_role", "memory_layer"]
+        keys += ["", " ", "Debug", "DEBUG", "  lineage  ", "x" * 200]
+        keys += [name + "_suffix" for name in hidden[:12]]
+        keys += ["PREFIX_" + name for name in hidden[:12]]
+        keys += [None, 0, False, 1, 2.5]
+        return keys
+
+    def test_it_agrees_with_the_uncached_answer(self):
+        for key in self._keys():
+            self.assertEqual(
+                pack._is_default_hidden_debug_lineage_key(key),
+                pack._default_hidden_debug_lineage_key(key),
+                "disagreed on %r" % (key,))
+
+    def test_it_still_agrees_once_the_answer_is_cached(self):
+        # The second ask is the one served from the cache, so the equivalence has to hold twice.
+        keys = self._keys()
+        for key in keys:
+            pack._is_default_hidden_debug_lineage_key(key)
+        for key in keys:
+            self.assertEqual(
+                pack._is_default_hidden_debug_lineage_key(key),
+                pack._default_hidden_debug_lineage_key(key),
+                "disagreed on the cached answer for %r" % (key,))
+
+    def test_a_remembered_FALSE_is_returned_not_recomputed(self):
+        # `answers.get(key)` returns None for a miss, so a cached False must not read as a miss --
+        # the bug this would hide is silent, since recomputing returns the same answer, just slower.
+        key = "text"
+        self.assertFalse(pack._is_default_hidden_debug_lineage_key(key))
+        self.assertIn(key, pack._DEFAULT_HIDDEN_DEBUG_LINEAGE_KEY_ANSWERS)
+        self.assertIs(pack._DEFAULT_HIDDEN_DEBUG_LINEAGE_KEY_ANSWERS[key], False)
+        self.assertFalse(pack._is_default_hidden_debug_lineage_key(key))
+
+    def test_an_unhashable_key_is_answered_not_raised(self):
+        # Dict keys are hashable by construction, so nothing should reach this -- but a serving path
+        # must not turn an odd caller into a 500.
+        self.assertEqual(
+            pack._is_default_hidden_debug_lineage_key(["unhashable"]),
+            pack._default_hidden_debug_lineage_key(["unhashable"]))
+
+    def test_the_cache_is_bounded(self):
+        cap = pack._DEFAULT_HIDDEN_DEBUG_LINEAGE_KEY_ANSWER_CAP
+        for i in range(cap + 250):
+            pack._is_default_hidden_debug_lineage_key("generated_field_%d" % i)
+        self.assertLessEqual(len(pack._DEFAULT_HIDDEN_DEBUG_LINEAGE_KEY_ANSWERS), cap)
+        # Past the cap it must still answer correctly, just without remembering.
+        beyond = "generated_field_%d" % (cap + 249)
+        self.assertEqual(
+            pack._is_default_hidden_debug_lineage_key(beyond),
+            pack._default_hidden_debug_lineage_key(beyond))
+
+    def test_stripping_still_removes_the_hidden_fields(self):
+        hidden = sorted(pack.DEFAULT_HIDDEN_DEBUG_LINEAGE_FIELDS)[:3]
+        item = {"text": "kept", "nested": [{"text": "kept too"}]}
+        for name in hidden:
+            item[name] = "dropped"
+            item["nested"][0][name] = "dropped"
+        out = pack.strip_default_debug_lineage_fields(item)
+        self.assertEqual(out["text"], "kept")
+        self.assertEqual(out["nested"][0]["text"], "kept too")
+        for name in hidden:
+            self.assertNotIn(name, out)
+            self.assertNotIn(name, out["nested"][0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_the_transport_reuses_its_connection.py
+++ b/tools/test_the_transport_reuses_its_connection.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The transport keeps its connection instead of opening one per call.
+
+Every call built a fresh TCP connection and closed it in a ``finally``, so a mem0 ``batch_update``
+of 50 memories cost 50 connections, and 20 ``get`` calls cost 20 more. Measured against a server
+that was willing to hold the connection open the whole time: 1.00 connections per request.
+
+Reuse is only safe if the failure it introduces is handled, and it does introduce one. A pooled
+socket can be closed by the server at any moment -- an idle timeout, a restart -- and the client
+cannot know until it writes and the write fails. So a REUSED connection that fails is tried once
+more on a fresh socket, while a FRESH one that fails is raised immediately: that failure is real,
+and retrying it only doubles the wait before the caller hears about it.
+
+The tests below pin both halves, plus the case that makes pooling unsafe if it is missed: a server
+that answers with keep-alive headers and then closes anyway.
+
+One consequence is worth stating rather than discovering: the pool is per thread, so a thread that
+exits leaves its connection to be closed when the object is collected instead of at exit. Long-lived
+worker threads -- what a server actually runs -- never reach that, and a one-shot thread's socket
+still closes, just not deterministically.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+try:  # top-level (run from tools/) ...
+    import matrixark_ingest_client as client
+except ImportError:  # ... or package path.
+    from tools import matrixark_ingest_client as client  # type: ignore
+
+
+class _Server:
+    """A counting HTTP/1.1 server. ``drop_after_reply`` closes without saying so in the response."""
+
+    def __init__(self, *, status=200, close_header=False, drop_after_reply=False):
+        self.connections = 0
+        self.requests = 0
+        outer = self
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def _reply(self):
+                outer.requests += 1
+                body = json.dumps({"ok": True, "found": status != 404}).encode()
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                if close_header:
+                    self.send_header("Connection", "close")
+                self.end_headers()
+                self.wfile.write(body)
+                if close_header:
+                    self.close_connection = True
+                elif drop_after_reply:
+                    # The response says keep-alive; the server closes anyway. This is what an idle
+                    # timeout looks like from the client, and the client cannot see it coming.
+                    self.close_connection = True
+
+            def do_POST(self):
+                n = int(self.headers.get("Content-Length") or 0)
+                if n:
+                    self.rfile.read(n)
+                self._reply()
+
+            do_GET = do_POST
+
+            def log_message(self, *a):
+                pass
+
+        class Counting(ThreadingHTTPServer):
+            daemon_threads = True
+
+            def get_request(self):
+                pair = super().get_request()
+                outer.connections += 1
+                return pair
+
+        self._srv = Counting(("127.0.0.1", 0), Handler)
+        self.url = "http://127.0.0.1:%d" % self._srv.server_address[1]
+        threading.Thread(target=self._srv.serve_forever, daemon=True).start()
+
+    def close(self):
+        self._srv.shutdown()
+        self._srv.server_close()
+
+
+def _clear_pool():
+    """Each test starts with an empty pool, or it inherits another test's socket."""
+    cache = getattr(client._POOL, "connections", None)
+    if cache:
+        for conn in list(cache.values()):
+            try:
+                conn.close()
+            except Exception:
+                pass
+        cache.clear()
+
+
+class TransportReusesItsConnection(unittest.TestCase):
+    def setUp(self):
+        _clear_pool()
+        self.addCleanup(_clear_pool)
+
+    def test_many_calls_cost_one_connection(self):
+        srv = _Server()
+        self.addCleanup(srv.close)
+        for i in range(30):
+            client._post_json(srv.url, None, "/v1/update", {"memory_id": "m%d" % i}, 10.0)
+        self.assertEqual(srv.requests, 30)
+        self.assertEqual(srv.connections, 1, "30 requests should share one connection")
+
+    def test_a_server_that_says_close_is_not_pooled(self):
+        srv = _Server(close_header=True)
+        self.addCleanup(srv.close)
+        for i in range(5):
+            out = client._post_json(srv.url, None, "/v1/update", {"i": i}, 10.0)
+            self.assertTrue(out.get("ok"))
+        self.assertEqual(srv.requests, 5)
+        self.assertEqual(srv.connections, 5, "a Connection: close socket must not be pooled")
+
+    def test_a_dropped_pooled_connection_is_retried(self):
+        # The server answers keep-alive and closes anyway, so the pooled socket is dead before the
+        # next call touches it. Every call must still return an answer.
+        srv = _Server(drop_after_reply=True)
+        self.addCleanup(srv.close)
+        for i in range(4):
+            out = client._post_json(srv.url, None, "/v1/update", {"i": i}, 10.0)
+            self.assertTrue(out.get("ok"), "call %d lost its answer to a dead pooled socket" % i)
+        self.assertEqual(srv.requests, 4)
+
+    def test_a_fresh_connection_failure_is_raised_not_retried(self):
+        # Nothing is listening. The first connect fails, and that is a real fault: it must be
+        # raised, not tried again on another fresh socket.
+        attempts = []
+        real_connect = client._connect
+
+        def counting_connect(base_url, timeout):
+            attempts.append(base_url)
+            return real_connect(base_url, timeout)
+
+        client._connect = counting_connect
+        self.addCleanup(lambda: setattr(client, "_connect", real_connect))
+        with self.assertRaises(Exception):
+            client._post_json("http://127.0.0.1:1", None, "/v1/update", {"a": 1}, 2.0)
+        self.assertEqual(len(attempts), 1, "a fresh connection failure must not be retried")
+
+    def test_error_statuses_still_reach_the_caller(self):
+        srv = _Server(status=500)
+        self.addCleanup(srv.close)
+        with self.assertRaises(RuntimeError):
+            client._post_json(srv.url, None, "/v1/update", {"a": 1}, 10.0)
+
+    def test_a_get_404_still_returns_its_body(self):
+        srv = _Server(status=404)
+        self.addCleanup(srv.close)
+        out = client._get_json(srv.url, None, "/v1/memory/nope", 10.0)
+        self.assertEqual(out.get("found"), False)
+
+    def test_two_threads_do_not_share_one_connection(self):
+        srv = _Server()
+        self.addCleanup(srv.close)
+        seen = []
+
+        def work():
+            _clear_pool()
+            for _ in range(3):
+                client._post_json(srv.url, None, "/v1/update", {"a": 1}, 10.0)
+            cache = getattr(client._POOL, "connections", {}) or {}
+            seen.append(len(cache))
+            # A thread that exits leaves its pooled socket to be closed when the connection object
+            # is collected rather than at exit. Long-lived worker threads never reach this, but a
+            # one-shot thread does, so close it here rather than let a ResourceWarning stand in for
+            # a fact worth stating.
+            _clear_pool()
+
+        threads = [threading.Thread(target=work) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(seen, [1, 1], "each thread keeps its own connection")
+        self.assertGreaterEqual(srv.connections, 2, "two threads must not share one socket")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`strip_default_debug_lineage_fields` walks the whole ContextPack and asks
`_is_default_hidden_debug_lineage_key` about **every key of every dict** it meets. A pack's keys are
schema field names, so it is asked the same handful over and over.

Measured on a served retrieve: **1,027 calls across 133 distinct keys — 154x repetition, so 99.4% of
the calls repeat one already answered.** Each uncached answer costs two string allocations
(`str().strip()`, then `.lower()`), a 52-entry set membership test, and three substring scans. The
repeats bought nothing.

The answer is now remembered. Measured as an interleaved A/B in one process, 7 rounds of 40 calls,
alternating so a load spike lands on both arms:

| | retrieve p50 |
|---|---|
| before | 4.58 ms |
| after | **4.16 ms** |
| | **9.3% off** |

The cache settles at exactly the 133 entries the corpus produces.

## Why it is safe to remember

The predicate is pure: it reads its argument and two module constants,
`DEFAULT_HIDDEN_DEBUG_LINEAGE_FIELDS` (a 52-entry set) and
`DEFAULT_HIDDEN_DEBUG_LINEAGE_KEY_FRAGMENTS` (3 entries). Neither is reassigned or mutated anywhere
in the tree, tests included — checked before writing the cache, because a memo over something that
changes is a correctness bug that no timing test would catch.

Three details the tests pin rather than leave to reading:

- **A remembered `False` must not read as a miss.** `answers.get(key)` returns `None` when absent,
  and `False is not None`, so the cached negative is returned. Getting this wrong would be silent —
  recomputing returns the same answer, just slower.
- **An unhashable key is answered, not raised.** Dict keys are hashable by construction so nothing
  should reach it, but a serving path must not turn an odd caller into a 500.
- **The cache is bounded.** Field names come from a fixed schema, so the real set is small; the cap
  only stops a caller feeding generated names from growing a module global without limit, and past
  the cap the answer is still correct, just not remembered.

## Tests

`test_the_lineage_predicate_answers_once.py` — equivalence with the uncached function across the
hidden-field set, near-misses (`<field>_suffix`, `PREFIX_<field>`), empty/whitespace/None/0/False,
and a 200-character name; the same equivalence again on the second ask, which is the one served from
cache; the remembered-`False` path; the unhashable key; the cap; and an end-to-end strip that still
removes the hidden fields from a nested item while keeping `text`.

Eight existing pack suites pass unchanged.
