### PR TITLE
Regenerate the flag inventory, and say why the index-log compression flag has two paths

### DIFF
--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -8,7 +8,7 @@ within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 287 of them, read by 88 functions.
+There are 289 of them, read by 90 functions.
 
 Deleting unreachable code is not the lever. An earlier version of this document argued that
 by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
@@ -60,15 +60,15 @@ Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 287 |
-| booleans whose default this could read off the source | 47 |
-| numbers whose default this could read off the source | 69 |
+| total | 289 |
+| booleans whose default this could read off the source | 48 |
+| numbers whose default this could read off the source | 70 |
 | **defaulting on, and set by nothing** | 5 |
 | offered on the portal | 26 |
-| **that nothing in this repository sets** | 158 |
+| **that nothing in this repository sets** | 160 |
 | documented as keeping an older path alive | 3 |
 | reaching more than two files | 15 |
-| whose doc comment is really about another flag | 43 |
+| whose doc comment is really about another flag | 42 |
 
 ## topology (38)
 
@@ -213,7 +213,7 @@ The shape of what is written. Readers generally accept both shapes, which is wha
 | `TS_VECTOR_INT8` | off | test, portal | 1 | — |
 | `TS_VECTOR_SCALED` | on | launch, test, portal | 1 | — |
 
-## capacity (80)
+## capacity (81)
 
 Sizes, ceilings and intervals. The tuning a deployment actually reaches for.
 
@@ -249,6 +249,7 @@ Sizes, ceilings and intervals. The tuning a deployment actually reaches for.
 | `TS_DISTRIBUTED_RAFT_CATCHUP_TIMEOUT_SECS` | 30 | nothing | 1 | — |
 | `TS_EVICT_POOL_SIZE` | — | nothing | 1 | — |
 | `TS_INDEX_DUMP_OPLOG_GAP_BYTES` | — | config | 1 | — |
+| `TS_INDEX_LOG_COMPRESSION_MIN_BYTES` | 256 | nothing | 1 | — |
 | `TS_MATRIXOBJECT_FLUSH_INTERVAL_MS` | 100 | nothing | 1 | — |
 | `TS_MATRIXOBJECT_PROBE_TIMEOUT_MS` | — | nothing | 1 | — |
 | `TS_MAX_RETAINED_FINISHED_JOBS` | 64 | portal | 1 | — |
@@ -365,7 +366,7 @@ Read only by the benchmark harnesses. Never consulted on a serving path.
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_SELECTED_ID_LIMIT` | 128 | script | 1 | — |
 | `TEMPORALSTORE_CONTEXT_BENCHMARK_SOURCE_ORDER_RANKING` | off | script | 1 | — |
 
-## behaviour (62)
+## behaviour (63)
 
 Everything else that changes what the engine does.
 
@@ -396,6 +397,7 @@ Everything else that changes what the engine does.
 | `TS_DATA_RAFT_READ_MODE` | — | config | 1 | — |
 | `TS_EVICT_SAMPLES` | — | nothing | 1 | — |
 | `TS_EVICT_SCAN_TURNS` | — | nothing | 1 | — |
+| `TS_INDEX_LOG_COMPRESSION_ENABLED` | off | nothing | 1 | — |
 | `TS_MALLOC_TRIM` | on | test, portal | 1 | — |
 | `TS_MATRIXOBJECT_CHECKPOINT_ON_START` | on | nothing | 1 | — |
 | `TS_MATRIXOBJECT_FLUSH_BATCH` | 256 | nothing | 1 | — |

--- a/tools/test_a_two_path_flag_says_why.py
+++ b/tools/test_a_two_path_flag_says_why.py
@@ -112,6 +112,10 @@ KNOWN_TWO_PATH_FLAGS: Dict[str, str] = {
     "TS_META_SHARD_DIVERGENCE_CHECK":
         "compares the owner map against what each datanode reports serving and re-places the "
         "difference. Off because it moves shards",
+    "TS_INDEX_LOG_COMPRESSION_ENABLED":
+        "gates only the WRITING of compressed index-log payloads; reading codec 2 is unconditional, "
+        "which is what lets a store roll forward and back without a migration. Off is the end that "
+        "an older binary can still read",
     "TS_REVERIFY_ALL_SLABS":
         "re-verifies every slab on every open, as the store did before the check was made "
         "skippable. Off because the skip is the whole saving; the engine calls this the "


### PR DESCRIPTION
`TS_INDEX_LOG_COMPRESSION_ENABLED` and `TS_INDEX_LOG_COMPRESSION_MIN_BYTES` landed in `index_log.rs` without the generated inventory being regenerated. Two guards are red on main because of it, and on every branch cut from main:

- `test_every_flag_named_in_the_engine_is_listed` — the engine names flags the document does not list.
- `test_regenerating_produces_the_same_document` — the counts on paper no longer match the tree.

Regenerating adds both rows. That surfaces the boolean to `test_a_two_path_flag_says_why`, which wants a recorded reason for its off side, so the second half of this supplies one taken from what the engine already says at the read:

> Whether new index-log payloads are written compressed. Off by default. Reading codec 2 is unconditional; only writing it is gated, so a store can be rolled forward and back without a migration.

I derived that from the code rather than from the author, so if the intent was different the wording is the part to correct.

## This is the third time

Same two guard names, third occurrence — #1269 and #1321 were the same thing with different flags. The detector works; it just reports on the *next* pull request rather than on the one that added the flag, so the cost lands on whoever pushes next and the staleness accumulates until someone regenerates.

Worth a maintainer decision rather than another regeneration from me: either the ratchet blocks merge, or the inventory stops being a committed artifact that can drift. I have not changed either here.

Checked: `test_a_two_path_flag_says_why`, `test_matrixark_engine_flag_inventory`, `test_matrixark_engine_settings_match_the_engine`, `test_matrixark_every_live_claim_is_checked` and `test_the_loader_maps_every_config_key` all pass. No engine code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)