### PR TITLE
The log files are named for the binary they hold

### DIFF
--- a/crates/temporalstore-rust/src/bin/reclaim_ab.rs
+++ b/crates/temporalstore-rust/src/bin/reclaim_ab.rs
@@ -50,7 +50,7 @@ fn main() {
     }
     let append_ms = started.elapsed().as_secs_f64() * 1000.0;
 
-    let path = dir.join("shard-1.wal.jsonl");
+    let path = dir.join("shard-1.wal.bin");
     let bytes_before = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
 
     // Reclaim the first tenth, which is the shape that matters: a small prefix removed from a

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -1041,7 +1041,7 @@ fn atomic_batch_is_all_or_nothing_when_commit_marker_lost() {
     drop(engine);
 
     // Simulate the lost commit marker: drop the last WAL line (batch_index == batch_size).
-    let wal_path = index_dir.join("wals").join("shard-1.wal.jsonl");
+    let wal_path = index_dir.join("wals").join("shard-1.wal.bin");
     // Read as BYTES and walk the records by their FRAMES, not by newlines. A record is only a
     // "line" while the frame ends with one; once it declares its own length the payload carries
     // 0x0A freely, and splitting on that byte cuts records in half -- which makes this test

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -3956,7 +3956,7 @@ fn corrupt_index_log_delta_refuses_load_rather_than_silently_skipping() {
 
     let index_log_path = index_dir
         .join("indexlogs")
-        .join("shard-1.indexlog.jsonl");
+        .join("shard-1.indexlog.bin");
     let contents = std::fs::read(&index_log_path).unwrap();
     // Walk frames, not newlines: a record's payload may hold a 0x0A, so splitting on one
     // yields fragments rather than records and the corruption below would land nowhere.
@@ -6720,7 +6720,7 @@ fn what_an_index_log_record_costs() {
             });
         }
         // Deliberately NO maintenance: this is the written size, not the retained one.
-        let log = index_dir.join("indexlogs").join("shard-1.indexlog.jsonl");
+        let log = index_dir.join("indexlogs").join("shard-1.indexlog.bin");
         let bytes = std::fs::metadata(&log).map(|m| m.len()).unwrap_or(0);
         let raw = std::fs::read(&log).unwrap_or_default();
         let printable = raw

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -1136,7 +1136,7 @@ fn sync_write_surfaces_wal_commit_failure_instead_of_acking_ok() {
         "baseline write should succeed: {:?}",
         baseline.status
     );
