### PR TITLE
A test set a variable nothing reads, and called it the gate

### DIFF
--- a/crates/temporalstore-rust/src/bin/upsert_reload_harness.rs
+++ b/crates/temporalstore-rust/src/bin/upsert_reload_harness.rs
@@ -2,7 +2,8 @@
 // Copyright 2026 MatrixArkAI
 
 //! Scale reload-equality harness for the upsert index-log delta records
-//! (TS_INDEXLOG_UPSERT_DELTAS). Builds a store the way a batch-committing ingest does --
+//! (`TS_INDEXLOG_UPSERT_DELTAS` names the feature; nothing reads that variable any more, so
+//! it gates nothing). Builds a store the way a batch-committing ingest does --
 //! thousands of hash batches (HashMultiSet + StringSet only, so every batch emits ONE
 //! upsert delta record), a durably-logged shard config (config-log present), threshold
 //! dumps part-way through (anchored base + durable pages), and an abrupt abort in place

--- a/crates/temporalstore-rust/src/engine/tests/upsert_deltas.rs
+++ b/crates/temporalstore-rust/src/engine/tests/upsert_deltas.rs
@@ -2,7 +2,8 @@
 // Copyright 2026 MatrixArkAI
 
 //! Reload-equality coverage for the upsert index-log delta records
-//! (TS_INDEXLOG_UPSERT_DELTAS): the served view reconstructed through base-only fold
+//! (`TS_INDEXLOG_UPSERT_DELTAS` named the feature and gates nothing now): the served view
+//! reconstructed through base-only fold
 //! recovery must equal the pre-reload view at scale.
 #![allow(clippy::all)]
 use super::*;

--- a/crates/temporalstore-rust/tests/upsert_reload_equality.rs
+++ b/crates/temporalstore-rust/tests/upsert_reload_equality.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 MatrixArkAI
 
-//! Scale reload-equality for upsert index-log delta records (TS_INDEXLOG_UPSERT_DELTAS).
+//! Scale reload-equality for upsert index-log delta records. `TS_INDEXLOG_UPSERT_DELTAS`
+//! names the feature and no longer gates it -- nothing reads that variable.
 //!
 //! A ~45K-record production store built through batch-committing ingest reconstructed
 //! EMPTY on reload while the small-store proofs passed, so this drives the same shape at
@@ -36,8 +37,9 @@ fn run(mode: &str, root: &Path, batches: u64, extend: Option<u64>, legacy_recove
     if let Some(extend) = extend {
         cmd.args(["--extend", &extend.to_string()]);
     }
-    // The emission gate under test: every phase runs with upsert delta records ON.
-    cmd.env("TS_INDEXLOG_UPSERT_DELTAS", "1");
+    // No emission gate is set here. `TS_INDEXLOG_UPSERT_DELTAS` used to be one; nothing reads
+    // it now, so setting it selected nothing and this ran the default path either way. The
+    // variable below is read, which is why it is still passed.
     if legacy_recovery {
         cmd.env("TS_WAL_LEGACY_RECOVERY", "1");
     }


### PR DESCRIPTION
`tests/upsert_reload_equality.rs` carried this:

```rust
// The emission gate under test: every phase runs with upsert delta records ON.
cmd.env("TS_INDEXLOG_UPSERT_DELTAS", "1");
```

**Nothing reads `TS_INDEXLOG_UPSERT_DELTAS.`** There is no `env::var` for it anywhere in the
crate, and the generated flag inventory does not list it — the generator counts flags that have a
reader, and this one has none.

So the line selected nothing. Every phase ran the default path whether it was there or not, and
the test that exists to prove reload-equality *under that feature* was not choosing the feature at
all. The comment above it says otherwise, in the most direct terms available: "the emission gate
under test".

The line immediately below sets `TS_WAL_LEGACY_RECOVERY`, which **is** read. A dead switch sitting
beside a live one reads as equally live — that is how this survived, and it is why the fix says
plainly which of the two is which:

```rust
// No emission gate is set here. `TS_INDEXLOG_UPSERT_DELTAS` used to be one; nothing reads
// it now, so setting it selected nothing and this ran the default path either way. The
// variable below is read, which is why it is still passed.
```

## The three headers keep the name

`tests/upsert_reload_equality.rs`, `src/bin/upsert_reload_harness.rs` and
`src/engine/tests/upsert_deltas.rs` all name the variable in their module docs. The name stays —
it is what the feature is called, and the harness exists for it — but each now says what it is: a
label, not a switch. Removing the name outright would leave the next reader unable to connect the
harness to the thing it harnesses, which is the failure the codebase's own retirement notes
(`TS_HOT_PAGE_SPILL`, `TS_BLOCK_IN_WAL`) are written to avoid.

## Checks

`upsert_delta_store_reloads_to_the_view_it_acked` passes without the line, in 18.8 s — the same
path it was already taking, which is the point. `cargo check --release --lib --bins --tests` is
clean; the bins are built because one of the touched files is a binary, and `--lib` alone would
not have compiled it.

This removes a flag-shaped name from the tree without touching a serving path: no serving path
ever read it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
