### PR TITLE
The deployment plan reads the shared boolean vocabulary

### DIFF
--- a/tools/matrixark_deployment_plan.py
+++ b/tools/matrixark_deployment_plan.py
@@ -30,6 +30,11 @@ import os
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
+try:  # package import when tools/ is a package, plain import when it is on sys.path
+    from tools.matrixark_mcp_env import FALSE_VALUES, TRUE_VALUES
+except ImportError:  # pragma: no cover - exercised by the other import path
+    from matrixark_mcp_env import FALSE_VALUES, TRUE_VALUES
+
 Json = Dict[str, Any]
 
 # Values of TS_META_ADDR the engine reads as "no metaserver". Empty is one of them, so a plan can
@@ -170,13 +175,13 @@ def _auto(matrixobject_available: bool, endpoint: str, endpoint_reachable: bool,
 def is_standalone(env: Json) -> bool:
     """The engine's own derivation, which is not "TS_STANDALONE defaults to on"."""
     forced = _clean(env.get("TS_STANDALONE")).lower()
-    if forced in ("1", "true", "yes", "on"):
+    if forced in TRUE_VALUES:
         return True
-    if forced in ("0", "false", "no", "off"):
+    if forced in FALSE_VALUES:
         return False
     meta = _clean(env.get("TS_META_ADDR")).lower()
     meta_is_real = meta not in META_SENTINELS
-    distributed = _clean(env.get("TS_DISTRIBUTED")).lower() in ("1", "true", "yes", "on")
+    distributed = _clean(env.get("TS_DISTRIBUTED")).lower() in TRUE_VALUES
     return not (meta_is_real or distributed)
 
 


### PR DESCRIPTION
`is_standalone` spelled the boolean words three times in one function — twice for `TS_STANDALONE`, once for `TS_DISTRIBUTED` — while `matrixark_mcp_env` owns `TRUE_VALUES` and `FALSE_VALUES` for exactly this.

The copies agreed, so nothing was broken. What was missing is anything keeping them agreeing, and this is the class that already produced a real bug on the other side of the codebase: in #1308, nine rust readers had their own word list and writing `on` to a default-on flag turned it **off**.

The inline shape was also invisible to the python vocabulary guard. That guard scans for `os.environ.get(...).strip().lower() in {...}`; this reads `_clean(...).lower() in (...)`, so it was an unguarded copy sitting next to a guarded one.

## Behaviour is unchanged

Eleven cases across all three branches the function has, checked before and after:

- unset (standalone)
- `TS_STANDALONE` on and off, including ` ON ` and `Off` — the spacing and case a unit file leaves
- `TS_META_ADDR` sentinels `local` / ` Local `, and a real address `10.0.0.4:17001`
- `TS_DISTRIBUTED` yes / no / an unrecognised value

Same answers throughout. `test_matrixark_deployment_plan` and `test_env_flag_vocabulary` pass, and both import paths — `tools.matrixark_deployment_plan` and the bare module — resolve and answer identically, since `matrixark_mcp_env` is a leaf that imports only `os`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)