### PR TITLE
Drain a WAL backlog in fewer passes, now that probing a piece is cheap

### DIFF
--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -2950,11 +2950,28 @@ fn resolve_last_sequence_for_append(
 /// A bound does not reduce total work; it increases it, because every extra pass pays the
 /// directory barrier again. It bounds how long the lock is held in one pass, which is the thing
 /// writers actually feel.
+/// How many whole pieces one reclaim pass may unlink before stopping.
+///
+/// The pass runs under the append lock, so this bounds how long writers wait. 64 was chosen when
+/// deciding a piece was droppable meant decoding it forward: 24.9-72.2 ms per real piece, so even
+/// 64 was 1.6-4.6 s of held lock. Since the droppability test became a single record read from the
+/// next piece it costs 0.354-0.546 ms per piece, measured on real pieces and confirmed at 0.498 ms
+/// across 43 drops on a rolled log -- so the old number now bounds a cost that is ~50-100x smaller
+/// than the one it was set against.
+///
+/// That gap is not free. Pieces arrive faster than 64 per reclaim round on a busy log, so the
+/// backlog grows and the log never drains, and a log that does not drain is paid for at every
+/// restart: on a store whose page scan has been removed, draining the WAL took a restart from
+/// 5,456 ms to 1,908 ms.
+///
+/// 1024 is ~0.5 s of held lock at the measured rate and drains a backlog like that in one pass. It
+/// stays a bound rather than becoming unlimited, so a pathological backlog is still spread over
+/// several passes instead of stalling every writer at once.
 fn wal_reclaim_max_segments_per_pass() -> usize {
     std::env::var("TS_WAL_RECLAIM_MAX_SEGMENTS_PER_PASS")
         .ok()
         .and_then(|value| value.trim().parse::<usize>().ok())
-        .unwrap_or(64)
+        .unwrap_or(1024)
 }
 
 /// TS_WAL_PREALLOCATE (default ON): write records inside a file that has already been grown
@@ -8645,6 +8662,73 @@ mod tests {
         if head_us > 0.0 {
             println!("  ratio: {:.0}x cheaper per segment", walk_us / head_us);
         }
+    }
+
+    /// What one reclaim pass costs per segment, swept over piece size.
+    ///
+    /// The per-pass cap bounds how long the append lock is held. Since mx#1295 made the
+    /// droppability probe a single record read, that cap is set against a cost that no longer
+    /// exists. This measures the cost that does, and prints the piece count so a threshold that
+    /// silently fails to roll cannot be read as a fast result -- an earlier version of this test
+    /// produced exactly that, one piece and zero drops.
+    #[test]
+    fn what_one_reclaim_pass_costs_per_segment() {
+        let mut measured = 0usize;
+        for threshold in [8 * 1024u64, 64 * 1024, 256 * 1024, 1024 * 1024] {
+            set_wal_segment_bytes_for_test(Some(threshold));
+            let dir = tempfile::tempdir().unwrap();
+            let store = LocalWriteAheadLogStore::new(dir.path());
+            let records = 6_000u64;
+            for index in 0..records {
+                store
+                    .append_with_sync(
+                        1,
+                        Command::StringSet {
+                            key: format!("k{index:06}"),
+                            value: vec![118u8; 512],
+                        },
+                        false,
+                    )
+                    .unwrap();
+            }
+            let before = wal_segment_paths(dir.path(), 1).len();
+            let started = std::time::Instant::now();
+            let report = store.gc_before_sequence_unchecked(1, records - 10).unwrap();
+            let micros = started.elapsed().as_secs_f64() * 1e6;
+            let each = if report.dropped_segments > 0 {
+                micros / 1000.0 / report.dropped_segments as f64
+            } else {
+                0.0
+            };
+            // Per-segment is only meaningful once enough pieces are dropped that the one
+            // active-piece rewrite -- a fixed cost, paid whatever the piece count -- is a small
+            // share of the total. Below that it is a fixed cost divided by a small number, which
+            // is how an earlier version of this line made the cost look like it grew 70x with
+            // piece size when the total was flat.
+            let projection = if report.dropped_segments >= 20 {
+                format!("688 would be {:>6.2} s", each * 688.0 / 1000.0)
+            } else {
+                "too few drops to project".to_string()
+            };
+            println!(
+                "  threshold {:>7} KB: {:>4} pieces, dropped {:>4} ({:>9} B), total {:>9.0} us, {:>7.3} ms each, {}",
+                threshold / 1024,
+                before,
+                report.dropped_segments,
+                report.dropped_segment_bytes,
+                micros,
+                each,
+                projection
+            );
+            if report.dropped_segments > 0 {
+                measured += 1;
+            }
+            set_wal_segment_bytes_for_test(None);
+        }
+        assert!(
+            measured > 0,
+            "no threshold produced a rolled log, so nothing here measured a pass"
+        );
     }
 
     #[test]


### PR DESCRIPTION
`drop_covered_wal_segments` stops after `TS_WAL_RECLAIM_MAX_SEGMENTS_PER_PASS` pieces, so the append
lock is not held for a whole backlog.

**64 was the right number for the cost it was set against.** Deciding a piece was droppable meant
decoding it forward — measured at **24.9–72.2 ms per real piece**, so even 64 was 1.6–4.6 s of held
lock, and a full backlog would have been 15–50 s.

That probe is now a single record read from the next piece: **0.354–0.546 ms** on real pieces,
confirmed at **0.339 ms across 43 drops** on a rolled log. The cap was never revisited, so a pass
still stops at 64 and bounds a cost ~50–100x smaller than the one it was written for.

### Why this is restart latency, not disk usage

Pieces arrive faster than 64 per reclaim round, so the backlog grows and the log never drains — the
live store carries **688 sealed pieces** on a six-hourly cadence.

Draining a copy's WAL, on the current shape, page cache dropped before every open:

| open | wall | read | cpu | records |
|---|---|---|---|---|
| full-2 | 5,456 ms | 262.2 MB | 4.1 s | 16,717 |
| **drained-2** | **1,908 ms** | **126.3 MB** | **1.9 s** | 16,717 |

**2.9x.** The same drain bought *nothing* earlier today — I ran it and recorded "restart cost is not
WAL size". That was true of the store as it then was: the page scan dominated so completely that WAL
bytes could not show through. With that scan gone the WAL is 272 MB of the 295 MB a restart reads,
and the result inverts. The earlier finding is shape-dependent, not a law.

### The number

1024 is ~0.23–0.5 s of held lock at the measured rate, and drains a backlog like the live one in a
single pass. It stays a **bound**, not unlimited: a pathological backlog should still be spread over
passes rather than stalling every writer at once. The environment variable still overrides it.

### Tests

The sweep that produced the rate is kept, and it **refuses to project** a backlog cost from a run
with too few drops. An earlier version did project from every row and reported per-piece cost
apparently growing 70x with piece size:

```
  8 KB:  44 pieces, dropped 43, total 21,413 us ->  0.498 ms each
 64 KB:   6 pieces, dropped  5, total 17,547 us ->  3.509 ms each
256 KB:   2 pieces, dropped  1, total 35,720 us -> 35.720 ms each
```

The totals are flat. The data volume is identical in every row, and most of that time is the one
active-piece rewrite — a fixed cost — so dividing it by a small drop count invents a per-piece
number. Left in with the guard rather than deleted, because the flat total is the evidence that
probing no longer dominates a pass.

Suite: **1721 passed, 1 failed** — `storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_flags`,
which fails identically on base.

An earlier run of the same suite showed four additional failures in `client::tests::part1::*`. They
do not appear on base, and they did not reproduce on a second run with this change; another session
was compiling on the box throughout the first run. Recorded here rather than omitted, since they are
in the log: three runs (5 failures / base 2 / 1) place them as load-flaky rather than attributable.
