### PR TITLE
The index log derives the key and size it was repeating

### DIFF
--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -219,6 +219,79 @@ impl IndexItem {
     ///
     /// Only what MATCHES is dropped. An address that carries a different object id keeps it, and
     /// `restore_address_repeats` puts back only what is absent, so the pair round-trips.
+    /// Drop the composite key when the record already carries every part of it.
+    ///
+    /// `page_ref_key` is `page_ref_key_from_parts` of this item's own model, object key,
+    /// component and address -- measured at 43 bytes of a 176-byte record, the largest single
+    /// field in the index log, and every byte of it is spelled out again in the fields beside it.
+    /// A reader rebuilds it with the same function, so the log carries the parts and not the
+    /// concatenation.
+    ///
+    /// Cleared only on an exact match. Anything the derivation does not reproduce is written as
+    /// it stands, so a key that is not the composite -- the numeric handle form, for one --
+    /// survives untouched.
+    fn strip_page_ref_key_repeat(&mut self) {
+        let Some(address) = self.address.as_ref() else {
+            return;
+        };
+        let derived = page_ref_key_from_parts(
+            &self.model_id,
+            &self.object_key,
+            self.component.as_deref(),
+            address.block_slab_id,
+            address.offset,
+            address.length,
+            address.page_id().unwrap_or_default(),
+            address.generation().unwrap_or_default(),
+        );
+        if derived == self.page_ref_key {
+            self.page_ref_key.clear();
+        }
+    }
+
+    /// Rebuild the composite key the writer left out.
+    ///
+    /// The inverse of `strip_page_ref_key_repeat`. A log written before that stripping carries the
+    /// key, and this leaves it alone: it fills only what is absent.
+    fn restore_page_ref_key_repeat(&mut self) {
+        if !self.page_ref_key.is_empty() {
+            return;
+        }
+        let Some(address) = self.address.as_ref() else {
+            return;
+        };
+        self.page_ref_key = page_ref_key_from_parts(
+            &self.model_id,
+            &self.object_key,
+            self.component.as_deref(),
+            address.block_slab_id,
+            address.offset,
+            address.length,
+            address.page_id().unwrap_or_default(),
+            address.generation().unwrap_or_default(),
+        );
+    }
+
+    /// Drop the size when the address already states it.
+    ///
+    /// `size` and `address.length` are the same number on a page item, written twice.
+    fn strip_size_repeat(&mut self) {
+        if let Some(address) = self.address.as_ref() {
+            if self.size == address.length {
+                self.size = 0;
+            }
+        }
+    }
+
+    /// Put the size back from the address that carries it.
+    fn restore_size_repeat(&mut self) {
+        if self.size == 0 {
+            if let Some(address) = self.address.as_ref() {
+                self.size = address.length;
+            }
+        }
+    }
+
     fn strip_address_repeats(&mut self) {
         let object_id = self.object_id;
         let routing_bucket = self.routing_bucket;
@@ -805,6 +878,8 @@ impl LocalIndexLogStore {
         // item. `restore_address_repeats` at the decode site puts them back.
         let mut items = items;
         for item in items.iter_mut() {
+            item.strip_page_ref_key_repeat();
+            item.strip_size_repeat();
             item.strip_address_repeats();
         }
         let record = IndexDeltaRecord {
@@ -891,6 +966,8 @@ impl LocalIndexLogStore {
             // written before that stripping carries both already, and this leaves those alone.
             for item in record.items.iter_mut() {
                 item.restore_address_repeats();
+                item.restore_page_ref_key_repeat();
+                item.restore_size_repeat();
             }
             // Enforce delta sequence-continuity: sequences are assigned strictly monotonically
             // across ALL appended records (whole-index and delta share one counter), and GC


### PR DESCRIPTION
The index log wrote a key it could have derived, and a size it already had.

Its records are msgpack, struct-as-map. Priced by bytes on a 10,000-write store, a 176-byte item
spends 43 bytes on `page_ref_key` -- the largest single field in the log -- and every byte of it is
spelled out again in the fields beside it. A real item:

    k  = 'page'
    pk = 'string:sbk-0000000000::0:0:137:0:0'
    ok = 'sbk-0000000000'
    mi = 'string'
    a  = {'ps': 0, 'o': 0, 'l': 137, 'pi': 0, 'g': 0, 'b': 0}
    sz = 137

`pk` is `page_ref_key_from_parts` of that item's own model, object key, component and address; `sz`
is `a.l` written twice. The parts are what the record needs to carry, so it carries them and not the
concatenation as well.

Same shape as the address stripping already in this file: cleared on write, rebuilt on read by the
one function that owns the spelling, so nothing downstream sees a different item. Cleared only on an
exact match -- a `page_ref_key` the derivation does not reproduce, such as the numeric handle form,
is written as it stands -- and restored only when absent, so a log written before this keeps working
and one written after round-trips.

Measured on 10,000 writes of a 78-byte payload:

    index log   189 -> 138 bytes per record   (-27%)
    total       482 -> 431 bytes per record
    written     6.17x -> 5.52x the payload

Two related things measured and NOT done, recorded so they are not re-derived:

Struct-as-array would drop the 28 bytes per record of msgpack field names, and the note above
`encode_index_payload` already rejects it: the array form is positional, which mis-reads a struct
that skipped an absent optional, and the anchor probe pulls fields out of an arbitrary record by
name. Those bytes are paid deliberately.

`object_id` is a 64-bit hash here and stays one. A narrower id would save four bytes and buy
collisions.
