### PR TITLE
Did this call fall back, not has anything ever

### DIFF
--- a/tools/matrixark_mcp_embeddings.py
+++ b/tools/matrixark_mcp_embeddings.py
@@ -9,6 +9,7 @@ import collections
 import hashlib
 import math
 import os
+import threading as _threading
 import threading
 from typing import Any
 
@@ -71,7 +72,21 @@ def embedding_cache_stats() -> dict:
         looked_up = stats["hits"] + stats["misses"]
         stats["hit_rate"] = round(stats["hits"] / looked_up, 4) if looked_up else 0.0
         return stats
-_EMBEDDING_FALLBACK_USED = False
+_EMBEDDING_CALL_STATE = _threading.local()
+
+
+def _begin_embedding_call() -> None:
+    """Start a fresh answer for this thread. Called by the public entry points below.
+
+    The question every reader asks is "did THIS call fall back", and the flag used to answer "has
+    anything fallen back since this process started" -- which is true for ever after the first
+    time, so a retrieve served correctly by a recovered encoder still reported the fallback.
+    """
+    _EMBEDDING_CALL_STATE.fallback_used = False
+
+
+def _mark_embedding_fallback() -> None:
+    _EMBEDDING_CALL_STATE.fallback_used = True
 
 
 # Some encoder families are trained with an instruction prefix on the input and score materially
@@ -141,6 +156,7 @@ def _with_prefix(text: str, role: str) -> str:
 
 
 def embedding_for_text(text: str, role: str = "passage") -> list[float]:
+    _begin_embedding_call()
     model = embedding_model_name()
     text = _with_prefix(text, role)
     cache_key = (model, text)
@@ -169,6 +185,7 @@ def embedding_for_text(text: str, role: str = "passage") -> list[float]:
 
 def embeddings_for_texts(texts: list[str], role: str = "passage") -> list[list[float]]:
     """Batch-friendly embedding helper with the same cache as embedding_for_text."""
+    _begin_embedding_call()
     if not texts:
         return []
     texts = [_with_prefix(text, role) for text in texts]
@@ -245,7 +262,7 @@ def embedding_execution_mode_name() -> str:
 
 
 def embedding_fallback_used() -> bool:
-    return _EMBEDDING_FALLBACK_USED
+    return bool(getattr(_EMBEDDING_CALL_STATE, "fallback_used", False))
 
 
 # --- API embedding providers (production: OpenAI / Voyage / any OpenAI-compatible endpoint) -------
