### PR TITLE
The candidate scan filters by status in the engine

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -79,6 +79,14 @@ struct RecordLogRequest {
     shard_size: Option<u64>,
     #[serde(default)]
     record_types: Option<Vec<String>>,
+    /// Keep only records whose `status` is one of these, when the caller supplies any.
+    ///
+    /// A consumer that acts on a narrow set of statuses -- the pre-retrieval idle-commit flush reads
+    /// three of the seven a pipeline task can carry -- otherwise receives every row of the type and
+    /// discards most of them after they have been decoded. Absent or empty means no status
+    /// filtering, so a caller that wants the whole type is unaffected.
+    #[serde(default)]
+    record_statuses: Option<Vec<String>>,
     /// Cap the scan to the newest N locations of a given record type, by append order.
     ///
     /// For a consumer that only ever looks at the tail of a type -- prior context reads the newest
@@ -1101,6 +1109,10 @@ fn matrixark_scan_cache_key(command: &RecordLogRequest, count: u64) -> String {
         "shard_size": command.shard_size.unwrap_or(1024).max(1),
         "count": count,
         "record_types": command.record_types,
+        // A status-filtered scan is a SUBSET of the same question, exactly like
+        // `newest_by_type` below -- sharing an entry would serve the subset to a
+        // caller that asked for the whole type.
+        "record_statuses": command.record_statuses,
         "record_ids": command.record_ids,
         "selected_node_hashes": command.selected_node_hashes,
         "secondary_index_groups": command.secondary_index_groups,
@@ -2068,6 +2080,12 @@ fn scan_matrixark_candidates(
         .unwrap_or_default()
         .into_iter()
         .collect();
+    let allowed_statuses: HashSet<String> = command
+        .record_statuses
+        .clone()
+        .unwrap_or_default()
+        .into_iter()
+        .collect();
     let selected_nodes: HashSet<u64> = command
         .selected_node_hashes
         .clone()
@@ -2083,6 +2101,7 @@ fn scan_matrixark_candidates(
     let mut placement_partitions_touched = if count == 0 { 0 } else { max_shard + 1 };
     let mut scanned_records = 0_u64;
     let mut dropped_by_type = 0_u64;
+    let mut dropped_by_status = 0_u64;
     let mut dropped_by_scope = 0_u64;
     let mut selected_node_dropped = 0_u64;
     // Collect payloads first -- from the type index when it can answer, from the shard walk
@@ -2184,6 +2203,16 @@ fn scan_matrixark_candidates(
                 if !allowed_types.is_empty() && !allowed_types.contains(record_type) {
                     dropped_by_type += 1;
                     continue;
+                }
+                if !allowed_statuses.is_empty() {
+                    let record_status = record
+                        .get("status")
+                        .and_then(Value::as_str)
+                        .unwrap_or("");
+                    if !allowed_statuses.contains(record_status) {
+                        dropped_by_status += 1;
+                        continue;
+                    }
                 }
                 if !requested_id_set.is_empty() && !record_id_linked(&record, &requested_id_set) {
                     dropped_by_scope += 1; // id-filtered, counted with scope drops
@@ -2331,6 +2360,7 @@ fn scan_matrixark_candidates(
             "non_serving_record_dropped_count": non_serving_dropped,
             "return_index_records": command.return_index_records,
             "dropped_by_type": dropped_by_type,
+            "dropped_by_status": dropped_by_status,
             "dropped_by_scope": dropped_by_scope,
             "selected_node_dropped_candidate_count": selected_node_dropped,
             "secondary_index_groups_supplied": secondary_groups.len(),
@@ -5481,6 +5511,73 @@ fn _request_shape_for_docs() -> serde_json::Value {
 #[cfg(test)]
 mod tests {
     use super::compare_scored_candidate;
+    use super::{matrixark_scan_cache_key, RecordLogRequest};
+
+    /// A scan request, built from the module's own helper.
+    ///
+    /// Building one from bare JSON does not work: `RecordLogRequest` has required fields and serde
+    /// will not invent them -- the first version of this failed with `missing field op`.
+    fn scan_command(statuses: Option<Vec<String>>) -> RecordLogRequest {
+        let mut command = request("matrixark_scan_candidates");
+        command.count_key = Some("matrixark:count".to_string());
+        command.record_hash_key = Some("matrixark:records".to_string());
+        command.shard_size = Some(1024);
+        command.record_types = Some(vec!["matrixark_async_pipeline_task".to_string()]);
+        command.record_statuses = statuses;
+        command
+    }
+
+    /// A status-filtered scan answers a SUBSET of the same question. If it shared a cache entry
+    /// with an unfiltered scan, a caller asking for the whole record type would be served the
+    /// subset -- and both are valid-looking results, so nothing would error.
+    #[test]
+    fn a_status_filtered_scan_does_not_share_a_cache_entry() {
+        let unfiltered = scan_command(None);
+        let filtered = scan_command(Some(vec!["idle_commit_scheduled".to_string()]));
+
+        // Control first: without it, an assert_ne that always holds would look like proof.
+        assert_eq!(
+            matrixark_scan_cache_key(&unfiltered, 7),
+            matrixark_scan_cache_key(&unfiltered, 7),
+            "the same command produced two different keys, so the comparison below means nothing"
+        );
+
+        assert_ne!(
+            matrixark_scan_cache_key(&unfiltered, 7),
+            matrixark_scan_cache_key(&filtered, 7),
+            "a status-filtered scan shares a cache entry with an unfiltered one"
+        );
+    }
+
+    /// Two different status sets are two different questions.
+    #[test]
+    fn two_status_sets_do_not_share_a_cache_entry() {
+        let scheduled = scan_command(Some(vec!["idle_commit_scheduled".to_string()]));
+        let committed = scan_command(Some(vec!["idle_commit_committed".to_string()]));
+        assert_ne!(
+            matrixark_scan_cache_key(&scheduled, 7),
+            matrixark_scan_cache_key(&committed, 7),
+            "two different status filters share one cache entry"
+        );
+    }
+
+    /// Absent means no filtering. This is what lets every existing caller keep its behaviour, and
+    /// what lets an older caller talk to a newer engine unchanged.
+    #[test]
+    fn an_absent_status_filter_is_not_an_empty_one() {
+        let absent = scan_command(None);
+        assert!(
+            absent.record_statuses.is_none(),
+            "an absent record_statuses decoded as something other than None, so the scan would \
+             filter when the caller asked for no filtering"
+        );
+        let empty = scan_command(Some(Vec::new()));
+        assert_eq!(
+            Some(Vec::<String>::new()),
+            empty.record_statuses,
+            "an explicitly empty list should decode as empty, and the scan treats it as no filter"
+        );
+    }
 
     use super::native_correctness_evidence;
 
@@ -5768,6 +5865,8 @@ mod tests {
             record_hash_key: None,
             shard_size: None,
             record_types: None,
+            // No status filtering: this helper builds the request every other test starts from.
+            record_statuses: None,
             newest_by_type: None,
             selected_node_hashes: None,
             secondary_index_groups: None,

--- a/tools/matrixark_mcp_rust_proxy_client.py
+++ b/tools/matrixark_mcp_rust_proxy_client.py
@@ -675,12 +675,18 @@ class MatrixArkRustProxyClient(MatrixArkRustProxyCacheMixin):
         record_ids: list[str] | None = None,
         return_index_records: bool = False,
         newest_by_type: Json | None = None,
+        record_statuses: list[str] | None = None,
     ) -> Json:
         extra: Json = {}
         if record_ids:
             extra["record_ids"] = [str(item) for item in record_ids]
         if return_index_records:
             extra["return_index_records"] = True
+        # Keep only these statuses, in the engine. Sent only when asked for, so a request that
+        # does not carry it is byte-identical to before -- and the engine treats absent as "no
+        # status filtering", so an older engine ignores it rather than returning nothing.
+        if record_statuses:
+            extra["record_statuses"] = sorted({str(status) for status in record_statuses})
         # Cap the scan to the newest N locations of a named type. Sent only when asked for, so a
         # request that does not carry it is byte-identical to before.
         if newest_by_type:

--- a/tools/matrixark_temporal_direct_read.py
+++ b/tools/matrixark_temporal_direct_read.py
@@ -348,6 +348,7 @@ class _TemporalDirectReadMixin:
         record_types: set[str],
         secondary_index_groups: list[set[str]] | None,
         selected_node_hashes: set[int] | None,
+        record_statuses: set[str] | None = None,
     ) -> Json | None:
         scanner = getattr(getattr(self, "_client", None), "matrixark_scan_candidates", None)
         if not callable(scanner):
@@ -361,6 +362,7 @@ class _TemporalDirectReadMixin:
                 record_types=sorted(record_types),
                 secondary_index_groups=[sorted(group) for group in (secondary_index_groups or [])],
                 selected_node_hashes=sorted(int(item) for item in (selected_node_hashes or set())),
+                record_statuses=sorted(record_statuses) if record_statuses else None,
             )
         except Exception as exc:
             if native_candidate_prefilter_required(backend_label=self._backend_label()) and not getattr(self, "_native_context_pack_fallback_active", False):
@@ -404,11 +406,21 @@ class _TemporalDirectReadMixin:
 
     def idle_commit_task_records(self, scope: Json) -> list[Json]:
         """Read only scheduled idle-commit tasks without broad Python materialization."""
+        try:  # package path
+            from tools.matrixark_mcp_retrieve_request import IDLE_COMMIT_ACTED_ON_STATUSES
+        except ImportError:  # Direct script execution from tools/.
+            from matrixark_mcp_retrieve_request import IDLE_COMMIT_ACTED_ON_STATUSES
+
+        # Ask the engine for only the statuses this method's consumers read. Every one of them was
+        # checked: the flush reads the resolved set and "idle_commit_scheduled"; the stream
+        # materializer does not look at the rows; the drain reads "idle_commit_scheduled" and
+        # "idle_commit_committed". Their union is exactly this set.
         result = self._native_candidate_scan(
             scope=scope,
             record_types={"matrixark_async_pipeline_task"},
             secondary_index_groups=None,
             selected_node_hashes=None,
+            record_statuses=set(IDLE_COMMIT_ACTED_ON_STATUSES),
         )
         if not isinstance(result, dict):
             return []


### PR DESCRIPTION
The candidate scan filtered on `record_types` and handed every matching row back; Python then
dropped the ones its callers could not act on. On a real store that is **572 pipeline-task rows
returned to use 89** — the other 483 cross the boundary, get decoded into Python dictionaries, and
are discarded. Once per retrieve, growing with the number of ingests the store has ever taken.

This moves that predicate into the engine.

## The change

| layer | change |
|---|---|
| `matrixark_rust_proxy_impl.rs` | optional `record_statuses` on the scan command, applied in the same per-record loop as the type filter, with its own `dropped_by_status` stat |
| the scan cache key | carries `record_statuses` |
| `matrixark_mcp_rust_proxy_client` | forwards it, only when supplied |
| `_native_candidate_scan` | accepts and forwards it, defaulting to `None` |
| `idle_commit_task_records` | asks for only the statuses its consumers read |

## Absent means no filtering, checked at the right boundary

The claim "a request without the filter is byte-identical to before" is about the request handed to
the **engine**, so that is where it was measured — the real client with its transport stubbed:

| case | reaches the engine |
|---|---|
| no filter supplied | no |
| explicitly `None` | no |
| explicitly empty | no |
| supplied | yes, deduped and sorted |

A first attempt stubbed the client *method* instead and reported the filter as "sent" for an
explicit `None` — one layer too early, and it would have made this claim look false.

## The cache key is the part that could go wrong quietly

A status-filtered scan answers a *subset* of the same question. Sharing a cache entry with an
unfiltered scan would serve that subset to a caller asking for the whole record type — both are
valid-looking results, so nothing would error. Same reasoning the `newest_by_type` cap already
carries.

Three tests cover it: filtered and unfiltered must not share an entry, two different status sets
must not share one, and an absent field must decode as `None` rather than an empty filter. The first
carries a same-command control *before* its `assert_ne`, because an assertion that always held would
otherwise read as proof.

## Every consumer was read, not assumed

Narrowing a shared method is what I declined to do when this was first measured, so each consumer of
`idle_commit_task_records` was checked:

| consumer | statuses it reads |
|---|---|
| `pre_retrieval_idle_commit_flush` | `IDLE_COMMIT_RESOLVED_STATUSES` + `idle_commit_scheduled` |
| `matrixark_mcp_stream_materialize` | none — it checks the method exists, then calls the flush per scope |
| `drain_due_idle_session_commits` | `idle_commit_scheduled`, `idle_commit_committed` |

Their union is exactly `IDLE_COMMIT_ACTED_ON_STATUSES`. The drain also compares against `"accepted"`
and `"committed"`, which read like two more statuses and are not: both come from
`result.get("status")` — the commit *result*, not a record. Verified at the call site, because that
same false positive had already tripped a guard in this work.

`IDLE_COMMIT_ACTED_ON_STATUSES` is imported **inside** the method. At module level it would add an
edge from the direct reader to the retrieve request, and this tree has already had a cycle closed
that way — five modules failing with `cannot import name … from partially initialized module`.

## What the checks caught

`cargo check -p temporalstore-rust --lib --bins` passed. It was not sufficient, twice over:

* **It does not compile test code.** A test helper builds `RecordLogRequest` as a struct literal, so
  the new field broke the test build with `missing field record_statuses` — invisible to `check`.
* **`cargo test --lib` reported `ok. 0 passed … 1793 filtered out`, exit 0.** This file is compiled
  through `src/bin/../`, so the lib test binary does not contain it and the new tests never ran. The
  `running 0 tests` line is the only thing that gave it away; the exit code did not.

Both are why the gate here is `cargo test --bins`, not `cargo check`.
