### PR TITLE
Slabs get a backend of their own

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -20,6 +20,8 @@ mod append;
 mod read;
 mod gc;
 mod slab_ids;
+mod slab_backend;
+use slab_backend::{LocalSlabBackend, SlabBackend};
 mod record;
 
 pub(crate) use record::block_index_checksums_enabled;

--- a/crates/temporalstore-rust/src/block_store/read.rs
+++ b/crates/temporalstore-rust/src/block_store/read.rs
@@ -11,11 +11,11 @@ impl LocalBlockStore {
         // metadata-only restore, fetch + cache it before serving the read.
         self.ensure_slab_present(address.block_slab_id)?;
         let mut inner = self.inner.lock().expect("block store lock poisoned");
-        let path = slab_path(&inner.root, address.block_slab_id);
-        let mut file = File::open(path)?;
-        file.seek(SeekFrom::Start(address.offset))?;
-        let mut bytes = vec![0; address.length as usize];
-        file.read_exact(&mut bytes)?;
+        let bytes = LocalSlabBackend::new(&inner.root).read_range(
+            address.block_slab_id,
+            address.offset,
+            address.length,
+        )?;
         let decoded = decode_page_record(&bytes, address)?;
         // `decode_page_record` just verified this payload against the digest stored in the
         // page envelope, and cross-checked the record header's page id, object id and routing
@@ -63,8 +63,7 @@ impl LocalBlockStore {
         // streaming reads too, so a not-yet-fetched checkpoint slab is pulled + cached on demand.
         self.ensure_slab_present(block_slab_id)?;
         let mut inner = self.inner.lock().expect("block store lock poisoned");
-        let path = slab_path(&inner.root, block_slab_id);
-        let slab = fs::read(path)?;
+        let slab = LocalSlabBackend::new(&inner.root).read_all(block_slab_id)?;
         let range = logical_range_from_slab(&slab, block_slab_id, offset, size)?;
         let bytes = range.bytes;
         inner.stats.reads += 1;

--- a/crates/temporalstore-rust/src/block_store/slab_backend.rs
+++ b/crates/temporalstore-rust/src/block_store/slab_backend.rs
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Where slab bytes actually live.
+//!
+//! The block store is the one log in this tree that writes straight to files. The write-ahead
+//! log, the index log and the raft log all go through `log_framing`, and the replicator goes
+//! through the `ObjectStore` backends -- so the two halves of a storage layer exist here, and
+//! the block store uses neither.
+//!
+//! This is the half the block store was missing: the operations it performs on a slab, named
+//! once, so a slab can live on a local file or on an object backend without the block store
+//! knowing which. It is deliberately NOT the object-store trait: that one is key-and-bytes with
+//! ranges, while a slab is appended to and read back by offset, and mapping one onto the other
+//! at every call site is what this exists to avoid.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// One slab's worth of storage, addressed by the id the block store already uses.
+pub(crate) trait SlabBackend: Send + Sync {
+    /// Append bytes to a slab, answering the offset they landed at.
+    ///
+    /// The offset is the backend's to report rather than the caller's to assume: an object
+    /// backend appends into an object whose length it knows, and a caller tracking its own
+    /// offset would be guessing at it.
+    fn append(&self, slab_id: u64, bytes: &[u8]) -> io::Result<u64>;
+
+    /// Read one record's bytes back, given where the address says they are.
+    fn read_range(&self, slab_id: u64, offset: u64, length: u64) -> io::Result<Vec<u8>>;
+
+    /// The whole slab, for the walks that summarise or inspect one.
+    fn read_all(&self, slab_id: u64) -> io::Result<Vec<u8>>;
+
+    /// How long the slab is, without reading it.
+    fn len(&self, slab_id: u64) -> io::Result<u64>;
+
+    /// Cut a slab back to a length, which is how a torn tail is fenced on reopen.
+    fn truncate(&self, slab_id: u64, length: u64) -> io::Result<()>;
+
+    /// Forget a slab entirely.
+    fn remove(&self, slab_id: u64) -> io::Result<()>;
+
+    /// Which slabs exist.
+    fn slab_ids(&self) -> io::Result<Vec<u64>>;
+
+    /// Make everything written to a slab durable.
+    fn sync(&self, slab_id: u64) -> io::Result<()>;
+
+    /// Whether a slab exists at all.
+    fn exists(&self, slab_id: u64) -> bool;
+}
+
+/// Slabs as files in a directory, which is what this has always done.
+///
+/// Every method is the code the block store ran inline before, moved behind the name of the
+/// operation it performs.
+pub(crate) struct LocalSlabBackend<'a> {
+    root: &'a Path,
+}
+
+impl<'a> LocalSlabBackend<'a> {
+    /// Borrows the root rather than owning it, so a caller on a read path can make one without
+    /// allocating: the block store already holds the root it would have cloned.
+    pub(crate) fn new(root: &'a Path) -> Self {
+        Self { root }
+    }
+
+    pub(crate) fn root(&self) -> &Path {
+        self.root
+    }
+
+    fn path(&self, slab_id: u64) -> PathBuf {
+        super::slab_path(self.root, slab_id)
+    }
+}
+
+impl SlabBackend for LocalSlabBackend<'_> {
+    fn append(&self, slab_id: u64, bytes: &[u8]) -> io::Result<u64> {
+        use std::io::Write as _;
+        std::fs::create_dir_all(self.root)?;
+        let path = self.path(slab_id);
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)?;
+        // The offset is read from the file rather than tracked by the caller, so a slab that
+        // grew underneath us is not silently written over.
+        let offset = file.metadata()?.len();
+        file.write_all(bytes)?;
+        file.flush()?;
+        Ok(offset)
+    }
+
+    fn read_range(&self, slab_id: u64, offset: u64, length: u64) -> io::Result<Vec<u8>> {
+        use std::io::{Read as _, Seek as _, SeekFrom};
+        let mut file = std::fs::File::open(self.path(slab_id))?;
+        file.seek(SeekFrom::Start(offset))?;
+        let mut bytes = vec![0_u8; length as usize];
+        file.read_exact(&mut bytes)?;
+        Ok(bytes)
+    }
+
+    fn read_all(&self, slab_id: u64) -> io::Result<Vec<u8>> {
+        std::fs::read(self.path(slab_id))
+    }
+
+    fn len(&self, slab_id: u64) -> io::Result<u64> {
+        Ok(std::fs::metadata(self.path(slab_id))?.len())
+    }
+
+    fn truncate(&self, slab_id: u64, length: u64) -> io::Result<()> {
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(self.path(slab_id))?;
+        file.set_len(length)
+    }
+
+    fn remove(&self, slab_id: u64) -> io::Result<()> {
+        std::fs::remove_file(self.path(slab_id))
+    }
+
+    fn slab_ids(&self) -> io::Result<Vec<u64>> {
+        super::slab_ids::slab_ids_at(self.root).map_err(|err| io::Error::other(err.to_string()))
+    }
+
+    fn sync(&self, slab_id: u64) -> io::Result<()> {
+        let file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(self.path(slab_id))?;
+        file.sync_all()
+    }
+
+    fn exists(&self, slab_id: u64) -> bool {
+        self.path(slab_id).exists()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Append answers where the bytes landed, and a read at that offset gives them back.
+    #[test]
+    fn a_slab_appends_and_reads_back_by_offset() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let backend = LocalSlabBackend::new(dir.path());
+
+        let first = backend.append(0, b"first-record").expect("append");
+        let second = backend.append(0, b"second-record").expect("append");
+        assert_eq!(first, 0, "the first record starts at the beginning");
+        assert_eq!(
+            second,
+            b"first-record".len() as u64,
+            "the second starts where the first ended"
+        );
+        assert_eq!(
+            backend
+                .read_range(0, second, b"second-record".len() as u64)
+                .expect("read"),
+            b"second-record",
+        );
+        assert_eq!(
+            backend.len(0).expect("len"),
+            (b"first-record".len() + b"second-record".len()) as u64
+        );
+    }
+
+    /// Truncating fences a tail, and what was before it still reads.
+    #[test]
+    fn truncating_keeps_the_prefix() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let backend = LocalSlabBackend::new(dir.path());
+        backend.append(1, b"keep").expect("append");
+        backend.append(1, b"lose").expect("append");
+        backend.truncate(1, 4).expect("truncate");
+        assert_eq!(backend.len(1).expect("len"), 4);
+        assert_eq!(backend.read_all(1).expect("read"), b"keep");
+    }
+
+    /// Slabs are found by id, and a removed one is gone.
+    #[test]
+    fn slabs_are_listed_and_removed_by_id() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let backend = LocalSlabBackend::new(dir.path());
+        backend.append(3, b"three").expect("append");
+        backend.append(7, b"seven").expect("append");
+        let mut ids = backend.slab_ids().expect("list");
+        ids.sort_unstable();
+        assert_eq!(ids, vec![3, 7]);
+        assert!(backend.exists(3));
+        backend.remove(3).expect("remove");
+        assert!(!backend.exists(3));
+        let ids = backend.slab_ids().expect("list");
+        assert_eq!(ids, vec![7]);
+    }
+}


