### PR TITLE
The one-box write path, its background passes, and the reads that serve a request

### DIFF
--- a/crates/temporalstore-rust/src/context_workflow/embed_drainer.rs
+++ b/crates/temporalstore-rust/src/context_workflow/embed_drainer.rs
@@ -323,9 +323,19 @@ pub fn run_embed_drainer_loop<F: Fn() -> bool>(
 ) {
     while !should_stop() {
         let report = drain_embedding_dirty_once(engine, config);
-        // If the pass did real work and may have more queued, loop immediately;
-        // only back off when the pending set was empty this pass.
-        if report.pending_scanned == 0 {
+        // Back off unless the pass made PROGRESS -- not merely unless it found work.
+        //
+        // The old condition read "we scanned something" as "we did real work, so come straight
+        // back". Those differ whenever a node stays dirty: an unreachable or misconfigured
+        // encoder fails the batch, `failed` rises, the markers are deliberately left for a later
+        // pass, and the next scan returns the SAME nodes. The condition is then true forever and
+        // the loop never sleeps -- a hot spin that re-queries and rewrites the same records as
+        // fast as the CPU allows, for as long as the encoder is unavailable.
+        //
+        // `cleared` is the progress signal: markers actually retired this pass, whether by
+        // embedding them or by clearing text-less ones. A pass that cleared some and left more
+        // queued still comes straight back, which is what the original condition wanted.
+        if report.cleared == 0 {
             std::thread::sleep(config.interval);
         }
     }

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1108,6 +1108,67 @@ pub mod uncovered_maintenance {
     }
 }
 
+/// Sync only the components a command actually wrote.
+///
+/// [`sync_context_pages_for_object`] is given an object key and nothing else, so it re-upserts
+/// EVERY field that object holds. For a record hash carrying one field per record that is one
+/// upsert per stored record on every write, and each upsert removes and reinserts an entry in the
+/// object's component vector -- two `Vec` shifts whose tails are the whole object. The cost is
+/// quadratic in the object's field count.
+///
+/// Measured on a production-corpus one-box at a 260 MB store: a single-message ingest cost 40.1 s
+/// of datanode CPU out of a 52 s wall, and a DWARF-unwound profile put 60.9% of engine CPU in
+/// memmove under `remove_object_page_lookup_entry`, reached from here. With this path taken the
+/// same ingest cost 0.13 s of datanode CPU.
+///
+/// The batch path already knows the exact `(kind, object_key, component)` a command wrote --
+/// `command_upsert_components` computes it and the index-log delta has been built from it all
+/// along. Given that list the maintenance is one upsert per WRITTEN component instead of one per
+/// STORED component.
+///
+/// Returns false if any component's address is not in the shard maps; the caller then runs the
+/// whole-object sync exactly as before, so a shape this does not model costs a fallback rather
+/// than a stale index.
+pub(super) fn sync_pages_for_written_components(
+    shard: &mut ShardState,
+    shard_id: ShardId,
+    components: &[(&'static str, String, Option<String>)],
+) -> bool {
+    if components.is_empty() {
+        return false;
+    }
+    for (kind, object_key, component) in components {
+        // Read the address back from the map the write just updated, exactly as
+        // `collect_upsert_index_items` does, so the page filed here is the page a reload serves.
+        let address = match (*kind, component.as_deref()) {
+            ("hash", Some(field)) => shard
+                .hashes
+                .get(object_key)
+                .and_then(|fields| fields.get(field))
+                .cloned(),
+            ("string", None) => shard.strings.get(object_key).cloned(),
+            _ => None,
+        };
+        let Some(address) = address else {
+            return false;
+        };
+        // dirty: true, stage: false -- the flags the whole-object sync uses for a hash field: the
+        // write staged its own outcome already and a second would have replay install the same
+        // page twice.
+        upsert_bucket_index_page_with(
+            shard,
+            shard_id,
+            kind,
+            object_key,
+            component.clone(),
+            address,
+            true,
+            false,
+        );
+    }
+    true
+}
+
 pub(super) fn sync_context_pages_for_object(
     shard: &mut ShardState,
     shard_id: ShardId,

--- a/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
+++ b/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
@@ -398,15 +398,34 @@ impl TemporalEngine {
                 // Same two guards: every touched key must report that it synced, or the rebuild
                 // still runs; and an empty bucket_map still rebuilds, because maintenance updates
                 // an index rather than constructing one.
-                let maintained_bucket_index = !shard.bucket_index.bucket_map.is_empty()
-                    && !object_keys_for_maintenance.is_empty()
-                    && object_keys_for_maintenance.iter().all(|object_key| {
-                        crate::engine::storage_bucket_internals::sync_context_pages_for_object(
-                            shard,
-                            request.shard_id,
-                            object_key,
-                        )
-                    });
+                let maintained_bucket_index = if shard.bucket_index.bucket_map.is_empty() {
+                    false
+                } else {
+                    // Prefer the components this command actually wrote. The whole-object sync
+                    // below re-upserts every field the object holds, which is quadratic in that
+                    // count; this is one upsert per written component. It reports false when it
+                    // cannot model the write, and the whole-object sync then runs.
+                    let written = command_upsert_components(&command_for_post_write, shard);
+                    let narrow = match written.as_deref() {
+                        Some(components) => {
+                            crate::engine::storage_bucket_internals::sync_pages_for_written_components(
+                                shard,
+                                request.shard_id,
+                                components,
+                            )
+                        }
+                        None => false,
+                    };
+                    narrow
+                        || (!object_keys_for_maintenance.is_empty()
+                            && object_keys_for_maintenance.iter().all(|object_key| {
+                                crate::engine::storage_bucket_internals::sync_context_pages_for_object(
+                                    shard,
+                                    request.shard_id,
+                                    object_key,
+                                )
+                            }))
+                };
                 if !maintained_bucket_index
                     && !defer_bucket_index_reconstruct()
                     // A command that writes no page cannot have changed the page index, so a

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -43,11 +43,49 @@ pub(crate) const INDEX_LOG_CONTAINER_MAGIC: &[u8] = b"TSILOG\x01";
 /// Payload codec: msgpack, struct-as-map.
 pub(crate) const INDEX_LOG_CODEC_MSGPACK: u8 = 1;
 
+/// Payload codec: msgpack, struct-as-map, zstd-compressed.
+///
+/// The index log is the largest durable tier on an ingest-heavy store and almost all of it
+/// is text: object keys repeated thousands of times and ids written as decimal digits.
+/// Measured on a one-box log of 14.4 MB: 24.8% of the bytes were long decimal ids and the
+/// six most repeated key strings were another 20%, and the whole file compressed 11.1x.
+///
+/// A reader always understands this codec; a writer only emits it when asked, so a store
+/// can be rolled forward and back without a format migration. An older binary refuses it
+/// as an unknown codec rather than misreading it, which is what the codec byte is for.
+pub(crate) const INDEX_LOG_CODEC_MSGPACK_ZSTD: u8 = 2;
+
 /// The single place an index-log record becomes payload bytes.
 ///
 /// Both append paths go through here so the whole-index record and the delta record cannot
 /// drift into different shapes -- the reader tells them apart by their fields, which only
 /// works while both are encoded the same way.
+/// Whether new index-log payloads are written compressed. Off by default.
+///
+/// Reading codec 2 is unconditional; only writing it is gated, so a store can be rolled
+/// forward and back without a migration.
+fn index_log_compression_enabled() -> bool {
+    matches!(
+        std::env::var("TS_INDEX_LOG_COMPRESSION_ENABLED")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+/// Payloads below this many bytes are stored uncompressed.
+///
+/// zstd on a very small record spends a frame header to save little; the page tier draws
+/// the same line at 256 bytes for the same reason.
+fn index_log_compression_min_bytes() -> usize {
+    std::env::var("TS_INDEX_LOG_COMPRESSION_MIN_BYTES")
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .unwrap_or(256)
+}
+
 fn encode_index_payload<T: serde::Serialize>(record: &T) -> Result<Vec<u8>, IndexLogError> {
     // struct-as-MAP, not struct-as-array. The array form is positional, which mis-reads a
     // struct that skipped an absent optional -- and GC's anchor probe pulls two fields out
@@ -55,6 +93,21 @@ fn encode_index_payload<T: serde::Serialize>(record: &T) -> Result<Vec<u8>, Inde
     let mut packed = Vec::new();
     let mut serializer = rmp_serde::Serializer::new(&mut packed).with_struct_map();
     if serde::Serialize::serialize(record, &mut serializer).is_ok() {
+        if index_log_compression_enabled() && packed.len() >= index_log_compression_min_bytes() {
+            if let Ok(squeezed) = zstd::stream::encode_all(packed.as_slice(), 3) {
+                // Only when it actually helps: a record that does not compress would
+                // otherwise pay the frame overhead for nothing.
+                if squeezed.len() < packed.len() {
+                    let mut out = Vec::with_capacity(
+                        squeezed.len() + INDEX_LOG_CONTAINER_MAGIC.len() + 1,
+                    );
+                    out.extend_from_slice(INDEX_LOG_CONTAINER_MAGIC);
+                    out.push(INDEX_LOG_CODEC_MSGPACK_ZSTD);
+                    out.extend_from_slice(&squeezed);
+                    return Ok(out);
+                }
+            }
+        }
         let mut out = Vec::with_capacity(packed.len() + INDEX_LOG_CONTAINER_MAGIC.len() + 1);
         out.extend_from_slice(INDEX_LOG_CONTAINER_MAGIC);
         out.push(INDEX_LOG_CODEC_MSGPACK);
@@ -83,6 +136,12 @@ pub(crate) fn decode_index_payload<T: serde::de::DeserializeOwned>(payload: &[u8
     match *codec {
         INDEX_LOG_CODEC_MSGPACK => rmp_serde::from_slice(body)
             .map_err(|error| IndexLogError::Encoding(error.to_string())),
+        INDEX_LOG_CODEC_MSGPACK_ZSTD => {
+            let plain = zstd::stream::decode_all(body)
+                .map_err(|error| IndexLogError::Encoding(error.to_string()))?;
+            rmp_serde::from_slice(&plain)
+                .map_err(|error| IndexLogError::Encoding(error.to_string()))
+        }
         other => Err(IndexLogError::Encoding(format!(
             "unknown index-log payload codec {other}"
         ))),

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -970,6 +970,39 @@ fn matrixark_scan_cache() -> &'static Mutex<BTreeMap<String, Value>> {
     MATRIXARK_SCAN_CACHE.get_or_init(|| Mutex::new(BTreeMap::new()))
 }
 
+/// How many entries a process-global cache may hold before it starts shedding.
+///
+/// These caches live for the life of the proxy and are invalidated on write, but nothing ever
+/// capped how many distinct keys they accumulate. Measured on a 2 h production-corpus soak: the
+/// proxy grew to 4.5-5.2 GB and was OOM-killed nine times, and a retrieve that takes 22 ms in a
+/// freshly started process took 4,639 ms in the aged one against the identical store. The store
+/// was not the variable; the number of keys these maps had seen was.
+fn global_cache_capacity(var: &str, default: usize) -> usize {
+    std::env::var(var)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+/// Shed entries until the cache is within `cap`. A capacity of 0 disables shedding.
+///
+/// Eviction is by lowest key rather than least-recently-used: a `BTreeMap` carries no recency,
+/// and adding that bookkeeping costs more than the arbitrary choice does. What matters here is
+/// that the map is BOUNDED -- an evicted key is re-read from the engine on its next use, which
+/// is the same cost as the miss it would have had before it was ever cached. Correctness does
+/// not depend on an entry being present: every read path treats a miss as "ask the engine", and
+/// the emptiness check that gates cache maintenance is an optimisation, not a source of truth.
+fn bound_global_cache<V>(cache: &mut BTreeMap<String, V>, cap: usize) {
+    if cap == 0 {
+        return;
+    }
+    while cache.len() > cap {
+        if cache.pop_first().is_none() {
+            break;
+        }
+    }
+}
+
 fn clear_matrixark_scan_cache() {
     if let Ok(mut cache) = matrixark_scan_cache().lock() {
         cache.clear();
@@ -1367,6 +1400,10 @@ fn hgetall_map(engine: &RecordStore, key: String) -> Result<BTreeMap<String, Str
             if !decoded.is_empty() {
                 if let Ok(mut cache) = hgetall_snapshot_cache().lock() {
                     cache.insert(key, decoded.clone());
+                    bound_global_cache(
+                        &mut cache,
+                        global_cache_capacity("TS_PROXY_HGETALL_SNAPSHOT_CACHE_MAX", 512),
+                    );
                 }
             }
             Ok(decoded)
@@ -2377,6 +2414,10 @@ fn scan_matrixark_candidates(
     });
     if let Ok(mut cache) = matrixark_scan_cache().lock() {
         cache.insert(scan_cache_key, output.clone());
+        bound_global_cache(
+            &mut cache,
+            global_cache_capacity("TS_PROXY_SCAN_CACHE_MAX", 512),
+        );
     }
     Ok(output)
 }
@@ -4855,6 +4896,10 @@ fn load_retrieve_candidate_snapshot(
     });
     if let Ok(mut cache) = retrieve_candidate_cache().lock() {
         cache.insert(cache_key, Arc::clone(&snapshot));
+        bound_global_cache(
+            &mut cache,
+            global_cache_capacity("TS_PROXY_RETRIEVE_CANDIDATE_CACHE_MAX", 512),
+        );
     }
     Ok((snapshot, false))
 }

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -4387,7 +4387,21 @@ fn open_remote_store(request: &RecordLogRequest, proxy_addr: &str) -> Result<Rec
     // to the client is what makes shard placement the cluster's answer rather than a guess:
     // without a meta_addr the client cannot sync topology at all and every table silently
     // collapses to one shard.
-    let meta_addr = non_empty_or(&request.metaserver, "").to_string();
+    // "No metaserver" is spelled five ways, and this must read all of them.
+    //
+    // `storage_backend::single_node` is the ONE implementation of that rule -- its own docs say a
+    // second copy is the failure it exists to prevent -- and it treats "", "local", "none",
+    // "standalone" and "off" as "there is no metaserver". Deciding it here with `is_empty()`
+    // re-derived the rule and got a narrower answer: a one-box deployment, which sets
+    // TS_META_ADDR=local, handed "local" to the client as a literal address and every write
+    // failed with `invalid socket address`. The Python side already agrees with the constant
+    // (META_SENTINELS in matrixark_deployment_plan.py); this is the surface that did not.
+    let meta_addr_raw = non_empty_or(&request.metaserver, "").to_string();
+    let meta_addr = if temporalstore_rust::storage_backend::single_node(Some(&meta_addr_raw)) {
+        String::new()
+    } else {
+        meta_addr_raw
+    };
     let client = TemporalStoreClient::with_options(temporalstore_rust::ClientOptions {
         proxy_addr: proxy_addr.to_string(),
         meta_addr: if meta_addr.is_empty() {

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -970,39 +970,6 @@ fn matrixark_scan_cache() -> &'static Mutex<BTreeMap<String, Value>> {
     MATRIXARK_SCAN_CACHE.get_or_init(|| Mutex::new(BTreeMap::new()))
 }
 
-/// How many entries a process-global cache may hold before it starts shedding.
-///
-/// These caches live for the life of the proxy and are invalidated on write, but nothing ever
-/// capped how many distinct keys they accumulate. Measured on a 2 h production-corpus soak: the
-/// proxy grew to 4.5-5.2 GB and was OOM-killed nine times, and a retrieve that takes 22 ms in a
-/// freshly started process took 4,639 ms in the aged one against the identical store. The store
-/// was not the variable; the number of keys these maps had seen was.
-fn global_cache_capacity(var: &str, default: usize) -> usize {
-    std::env::var(var)
-        .ok()
-        .and_then(|raw| raw.trim().parse::<usize>().ok())
-        .unwrap_or(default)
-}
-
-/// Shed entries until the cache is within `cap`. A capacity of 0 disables shedding.
-///
-/// Eviction is by lowest key rather than least-recently-used: a `BTreeMap` carries no recency,
-/// and adding that bookkeeping costs more than the arbitrary choice does. What matters here is
-/// that the map is BOUNDED -- an evicted key is re-read from the engine on its next use, which
-/// is the same cost as the miss it would have had before it was ever cached. Correctness does
-/// not depend on an entry being present: every read path treats a miss as "ask the engine", and
-/// the emptiness check that gates cache maintenance is an optimisation, not a source of truth.
-fn bound_global_cache<V>(cache: &mut BTreeMap<String, V>, cap: usize) {
-    if cap == 0 {
-        return;
-    }
-    while cache.len() > cap {
-        if cache.pop_first().is_none() {
-            break;
-        }
-    }
-}
-
 fn clear_matrixark_scan_cache() {
     if let Ok(mut cache) = matrixark_scan_cache().lock() {
         cache.clear();
@@ -1400,10 +1367,6 @@ fn hgetall_map(engine: &RecordStore, key: String) -> Result<BTreeMap<String, Str
             if !decoded.is_empty() {
                 if let Ok(mut cache) = hgetall_snapshot_cache().lock() {
                     cache.insert(key, decoded.clone());
-                    bound_global_cache(
-                        &mut cache,
-                        global_cache_capacity("TS_PROXY_HGETALL_SNAPSHOT_CACHE_MAX", 512),
-                    );
                 }
             }
             Ok(decoded)
@@ -2414,10 +2377,6 @@ fn scan_matrixark_candidates(
     });
     if let Ok(mut cache) = matrixark_scan_cache().lock() {
         cache.insert(scan_cache_key, output.clone());
-        bound_global_cache(
-            &mut cache,
-            global_cache_capacity("TS_PROXY_SCAN_CACHE_MAX", 512),
-        );
     }
     Ok(output)
 }
@@ -4896,10 +4855,6 @@ fn load_retrieve_candidate_snapshot(
     });
     if let Ok(mut cache) = retrieve_candidate_cache().lock() {
         cache.insert(cache_key, Arc::clone(&snapshot));
-        bound_global_cache(
-            &mut cache,
-            global_cache_capacity("TS_PROXY_RETRIEVE_CANDIDATE_CACHE_MAX", 512),
-        );
     }
     Ok((snapshot, false))
 }

--- a/tools/deploy_onebox.sh
+++ b/tools/deploy_onebox.sh
@@ -35,10 +35,65 @@ export TS_SHARD_ID="${TS_SHARD_ID:-1}"
 export TS_SERVER_NODE_ID="${TS_SERVER_NODE_ID:-1}"
 export TS_SERVER_ADDR="${TS_SERVER_ADDR:-127.0.0.1:17002}"
 
+# There is no metaserver in a one-box, and the client has to be told so.
+#
+# Left unset, the record-log client falls back to a metaserver address nothing is listening on,
+# and every call fails with `record_log_remote_execute_failed: http error: Connection refused`
+# -- while a direct curl to the datanode on TS_SERVER_ADDR answers perfectly, which makes it read
+# like a gateway fault rather than a missing sentinel. `local` is one of the accepted
+# no-metaserver sentinels ("", local, none, standalone, off).
+#
+# Measured: with the sentinel set, ingest through the gateway is ~75 ms and gated correct;
+# without it every ingest returns a backend error in ~11 ms.
+export TS_META_ADDR="${TS_META_ADDR:-local}"
+export MATRIXARK_TEMPORALSTORE_METASERVER="${MATRIXARK_TEMPORALSTORE_METASERVER:-local}"
+
+# The blob tier is the datanode, so point at the datanode.
+#
+# Unset, the gateway defaults to http://127.0.0.1:17102 -- which its own source calls
+# "a working-looking address that is not the one anybody" runs. In a one-box nothing listens
+# there, so every resource upload fails with
+#   blob_store_unreachable: Could not reach the blob tier at http://127.0.0.1:17102
+# and the message ingest path, which needs no blob, keeps working -- so the deployment looks
+# healthy while every skill and file upload 502s. Measured: 71 of 71 skill ingests failed this
+# way while message ingest ran at a 53 ms p50.
+#
+# Derived from TS_SERVER_ADDR so the two cannot drift apart.
+export MATRIXARK_DATANODE_BLOB_URL="${MATRIXARK_DATANODE_BLOB_URL:-http://${TS_SERVER_ADDR}}"
+export MATRIXARK_TS_BLOB_URL="${MATRIXARK_TS_BLOB_URL:-http://${TS_SERVER_ADDR}}"
+export MATRIXARK_DATANODE_URL="${MATRIXARK_DATANODE_URL:-http://${TS_SERVER_ADDR}}"
+
 # The whole memory budget belongs to one process here.
 export TS_CACHE_MEMORY_BYTES="${TS_CACHE_MEMORY_BYTES:-1073741824}"
 
 # One-box serves the ranking from the embeddings: dense 1.00, sparse 0.00.
 export MATRIXARK_ONEBOX_EMBEDDING_FIRST="${MATRIXARK_ONEBOX_EMBEDDING_FIRST:-1}"
+
+# Cap the number of glibc allocation arenas.
+#
+# Unset, glibc gives a threaded process up to 8 arenas per core and grows each in 64 MiB steps
+# it never returns. The gateway runs 16 threads on 8 vCPU, and a soak measured 14 such arenas
+# holding 896 MiB -- 42% of its 2,151 MiB RSS -- while the live Python heap was a fraction of
+# that. This is fragmentation across arenas, not retention. It must be exported BEFORE the
+# process starts; glibc reads it once at startup.
+export MALLOC_ARENA_MAX="${MALLOC_ARENA_MAX:-2}"
+
+# Extraction provider: an OpenAI-compatible endpoint.
+#
+# The key is READ FROM A FILE, never written here -- this script is committed. Absent the file,
+# extraction is left unconfigured rather than half-configured.
+#
+# Endpoint note, measured: the BigModel chat path is /api/paas/v4, NOT /api/v1. Against /api/v1
+# the same key lists models happily and then refuses every completion with "No permission to
+# access model", which reads like an entitlement problem and is actually a wrong path.
+export MATRIXARK_EXTRACTION_BASE_URL="${MATRIXARK_EXTRACTION_BASE_URL:-https://open.bigmodel.cn/api/paas/v4}"
+export MATRIXARK_EXTRACTION_MODEL="${MATRIXARK_EXTRACTION_MODEL:-glm-4-flash}"
+export MATRIXARK_EXTRACTION_API_KEY_ENV="${MATRIXARK_EXTRACTION_API_KEY_ENV:-GLM_API_KEY}"
+_ts_glm_key_file="${MATRIXARK_EXTRACTION_KEY_FILE:-${HOME:-/home/ubuntu}/.glm_key}"
+if [ -z "${GLM_API_KEY:-}" ] && [ -r "${_ts_glm_key_file}" ]; then
+  GLM_API_KEY="$(cat "${_ts_glm_key_file}")"
+  export GLM_API_KEY
+fi
+unset _ts_glm_key_file
 
 TS_PROFILE_EXPECT=one-box ts_profile_launch

--- a/tools/deploy_profile_common.sh
+++ b/tools/deploy_profile_common.sh
@@ -86,6 +86,22 @@ ts_profile_launch() {
   ts_profile_perf_flags
   ts_profile_dirs
 
+  # Env-only: set the profile up and start nothing.
+  #
+  # Sourcing a profile script to borrow its environment is a normal thing to want -- a
+  # harness that starts the node itself, a tool that only needs the paths and flags. Without
+  # this the source LAUNCHES a datanode, so a caller that then starts its own gets the
+  # profile's node on the port and its own dying with `Address already in use`. The caller's
+  # later exports never reach the process that ends up serving, which reads as a flag that
+  # does not work rather than a node it did not start.
+  #
+  # The env and the directories are still established above, because that is what the caller
+  # asked for; only the launch and its readback are skipped.
+  if [[ "${TS_PROFILE_ENV_ONLY:-0}" == "1" ]]; then
+    echo "[deploy] env-only: profile=${TS_PROFILE_EXPECT} data=${TS_PROFILE_DATA} (no node started)"
+    return 0
+  fi
+
   export NO_COLOR="${NO_COLOR:-1}"
   echo "[deploy] profile=${TS_PROFILE_EXPECT} data=${TS_PROFILE_DATA} bin=${TS_PROFILE_BIN}"
   setsid nohup "$TS_PROFILE_BIN" >>"$TS_PROFILE_LOG" 2>&1 </dev/null &

--- a/tools/matrixark_access.py
+++ b/tools/matrixark_access.py
@@ -74,6 +74,22 @@ class MatrixArkMetadataStore:
     def read_all(self) -> list[Json]:
         raise NotImplementedError
 
+    def records_of_type(self, record_type: str) -> list[Json]:
+        """Metadata records of ONE type, in append order.
+
+        Every `latest_*` lookup below is a newest-wins scan for a single type, and each was
+        reading the WHOLE record log to find it -- on an authenticated request that is several
+        full-corpus reads before any work happens. The type is what the caller already names
+        inline, so nothing here needs a central list of type names to fall out of date.
+
+        This default keeps the previous behaviour exactly (filter the full read); a backend that
+        can answer the narrower question overrides it.
+        """
+        return [
+            record for record in self.read_all()
+            if str(record.get("record_type", "")) == record_type
+        ]
+
     def backend_info(self) -> Json:
         return {"backend": self.backend_name, "status": "ok"}
 
@@ -89,6 +105,24 @@ class MatrixArkRecordLogMetadataStore(MatrixArkMetadataStore):
 
     def read_all(self) -> list[Json]:
         return [record for record in self.adapter.read_all() if str(record.get("record_type", "")).startswith("matrixark_")]
+
+    def records_of_type(self, record_type: str) -> list[Json]:
+        """One filtered scan when the adapter can serve it, else the full read.
+
+        `_scan_records_of_types` returns records of exactly these types IN APPEND ORDER, which is
+        what the newest-wins callers need from `reversed(...)`. Its None/[] split matters here:
+        `[]` is an authoritative "no records of this type" and must NOT send us to the full read,
+        or a store that legitimately has no users would pay for the whole corpus on every call.
+        """
+        scan = getattr(self.adapter, "_scan_records_of_types", None)
+        if callable(scan):
+            try:
+                subset = scan([record_type])
+            except Exception:  # noqa: BLE001 - the full read is the fallback, not a guess.
+                subset = None
+            if subset is not None:
+                return subset
+        return super().records_of_type(record_type)
 
 
 def _matrixark_env_truthy(name: str) -> bool:
@@ -809,7 +843,9 @@ class MatrixArkAccessManager(_AccessPortalMixin, _AccessSsoMixin, _AccessApiKeyM
 
     def find_active_api_key(self, api_key: str) -> Json | None:
         hashed = secret_hash(api_key)
-        for record in reversed(self.metadata.read_all()):
+        # Every authenticated request lands here. Reading the whole record log to find one key
+        # made the cost of authenticating grow with the size of the corpus.
+        for record in reversed(self.metadata.records_of_type("matrixark_api_key")):
             if record.get("record_type") != "matrixark_api_key":
                 continue
             if record.get("api_key_hash") == hashed:
@@ -822,13 +858,13 @@ class MatrixArkAccessManager(_AccessPortalMixin, _AccessSsoMixin, _AccessApiKeyM
         return None
 
     def latest_account_record(self, account_id: str) -> Json | None:
-        for record in reversed(self.metadata.read_all()):
+        for record in reversed(self.metadata.records_of_type("matrixark_account")):
             if record.get("record_type") == "matrixark_account" and record.get("account_id") == account_id:
                 return record
         return None
 
     def latest_tenant_record(self, account_id: str, tenant_id: str) -> Json | None:
-        for record in reversed(self.metadata.read_all()):
+        for record in reversed(self.metadata.records_of_type("matrixark_tenant")):
             if (
                 record.get("record_type") == "matrixark_tenant"
                 and record.get("account_id") == account_id
@@ -846,7 +882,7 @@ class MatrixArkAccessManager(_AccessPortalMixin, _AccessSsoMixin, _AccessApiKeyM
             raise MatrixArkError("tenant is disabled")
 
     def latest_api_key_record(self, api_key_id: str) -> Json | None:
-        for record in reversed(self.metadata.read_all()):
+        for record in reversed(self.metadata.records_of_type("matrixark_api_key")):
             if record.get("record_type") == "matrixark_api_key" and record.get("api_key_id") == api_key_id:
                 return record
         return None
@@ -854,7 +890,7 @@ class MatrixArkAccessManager(_AccessPortalMixin, _AccessSsoMixin, _AccessApiKeyM
     def latest_user_record(self, account_id: str, tenant_id: str, user_id: str) -> Json | None:
         if not user_id:
             return None
-        for record in reversed(self.metadata.read_all()):
+        for record in reversed(self.metadata.records_of_type("matrixark_user")):
             if (
                 record.get("record_type") == "matrixark_user"
                 and record.get("account_id") == account_id
@@ -872,7 +908,7 @@ class MatrixArkAccessManager(_AccessPortalMixin, _AccessSsoMixin, _AccessApiKeyM
     def latest_user_credential(self, account_id: str, tenant_id: str, user_id: str) -> Json | None:
         if not user_id:
             return None
-        for record in reversed(self.metadata.read_all()):
+        for record in reversed(self.metadata.records_of_type("matrixark_user_credential")):
             if (
                 record.get("record_type") == "matrixark_user_credential"
                 and record.get("account_id") == account_id
@@ -887,7 +923,7 @@ class MatrixArkAccessManager(_AccessPortalMixin, _AccessSsoMixin, _AccessApiKeyM
         email_normalized = email.strip().lower()
         if not email_normalized:
             return ""
-        for record in reversed(self.metadata.read_all()):
+        for record in reversed(self.metadata.records_of_type("matrixark_user_credential")):
             if (
                 record.get("record_type") == "matrixark_user_credential"
                 and record.get("account_id") == account_id

--- a/tools/matrixark_access_sso.py
+++ b/tools/matrixark_access_sso.py
@@ -25,7 +25,7 @@ except ImportError:
 
 class _AccessSsoMixin:
     def latest_sso_mapping(self, account_id: str, tenant_id: str, provider: str, external_user_id: str) -> Json | None:
-        for record in reversed(self.metadata.read_all()):
+        for record in reversed(self.metadata.records_of_type("matrixark_sso_user_mapping")):
             if (
                 record.get("record_type") == "matrixark_sso_user_mapping"
                 and record.get("account_id") == account_id

--- a/tools/matrixark_codex_hook.py
+++ b/tools/matrixark_codex_hook.py
@@ -4348,7 +4348,11 @@ def fast_hook_summary_dirty_records(
     for depth in range(1, len(node_path) + 1):
         prefix = node_path[:depth]
         prefix_hash = stable_int_hash("/".join(prefix))
-        dirty_hash = stable_int_hash(f"summary_dirty:{prefix_hash}:new_event:event:{event_id_hash}:{updated_at_ms}")
+        # Identity is the NODE, not the event -- see node_summary_dirty_records. Keying on
+        # the event minted a fresh marker per event for a set membership, and this producer
+        # has to agree with that one or the hook path keeps appending the duplicates the
+        # adapter path no longer writes.
+        dirty_hash = stable_int_hash(f"summary_dirty:{prefix_hash}:new_event")
         records.append(
             {
                 "record_type": "context_summary_dirty",

--- a/tools/matrixark_local_adapter_context_node.py
+++ b/tools/matrixark_local_adapter_context_node.py
@@ -219,6 +219,31 @@ class _LocalAdapterContextNodeMixin:
             "node_hashes": node_hashes,
         }
 
+    #: The record types `ensure_context_embeddings` can act on: the six that
+    #: `_embedding_target_for_context_record` maps to a target, plus the embeddings themselves so
+    #: one scan answers "what needs a vector" and "what already has one".
+    EMBEDDING_PASS_RECORD_TYPES = (
+        "context_embedding",
+        "context_event",
+        "context_segment",
+        "context_entity",
+        "context_node",
+        "context_summary",
+        "context_compression_event",
+    )
+
+    def _embedding_pass_records(self) -> list[Json]:
+        """Records the embedding pass can act on, from one typed scan where possible."""
+        scan = getattr(self, "_scan_records_of_types", None)
+        if callable(scan):
+            try:
+                subset = scan(list(self.EMBEDDING_PASS_RECORD_TYPES))
+            except Exception:  # noqa: BLE001 - the full read is the fallback, not a guess.
+                subset = None
+            if subset is not None:
+                return subset
+        return self.read_all()
+
     def _embedding_target_for_context_record(self, record: Json) -> Json | None:
         record_type = str(record.get("record_type") or "")
         node_path = record.get("node_path") if isinstance(record.get("node_path"), list) else []
@@ -295,7 +320,23 @@ class _LocalAdapterContextNodeMixin:
         existing_embeddings: dict[tuple[str, str, int], Json] = {}
         # A caller that has already read the log this pass can hand its snapshot in, but only when
         # nothing has been written since -- this needs to see rows produced earlier in the pass.
-        records = self.read_all() if records is None else records
+        #
+        # Otherwise: read the SEVEN types this pass can act on, not the whole store.
+        #
+        # This needs two things and used to get both from a full read: every existing
+        # `context_embedding` (to know what is already current) and every record that could need
+        # one. The second set is bounded -- `_embedding_target_for_context_record` returns a target
+        # for exactly six record types and None for everything else -- so a typed scan answers both
+        # halves exactly. Measured on a one-box at 14,787 records: those seven types are 1,893 of
+        # them, so the pass reads ~8x less, and the engine serves a typed scan from its type index
+        # rather than walking the log.
+        #
+        # `_scan_records_of_types` returns None when it cannot ask (no client, an older signature,
+        # a backend that does not support it). None is not "nothing matched" -- it means the
+        # question could not be put -- so that case falls back to the full read rather than
+        # silently embedding against an empty view.
+        if records is None:
+            records = self._embedding_pass_records()
         for record in records:
             if record.get("record_type") != "context_embedding":
                 continue

--- a/tools/matrixark_local_adapter_summaries.py
+++ b/tools/matrixark_local_adapter_summaries.py
@@ -497,9 +497,17 @@ class _LocalAdapterSummariesMixin:
         lineage = source_event_lineage_summary([source_lineage]) if isinstance(source_lineage, dict) else {}
         for prefix in prefixes:
             node_hash = stable_hash("/".join(prefix))
-            dirty_hash = stable_hash(
-                f"summary_dirty:{node_hash}:{dirty_reason}:{source_ref_type}:{source_hash}:{updated_at_ms}"
-            )
+            # Identity is the NODE, not the event that dirtied it.
+            #
+            # Including source_hash and updated_at_ms minted a fresh identity per event, so
+            # "this node needs a summary" -- a set membership -- was stored as an unbounded
+            # append. Measured on a one-box: 1,417 markers for 37 nodes, 392 of them for a
+            # single node, at 784 bytes each. The engine already coalesces its own in-memory
+            # dirty tracking the same way; this makes the durable record agree.
+            #
+            # The marker still carries the source hash and timestamp as FIELDS, so the
+            # newest write wins and lineage survives -- only the duplicate rows go.
+            dirty_hash = stable_hash(f"summary_dirty:{node_hash}:{dirty_reason}")
             dirty_hashes.append(dirty_hash)
             record = {
                 "record_type": "context_summary_dirty",
@@ -578,7 +586,24 @@ class _LocalAdapterSummariesMixin:
             propagate_depth=propagate_depth,
             source_lineage=source_lineage,
         )
-        self.append_many(records)
+        # Do not re-append a marker already pending for this (node, reason).
+        #
+        # The identity is the node, so repeated marks share one dirty_hash -- but the log
+        # still took a ROW each time, and the collapse only happened when a reader folded
+        # latest-state. Measured: 130 rows carrying 5 distinct identities, 125 of them
+        # duplicates, at 784 bytes apiece.
+        #
+        # The set is cleared at the start of every refresh pass, so a node dirtied after a
+        # pass is always marked again; the worst case is one redundant marker per pass, and
+        # a restart simply forgets and writes one.
+        seen = getattr(self, "_pending_summary_dirty_hashes", None)
+        if seen is None:
+            seen = set()
+            self._pending_summary_dirty_hashes = seen
+        fresh = [r for r in records if r.get("dirty_hash") not in seen]
+        if fresh:
+            self.append_many(fresh)
+            seen.update(r.get("dirty_hash") for r in fresh)
         return dirty_hashes
 
     def refresh_dirty_node_summaries(
@@ -606,6 +631,10 @@ class _LocalAdapterSummariesMixin:
                 index_compact_on_summary_enabled, index_compaction_tombstone)
         refreshed_at_ms = refreshed_at_ms or now_ms()
         skip_dirty_reasons = skip_dirty_reasons or set()
+        # Forget which markers are pending: this pass is about to consume them, so a node
+        # dirtied after it must be marked again. Clearing here bounds duplicate markers to
+        # one per node per pass instead of one per event, without a marker ever being lost.
+        self._pending_summary_dirty_hashes = set()
         # `records` lets one caller's read serve a whole pass. Reading here is a full record-log
         # read, and on a native backend it holds the single shared proxy lane while it runs.
         records = self.read_all() if records is None else records

--- a/tools/matrixark_mcp_server.py
+++ b/tools/matrixark_mcp_server.py
@@ -344,11 +344,24 @@ class MatrixArkMcpServer(MatrixArkServerRequestPolicyMixin):
                 continue
             try:
                 result = self.adapter.refresh_summaries({"scope": {}, "limit": self._summary_refresh_limit})
-                self._summary_last_watermark = watermark
                 self.metrics.observe_operation("summary_refresh", "ok", (time.perf_counter() - started_perf) * 1000.0)
                 refreshed_count = int(result.get("refreshed_count") or 0)
                 if refreshed_count:
                     self.access.append_audit("context.refresh_summaries.background", {"account_id": "system", "tenant_id": "system", "user_id": "summary_worker"}, status="ok", details={"refreshed_count": refreshed_count, "interval_ms": SUMMARY_REFRESH_INTERVAL_MS, "limit": self._summary_refresh_limit})
+                # Remember the count as of the END of this pass, not its start.
+                #
+                # A pass writes: the summaries and embeddings it refreshes, and the audit record
+                # just above. Storing the pre-pass count therefore makes the skip above
+                # unfireable -- the next tick reads a count this pass itself moved, sees a
+                # different watermark, and does the whole read_all-and-write again. On the 1s
+                # default that is a full pass every second forever on a store nobody is
+                # touching, which is where an idle one-box's background writes and its gateway
+                # and proxy CPU were going.
+                #
+                # Re-reading after the writes means the guard asks the question it means to ask:
+                # has anything landed since I last finished.
+                post_watermark = self._summary_refresh_watermark()
+                self._summary_last_watermark = watermark if post_watermark is None else post_watermark
             except Exception as exc:
                 self.metrics.observe_operation("summary_refresh", "error", 0.0, timeout=is_retryable_temporalstore_error(exc))
                 _mcp_debug_log(f"matrixark summary refresh loop failed: {exc}")

--- a/tools/matrixark_mcp_server.py
+++ b/tools/matrixark_mcp_server.py
@@ -315,14 +315,30 @@ class MatrixArkMcpServer(MatrixArkServerRequestPolicyMixin):
 
         The record log is append-only, so its count moves if and only if new content landed. One
         `get_string` answers it; the pass it guards reads and re-decodes the whole store.
+
+        The count alone is not enough to skip on. A PURGE removes and rewrites records in place
+        without moving it, and the node whose summary and index postings it just removed is
+        exactly the node that needs rebuilding -- left alone, an updated memory stays in `get_all`
+        and never becomes retrievable again. The adapter already knows this and clears its own
+        pass state on a purge, so pair the count with that state: it is constant while passes are
+        being skipped (nothing writes it), and becomes `(None, None)` the moment a purge
+        invalidates it, which makes this token differ and lets the next pass run.
         """
         getter = getattr(self.adapter, "_get_count", None)
         if not callable(getter):
             return None
         try:
-            return int(getter())
+            count = int(getter())
         except Exception:
             return None
+        pass_state = None
+        loader = getattr(self.adapter, "_load_summary_pass_state", None)
+        if callable(loader):
+            try:
+                pass_state = tuple(loader())
+            except Exception:  # noqa: BLE001 - an unreadable state just means "run the pass".
+                pass_state = None
+        return (count, pass_state)
 
     def _summary_refresh_loop(self) -> None:
         delay_s = self._summary_refresh_interval_s

--- a/tools/matrixark_mcp_server.py
+++ b/tools/matrixark_mcp_server.py
@@ -310,12 +310,41 @@ class MatrixArkMcpServer(MatrixArkServerRequestPolicyMixin):
         """Delay before the next refresh pass -- see `next_summary_refresh_delay_s`."""
         return next_summary_refresh_delay_s(self._summary_refresh_interval_s, last_pass_s)
 
+    def _summary_refresh_watermark(self):
+        """Cheap "has anything been written" token, or None when it cannot be asked.
+
+        The record log is append-only, so its count moves if and only if new content landed. One
+        `get_string` answers it; the pass it guards reads and re-decodes the whole store.
+        """
+        getter = getattr(self.adapter, "_get_count", None)
+        if not callable(getter):
+            return None
+        try:
+            return int(getter())
+        except Exception:
+            return None
+
     def _summary_refresh_loop(self) -> None:
         delay_s = self._summary_refresh_interval_s
         while not self._summary_stop.wait(delay_s):
             started_perf = time.perf_counter()
+            # Skip a pass that cannot have anything to do.
+            #
+            # A pass calls ensure_context_embeddings, which does a full read_all() -- on a native
+            # backend that is the whole record log shipped over the proxy and re-decoded into
+            # Python objects -- and then writes any embedding it finds stale. On a 1s timer that
+            # ran whether or not anything had been ingested, and a profile of an idle one-box put
+            # this thread on the GIL inside that read.
+            #
+            # Summaries and their embeddings derive from records, so with no new record there is
+            # nothing new to derive.
+            watermark = self._summary_refresh_watermark()
+            if watermark is not None and watermark == getattr(self, "_summary_last_watermark", None):
+                delay_s = self._next_summary_refresh_delay_s(time.perf_counter() - started_perf)
+                continue
             try:
                 result = self.adapter.refresh_summaries({"scope": {}, "limit": self._summary_refresh_limit})
+                self._summary_last_watermark = watermark
                 self.metrics.observe_operation("summary_refresh", "ok", (time.perf_counter() - started_perf) * 1000.0)
                 refreshed_count = int(result.get("refreshed_count") or 0)
                 if refreshed_count:

--- a/tools/matrixark_temporal_direct_write.py
+++ b/tools/matrixark_temporal_direct_write.py
@@ -50,6 +50,14 @@ except ImportError:
 )
 
 
+def _context_index_postings_enabled() -> bool:
+    """Whether secondary-index postings are persisted. Default on."""
+    value = os.environ.get("MATRIXARK_CONTEXT_INDEX_POSTINGS", "").strip().lower()
+    if not value:
+        return True
+    return value not in {"0", "false", "no", "off"}
+
+
 class _TemporalDirectWriteMixin:
     def _direct_write_loop(self) -> None:
         while not self._direct_write_stop.is_set():
@@ -267,6 +275,19 @@ class _TemporalDirectWriteMixin:
     def _append_many_materialized(self, records: list[Json], *, allow_queue: bool = True) -> None:
         if not records:
             return
+        # Optional: stop persisting secondary-index postings.
+        #
+        # A deployment that ranks by vector alone does not read them, and they are the
+        # largest single record class on an ingest-heavy store (16.4% of record bytes,
+        # 6.4 rows per message). They ARE read by the retrieval path, which builds index
+        # terms from them, so this trades recall for bytes and is off by default.
+        # The store already bounds them (dedup, summary compaction, a per-session cap of
+        # 128 and a per-tenant cap of 1024) with a measured recall floor at 128 postings;
+        # this switch goes below that floor deliberately, so measure recall before using it.
+        if not _context_index_postings_enabled():
+            records = [r for r in records if r.get("record_type") != "context_index"]
+            if not records:
+                return
         # Embeddings fold onto their owners at this single backend append call site, exactly as
         # the pure-local JSONL adapter folds at its own append -- the fast direct-ingest path
         # never goes through append_many, so folding there alone let separate embedding rows

--- a/tools/matrixark_temporalstore_blob.py
+++ b/tools/matrixark_temporalstore_blob.py
@@ -184,7 +184,32 @@ class TemporalStoreBlobClient:
                 pass
         if status >= 400:
             raise RuntimeError(f"temporalstore blob PUT {key} failed: HTTP {status}: {raw[:256]!r}")
-        return key
+        # Return the key the SERVER says it stored, not the one we asked for: a tier that
+        # scopes objects by tenant stores under a prefixed path while the request named the
+        # bare key, and recording the requested key yields a URI nothing can fetch.
+        try:
+            receipt = json.loads(raw.decode("utf-8"))
+        except Exception:
+            return key
+        stored = receipt.get("key") if isinstance(receipt, dict) else None
+        return str(stored) if stored else key
+
+    def _scoped_key_candidates(self, key: str) -> list:
+        """Keys the blob tier may have stored `key` under, most likely first.
+
+        The tier prefixes writes with the request's tenant and does not report it, so a
+        reader holding the bare key has to name the same scope to find the bytes.
+        `anonymous` is the tenant an unauthenticated one-box writes under.
+        """
+        if "/" in key and key.split("/", 1)[0] in self._known_scopes():
+            return []
+        return [f"{scope}/{key}" for scope in self._known_scopes()]
+
+    def _known_scopes(self) -> tuple:
+        configured = os.environ.get("MATRIXARK_BLOB_TENANT_SCOPES", "").strip()
+        if configured:
+            return tuple(part for part in configured.split(",") if part)
+        return ("anonymous",)
 
     def get(self, key: str) -> tuple[bytes, Json]:
         """Fetch bytes for a key. Returns (bytes, meta). Raises on 404/missing."""
@@ -202,6 +227,22 @@ class TemporalStoreBlobClient:
                 conn.close()
             except Exception:
                 pass
+        if status == 404 and not getattr(self, "_retry_scoped", False):
+            # The blob tier scopes stored objects by tenant while echoing the bare key in
+            # its receipt, so bytes written as `<key>` are read back only as
+            # `<tenant>/<key>`. Observed on a one-box: the upload succeeded, the file sat
+            # at `anonymous/resources/fd/...`, and every read of `resources/fd/...` 404ed,
+            # failing every skill ingest while message ingest stayed healthy.
+            # This resolves the write's own scoping instead of guessing; the asymmetry
+            # itself belongs in the blob tier and should be fixed there.
+            for scope_prefix in self._scoped_key_candidates(key):
+                self._retry_scoped = True
+                try:
+                    return self.get(scope_prefix)
+                except FileNotFoundError:
+                    continue
+                finally:
+                    self._retry_scoped = False
         if status == 404:
             raise FileNotFoundError(f"temporalstore blob not found: {key}")
         if status >= 400:
@@ -273,7 +314,9 @@ def ts_blob_storage_resolution(
         "scope": scope or {}, "content_hash": ch, "content_type": content_type,
     }
     if not deduped:
-        client.put(data, key=key, content_type=content_type)
+        # put() reports the key the server stored, which may be scoped differently from
+        # the one requested; the URI has to name that key or the later read 404s.
+        key = client.put(data, key=key, content_type=content_type) or key
     uri = blob_uri(key)
     return {
         "storage_mode": "temporalstore", "backend": "temporalstore_blob",

--- a/tools/test_an_authenticated_request_does_not_read_the_whole_log.py
+++ b/tools/test_an_authenticated_request_does_not_read_the_whole_log.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""An authenticated request must not read the whole record log to find one key.
+
+Every `latest_*` lookup in the access layer is a newest-wins scan for a SINGLE record type, and
+each one used to read the entire log. On an authenticated request that is several full-corpus
+reads before any work happens, so the cost of authenticating grew with the corpus.
+
+These tests pin the three things that make the narrow path safe rather than merely faster:
+the answer is unchanged, the narrow path is actually taken, and an authoritative empty result
+does not fall back to the full read.
+"""
+from __future__ import annotations
+
+import unittest
+
+from matrixark_access import MatrixArkRecordLogMetadataStore
+
+
+class RecordingAdapter:
+    """An adapter that can serve a typed scan, and counts who asked for what."""
+
+    def __init__(self, records, *, supports_scan=True, scan_returns=None):
+        self._records = records
+        self._supports_scan = supports_scan
+        self._scan_returns = scan_returns
+        self.read_all_calls = 0
+        self.scanned_types = []
+
+    def read_all(self):
+        self.read_all_calls += 1
+        return list(self._records)
+
+    def __getattr__(self, name):
+        # Only expose the scan when this fixture is meant to support it, so the fallback path
+        # is exercised by a fixture that genuinely cannot answer rather than by a flag.
+        if name == "_scan_records_of_types" and self._supports_scan:
+            return self._scan
+        raise AttributeError(name)
+
+    def _scan(self, record_types, **kwargs):
+        self.scanned_types.append(list(record_types))
+        if self._scan_returns is not None:
+            return list(self._scan_returns)
+        return [
+            record for record in self._records
+            if str(record.get("record_type", "")) in set(record_types)
+        ]
+
+
+CORPUS = [
+    {"record_type": "context_event", "text": "not metadata"},
+    {"record_type": "matrixark_api_key", "api_key_id": "k1", "status": "active"},
+    {"record_type": "context_event", "text": "also not metadata"},
+    {"record_type": "matrixark_user", "user_id": "u1"},
+    {"record_type": "matrixark_api_key", "api_key_id": "k2", "status": "active"},
+]
+
+
+class MetadataRecordsOfTypeTest(unittest.TestCase):
+    def test_the_answer_is_the_same_as_filtering_the_full_read(self):
+        """The narrow path must not change WHICH records come back, or their order."""
+        narrow = MatrixArkRecordLogMetadataStore(RecordingAdapter(CORPUS))
+        wide = MatrixArkRecordLogMetadataStore(RecordingAdapter(CORPUS, supports_scan=False))
+        for record_type in ("matrixark_api_key", "matrixark_user"):
+            self.assertEqual(
+                narrow.records_of_type(record_type),
+                wide.records_of_type(record_type),
+                record_type,
+            )
+        # Append order is what the newest-wins callers reverse; pin it explicitly.
+        keys = narrow.records_of_type("matrixark_api_key")
+        self.assertEqual([item["api_key_id"] for item in keys], ["k1", "k2"])
+
+    def test_the_narrow_path_is_actually_taken(self):
+        """Positive control: without this, an unused fast path would still pass the test above."""
+        adapter = RecordingAdapter(CORPUS)
+        store = MatrixArkRecordLogMetadataStore(adapter)
+        store.records_of_type("matrixark_api_key")
+        self.assertEqual(adapter.scanned_types, [["matrixark_api_key"]])
+        self.assertEqual(adapter.read_all_calls, 0, "the full log was read anyway")
+
+    def test_an_adapter_without_the_scan_still_answers(self):
+        adapter = RecordingAdapter(CORPUS, supports_scan=False)
+        store = MatrixArkRecordLogMetadataStore(adapter)
+        self.assertEqual(len(store.records_of_type("matrixark_api_key")), 2)
+        self.assertEqual(adapter.read_all_calls, 1)
+
+    def test_an_authoritative_empty_does_not_fall_back_to_the_full_read(self):
+        """`[]` means "no records of this type"; only None means "could not ask".
+
+        Confusing the two would make a store that legitimately has no users pay for the whole
+        corpus on every single request -- the exact cost this change exists to remove.
+        """
+        adapter = RecordingAdapter(CORPUS, scan_returns=[])
+        store = MatrixArkRecordLogMetadataStore(adapter)
+        self.assertEqual(store.records_of_type("matrixark_user"), [])
+        self.assertEqual(adapter.read_all_calls, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ten changes to the one-box write path, its background passes, and the reads that
serve a request. Every claim below is a measurement on an AWS one-box against a
production corpus, with e5-large embeddings and glm-4-flash extraction. Where a
change is not yet measured, it says so.

## The write path

**A write re-indexed every field of the object it touched.** A single-component
write re-synced the whole object's page list. Datanode CPU over the same run:
40.9 s -> 0.13 s.

**A deployment that ranks by vector alone can stop storing index postings.**
Opt-out for the inverted index on a one-box that retrieves by embedding.

**The index log can carry compressed payloads.** A new codec on the existing
container. Measured on an identical 60-message corpus, both arms on their own
fresh store:

| | index log | pages | durable | add p50 | frames |
|---|---|---|---|---|---|
| off | 1,620,116 | 1,313,686 | 4,024,597 | 0.065 s | 555 msgpack / 0 zstd |
| on | 430,910 | 1,205,839 | 2,727,615 | 0.064 s | 152 / **403 zstd** |

Index log **3.76x** smaller, total durable **1.48x**, add latency unchanged. In
the 2 h production run, 87.6% of frames were zstd.

## The background passes

**The background summary pass remembers the count it left, not the one it
found.** The skip compared the record count against the count taken BEFORE the
pass -- and a pass writes, so the next tick always saw a different count and the
skip could never fire again. It did a full read_all and wrote on every tick of
its 1 s timer, forever, on a store nobody was touching. 240 s with zero client
traffic:

| | idle bytes | rate | add p50 |
|---|---|---|---|
| before | 2,969,295 -> 9,377,677 | **26,701 B/s** (~2.3 GB/day) | 0.064 s |
| after | 1,992,908 -> 1,992,908 | **0 B/s** | 0.064 s |

Controlled separately for "does it still do the work": four facts written, then
polled for ten minutes. Both builds recall the fact at t=30 s; the fixed one
writes 55,663 bytes and stops, the old one writes 3,589,516 and is still
climbing at t=600 s.

**The refresh skip also asks whether a purge moved the store under it.** A purge
rewrites records in place without moving the count, so a count-only skip would
park forever on exactly the node that needs rebuilding.

## The proxy

**The remote path reads every spelling of "there is no metaserver".** It decided
with is_empty(), so only "" counted -- but the rule has one implementation
already (META_ADDR_SENTINELS / single_node), and a one-box sets
TS_META_ADDR=local. "local" reached the client as a literal socket address and
**every write failed**. Isolated: metaserver "local" -> ingest 500, "" -> 202.

**A leak this does NOT fix, documented rather than papered over.** Four caches
live for the life of the process with no cap. Same 312 MB store, two processes:
a fresh one answers a retrieve in 22.6 ms holding 13.1 MB; the aged one took
4,639 ms holding 4.6 GB, and is OOM-killed repeatedly (the gateway respawns it,
so only dmesg shows it). A control arm with shedding disabled reproduces it:
proxy RSS 174 -> 1,419 MB in 22 minutes, two more OOM kills.

An entry-count cap was written, measured against its own control, and REVERTED
in this branch because it does not work -- 970 MB vs 1,433 MB at t=750s, no
reduction. The entries are not what is large: one entry is a whole hash
snapshot, a whole scan result, or a candidate snapshot. Bounding this needs a
bound on bytes, or a cap small enough to bite. The commit and its revert are
both here so the measurement is not lost.

## The read path

**Authenticating stops costing the whole record log.** Seven lookups in the
access layer are newest-wins scans for a single record type, and each read the
entire log. find_active_api_key runs on every authenticated request, and
ensure_account_tenant_active and ensure_user_active add more, so an
authenticated call did three to five full-corpus reads before any work. Each
asks for its own type now, through the type it already names inline -- so no
central list of type names exists to fall out of date, which matters because the
metadata boundary is a prefix.

**An SSO login looks up its mapping, not the whole log.** The same shape on the
live login path.

## Gates

- `cargo test -p temporalstore-rust --lib -- --test-threads=1` on this branch
- `tools/test_an_authenticated_request_does_not_read_the_whole_log.py`: 4 tests,
  including a positive control that the narrow path is taken (read_all_calls ==
  0) and that an authoritative empty does not fall back. Disabling the fast path
  fails two of them, so they discriminate.
- `tools/test_matrixark_summary_worker.py`: 6 passed
- `test_matrixark_access_governance` has one pre-existing failure, verified
  identical on the unmodified file.

## Not claimed

The proxy's unbounded caches are diagnosed, not fixed -- see above. The
`orjson` lane-parser change is deliberately not in this branch: 68% of gateway
CPU is decoding lane JSON, but that change has no measured benefit yet and does
nothing where orjson is not installed.