-    let wal_path = indexes.join("wals").join("shard-1.wal.jsonl");
+    let wal_path = indexes.join("wals").join("shard-1.wal.bin");
     fs::remove_file(&wal_path).unwrap();
     fs::create_dir(&wal_path).unwrap();
     let failed = engine.execute(ExecuteRequest {
@@ -3891,7 +3891,7 @@ fn corrupt_wal_scan_refuses_load_rather_than_truncating() {
     }
     drop(engine);
 
-    let wal_path = index_dir.join("wals").join("shard-1.wal.jsonl");
+    let wal_path = index_dir.join("wals").join("shard-1.wal.bin");
     let mut bytes = std::fs::read(&wal_path).unwrap();
     let position = bytes
         .windows(9)
@@ -10492,7 +10492,7 @@ fn a_torn_or_corrupted_tail_never_half_applies() {
             }
         }
 
-        let path = indexes.join("wals").join("shard-1.wal.jsonl");
+        let path = indexes.join("wals").join("shard-1.wal.bin");
         let mut bytes = std::fs::read(&path).expect("the log exists");
         // Trim the preallocated zero run so the edit lands on a record.
         while bytes.last() == Some(&0) {
@@ -11725,7 +11725,7 @@ fn what_eight_records_per_ingest_cost() {
         }
         engine.write_ahead_log_store().flush(1).ok();
         let after = engine.write_ahead_log_store().stats(1);
-        let path = index_dir.join("wals").join("shard-1.wal.jsonl");
+        let path = index_dir.join("wals").join("shard-1.wal.bin");
         let (_, record_end) = crate::wal::last_wal_sequence_in_for_test(&path).unwrap_or((0, 0));
         (
             record_end,

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -1219,8 +1219,31 @@ impl Default for LocalIndexLogStore {
     }
 }
 
+/// The suffix an index log is written with.
+///
+/// Its records are binary -- the same framing the write-ahead log uses, a frame magic then a
+/// payload -- and have been since the log stopped encoding JSON. A store written before this
+/// carries the older name, which claimed a format it no longer held.
+const INDEX_LOG_SUFFIX: &str = "bin";
+
+/// What the same file used to be called. Still read, never written.
+///
+/// Dropping it rather than keeping it would find no index log where one exists, which reads as an
+/// empty log rather than an error -- and an empty index log is a silently emptier shard.
+const LEGACY_INDEX_LOG_SUFFIX: &str = "jsonl";
+
 fn index_log_path(root: &Path, shard_id: ShardId) -> PathBuf {
-    root.join(format!("shard-{shard_id}.indexlog.jsonl"))
+    let renamed = root.join(format!("shard-{shard_id}.indexlog.{INDEX_LOG_SUFFIX}"));
+    if renamed.exists() {
+        return renamed;
+    }
+    // An existing store keeps the name it already has, so one shard's log is never split across
+    // two names. A store with neither is new, and starts under the current one.
+    let legacy = root.join(format!("shard-{shard_id}.indexlog.{LEGACY_INDEX_LOG_SUFFIX}"));
+    if legacy.exists() {
+        return legacy;
+    }
+    renamed
 }
 
 fn last_sequence_at(root: &Path, shard_id: ShardId) -> Result<u64, IndexLogError> {

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -5891,7 +5891,7 @@ mod tests {
         // absent (none was materialized), and a WAL record is corrupt -- so the reload must
         // replay the WAL and must refuse when it cannot.
         clear_engine_cache();
-        let wal_path = root.join("indexes").join("wals").join("shard-1.wal.jsonl");
+        let wal_path = root.join("indexes").join("wals").join("shard-1.wal.bin");
         let contents = std::fs::read(&wal_path).expect("wal exists");
         let mut damaged = b"GARBAGE-NOT-A-FRAMED-RECORD".to_vec();
         damaged.push(b'\n');

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -3,8 +3,9 @@
 
 //! The write-ahead log.
 //!
-//! A shard's log is a sequence of pieces. `shard-{id}.wal.jsonl` is the one being written;
-//! sealed ones are `shard-{id}.wal.{start_log_id:020}.jsonl`, named so they sort into log order.
+//! A shard's log is a sequence of pieces. `shard-{id}.wal.bin` is the one being written;
+//! sealed ones are `shard-{id}.wal.{start_log_id:020}.bin`, named so they sort into log order.
+//! Pieces written before the rename carry a `.jsonl` suffix; both are read, only `.bin` is written.
 //! `TS_WAL_SEGMENT_BYTES` sets when a piece is sealed. It defaults to
 //! [`DEFAULT_WAL_SEGMENT_BYTES`], 256 KiB, so a log ROLLS unless something says
 //! otherwise. Zero is still accepted and still means never seal, which leaves the log a
@@ -2639,8 +2640,32 @@ fn roll_wal_segment_if_due(
     Ok(true)
 }
 
+/// The suffix a piece of the log is written with.
+///
+/// The records inside are binary -- a frame magic, then protobuf -- and have been since the log
+/// stopped encoding JSON. The name said `.jsonl` for long enough that reading a store by eye
+/// suggested a format it had not used for a while.
+const WAL_PIECE_SUFFIX: &str = "bin";
+
+/// What the same piece used to be called. Still read, never written.
+///
+/// A store written before the rename has its pieces under this name, and the live one does. If
+/// this were dropped rather than kept, opening such a store would find no log where a log exists,
+/// which is indistinguishable from an empty log and loses every record in it.
+const LEGACY_WAL_PIECE_SUFFIX: &str = "jsonl";
+
 fn write_ahead_log_path(root: &Path, shard_id: ShardId) -> PathBuf {
-    root.join(format!("shard-{shard_id}.wal.jsonl"))
+    let renamed = root.join(format!("shard-{shard_id}.wal.{WAL_PIECE_SUFFIX}"));
+    if renamed.exists() {
+        return renamed;
+    }
+    // An existing store keeps the name it already has, so a rename never splits one shard's log
+    // across two names. A store that has neither yet is new, and starts under the current one.
+    let legacy = root.join(format!("shard-{shard_id}.wal.{LEGACY_WAL_PIECE_SUFFIX}"));
+    if legacy.exists() {
+        return legacy;
+    }
+    renamed
 }
 
 /// The active piece's path for this shard, built once and kept.
@@ -2674,7 +2699,9 @@ fn active_wal_path(inner: &mut WriteAheadLogInner, shard_id: ShardId) -> std::sy
 ///
 /// Zero-padded so the names sort into log order, which is the order the pieces are read in.
 fn sealed_wal_path(root: &Path, shard_id: ShardId, start_log_id: u64) -> PathBuf {
-    root.join(format!("shard-{shard_id}.wal.{start_log_id:020}.jsonl"))
+    root.join(format!(
+        "shard-{shard_id}.wal.{start_log_id:020}.{WAL_PIECE_SUFFIX}"
+    ))
 }
 
 /// Whether this file is an earlier piece of the given shard's log.
@@ -2683,9 +2710,12 @@ fn sealed_wal_path(root: &Path, shard_id: ShardId, start_log_id: u64) -> PathBuf
 /// section does not parse as a log id.
 fn sealed_wal_start_log_id(path: &Path, shard_id: ShardId) -> Option<u64> {
     let name = path.file_name()?.to_str()?;
-    let middle = name
-        .strip_prefix(&format!("shard-{shard_id}.wal."))?
-        .strip_suffix(".jsonl")?;
+    let middle = name.strip_prefix(&format!("shard-{shard_id}.wal."))?;
+    // Either name is a piece of the log. A store part-way through the rename holds both, and
+    // reading only one of them would silently skip whichever half it did not recognise.
+    let middle = middle
+        .strip_suffix(&format!(".{WAL_PIECE_SUFFIX}"))
+        .or_else(|| middle.strip_suffix(&format!(".{LEGACY_WAL_PIECE_SUFFIX}")))?;
     middle.parse().ok()
 }
 
@@ -4643,7 +4673,7 @@ mod tests {
                     let name = entry.file_name().to_string_lossy().into_owned();
                     name.starts_with("shard-1.wal.")
                         && name.ends_with(".jsonl")
-                        && name != "shard-1.wal.jsonl"
+                        && name != "shard-1.wal.bin"
                 })
                 .count()
         };
@@ -4754,7 +4784,7 @@ mod tests {
                 .flatten()
                 .filter(|entry| {
                     let name = entry.file_name().to_string_lossy().into_owned();
-                    name.contains("wal.") && name != "shard-1.wal.jsonl"
+                    name.contains("wal.") && name != "shard-1.wal.bin"
                 })
                 .count()
         };
@@ -9004,7 +9034,7 @@ mod tests {
             let dir = tempfile::tempdir().unwrap();
             let store = LocalWriteAheadLogStore::new(dir.path());
             append_n(&store, 1, 10);
-            let path = dir.path().join("shard-1.wal.jsonl");
+            let path = dir.path().join("shard-1.wal.bin");
             let physical = path.metadata().unwrap().len();
             let records = store.scan(1, 0, u64::MAX, u64::MAX).unwrap();
             assert_eq!(10, records.len());
@@ -9026,7 +9056,7 @@ mod tests {
             let dir = tempfile::tempdir().unwrap();
             let store = LocalWriteAheadLogStore::new(dir.path());
             append_n(&store, 1, 50);
-            let path = dir.path().join("shard-1.wal.jsonl");
+            let path = dir.path().join("shard-1.wal.bin");
             let physical = path.metadata().unwrap().len();
             // The file was grown to a chunk boundary, not to the records.
             assert_eq!(
@@ -9048,7 +9078,7 @@ mod tests {
             let dir = tempfile::tempdir().unwrap();
             let store = LocalWriteAheadLogStore::new(dir.path());
             append_n(&store, 1, 10);
-            let path = dir.path().join("shard-1.wal.jsonl");
+            let path = dir.path().join("shard-1.wal.bin");
             let physical_before = path.metadata().unwrap().len();
             for _ in 0..5 {
                 let records = store.scan(1, 0, u64::MAX, u64::MAX).unwrap();
@@ -9105,7 +9135,7 @@ mod tests {
                 sequence_end = store.scan(1, 0, u64::MAX, u64::MAX).unwrap().len();
             }
             assert_eq!(5, sequence_end);
-            let path = dir.path().join("shard-1.wal.jsonl");
+            let path = dir.path().join("shard-1.wal.bin");
             // Find where the records stop and plant garbage after it. The last newline answers
             // that only for records delimited by one -- a length-framed payload carries 0x0A of
             // its own, so the search lands inside a record and the garbage would overwrite half
@@ -9158,7 +9188,7 @@ mod tests {
             for entry in fs::read_dir(dir.path()).unwrap() {
                 let path = entry.unwrap().path();
                 let name = path.file_name().unwrap().to_string_lossy().to_string();
-                if name.starts_with("shard-1.wal.") && name.ends_with(".jsonl") && name != "shard-1.wal.jsonl" {
+                if name.starts_with("shard-1.wal.") && name.ends_with(".bin") && name != "shard-1.wal.bin" {
                     sealed += 1;
                     let bytes = fs::read(&path).unwrap();
                     assert!(!bytes.is_empty(), "a sealed piece must hold its records");


### PR DESCRIPTION
Both logs are binary -- a frame magic then a payload -- and both were named `.jsonl`. Reading a store by eye suggested a format neither had used for a while.

The write-ahead log's pieces and the index log are now written `.bin`. A store already on disk keeps the name it has: the reader takes either suffix, and the sealed-piece parser accepts both, so one shard's log is never split across two spellings. Dropping the old name instead would find no log where a log exists, which reads as an empty log rather than an error.

Verified by writing a store, renaming both pieces to the old suffix, and recovering from it: same sequence, same index bytes as the store that kept the new names.

Library suite 1719 passed, 2 failed -- `storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_flags` and `durable_bytes_never_exceed_the_bytes_the_log_holds`, both of which fail on main as well. Recovery suite 8 of 8.