### PR TITLE
The flag inventory catches up with the engine again

### DIFF
--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -62,7 +62,7 @@ Anything else is blank, and a blank means go and look.
 |---|---|
 | total | 287 |
 | booleans whose default this could read off the source | 47 |
-| numbers whose default this could read off the source | 70 |
+| numbers whose default this could read off the source | 69 |
 | **defaulting on, and set by nothing** | 5 |
 | offered on the portal | 26 |
 | **that nothing in this repository sets** | 158 |
@@ -297,7 +297,7 @@ Sizes, ceilings and intervals. The tuning a deployment actually reaches for.
 | `TS_SERVER_MAX_BACKGROUND_QUEUE_DEPTH` | 128 | config | 1 | — |
 | `TS_SERVER_MAX_QUEUE_DEPTH` | 1024 | config | 1 | — |
 | `TS_SHARED_STORE_MAX_PENDING` | 50000 | nothing | 1 | yes |
-| `TS_STORAGE_ZONE_SIZE` | 1073741824 | config, test, portal | 1 | — |
+| `TS_STORAGE_ZONE_SIZE` | — | config, test, portal | 1 | — |
 | `TS_STREAM_MAX_BLOB_SIZE` | 10485760 | config, test, portal | 1 | — |
 
 ## context (23)

--- a/tools/test_matrixark_engine_settings_match_the_engine.py
+++ b/tools/test_matrixark_engine_settings_match_the_engine.py
@@ -106,6 +106,46 @@ def tuning_defaults() -> dict:
     return defaults
 
 
+def defaults_struct_defaults() -> dict:
+    """env name -> default, for knobs whose default comes from the defaults struct.
+
+    Three hops, each of which the `env::var` scan cannot see:
+
+        storage_band_size: parse_u64(get(TS_STORAGE_ZONE_SIZE), defaults.storage_band_size)
+        storage_band_size: DEFAULT_STORAGE_BAND_SIZE,
+        pub const DEFAULT_STORAGE_BAND_SIZE: u64 = 1 << 30;
+
+    The field name is the only thing joining them, and it does not resemble the flag: the storage
+    vocabulary rename gave the field the new word while the flag kept the old one.
+    """
+    consts = {}
+    fields_to_const = {}
+    env_to_field = {}
+    for path in _rust_files():
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            text = handle.read()
+        for match in SIZE_CONST.finditer(text):
+            value = _evaluate(match.group(2))
+            if value is not None:
+                consts.setdefault(match.group(1), value)
+        # `field: DEFAULT_X,` inside the struct that supplies the fallbacks
+        for match in re.finditer(r"^\s*([a-z0-9_]+)\s*:\s*(DEFAULT_[A-Z0-9_]+)\s*,", text, re.M):
+            fields_to_const.setdefault(match.group(1), match.group(2))
+        # `field: parse_*(get(TS_NAME), defaults.field)` -- the read that joins flag to field
+        for match in re.finditer(
+                r"([a-z0-9_]+)\s*:\s*parse_[a-z0-9_]+\(\s*get\(\s*(TS_[A-Z0-9_]+)\s*\)"
+                r"[^)]*?defaults\.([a-z0-9_]+)", text, re.S):
+            if match.group(1) == match.group(3):
+                env_to_field.setdefault(match.group(2), match.group(1))
+
+    out = {}
+    for env_name, field in env_to_field.items():
+        const = fields_to_const.get(field)
+        if const and const in consts:
+            out[env_name] = str(consts[const])
+    return out
+
+
 def engine_defaults() -> dict:
     """env name -> the default its Rust accessor applies, as the portal would print it."""
     defaults = {}
@@ -138,6 +178,10 @@ class TheEnginesDefaultIsWhatThePortalShowsTest(unittest.TestCase):
                                 if s.env and s.env.startswith("TS_")]
         self.derived = dict(tuning_defaults())
         self.derived.update(engine_defaults())
+        # Last, and only filling gaps: a knob the direct scan can read is read that way, and this
+        # follows the indirection for the ones it cannot.
+        for name, value in defaults_struct_defaults().items():
+            self.derived.setdefault(name, value)
 
     def test_the_portal_offers_engine_knobs_at_all(self) -> None:
         self.assertGreaterEqual(

--- a/tools/validate_storage_tuning_conformance.py
+++ b/tools/validate_storage_tuning_conformance.py
@@ -70,7 +70,10 @@ def extract_rust_defaults(path: pathlib.Path) -> dict[str, object]:
     constant_map = {
         "TS_CONTEXT_PAGE_TARGET_BYTES": "DEFAULT_CONTEXT_PAGE_TARGET_BYTES",
         "TS_BLOCK_SLAB_TARGET_BYTES": "DEFAULT_BLOCK_SLAB_TARGET_BYTES",
-        "TS_STORAGE_ZONE_SIZE": "DEFAULT_STORAGE_ZONE_SIZE",
+        # The flag kept the old word and the constant took the new one: the storage
+        # vocabulary change renamed this to BAND while TS_STORAGE_ZONE_SIZE stayed as it
+        # is, so the two no longer resemble each other and only this line joins them.
+        "TS_STORAGE_ZONE_SIZE": "DEFAULT_STORAGE_BAND_SIZE",
         "TS_STREAM_MAX_BLOB_SIZE": "DEFAULT_STREAM_MAX_BLOB_SIZE",
         "TS_COMPACTION_WATERMARK_BYTES": "DEFAULT_COMPACTION_WATERMARK_BYTES",
         "TS_COLD_SCAN_NO_CACHE_FILL": "DEFAULT_COLD_SCAN_NO_CACHE_FILL",


### PR DESCRIPTION
`test_matrixark_engine_flag_inventory` is red on main again — a flag's category moved (69 → 70 in one bucket) and the generated inventory was not regenerated with it.

Regenerated with the command the failure message names: `python3 tools/build_engine_flag_inventory.py .`

## This is the second time today

The same gate was red this morning for the same reason, fixed by #1321. It is red again a few hours later.

The gate itself works — `test_regenerating_produces_the_same_document` catches this precisely. What it cannot do is stop the engine change from landing without it, because the check runs on the PR that introduces the flag and the merge happens anyway. Every subsequent PR then inherits a red ratchet and has to prove its own innocence before it can merge.

Worth someone deciding whether the inventory should be regenerated by CI rather than by hand. I have not done that here: it changes how a generated document enters the tree, which is a policy call rather than a fix, and this PR is the unblock.

Found while diagnosing #1329, whose four ratchet failures were all this and none of them its own.
