### PR TITLE
A batched page write carries its pages

### DIFF
--- a/crates/temporalstore-rust/src/bin/wal_single_barrier_crash_harness.rs
+++ b/crates/temporalstore-rust/src/bin/wal_single_barrier_crash_harness.rs
@@ -307,7 +307,30 @@ fn populate_feature(root: PathBuf) -> ! {
 
 fn recover_feature(root: PathBuf) {
     let engine = open_engine(&root);
-    engine.load_shard(1); // forces WAL replay from the durable watermark
+    // Say what the load answered, for the same reason `recover` does: a refused load and an empty
+    // series produce the same report otherwise.
+    let load = engine.load_shard_with(LoadShardRequest {
+        shard_id: 1,
+        load_version: 0,
+        local_node_id: None,
+        shard_uri: String::new(),
+        start_routing_bucket: 0,
+        end_routing_bucket: u32::MAX,
+        readonly: false,
+        table_name: String::new(),
+    });
+    if !load.status.ok {
+        eprintln!(
+            "load refused: code={} message={}",
+            load.status.code, load.status.message
+        );
+    }
+    let stats = engine.write_ahead_log_store().stats(1);
+    eprintln!(
+        "log: last_sequence={} | recovery: {:?}",
+        stats.last_sequence,
+        engine.storage_recovery_report(1)
+    );
     let got: Vec<u64> = match engine
         .execute(ExecuteRequest {
             shard_id: 1,

--- a/crates/temporalstore-rust/src/engine/packed_pages.rs
+++ b/crates/temporalstore-rust/src/engine/packed_pages.rs
@@ -281,6 +281,18 @@ fn append_timestamped_kv_pages_inner(
             .iter()
             .map(|packed| (packed.as_slice(), Some(object_id), Some(routing_bucket)))
             .collect();
+        // Carry these pages in this write's record, the way `append_value` does for a single
+        // page. This writer batches straight to the block store, so it never staged anything: a
+        // synchronous feature write's record named an address and carried nothing, and because it
+        // carried nothing the record kept its operation instead. After a crash that loses the
+        // un-fsynced block -- which the single barrier permits -- replay installed the outcomes,
+        // the outcomes named a block that was never written, and the read had nothing to fall back
+        // to. The whole series came back empty.
+        if block_store.block_in_wal() {
+            for packed in &encoded_pages {
+                super::block_in_wal::stage(object_id, packed.as_slice());
+            }
+        }
         let addresses = block_store.append_batch_with_page_metadata(writes)?;
         if addresses.len() != chunk_points.len() {
             return Err(BlockStoreError::Io(std::io::Error::new(


### PR DESCRIPTION
A synchronous feature write recorded an address and carried nothing, so losing the block lost the
series entirely.

`append_value` carries a page into the record that acked it. The packed-page writer does not go
through it: its synchronous arm builds every chunk and hands them to
`append_batch_with_page_metadata` in one call, straight to the block store. Nothing was staged, so
the record named addresses and carried no bytes.

That is enough to lose an acknowledged write on its own, because the single barrier acks on the log
fsync and defers the block fsync. It also had a second effect that hid the first. A record may drop
its operation and keep only its results when the blocks those results name survive a crash, and
carrying them is what qualifies -- so a record that carries nothing keeps its operation instead.
The feature record was 210 bytes of JSON operation and no carried page, while a string record beside
it carried its page and had dropped its operation. Replay prefers recorded results to re-execution,
installed the results, and they named a block that the crash had taken. The read had nothing to fall
back to and the series came back empty -- not short, empty.

Staging each chunk before the batch append fixes both: the pages travel in the record, and because
they do, the operation is dropped and the record becomes results plus bytes.

`single_barrier_evict_then_crash_before_dump_does_not_resurrect` was the last failure in
`wal_single_barrier_recovery`, a suite whose CI step still carries `continue-on-error: true` because
it has never been green. It is green now: 8 passed, 0 failed. The library suite is 1720 passed with
one failure, `storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_flags`,
which fails on main as well.

One limit worth recording rather than discovering later: every chunk of one object shares a single
`stable_page_object_id`, and the registry is keyed by object, so an object whose points span several
pages can be answered for one of them. A read for another chunk misses and returns nothing, which is
the behaviour before this change rather than a new way to be wrong.
