### PR TITLE
Regenerate the flag inventory, and say why the lane codec has two paths

### DIFF
--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -8,7 +8,7 @@ within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 289 of them, read by 90 functions.
+There are 290 of them, read by 91 functions.
 
 Deleting unreachable code is not the lever. An earlier version of this document argued that
 by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
@@ -60,12 +60,12 @@ Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 289 |
-| booleans whose default this could read off the source | 48 |
+| total | 290 |
+| booleans whose default this could read off the source | 49 |
 | numbers whose default this could read off the source | 70 |
 | **defaulting on, and set by nothing** | 5 |
 | offered on the portal | 26 |
-| **that nothing in this repository sets** | 160 |
+| **that nothing in this repository sets** | 161 |
 | documented as keeping an older path alive | 3 |
 | reaching more than two files | 15 |
 | whose doc comment is really about another flag | 42 |
@@ -201,12 +201,13 @@ What is written, when it is flushed, and what is reclaimed. The escape hatches h
 | `TS_WAL_RESIDENT_PAGES` | 4096 | test | 1 | — |
 | `TS_WAL_SEGMENT_BYTES` | 262144 | nothing | 1 | — |
 
-## format (5)
+## format (6)
 
 The shape of what is written. Readers generally accept both shapes, which is what makes these safe to flip and hard to retire.
 
 | flag | default | set by | files | keeps an older path |
 |---|---|---|---|---|
+| `MATRIXARK_LANE_CODEC` | off | nothing | 1 | — |
 | `TS_INDEX_CODEC` | — | test | 1 | — |
 | `TS_NODE_SUMMARY_VECTOR` | on | test, portal | 1 | — |
 | `TS_PROXY_BINARY_VERSION` | — | nothing | 1 | — |

--- a/tools/test_a_two_path_flag_says_why.py
+++ b/tools/test_a_two_path_flag_says_why.py
@@ -112,6 +112,11 @@ KNOWN_TWO_PATH_FLAGS: Dict[str, str] = {
     "TS_META_SHARD_DIVERGENCE_CHECK":
         "compares the owner map against what each datanode reports serving and re-places the "
         "difference. Off because it moves shards",
+    "MATRIXARK_LANE_CODEC":
+        "picks the codec the proxy lane speaks, decided ONCE from the environment the process "
+        "was spawned with because the lane is a single pipe and a codec that changed partway "
+        "would leave the reader mid-frame. Off is what an older spawner gets: the JSON lines "
+        "it has always got",
     "TS_INDEX_LOG_COMPRESSION_ENABLED":
         "gates only the WRITING of compressed index-log payloads; reading codec 2 is unconditional, "
         "which is what lets a store roll forward and back without a migration. Off is the end that "


### PR DESCRIPTION
`MATRIXARK_LANE_CODEC` landed in `matrixark_rust_proxy_impl.rs` without the generated inventory
being regenerated, so two guards are red on main and on every branch cut from it:

- `test_every_flag_named_in_the_engine_is_listed`
- `test_regenerating_produces_the_same_document`

Regenerating adds the row and surfaces the flag to `test_a_two_path_flag_says_why`, which wants a
recorded reason for its off side. Taken from what the engine already says at the read:

> Decided ONCE, from the environment the process was spawned with — never per request. The lane
> is a single pipe carrying a stream of responses, so a codec that changed partway would leave
> the reader mid-frame with no way back. The spawner chooses; an older spawner sets nothing and
> gets the JSON lines it has always got.

I derived that from the code rather than from the author, so if the intent differs the wording is
the part to correct.

## This is the fourth time

#1269, #1321, #1346, and now this one — always the same two guard names, always a flag added
without the regeneration step.

The detector works and the fix is mechanical. What does not work is *when* it reports: the
ratchet is not a blocking check, so the change that adds a flag merges red and the cost lands on
whoever pushes next. Four unrelated pull requests have now paid it, and the staleness accumulates
until someone happens to regenerate.

I raised this for a maintainer decision in #1346 and nothing changed, so I am raising it again
rather than absorbing it silently. Two options, both policy calls I have not made here:

- make the ratchet blocking, so the flag-adding change is the one that goes red; or
- stop committing the inventory as an artifact that can drift, and generate it at read time.

Checked: `test_a_two_path_flag_says_why`, `test_matrixark_engine_flag_inventory` and
`test_matrixark_engine_settings_match_the_engine` all pass. No engine code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
