### PR TITLE
A known model is written as its number

### DIFF
--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -160,7 +160,13 @@ pub struct IndexItem {
     pub page_ref_key: String,
     #[serde(rename = "ok", alias = "object_key", default)]
     pub object_key: String,
-    #[serde(rename = "mi", alias = "model_id", default)]
+    #[serde(
+        rename = "mi",
+        alias = "model_id",
+        default,
+        serialize_with = "model_id_as_number_when_it_is_known",
+        deserialize_with = "model_id_either_shape"
+    )]
     pub model_id: String,
     #[serde(rename = "c", alias = "component", default, skip_serializing_if = "Option::is_none")]
     pub component: Option<String>,
@@ -322,6 +328,85 @@ impl IndexItem {
             }
         }
     }
+}
+
+/// The model names this log writes as a number instead of as themselves.
+///
+/// A page header in this design spells the model as an integer; ours spelled it as its name, on
+/// every item -- "string" and "hash" written out again for every page a shard has ever indexed,
+/// measured at 7 bytes of a 176-byte item.
+///
+/// APPEND ONLY, and never reordered. The position IS what goes on disk, so moving a name changes
+/// what an already-written log says. A name that is not in this table is written as itself, so the
+/// table never has to be complete and a new model costs nothing until it is added here.
+const MODEL_ID_NUMBERS: &[&str] = &[
+    "string",
+    "hash",
+    "set",
+    "feature",
+    "sequence",
+    "control_state",
+    "context_node",
+    "context_event",
+    "context_index",
+    "context_audit",
+    "context_child",
+    "context_embedding",
+    "context_summary",
+    "context_compression",
+    "context_entity",
+];
+
+fn model_id_as_number_when_it_is_known<S>(value: &str, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    match MODEL_ID_NUMBERS.iter().position(|name| *name == value) {
+        Some(index) => serializer.serialize_u64(index as u64),
+        None => serializer.serialize_str(value),
+    }
+}
+
+fn model_id_either_shape<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct EitherShape;
+
+    impl serde::de::Visitor<'_> for EitherShape {
+        type Value = String;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a model, as its name or as its number")
+        }
+
+        fn visit_str<E: serde::de::Error>(self, value: &str) -> Result<String, E> {
+            Ok(value.to_string())
+        }
+
+        fn visit_string<E: serde::de::Error>(self, value: String) -> Result<String, E> {
+            Ok(value)
+        }
+
+        fn visit_u64<E: serde::de::Error>(self, value: u64) -> Result<String, E> {
+            // A number this table cannot name is refused rather than guessed. Answering the wrong
+            // model would file a page under a model that did not write it, which reads as missing
+            // data for one model and foreign data for another.
+            MODEL_ID_NUMBERS
+                .get(value as usize)
+                .map(|name| (*name).to_string())
+                .ok_or_else(|| E::custom(format!("unknown model number {value}")))
+        }
+
+        fn visit_i64<E: serde::de::Error>(self, value: i64) -> Result<String, E> {
+            if value < 0 {
+                return Err(E::custom(format!("negative model number {value}")));
+            }
+            self.visit_u64(value as u64)
+        }
+    }
+
+    deserializer.deserialize_any(EitherShape)
 }
 
 fn page_ref_key_as_number_when_it_is_one<S>(value: &str, serializer: S) -> Result<S::Ok, S::Error>


### PR DESCRIPTION
The index log spelled the model out on every item.

A page header in this design carries the model as an integer. Ours carried its name -- `"string"`,
`"hash"` -- once per index item, which on a 10,000-write store is 7 bytes of a 176-byte item spent
writing the same handful of words over and over.

The write-ahead log already settled this. `wal_proto` keeps a `KIND_CODES` table and its note says
it plainly: a known kind travels as a code, anything else keeps its name. The index log now does the
same for the model, with the same shape the page handle beside it already uses -- a number when the
value is one, the value itself otherwise, and a decoder that takes either.

The table is APPEND ONLY and must never be reordered, because the position is what lands on disk:
moving a name changes what an already-written log says. A model that is not in the table is written
as itself, so the table never has to be complete, and a new model costs nothing until someone adds
it. A number the table cannot name is refused rather than guessed -- answering the wrong model would
file a page under a model that never wrote it, which reads as missing data for one model and
foreign data for another.

Measured on 10,000 writes of a 78-byte payload:

    index log   138 -> 131 bytes per record
    total       431 -> 424 bytes per record
    written     5.52x -> 5.43x the payload

Together with the derivation that landed before it, the index log has gone 189 -> 131 bytes per
record, and the store writes 6.17x -> 5.43x its payload.

Library suite 1719 passed, 3 failed -- `storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_flags`,
`emptied_buckets_are_dropped_without_walking_the_map` and `durable_bytes_never_exceed_the_bytes_the_log_holds`,
all three of which fail on main as well. Recovery suite 8 of 8.
