### PR TITLE
The operations manual named a backend switch that does not exist

### DIFF
--- a/docs/matrixark_installation_operations_monitoring.md
+++ b/docs/matrixark_installation_operations_monitoring.md
@@ -137,7 +137,7 @@ MatrixArk should operate against either TemporalStore implementation through the
 
 | Area | TemporalStore | Rust TemporalStore | Required conformance |
 | --- | --- | --- | --- |
-| Local developer mode | Native process, direct SDK, or proxy/gateway. | Long-lived Rust proxy or binding; CLI-per-operation is debug only. | Same `backend=native|rust` switch in config and Docker. |
+| Local developer mode | Native process, direct SDK, or proxy/gateway. | Long-lived Rust proxy or binding; CLI-per-operation is debug only. | Same `MATRIXARK_MCP_BACKEND` switch (`local` or `temporalstore-rust`) in config and Docker. |
 | Serving data | ContextNode, ContextSummary, ContextEmbedding, ContextEvent, ContextEntity, ContextIndex, ResourceChunk, SkillManifest, ContextPackAudit. | Same logical records and wire shape. | Same record keys, timestamps, ids, and replay output. |
 | Ingestion | API, MCP, hook, batch/session commit, streaming, resource, skill, feedback. | Same ingestion APIs. | Same idempotency behavior and audit refs. |
 | Retrieval | Tree-first traversal, secondary-index filtering, event/entity/resource/skill selection, token-budget packing. | Same retrieval semantics. | Same selected refs and dropped-ref reasons for conformance tests. |
@@ -147,10 +147,10 @@ MatrixArk should operate against either TemporalStore implementation through the
 Backend selection should be explicit:
 
 ```bash
-export MATRIXARK_TEMPORALSTORE_BACKEND=native
+export MATRIXARK_MCP_BACKEND=local
 python3 tools/matrixark_mcp_server.py --event-log "$MATRIXARK_MCP_EVENT_LOG"
 
-export MATRIXARK_TEMPORALSTORE_BACKEND=rust
+export MATRIXARK_MCP_BACKEND=temporalstore-rust
 python3 tools/matrixark_mcp_server.py --event-log "$MATRIXARK_MCP_EVENT_LOG"
 ```
 
@@ -280,7 +280,8 @@ Common fixes:
 - Slow retrieval: check model encode latency, TemporalStore write/audit backlog, and tree traversal fallback.
 - Resource miss: inspect parser output, chunk hashes, L0 summary, chunk embeddings, and resource access scope.
 - Skill miss: inspect skill triggers, owner scope, status, precedence, and selected-skill audit.
-- Backend mismatch: run the same conformance fixture with `backend=native` and `backend=rust`; compare ContextPack JSONL, selected refs, dropped refs, and audit rows.
+- Backend mismatch: run the same conformance fixture with `MATRIXARK_MCP_BACKEND=local` and
+  `MATRIXARK_MCP_BACKEND=temporalstore-rust`; compare ContextPack JSONL, selected refs, dropped refs, and audit rows.
 - Rust slow path: verify the Rust backend is a Rust proxy/binding, not CLI-per-operation.
 - slow path: verify async oplog, batch append, audit buffering, and data-node count before raising retrieval worker concurrency.
 

--- a/tools/temporalstore-monitoring-ui/README.md
+++ b/tools/temporalstore-monitoring-ui/README.md
@@ -72,7 +72,8 @@ matrixark-server apply-key --agent codex
 
 Backend conformance expectations:
 
-- The same monitoring UI must work for `backend=native` and `backend=rust`.
+- The same monitoring UI must work for `MATRIXARK_MCP_BACKEND=local` and
+  `MATRIXARK_MCP_BACKEND=temporalstore-rust`.
 - Health payloads should expose `temporalstore.backend`, `mode`, `storage`, `raft`, and `gateway`.
 - and Rust runs should render the same ContextNode topology, summaries, embeddings, events, entities, resource chunks, skills, ContextPacks, and audit rows.
 - Rust CLI-per-operation is acceptable for debug conformance only; production Rust should use the Rust proxy or Rust direct SDK.


### PR DESCRIPTION
Under **"Backend selection should be explicit"**, the installation / operations / monitoring
manual told an operator to run:

```bash
export MATRIXARK_TEMPORALSTORE_BACKEND=native
export MATRIXARK_TEMPORALSTORE_BACKEND=rust
```

**Nothing reads `MATRIXARK_TEMPORALSTORE_BACKEND`.** Those two lines were its only occurrences in
the entire tree — no Rust, no Python, no shell, no compose file.

The switch that exists is `MATRIXARK_MCP_BACKEND`, read by
`matrixark_mcp_backends.default_mcp_backend()` and used as the argparse default for `--backend`,
whose `choices` are `local`, `temporalstore-local`, `temporalstore-direct`, `temporalstore-rust`.

So both halves were wrong — the variable name *and* the values. An operator following the section
exported something inert and got whichever backend the default resolved to, with nothing
reporting that the selection had not been made. That is precisely the opposite of what a section
titled "should be explicit" promises, and the failure is silent: `default_mcp_backend()` returns
a perfectly good backend, so the deployment looks configured.

## Also corrected, same vocabulary used as instruction

- the conformance table cell — "Same `backend=native|rust` switch in config and Docker"
- the troubleshooting step — "run the same conformance fixture with `backend=native` and
  `backend=rust`"
- `tools/temporalstore-monitoring-ui/README.md` — "must work for `backend=native` and
  `backend=rust`"

All three now name the variable that is read, with values that are in the `choices` list. After
this, `MATRIXARK_TEMPORALSTORE_BACKEND`, `backend=native` and `backend=rust` appear nowhere in
the tree.

## How it was found

A sweep for variables something **sets** that nothing **reads** — the same shape as #1356, where
a test set `TS_INDEXLOG_UPSERT_DELTAS` and called it "the emission gate under test" while nothing
read it. Two of the four hits were false positives worth naming: `TS_URL` is read two lines later
as `"$TS_URL/context/manage"`, and my expansion pattern required a `:` or `}` after the name.

Documentation only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
