### PR TITLE
A record can cross the lane as a document instead of a string

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -19,6 +19,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue;
 use serde_json::{json, Value};
 use temporalstore_rust::{
     BatchExecuteRequest, BatchExecuteResponse, BlockStoreOptions, Command, CommandResponse,
@@ -65,6 +66,10 @@ struct RecordLogRequest {
     query: String,
     #[serde(default)]
     max_selected_refs: usize,
+    /// Send record payloads as sub-documents instead of JSON strings (see `RecordPayload`).
+    /// Absent means the historical string shape, so an older reader is unaffected.
+    #[serde(default)]
+    records_inline_json: bool,
     #[serde(default, deserialize_with = "deserialize_null_default")]
     entries: Vec<HashEntry>,
     #[serde(default, deserialize_with = "deserialize_null_default")]
@@ -148,11 +153,47 @@ struct HashEntry {
 #[derive(Clone, Debug, Deserialize)]
 struct CompactHashEntry(String, String, String);
 
+/// A record payload on the wire.
+///
+/// `Text` is the shape this lane has always used: the stored record's JSON as a STRING. That
+/// costs twice. Serializing escapes every quote in the payload into a new allocation here, and
+/// the reader then parses the envelope AND parses each record's string a second time -- the
+/// stored bytes are already JSON, so both sides are converting JSON to JSON.
+///
+/// `Inline` embeds the stored bytes verbatim as a sub-document. Nothing is escaped on the way
+/// out and the reader parses once. Only a caller that asked for it gets it, so a reader that
+/// still expects a string keeps getting one.
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+enum RecordPayload {
+    Inline(Box<RawValue>),
+    Text(String),
+}
+
+/// Wrap a stored payload for the wire, inline when the caller asked and the bytes really are JSON.
+///
+/// The validation is not optional: `RawValue` is emitted VERBATIM, so handing it a value that is
+/// not JSON would produce a malformed response for the whole batch rather than one bad record.
+/// A payload that does not parse falls back to the string shape, which is exactly what this lane
+/// did before.
+fn record_payload(value: String, inline: bool) -> RecordPayload {
+    if inline && serde_json::from_str::<serde::de::IgnoredAny>(&value).is_ok() {
+        // The clone is a memcpy on a string we have already scanned, and it buys the caller a
+        // whole parse. `from_string` can only reject invalid JSON, which the check above has
+        // excluded, but falling through rather than unwrapping keeps a surprise from costing
+        // the record.
+        if let Ok(raw) = RawValue::from_string(value.clone()) {
+            return RecordPayload::Inline(raw);
+        }
+    }
+    RecordPayload::Text(value)
+}
+
 #[derive(Debug, Serialize)]
 struct HashReadRecord {
     key: String,
     field: String,
-    value: String,
+    value: RecordPayload,
 }
 
 #[derive(Clone, Debug)]
@@ -3573,6 +3614,9 @@ fn execute_record_log_request(
                     response.responses.len()
                 ));
             }
+            // Read the caller's choice before the loop: a bool is Copy, so this stays valid
+            // even where the arm has already moved other fields out of the request.
+            let inline_json = request.records_inline_json;
             for ((key, fields), item) in grouped_entries.into_iter().zip(response.responses) {
                 if !item.status.ok {
                     return Err(format!("{}: {}", item.status.code, item.status.message));
@@ -3592,7 +3636,7 @@ fn execute_record_log_request(
                     records.push(HashReadRecord {
                         key: key.clone(),
                         field,
-                        value,
+                        value: record_payload(value, inline_json),
                     });
                 }
             }
@@ -3622,7 +3666,10 @@ fn execute_record_log_request(
             )?;
             empty_output(root)
         }
-        "hgetall" | "scan_hash" => hash_entries_output(&engine, request.key, root)?,
+        "hgetall" | "scan_hash" => {
+            let inline_json = request.records_inline_json;
+            hash_entries_output(&engine, request.key, root, inline_json)?
+        }
         // Read the durability barrier counters. They are collected by every site that takes a
         // barrier and were, until now, unreachable from outside the process -- so the one number
         // that says how much of a write is barrier-bound could not be measured, only argued.
@@ -3956,6 +4003,7 @@ fn hash_entries_output(
     engine: &RecordStore,
     key: String,
     root: PathBuf,
+    inline_json: bool,
 ) -> Result<RecordLogOutput, String> {
     // Read through the hash snapshot: a raw HashGetAll re-reads every field's page uncached on
     // each call (measured 14.6 ms warm for a 27-field hash), while the snapshot is read once and
@@ -3968,7 +4016,7 @@ fn hash_entries_output(
                 records.push(HashReadRecord {
                     key: key.clone(),
                     field: field.clone(),
-                    value: value.clone(),
+                    value: record_payload(value.clone(), inline_json),
                 });
             }
             let mut extra = BTreeMap::new();
@@ -5524,6 +5572,63 @@ fn _request_shape_for_docs() -> serde_json::Value {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn a_record_payload_is_a_string_unless_the_caller_asked_for_a_document() {
+        let stored = "{\"record_type\":\"context_event\",\"text\":\"a \\\"quoted\\\" value\"}";
+        let record = HashReadRecord {
+            key: "k".to_string(),
+            field: "f".to_string(),
+            value: record_payload(stored.to_string(), false),
+        };
+        let wire = serde_json::to_string(&record).expect("serializes");
+        let parsed: Value = serde_json::from_str(&wire).expect("parses");
+        assert!(parsed["value"].is_string(), "default must stay a string: {wire}");
+        let inner: Value =
+            serde_json::from_str(parsed["value"].as_str().unwrap()).expect("inner parses");
+        assert_eq!(inner["record_type"], "context_event");
+    }
+
+    #[test]
+    fn an_inline_payload_carries_the_same_record_without_the_second_parse() {
+        let stored = "{\"record_type\":\"context_event\",\"text\":\"a \\\"quoted\\\" value\",\"n\":12345}";
+        let inline_wire = serde_json::to_string(&HashReadRecord {
+            key: "k".to_string(),
+            field: "f".to_string(),
+            value: record_payload(stored.to_string(), true),
+        })
+        .expect("serializes");
+        let inline: Value = serde_json::from_str(&inline_wire).expect("parses");
+        assert!(inline["value"].is_object(), "inline must be a document: {inline_wire}");
+        assert_eq!(inline["value"]["n"], 12345);
+
+        let text_wire = serde_json::to_string(&HashReadRecord {
+            key: "k".to_string(),
+            field: "f".to_string(),
+            value: record_payload(stored.to_string(), false),
+        })
+        .expect("serializes");
+        let text: Value = serde_json::from_str(&text_wire).expect("parses");
+        let from_text: Value =
+            serde_json::from_str(text["value"].as_str().unwrap()).expect("inner parses");
+        assert_eq!(from_text, inline["value"], "the shape changes, the record must not");
+    }
+
+    #[test]
+    fn a_payload_that_is_not_json_falls_back_rather_than_corrupting_the_batch() {
+        for stored in ["not json at all", "", "{unclosed"] {
+            let wire = serde_json::to_string(&HashReadRecord {
+                key: "k".to_string(),
+                field: "f".to_string(),
+                value: record_payload(stored.to_string(), true),
+            })
+            .expect("serializes");
+            let parsed: Value = serde_json::from_str(&wire)
+                .unwrap_or_else(|e| panic!("malformed for {stored:?}: {e} / {wire}"));
+            assert!(parsed["value"].is_string(), "must fall back for {stored:?}");
+            assert_eq!(parsed["value"].as_str().unwrap(), stored);
+        }
+    }
     use super::compare_scored_candidate;
     use super::{matrixark_scan_cache_key, RecordLogRequest};
 
@@ -5860,6 +5965,7 @@ mod tests {
 
     fn request(op: &str) -> RecordLogRequest {
         RecordLogRequest {
+            records_inline_json: false,
             // This request names no identities: the field is only read by the delete op.
             record_ids: None,
             op: op.to_string(),
@@ -6637,6 +6743,7 @@ mod tests {
             &engine,
             "matrixark:test:records".to_string(),
             record_log_root(&health),
+            false,
         )
         .expect("hgetall output");
         assert_eq!(output.count, Some(2));
@@ -6661,6 +6768,7 @@ mod tests {
             &engine,
             "matrixark:test:records".to_string(),
             record_log_root(&health),
+            false,
         )
         .expect("hgetall after delete");
         assert_eq!(output.count, Some(1));

--- a/tools/matrixark_temporal_direct_read.py
+++ b/tools/matrixark_temporal_direct_read.py
@@ -3,6 +3,29 @@
 """_TemporalDirectReadMixin methods split from matrixark_mcp_temporal_adapters.MatrixArkTemporalStoreDirectAdapter (mixin)."""
 from __future__ import annotations
 
+def lane_record_payload(value):
+    """A lane record's payload as a dict, whether it arrived as a document or as a string.
+
+    The lane has always sent a record's stored JSON as a STRING, so every reader parses the
+    envelope and then parses the record a second time. The proxy can now send the record as a
+    sub-document instead (`records_inline_json`), which removes that second parse -- but only if
+    the readers accept both shapes. This accepts both, so the two sides can be switched over
+    independently instead of in one flip.
+
+    Returns {} for anything that is neither, which is what the callers' try/except did before.
+    """
+    if isinstance(value, dict):
+        return value
+    if not value:
+        return {}
+    try:
+        import json as _json
+        decoded = _json.loads(value if isinstance(value, str) else str(value))
+    except (TypeError, ValueError):
+        return {}
+    return decoded if isinstance(decoded, dict) else {}
+
+
 try:
     from tools.matrixark_mcp_env import env_bool
 except ImportError:  # Direct script execution from tools/.
@@ -681,7 +704,7 @@ class _TemporalDirectReadMixin:
             if not isinstance(row, dict) or not row.get("value"):
                 continue
             try:
-                decoded = json.loads(str(row.get("value")))
+                decoded = lane_record_payload(row.get("value"))
             except Exception:
                 continue
             if not isinstance(decoded, dict):
@@ -709,7 +732,7 @@ class _TemporalDirectReadMixin:
             if not value:
                 continue
             try:
-                decoded = json.loads(str(value))
+                decoded = lane_record_payload(value)
             except Exception:
                 continue
             raw_refs = decoded.get("ref_hashes", []) if isinstance(decoded, dict) else []
@@ -757,7 +780,7 @@ class _TemporalDirectReadMixin:
             if not isinstance(row, dict) or not row.get("value"):
                 continue
             try:
-                decoded = json.loads(str(row.get("value")))
+                decoded = lane_record_payload(row.get("value"))
             except Exception:
                 continue
             if not isinstance(decoded, dict):
@@ -786,7 +809,7 @@ class _TemporalDirectReadMixin:
             if not value:
                 continue
             try:
-                decoded = json.loads(str(value))
+                decoded = lane_record_payload(value)
             except Exception:
                 continue
             raw_locations = decoded.get("locations", []) if isinstance(decoded, dict) else []

--- a/tools/matrixark_temporal_direct_retrieve.py
+++ b/tools/matrixark_temporal_direct_retrieve.py
@@ -3,6 +3,29 @@
 """_TemporalDirectRetrieveMixin methods split from matrixark_mcp_temporal_adapters.MatrixArkTemporalStoreDirectAdapter (mixin)."""
 from __future__ import annotations
 
+def lane_record_payload(value):
+    """A lane record's payload as a dict, whether it arrived as a document or as a string.
+
+    The lane has always sent a record's stored JSON as a STRING, so every reader parses the
+    envelope and then parses the record a second time. The proxy can now send the record as a
+    sub-document instead (`records_inline_json`), which removes that second parse -- but only if
+    the readers accept both shapes. This accepts both, so the two sides can be switched over
+    independently instead of in one flip.
+
+    Returns {} for anything that is neither, which is what the callers' try/except did before.
+    """
+    if isinstance(value, dict):
+        return value
+    if not value:
+        return {}
+    try:
+        import json as _json
+        decoded = _json.loads(value if isinstance(value, str) else str(value))
+    except (TypeError, ValueError):
+        return {}
+    return decoded if isinstance(decoded, dict) else {}
+
+
 try:  # package path
     from tools.matrixark_mcp_core import *  # noqa: F401,F403
 except ImportError:
@@ -112,7 +135,7 @@ class _TemporalDirectRetrieveMixin:
             if not isinstance(row, dict) or not row.get("value"):
                 continue
             try:
-                decoded = json.loads(str(row.get("value")))
+                decoded = lane_record_payload(row.get("value"))
             except Exception:
                 continue
             if not isinstance(decoded, dict):
@@ -141,7 +164,7 @@ class _TemporalDirectRetrieveMixin:
             if not value:
                 continue
             try:
-                decoded = json.loads(str(value))
+                decoded = lane_record_payload(value)
             except Exception:
                 continue
             raw_locations = decoded.get("locations", []) if isinstance(decoded, dict) else []

--- a/tools/test_a_lane_record_reads_the_same_either_shape.py
+++ b/tools/test_a_lane_record_reads_the_same_either_shape.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A lane record must read the same whether it arrived as a document or as a string.
+
+The lane has always sent a record's stored JSON as a STRING, so every reader parses the envelope
+and then parses the record again. The proxy can now send the record as a sub-document instead,
+which removes that second parse -- but the switch is only safe if readers accept both shapes,
+because the two sides are deployed independently.
+"""
+from __future__ import annotations
+
+import unittest
+
+# `matrixark_temporal_direct_read` is a mixin the adapters module imports back, so it does
+# not import standalone. Import in the order production does, then take the helper.
+import matrixark_mcp_temporal_adapters  # noqa: F401
+from matrixark_temporal_direct_read import lane_record_payload
+
+
+class LaneRecordPayloadTest(unittest.TestCase):
+    def test_a_string_payload_reads_as_it_always_did(self):
+        self.assertEqual(
+            lane_record_payload('{"record_type":"context_event","n":7}'),
+            {"record_type": "context_event", "n": 7},
+        )
+
+    def test_a_document_payload_reads_the_same(self):
+        """The point of the change: no second parse, same answer."""
+        as_doc = {"record_type": "context_event", "n": 7}
+        self.assertEqual(lane_record_payload(as_doc), lane_record_payload('{"record_type":"context_event","n":7}'))
+        # and it is the SAME object, not a copy -- the parse is genuinely skipped
+        self.assertIs(lane_record_payload(as_doc), as_doc)
+
+    def test_junk_is_empty_rather_than_raising(self):
+        """The callers' old try/except swallowed bad payloads; that behaviour is preserved."""
+        for junk in ("", None, "not json", "[1,2,3]", 17):
+            self.assertEqual(lane_record_payload(junk), {}, junk)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The lane carries a record's stored JSON as a **string** inside the JSON envelope, so the same
bytes are converted to JSON twice. The proxy escapes every quote in the payload into a fresh
allocation on the way out, and the reader parses the envelope and then parses each record's
string again. The stored bytes are already JSON: both sides are converting JSON to JSON.

That matters because JSON decode is where the gateway's CPU goes. A sampled profile under load
put `raw_decode` at 49.4% of gateway self time with another 15.3% in the lane reader, and the
proxy's own hottest frames are the construction and teardown of the matching values.

## What changes

`RecordPayload::Inline` embeds the stored bytes verbatim using serde_json's `RawValue`. Nothing
is escaped on the way out, and the reader parses once.

A caller only gets it by asking (`records_inline_json`). A reader that still expects a string
sees the byte-identical shape it always saw. The two sides deploy independently, so this is a
negotiation rather than a flag flip -- a lane whose codec changes under a running reader is an
outage, not a speedup.

Validation before wrapping is not optional. `RawValue` is emitted **verbatim**, so a payload that
is not JSON would make the whole batch malformed rather than one record. A payload that does not
parse falls back to the string shape.

The readers accept both shapes now (`lane_record_payload`), which is what lets the two sides be
switched over one at a time. **That half is inert today**: every value is still a string, and the
helper returns the same dict the callers' `try/except` produced.

## Gates

- `cargo test --bin matrixark_rust_proxy` -- 3 passed. This file compiles through `src/bin`, so
  `--lib` does not run these tests at all; running it that way reports success while executing
  none of them.
  - the default stays a string and still survives the reader's second parse
  - an inline payload carries the identical record -- asserted equal to what the string path
    produces, so the shape changes and the content does not
  - a non-JSON payload falls back rather than corrupting the batch
  - disabling the inline path fails one of the three, so they discriminate
- `tools/test_a_lane_record_reads_the_same_either_shape.py` -- 3 passed: both shapes read the
  same, the document shape is returned without a parse, junk stays empty rather than raising.

## What this does not claim

No end-to-end CPU delta is quoted. Three attempts to measure lane bytes per call were each
contaminated -- by a concurrent soak, and then by the gateway's own background passes, which
produced a reading of 1.34 GB for a single ingest against a 328 MB store. Process-level counters
cannot isolate one request here, so the number is not reported rather than reported badly. The
case for this change is structural: the second parse and the escaping are visible in the code.

The enable flag stays off until the `batch_hget` consumers are audited; several of them still do
`str(row.get("value"))` and would read a document as its repr.