@@ -333,13 +350,12 @@ def api_embedding_for_texts(texts: list[str], provider: str) -> list[list[float]
     """Embed via an OpenAI-compatible or Voyage embeddings API. Falls back to the deterministic
     encoder on missing key / network error unless MATRIXARK_REQUIRE_API_EMBEDDINGS is set (then it
     raises, so production fails fast instead of silently poisoning the store with mismatched-dim vectors)."""
-    global _EMBEDDING_FALLBACK_USED
     endpoint, api_key, model, key_env = _api_embedding_config(provider)
     require = require_model_embeddings("MATRIXARK_REQUIRE_API_EMBEDDINGS")
     if not api_key:
         if require:
             raise MatrixArkError(f"API embeddings require {key_env} for provider '{provider}'")
-        _EMBEDDING_FALLBACK_USED = True
+        _mark_embedding_fallback()
         return [_deterministic_embedding_for_text(text) for text in texts]
     try:
         import json as _json
@@ -363,7 +379,7 @@ def api_embedding_for_texts(texts: list[str], provider: str) -> list[list[float]
     except Exception as exc:  # network / auth / shape errors
         if require:
             raise MatrixArkError(f"API embedding call failed for provider '{provider}' ({model}): {exc}") from exc
-        _EMBEDDING_FALLBACK_USED = True
+        _mark_embedding_fallback()
         return [_deterministic_embedding_for_text(text) for text in texts]
 
 
@@ -373,7 +389,6 @@ def api_embedding_for_text(text: str, provider: str) -> list[float]:
 
 
 def oss_embedding_for_text(text: str) -> list[float]:
-    global _EMBEDDING_FALLBACK_USED
     model_ref = os.environ.get("MATRIXARK_EMBEDDING_MODEL_PATH") or os.environ.get(
         "MATRIXARK_EMBEDDING_MODEL",
         "intfloat/multilingual-e5-large",
@@ -390,7 +405,7 @@ def oss_embedding_for_text(text: str) -> list[float]:
     except Exception as exc:  # pragma: no cover - depends on optional local model packages.
         if require_model_embeddings("MATRIXARK_REQUIRE_OSS_EMBEDDINGS"):
             raise MatrixArkError(f"OSS embedding model is required but unavailable: {model_ref}: {exc}") from exc
-        _EMBEDDING_FALLBACK_USED = True
+        _mark_embedding_fallback()
         previous = os.environ.get("MATRIXARK_EMBEDDING_PROVIDER")
         try:
             os.environ["MATRIXARK_EMBEDDING_PROVIDER"] = "deterministic"

--- a/tools/test_matrixark_did_this_call_fall_back.py
+++ b/tools/test_matrixark_did_this_call_fall_back.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+""""Did this call fall back?" is a question about this call.
+
+Every retrieve reports ``embedding_fallback_used`` and ``embedding_execution_mode`` in its context
+pack. Both read one module global, which was set True in three places and reset **nowhere** -- the
+only assignment to False was the import-time initialiser.
+
+So one fallback, anywhere, at any point in the process, made every later retrieve report that it
+had fallen back. Including the ones a recovered encoder served correctly. The pack states it as a
+fact about that retrieve, and after the first fallback it was never true again.
+
+Measured on main before the change, with the same two probes this suite uses::
+
+    after a call that fell back      True
+    after a call that did not        True   <- and for the rest of the process
+    execution mode                   local_hash_embedding_fallback
+
+**Per call and per thread.** The gateway serves retrieves through ``asyncio.to_thread``, so two
+requests can be inside the encoder at once. A single global reset at entry would let one request's
+reset erase the other's answer, which is a worse failure than the one being fixed: intermittent
+rather than permanent, and therefore much harder to see.
+"""
+from __future__ import annotations
+
+import itertools
+import os
+import sys
+import threading
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_mcp_embeddings as embeddings  # noqa: E402
+
+FELL_BACK = {"MATRIXARK_EMBEDDING_PROVIDER": "openai"}      # configured, no key -> falls back
+DID_NOT = {"MATRIXARK_EMBEDDING_PROVIDER": "deterministic"}  # the encoder that always answers
+
+
+class _Env:
+    """Set some variables, and put the environment back exactly as it was."""
+
+    def __init__(self, **values):
+        self.values = values
+        self.original = {}
+
+    def __enter__(self):
+        for name, value in self.values.items():
+            self.original[name] = os.environ.get(name)
+            os.environ[name] = value
+        self.original["OPENAI_API_KEY"] = os.environ.pop("OPENAI_API_KEY", None)
+        return self
+
+    def __exit__(self, *exc):
+        for name, value in self.original.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        return False
+
+
+_PROBE = itertools.count()
+
+
+def _fresh_text() -> str:
+    """A text no earlier call has encoded.
+
+    Vectors are cached, and a cache hit never reaches the provider -- so it cannot fall back, and
+    reports that it did not. That is the right answer, and it made the first version of this suite
+    order-dependent: tests run alphabetically, an earlier one had already encoded the shared
+    string, and the floor below then measured a cache hit instead of the encoder.
+    """
+    return "a probe sentence number %d" % next(_PROBE)
+
+
+def encode(**env) -> bool:
+    """Encode one text under `env`, and report whether THAT call fell back."""
+    with _Env(**env):
+        embeddings.embedding_for_text(_fresh_text())
+        return embeddings.embedding_fallback_used()
+
+
+class TheAnswerFollowsTheCallTest(unittest.TestCase):
+
+    def test_a_call_that_fell_back_says_so(self) -> None:
+        """The floor. Everything below passes on a flag hard-wired to False."""
+        self.assertTrue(encode(**FELL_BACK))
+
+    def test_a_call_that_did_not_fall_back_says_that(self) -> None:
+        """The fix. On main this was True -- for ever, from the first fallback onward."""
+        encode(**FELL_BACK)
+        self.assertFalse(encode(**DID_NOT))
+
+    def test_the_execution_mode_follows_too(self) -> None:
+        """It is derived from the same flag, and it is the string a customer reads."""
+        encode(**FELL_BACK)
+        with _Env(**DID_NOT):
+            embeddings.embedding_for_text(_fresh_text())
+            self.assertNotEqual("local_hash_embedding_fallback",
+                                embeddings.embedding_execution_mode_name())
+
+    def test_a_batch_reports_its_own_answer(self) -> None:
+        """The other entry point. A batch that fell back must say so, and one after it must not
+        inherit that."""
+        with _Env(**FELL_BACK):
+            embeddings.embeddings_for_texts([_fresh_text(), _fresh_text()])
+            self.assertTrue(embeddings.embedding_fallback_used())
+        with _Env(**DID_NOT):
+            embeddings.embeddings_for_texts([_fresh_text(), _fresh_text()])
+            self.assertFalse(embeddings.embedding_fallback_used())
+
+
+    def test_a_fully_cached_batch_still_answers_for_itself(self) -> None:
+        """The batch entry point's own reset, which nothing else covers.
+
+        `embeddings_for_texts` delegates to `embedding_for_text` for anything it has to encode, and
+        that resets -- so removing the batch's own reset changes nothing on any path that encodes
+        something. A mutation doing exactly that survived the first version of this suite.
+
+        A batch served entirely from the cache never delegates. It is the one call that reaches the
+        batch entry and nothing beneath it, so it is the only place the entry's own reset is
+        observable.
+        """
+        texts = [_fresh_text(), _fresh_text()]
+        # The SAME provider both times. The cache is keyed on (model, text), so switching provider
+        # switches the model name and misses every entry -- which is why a first attempt at this
+        # test delegated after all, and the mutation it was written for survived it.
+        with _Env(**FELL_BACK):
+            embeddings.embeddings_for_texts(texts)
+            self.assertTrue(embeddings.embedding_fallback_used(), "the fixture did not fall back")
+        with _Env(**FELL_BACK):
+            embeddings.embeddings_for_texts(texts)   # every one already cached: no encoder call
+            self.assertFalse(embeddings.embedding_fallback_used(),
+                             "a batch served entirely from cache inherited the previous call's "
+                             "answer, so the batch entry point is not starting a fresh one")
+
+
+class OneThreadDoesNotAnswerForAnotherTest(unittest.TestCase):
+    """Why it is a thread-local and not one global reset at entry.
+
+    Retrieves are served through `asyncio.to_thread`, so two can be inside the encoder at once.
+    With a single global, whichever reset last would speak for both -- an intermittent wrong answer,
+    which is harder to notice than the permanent one this replaces.
+    """
+
+    def test_a_fallback_in_one_thread_is_not_reported_in_another(self) -> None:
+        """Driven through the flag itself rather than through the encoder.
+
+        Making each thread encode would mean each setting MATRIXARK_EMBEDDING_PROVIDER, and the
+        environment is process-wide: the two would stomp each other and the test would be measuring
+        that race rather than thread isolation. The property under test is that one thread's answer
+        does not become another's, and that is exactly what these two calls exercise.
+        """
+        answers = {}
+        both_marked = threading.Barrier(2, timeout=30)
+
+        def falls_back():
+            embeddings._begin_embedding_call()
+            embeddings._mark_embedding_fallback()
+            both_marked.wait()          # hold until the other thread has begun its own call
+            answers["fell_back"] = embeddings.embedding_fallback_used()
+
+        def stays_clean():
+            embeddings._begin_embedding_call()
+            both_marked.wait()
+            answers["clean"] = embeddings.embedding_fallback_used()
+
+        threads = [threading.Thread(target=falls_back), threading.Thread(target=stays_clean)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=60)
+
+        self.assertTrue(answers.get("fell_back"), "the falling-back thread lost its answer")
+        self.assertFalse(answers.get("clean"), "one thread's fallback was reported in another")
+
+    def test_the_main_thread_starts_with_no_answer(self) -> None:
+        """A thread that has not encoded anything has not fallen back, and must not inherit a
+        default of True from anywhere."""
+        state = embeddings._EMBEDDING_CALL_STATE
+        had = hasattr(state, "fallback_used")
+        previous = getattr(state, "fallback_used", None)
+        try:
+            if had:
+                del state.fallback_used
+            self.assertFalse(embeddings.embedding_fallback_used())
+        finally:
+            if had:
+                state.fallback_used = previous
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Every retrieve reports `embedding_fallback_used` and `embedding_execution_mode` in its context pack. Both read one module global, set `True` in three places and reset **nowhere** — the only assignment to `False` was the import-time initialiser.

So one fallback, anywhere, at any point in the process, made every later retrieve report that it had fallen back. Including the ones a recovered encoder served correctly. The pack states it as a fact about *that* retrieve, and after the first fallback it was never true again.

Measured on main, with the two probes this suite uses:

| | main | this change |
|---|---|---|
| after a call that fell back | `True` | `True` |
| after a call that did **not** | `True` — and for ever | `False` |
| execution mode | `local_hash_embedding_fallback` | `deterministic-token-hash` |

## Per call, and per thread

The gateway serves retrieves through `asyncio.to_thread`, so two requests can be inside the encoder at once. A single global reset at entry would let one request's reset erase the other's answer — an intermittent wrong answer, which is harder to notice than the permanent one being fixed. It is a thread-local.

## Checks

Five mutations, each reddening a distinct assertion, including *"it never resets"* — the exact behaviour this replaces.

The last one took three attempts, and both failures were worth having:

* **A batch delegates.** `embeddings_for_texts` calls `embedding_for_text` for anything it has to encode, and that resets — so removing the batch's own reset changes nothing on any path that encodes something. Only a batch served *entirely from cache* reaches the batch entry and nothing beneath it.
* **The cache is keyed on `(model, text)`.** A first attempt at that test switched provider between the two calls, which switches the model name and misses every cache entry — so it delegated after all. The working version uses the same provider both times.

The thread test is driven through the flag rather than the encoder: making each thread encode would mean each setting `MATRIXARK_EMBEDDING_PROVIDER`, and the environment is process-wide, so the two would stomp each other and the test would measure that race instead of thread isolation.
