### PR TITLE
Six timeout variables for three metaserver loops become two

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -957,11 +957,7 @@ fn start_auto_rebalance_loop(
     placement_aware: bool,
 ) -> std::thread::JoinHandle<()> {
     let interval = std::time::Duration::from_millis(interval_ms.max(1));
-    let http_options = HttpRequestOptions {
-        connect_timeout_ms: env_u64("TS_META_AUTO_REBALANCE_CONNECT_TIMEOUT_MS", 500),
-        io_timeout_ms: env_u64("TS_META_AUTO_REBALANCE_IO_TIMEOUT_MS", 2_000),
-        max_retries: 1,
-    };
+    let http_options = peer_loop_http_options(1);
     std::thread::spawn(move || loop {
         if meta.is_meta_change_muted() {
             std::thread::sleep(interval);
@@ -1088,11 +1084,8 @@ fn start_shard_divergence_loop(
     interval_ms: u64,
 ) -> std::thread::JoinHandle<()> {
     let interval = std::time::Duration::from_millis(interval_ms.max(1));
-    let http_options = HttpRequestOptions {
-        connect_timeout_ms: env_u64("TS_META_SHARD_DIVERGENCE_CONNECT_TIMEOUT_MS", 500),
-        io_timeout_ms: env_u64("TS_META_SHARD_DIVERGENCE_IO_TIMEOUT_MS", 2_000),
-        ..HttpRequestOptions::default()
-    };
+    // 0 retries, which is what `HttpRequestOptions::default()` gave this loop before.
+    let http_options = peer_loop_http_options(0);
     let mut checker = ShardChecker::new(options);
     std::thread::spawn(move || loop {
         if meta.is_meta_change_muted() {
@@ -1253,11 +1246,7 @@ fn start_raft_failover_loop(
     interval_ms: u64,
 ) -> std::thread::JoinHandle<()> {
     let interval = std::time::Duration::from_millis(interval_ms.max(1));
-    let http_options = HttpRequestOptions {
-        connect_timeout_ms: env_u64("TS_RAFT_AUTO_FAILOVER_CONNECT_TIMEOUT_MS", 500),
-        io_timeout_ms: env_u64("TS_RAFT_AUTO_FAILOVER_IO_TIMEOUT_MS", 2_000),
-        max_retries: 1,
-    };
+    let http_options = peer_loop_http_options(1);
     std::thread::spawn(move || {
         let mut driven: std::collections::HashSet<u64> = std::collections::HashSet::new();
         loop {
@@ -1338,6 +1327,25 @@ fn now_epoch_ms() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|duration| duration.as_millis() as u64)
         .unwrap_or_default()
+}
+
+/// Connect and read timeouts for the metaserver's background peer loops.
+///
+/// Three loops -- auto-rebalance, the shard-divergence check and raft failover -- each make short
+/// HTTP calls to peers from a background thread, and each used to read its own connect/io pair:
+/// six variables holding the same two numbers. Nothing set any of them, none was offered in the
+/// config file or on the portal, and no deployment distinguished the three, so the per-loop
+/// granularity existed only in the source. One pair now covers all three.
+///
+/// `max_retries` is deliberately NOT shared. Two of the loops pass 1 and the divergence checker
+/// took `HttpRequestOptions::default()`, which is 0; folding that in would have quietly given it
+/// a retry it never had.
+fn peer_loop_http_options(max_retries: usize) -> HttpRequestOptions {
+    HttpRequestOptions {
+        connect_timeout_ms: env_u64("TS_META_PEER_CONNECT_TIMEOUT_MS", 500),
+        io_timeout_ms: env_u64("TS_META_PEER_IO_TIMEOUT_MS", 2_000),
+        max_retries,
+    }
 }
 
 fn default_connect_timeout_ms() -> u64 {

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -8,7 +8,7 @@ within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 290 of them, read by 91 functions.
+There are 286 of them, read by 89 functions.
 
 Deleting unreachable code is not the lever. An earlier version of this document argued that
 by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
@@ -60,15 +60,15 @@ Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 290 |
+| total | 286 |
 | booleans whose default this could read off the source | 49 |
-| numbers whose default this could read off the source | 70 |
+| numbers whose default this could read off the source | 66 |
 | **defaulting on, and set by nothing** | 5 |
 | offered on the portal | 26 |
-| **that nothing in this repository sets** | 161 |
+| **that nothing in this repository sets** | 157 |
 | documented as keeping an older path alive | 3 |
 | reaching more than two files | 15 |
-| whose doc comment is really about another flag | 42 |
+| whose doc comment is really about another flag | 38 |
 
 ## topology (38)
 
@@ -214,7 +214,7 @@ The shape of what is written. Readers generally accept both shapes, which is wha
 | `TS_VECTOR_INT8` | off | test, portal | 1 | — |
 | `TS_VECTOR_SCALED` | on | launch, test, portal | 1 | — |
 
-## capacity (81)
+## capacity (77)
 
 Sizes, ceilings and intervals. The tuning a deployment actually reaches for.
 
@@ -254,9 +254,7 @@ Sizes, ceilings and intervals. The tuning a deployment actually reaches for.
 | `TS_MATRIXOBJECT_FLUSH_INTERVAL_MS` | 100 | nothing | 1 | — |
 | `TS_MATRIXOBJECT_PROBE_TIMEOUT_MS` | — | nothing | 1 | — |
 | `TS_MAX_RETAINED_FINISHED_JOBS` | 64 | portal | 1 | — |
-| `TS_META_AUTO_REBALANCE_CONNECT_TIMEOUT_MS` | 500 | nothing | 1 | — |
 | `TS_META_AUTO_REBALANCE_INTERVAL_MS` | — | nothing | 1 | — |
-| `TS_META_AUTO_REBALANCE_IO_TIMEOUT_MS` | 2000 | nothing | 1 | — |
 | `TS_META_CONVICT_CRITICAL_RATIO_PERCENT` | — | nothing | 1 | — |
 | `TS_META_CONVICT_MIN_ABNORMAL` | — | nothing | 1 | — |
 | `TS_META_CONVICT_WARNING_RATIO_PERCENT` | — | nothing | 1 | — |
@@ -266,14 +264,14 @@ Sizes, ceilings and intervals. The tuning a deployment actually reaches for.
 | `TS_META_FD_MAX_ROUND_PAUSE_MS` | — | nothing | 1 | — |
 | `TS_META_FREEZE_AGING_INTERVAL_MS` | 60000 | nothing | 1 | — |
 | `TS_META_FREEZE_AGING_MAX_DROPS` | — | nothing | 1 | — |
+| `TS_META_PEER_CONNECT_TIMEOUT_MS` | 500 | nothing | 1 | — |
+| `TS_META_PEER_IO_TIMEOUT_MS` | 2000 | nothing | 1 | — |
 | `TS_META_PROXY_CALIBRATION_INTERVAL_MS` | — | nothing | 1 | — |
 | `TS_META_PROXY_CALIBRATION_MAX_CHANGES` | — | nothing | 1 | — |
 | `TS_META_RAFT_HEARTBEAT_INTERVAL_MS` | 100 | nothing | 1 | — |
 | `TS_META_RETENTION_INTERVAL_MS` | 60000 | nothing | 1 | — |
 | `TS_META_RETENTION_MAX_PURGES` | — | nothing | 1 | — |
-| `TS_META_SHARD_DIVERGENCE_CONNECT_TIMEOUT_MS` | 500 | nothing | 1 | — |
 | `TS_META_SHARD_DIVERGENCE_INTERVAL_MS` | — | nothing | 1 | — |
-| `TS_META_SHARD_DIVERGENCE_IO_TIMEOUT_MS` | 2000 | nothing | 1 | — |
 | `TS_META_SHARD_DIVERGENCE_MAX_MOVES` | — | nothing | 1 | — |
 | `TS_META_TASK_SCHEDULER_MAX_INFLIGHT` | — | nothing | 1 | — |
 | `TS_META_TASK_SCHEDULER_MAX_POSTPONE_MS` | — | nothing | 1 | — |
@@ -290,9 +288,7 @@ Sizes, ceilings and intervals. The tuning a deployment actually reaches for.
 | `TS_PROXY_MAX_INFLIGHT_WRITE_REQUESTS` | — | nothing | 1 | — |
 | `TS_PROXY_MAX_RETRIES` | — | config | 1 | — |
 | `TS_PROXY_TOPOLOGY_CHECK_INTERVAL_MS` | — | nothing | 1 | — |
-| `TS_RAFT_AUTO_FAILOVER_CONNECT_TIMEOUT_MS` | 500 | nothing | 1 | — |
 | `TS_RAFT_AUTO_FAILOVER_INTERVAL_MS` | — | nothing | 1 | — |
-| `TS_RAFT_AUTO_FAILOVER_IO_TIMEOUT_MS` | 2000 | nothing | 1 | — |
 | `TS_RAFT_MAX_APPLIED_LOG_BYTES` | — | nothing | 1 | — |
 | `TS_RAFT_MAX_INFLIGHTS_REPLICATE` | — | test | 1 | — |
 | `TS_SERVER_HEARTBEAT_INTERVAL_MS` | 3000 | config, script | 1 | — |


### PR DESCRIPTION
The metaserver runs three background peer loops — auto-rebalance, the shard-divergence check, and
raft failover. Each makes short HTTP calls to peers, and each read **its own** connect/io timeout
pair:

```
TS_META_AUTO_REBALANCE_CONNECT_TIMEOUT_MS   / _IO_TIMEOUT_MS
TS_META_SHARD_DIVERGENCE_CONNECT_TIMEOUT_MS / _IO_TIMEOUT_MS
TS_RAFT_AUTO_FAILOVER_CONNECT_TIMEOUT_MS    / _IO_TIMEOUT_MS
```

Six variables holding the same two numbers, `500` and `2000`.

Nothing in the tree set any of them. None was offered in `config/temporalstore.toml` or on the
portal. The shipped inventory listed all six as **set by nothing**. So the per-loop granularity
existed only in the source: no deployment ever distinguished the three, and there was no
documented way to find the knobs in order to try.

One pair — `TS_META_PEER_CONNECT_TIMEOUT_MS` and `TS_META_PEER_IO_TIMEOUT_MS` — now covers all
three, with the same defaults. **The generated inventory goes from 290 flags to 286.**

## What is deliberately not shared

`max_retries`. Two loops passed `1`; the divergence checker used
`..HttpRequestOptions::default()`, and that default is **0**, not 1. Folding it into the helper
would have quietly given that loop a retry it never had — the kind of change that looks like
tidying and isn't. It stays a parameter, and each call site passes exactly what it passed before:

```rust
let http_options = peer_loop_http_options(1);   // auto-rebalance, as before
// 0 retries, which is what `HttpRequestOptions::default()` gave this loop before.
let http_options = peer_loop_http_options(0);   // divergence check, as before
let http_options = peer_loop_http_options(1);   // raft failover, as before
```

## On removing four names from a public repo

These are four fewer environment variables an outside user could set. They were undocumented —
absent from the config file, the portal, and every launcher — so reaching them required reading
`bin/metaserver.rs`. The behaviour they tuned is still tunable, through the pair that replaces
them, at the same defaults. I judged that worth stating rather than burying, since it is the one
cost here.

## Checks

52 metaserver binary tests pass. `test_matrixark_engine_flag_inventory`,
`test_a_two_path_flag_says_why`, `test_matrixark_engine_settings_match_the_engine`,
`test_numeric_defaults_agree` and `test_matrixark_every_live_claim_is_checked` all pass.
`cargo check --release --bins` is clean — `--bins` because `metaserver.rs` is a binary and
`--lib` would not have compiled it.

Nothing on the serving path reads any of these: the live proxy sets two `TS_*` variables and
neither is among them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
