### PR TITLE
An index item is written as a row

### DIFF
--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -194,7 +194,7 @@ impl Default for IndexItemKind {
 /// `object_id`/`page_id` mirror the durable page metadata so replay reconstructs the same
 /// `BlockIndex` the whole-index serialization would have produced. `deleted` is a
 /// tombstone: replaying it removes the entry.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct IndexItem {
     #[serde(
         rename = "k",
@@ -471,6 +471,63 @@ where
     }
 
     deserializer.deserialize_any(EitherShape)
+}
+
+/// A row, not a map: the values in field order, with the order fixed here.
+///
+/// Every row in this log has the same shape, so the shape does not belong in the row. As a map,
+/// each row carried its own field names -- measured at about 25 bytes of a 126-byte record, the
+/// largest single line item left in it. A protobuf design pays a tag for this; a self-describing
+/// one pays a name; a row pays nothing and is read by position.
+///
+/// The record AROUND the rows stays a map on purpose. Two record shapes share this log and one is
+/// read as the other -- a delta container is decoded as a whole index record by the sweep -- which
+/// works because a map matches by name and a missing field defaults. Positions cannot do that, so
+/// only the rows are positional.
+///
+/// The derived `Deserialize` takes either shape, so rows written before this still decode; the
+/// order below must match the field order of the struct and must not be reordered.
+impl serde::Serialize for IndexItem {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeSeq as _;
+
+        struct Kind<'a>(&'a IndexItemKind);
+        impl serde::Serialize for Kind<'_> {
+            fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+                item_kind_as_number(self.0, s)
+            }
+        }
+        struct Handle<'a>(&'a str);
+        impl serde::Serialize for Handle<'_> {
+            fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+                page_ref_key_as_number_when_it_is_one(self.0, s)
+            }
+        }
+        struct Model<'a>(&'a str);
+        impl serde::Serialize for Model<'_> {
+            fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+                model_id_as_number_when_it_is_known(self.0, s)
+            }
+        }
+
+        let mut row = serializer.serialize_seq(Some(12))?;
+        row.serialize_element(&Kind(&self.kind))?;
+        row.serialize_element(&self.routing_bucket)?;
+        row.serialize_element(&Handle(&self.page_ref_key))?;
+        row.serialize_element(&self.object_key)?;
+        row.serialize_element(&Model(&self.model_id))?;
+        row.serialize_element(&self.component)?;
+        row.serialize_element(&self.object_id)?;
+        row.serialize_element(&self.page_id)?;
+        row.serialize_element(&self.address)?;
+        row.serialize_element(&self.size)?;
+        row.serialize_element(&self.in_log)?;
+        row.serialize_element(&self.deleted)?;
+        row.end()
+    }
 }
 
 const MODEL_ID_NUMBERS: &[&str] = &[


### PR DESCRIPTION
Every row in the index log carried its own field names.

The rows are msgpack maps, so each one spelled out `k`, `rb`, `ok`, `mi`, `oi`, `pi`, `a`, `sz` and
the rest, once per row, for every page a shard has ever indexed. Measured on a 10,000-write store
that is about 25 bytes of a 126-byte record -- after the derivable fields were already gone, it was
the largest single line item left.

Every row in this log has the same shape, so the shape does not belong in the row. An item is now
written as its values in field order, and read by position. A tag-based design pays one byte for
this; a self-describing one pays a name; a row pays nothing.

The record AROUND the rows stays a map, deliberately. Two record shapes share this log and one is
read as the other -- the sweep decodes a delta container as a whole index record -- which works
because a map matches by name and an absent field defaults. Positions cannot do that. Making the
whole record positional was tried first and broke exactly there, with `array had incorrect length,
expected 3`, so only the rows are positional and the wrapper keeps its names.

Rows written before this still decode: a derived reader takes either shape, matching by name against
a map and by position against a row. The order in the row must match the field order of the struct
and must never be reordered, which is written where the order is.

Measured on 10,000 writes of a 78-byte payload:

    index log   126 -> 108 bytes per record
    total       402 -> 384 bytes per record
    written     5.15x -> 4.92x the payload

Across the sequence that led here the index log has gone 189 -> 108 bytes per record, and the store
writes 6.17x -> 4.92x its payload.

Library suite 1719 passed, 3 failed: `storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_flags`
and `durable_bytes_never_exceed_the_bytes_the_log_holds`, both of which fail on main, and
`distributed_raft_chunks_large_sequence_add_under_default_entry_limit`, which passes three times out
of three on this branch and on main when it is not competing with the rest of the suite. Index log
40 of 40. Recovery suite 8 of 8.