### PR DESCRIPTION
The block store is the one log in this tree that writes straight to files. The write-ahead log,
the index log and the raft log all go through `log_framing`; the replicator goes through the
`ObjectStore` backends. Both halves of a storage layer already exist here, and the block store
uses neither -- which is why its records carry their own marker, checksum and length while every
other log gets those from a frame.

This adds the half it was missing.

## What it is

`SlabBackend` names the operations the block store performs on a slab: append, read a range, read
it all, length, truncate, remove, list, sync, exists. `LocalSlabBackend` holds the `std::fs` code
that ran inline before. The read path and the logical range read go through it.

## Two decisions worth stating

**`append` answers the offset the bytes landed at rather than taking one.** A caller tracking its
own offset is guessing at where an object backend put them -- and the object side already reports
exactly this, as `AppendBlobReceipt { start_offset, end_offset, .. }`. So the trait asks for what
both kinds of backend can actually answer.

**It is deliberately not the `ObjectStore` trait.** That one is keys and bytes with ranges; a slab
is appended to and read back by offset. Mapping one onto the other at every call site is what this
exists to avoid, and is a fair part of why the two halves never joined.

The backend borrows its root rather than owning it, so constructing one on a read path costs
nothing.

## What this is not

It is not a prerequisite for shrinking the block header. I had claimed the comparison design's
block record carries no header, and that a framing layer beneath slabs was needed to justify
dropping ours. That was wrong: their block record has a 2-byte length prefix followed by a
serialized header message of twelve fields -- roughly 30 bytes without the key and timestamp,
about 55 with them. Ours is 14. The header direction was already finished.

This stands on its own: the block store genuinely has no backend abstraction while the replicator
has one, and that is worth fixing whatever the header does.

## Gates

- block store 73 passed, 0 failed
- crash recovery 8 passed, 0 failed
- library 1717 passed, 2 failed -- both already failing on main
