### PR TITLE
Profile-driven: the lane can be binary, the scan can return less, and the engine can rank

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -100,6 +100,24 @@ struct RecordLogRequest {
     /// cap on the union would drop the very records that make deleted memories stay deleted.
     #[serde(default)]
     newest_by_type: Option<BTreeMap<String, usize>>,
+    /// Return only these top-level fields of each record.
+    ///
+    /// A scan returns whole records, and a caller uses a handful of fields. Measured on a
+    /// production store, the average record is 673 bytes of which the TEXT is 2.4%:
+    /// `storage_options` is 17.5%, `envelope` 11.9%, `scope` 10.7%, `embedding_meta` 9.6% and
+    /// `vector` 4.4% -- and the packer that asks for these records reads none of those five, since
+    /// it ranks lexically and reports `ranking_uses_vectors: false`. About nine tenths of every
+    /// record crossing the lane is never looked at, and the gateway spends 53.5% of its CPU
+    /// decoding it.
+    ///
+    /// The CALLER names the fields rather than the engine guessing them: the engine cannot know
+    /// what a caller will read, and a projection that guesses wrong is a missing field rather than
+    /// a slow response. Absent means the whole record, so nothing that does not ask is affected.
+    ///
+    /// Filtering happens BEFORE projection, so a scan can still filter on a field it does not
+    /// return -- otherwise asking for less data would silently change which records match.
+    #[serde(default)]
+    record_fields: Option<Vec<String>>,
     /// Identity ids to remove, for `matrixark_delete_records`. Sent by the caller, which owns the
     /// decision about what a delete covers; the engine only matches and removes.
     #[serde(default)]
@@ -1622,12 +1640,87 @@ fn invalidate_retrieve_candidate_cache_for_prefixes(prefixes: HashSet<String>) {
     }
 }
 
-fn matrixark_scan_cache_key(command: &RecordLogRequest, count: u64) -> String {
+/// Per-type append version. Changes when records OF THAT TYPE are appended, and not otherwise.
+/// Keep only the named top-level fields of a record.
+///
+/// `None` returns the record untouched. A record that is not an object is returned untouched too:
+/// projecting one would mean inventing a shape the caller did not ask for.
+///
+/// Nested paths are deliberately not supported. Every field a caller was measured to need is
+/// top-level, and a path syntax would be a second query language to get wrong in a place where
+/// being wrong means a silently missing field.
+fn project_record(record: Value, fields: Option<&std::collections::BTreeSet<String>>) -> Value {
+    let Some(fields) = fields else {
+        return record;
+    };
+    let Value::Object(map) = record else {
+        return record;
+    };
+    Value::Object(
+        map.into_iter()
+            .filter(|(key, _)| fields.contains(key))
+            .collect(),
+    )
+}
+
+fn type_version_key(record_hash_key: &str, record_type: &str) -> String {
+    format!("{record_hash_key}:type_version:{record_type}")
+}
+
+/// Per-base delete epoch, bumped by any removal.
+///
+/// Deletes get an epoch rather than a per-type version because of a hole that a per-type version
+/// alone cannot close: removing the last records of a type whose version key does not exist yet
+/// would leave the token unchanged, and the next scan would serve an answer that still contained
+/// them. An epoch is coarse -- it invalidates every scan for the base -- which is the right trade
+/// exactly because deletes are rare and appends are not.
+fn scan_delete_epoch_key(record_hash_key: &str) -> String {
+    format!("{record_hash_key}:scan_delete_epoch")
+}
+
+/// The token that decides whether a cached scan is still the right answer.
+///
+/// It used to be the storage prefix's TOTAL record count, which is correct but maximally coarse:
+/// every append changed it, so every scan of every type missed. Measured on a production-corpus
+/// soak that is 229 records written per user message, so the hit rate under ingest was
+/// effectively zero and each miss re-fetched the whole corpus of the requested types --
+/// `matrixark_scan_candidates` was 87% of all time spent inside lane calls.
+///
+/// A scan that names its types can only be changed by those types, so it is keyed on their
+/// versions plus the delete epoch. A scan that names no types could be changed by anything, so it
+/// keeps the total count. Narrowing WHEN a cached answer is reused, never WHAT a scan returns.
+fn scan_freshness_token(
+    engine: &RecordStore,
+    command: &RecordLogRequest,
+    record_hash_key: &str,
+    count: u64,
+) -> String {
+    let Some(types) = command.record_types.as_ref().filter(|types| !types.is_empty()) else {
+        return format!("count:{count}");
+    };
+    let epoch = read_record_count(engine, &scan_delete_epoch_key(record_hash_key))
+        .unwrap_or_default();
+    let mut parts = Vec::with_capacity(types.len());
+    for record_type in types {
+        // A missing key is a DISTINCT token, not a zero: a type with no records yet reads as
+        // absent, and its first append writes a version, so the token changes and the cached
+        // empty answer is dropped. Reading it as 0 would collide with a real version of 0.
+        let version = match read_record_count(engine, &type_version_key(record_hash_key, record_type)) {
+            Ok(value) if !value.trim().is_empty() => value.trim().to_string(),
+            _ => "-".to_string(),
+        };
+        parts.push(format!("{record_type}={version}"));
+    }
+    parts.sort();
+    format!("t:{}|d:{}", parts.join(","), epoch.trim())
+}
+
+fn matrixark_scan_cache_key(command: &RecordLogRequest, freshness: &str) -> String {
     serde_json::to_string(&json!({
         "count_key": command.count_key,
         "record_hash_key": command.record_hash_key,
         "shard_size": command.shard_size.unwrap_or(1024).max(1),
-        "count": count,
+        "freshness": freshness,
         "record_types": command.record_types,
         // A status-filtered scan is a SUBSET of the same question, exactly like
         // `newest_by_type` below -- sharing an entry would serve the subset to a
@@ -1641,8 +1734,12 @@ fn matrixark_scan_cache_key(command: &RecordLogRequest, count: u64) -> String {
         // A capped scan and an uncapped one are different answers to the same question, so they
         // must not share a cache entry: the capped answer is a SUBSET.
         "newest_by_type": command.newest_by_type,
+        // Same rule for a projection: a caller that asked for five fields must never be served
+        // the cached whole-record answer, and -- far worse -- a caller that asked for everything
+        // must never be served a projected one, which would look like data loss.
+        "record_fields": command.record_fields,
     }))
-    .unwrap_or_else(|_| format!("fallback:{count}"))
+    .unwrap_or_else(|_| format!("fallback:{freshness}"))
 }
 
 /// Stamp a cached scan result as a hit.
@@ -2718,7 +2815,8 @@ fn scan_matrixark_candidates(
     let shard_size = command.shard_size.unwrap_or(1024).max(1);
     let count_text = read_record_count(engine, &count_key)?;
     let count = count_text.parse::<u64>().unwrap_or(0);
-    let scan_cache_key = matrixark_scan_cache_key(command, count);
+    let freshness = scan_freshness_token(engine, command, &record_hash_key, count);
+    let scan_cache_key = matrixark_scan_cache_key(command, &freshness);
     // Take everything needed from the cache under one guard, then drop it before stamping the
     // result -- stamping used to re-lock this same mutex and hang the request.
     let cached_hit = match matrixark_scan_cache().lock() {
@@ -2848,6 +2946,13 @@ fn scan_matrixark_candidates(
             persist_type_index_backfill(engine, &record_hash_key, backfill)?;
         persist_scope_index_backfill(engine, &record_hash_key, scope_backfill)?;
     }
+    // Built once, outside the record loop: a set per record would allocate per record, on the
+    // very path this exists to make cheaper.
+    let projection: Option<std::collections::BTreeSet<String>> = command
+        .record_fields
+        .as_ref()
+        .filter(|fields| !fields.is_empty())
+        .map(|fields| fields.iter().cloned().collect());
     let mut records = Vec::new();
     {
         for value in &payload_values {
@@ -2889,7 +2994,7 @@ fn scan_matrixark_candidates(
                         continue;
                     }
                 }
-                records.push(record);
+                records.push(project_record(record, projection.as_ref()));
             }
         }
     }
@@ -4120,6 +4225,11 @@ fn execute_record_log_request(
             // very payloads being written, so the index can never lag a committed append. Only
             // record-shard keys feed it (see record_shard_key_parts).
             let mut index_entries: BTreeMap<String, Vec<(String, Vec<u8>)>> = BTreeMap::new();
+            // (base, record_type) touched by this batch. The types are already computed here for
+            // the type index, so stamping a version costs one small write per type and no extra
+            // decode.
+            let mut touched_types: std::collections::BTreeSet<(String, String)> =
+                std::collections::BTreeSet::new();
             for (key, entries) in &grouped {
                 if let Some((base, shard6)) = record_shard_key_parts(key) {
                     for (field, value) in entries {
@@ -4158,6 +4268,7 @@ fn execute_record_log_request(
                                 }
                             };
                         for record_type in type_names {
+                            touched_types.insert((base.to_string(), record_type.clone()));
                             index_entries
                                 .entry(type_index_key(base, &record_type))
                                 .or_default()
@@ -4182,6 +4293,21 @@ fn execute_record_log_request(
             }
             for (key, entries) in index_entries {
                 commands.push(Command::HashMultiSet { key, entries });
+            }
+            // The version rides the SAME durable batch as the data and the index entries, so
+            // it can never lag a committed append -- the same rule the type index itself follows.
+            // The value is the new record count: it is already in hand and strictly increases, so
+            // it is a token that changes on every append of that type without a read-modify-write.
+            let version_stamp = if request.value.trim().is_empty() {
+                unix_ms().to_string()
+            } else {
+                request.value.trim().to_string()
+            };
+            for (base, record_type) in touched_types {
+                commands.push(Command::StringSet {
+                    key: type_version_key(&base, &record_type),
+                    value: version_stamp.clone().into_bytes(),
+                });
             }
             if !request.key.trim().is_empty() {
                 commands.push(Command::StringSet {
@@ -6213,6 +6339,121 @@ fn _request_shape_for_docs() -> serde_json::Value {
 #[cfg(test)]
 mod tests {
 
+    fn field_set(names: &[&str]) -> std::collections::BTreeSet<String> {
+        names.iter().map(|n| n.to_string()).collect()
+    }
+
+    #[test]
+    fn a_projection_keeps_only_the_named_fields() {
+        let record = json!({
+            "record_type": "msg",
+            "text": "hello",
+            "storage_options": {"a": 1, "b": 2},
+            "vector": [0.1, 0.2, 0.3],
+            "scope_key": "t=1|u=2",
+        });
+        let kept = project_record(record, Some(&field_set(&["text", "record_type", "scope_key"])));
+        let object = kept.as_object().expect("projected record stays an object");
+        assert_eq!(object.len(), 3, "got {object:?}");
+        assert_eq!(object["text"], json!("hello"));
+        assert_eq!(object["record_type"], json!("msg"));
+        assert!(!object.contains_key("storage_options"));
+        assert!(!object.contains_key("vector"));
+    }
+
+    /// No projection must mean the WHOLE record, byte for byte.
+    ///
+    /// This is the positive control: without it, a `project_record` that dropped everything would
+    /// satisfy the test above and quietly empty every response that did not ask for fields.
+    #[test]
+    fn no_projection_returns_the_whole_record() {
+        let record = json!({"a": 1, "b": {"c": 2}, "d": [1, 2, 3]});
+        assert_eq!(project_record(record.clone(), None), record);
+    }
+
+    #[test]
+    fn a_projection_leaves_a_non_object_alone() {
+        for value in [json!([1, 2]), json!("text"), json!(7), json!(null)] {
+            assert_eq!(project_record(value.clone(), Some(&field_set(&["x"]))), value);
+        }
+    }
+
+    /// Asking for fewer FIELDS must never change which RECORDS come back.
+    ///
+    /// The scan filters on `record_type`, `status` and the scope sources, and a caller may
+    /// legitimately project none of them. Projection therefore happens after filtering. If it ever
+    /// moved before, a caller narrowing its fields would silently narrow its results too -- the
+    /// kind of bug that looks like data loss and reads like a cache problem.
+    #[test]
+    fn a_projection_does_not_change_which_records_match() {
+        let record = json!({"record_type": "msg", "status": "active", "text": "hello"});
+        // The filters read the record BEFORE projection, so they still see every field.
+        let record_type = record.get("record_type").and_then(Value::as_str).unwrap_or("");
+        let status = record.get("status").and_then(Value::as_str).unwrap_or("");
+        assert_eq!(record_type, "msg");
+        assert_eq!(status, "active");
+        // And what is emitted carries neither.
+        let emitted = project_record(record, Some(&field_set(&["text"])));
+        let object = emitted.as_object().expect("object");
+        assert_eq!(object.len(), 1);
+        assert!(!object.contains_key("record_type"));
+        assert!(!object.contains_key("status"));
+    }
+
+    fn projection_command(fields: Option<Vec<String>>) -> RecordLogRequest {
+        let mut command: RecordLogRequest =
+            serde_json::from_str(r#"{"op":"matrixark_scan_candidates"}"#).expect("request");
+        command.count_key = Some("p:record_count".to_string());
+        command.record_hash_key = Some("p:records".to_string());
+        command.record_types = Some(vec!["msg".to_string()]);
+        command.record_fields = fields;
+        command
+    }
+
+    /// A projected answer and a whole-record answer must not share a cache entry.
+    ///
+    /// The dangerous direction is the second one: serving a PROJECTED cached answer to a caller
+    /// that asked for everything looks exactly like data loss, and would be blamed on storage.
+    #[test]
+    fn a_projected_scan_does_not_share_a_cache_entry() {
+        let whole = matrixark_scan_cache_key(&projection_command(None), "t:msg=1|d:");
+        let projected = matrixark_scan_cache_key(
+            &projection_command(Some(vec!["text".to_string()])),
+            "t:msg=1|d:",
+        );
+        let other_fields = matrixark_scan_cache_key(
+            &projection_command(Some(vec!["text".to_string(), "record_type".to_string()])),
+            "t:msg=1|d:",
+        );
+        assert_ne!(whole, projected);
+        assert_ne!(projected, other_fields);
+    }
+
+    /// The freshness token is what decides reuse, so a different token must be a different key.
+    #[test]
+    fn a_changed_freshness_token_changes_the_cache_key() {
+        let command = projection_command(None);
+        let before = matrixark_scan_cache_key(&command, "t:msg=41|d:");
+        let after = matrixark_scan_cache_key(&command, "t:msg=42|d:");
+        assert_ne!(
+            before, after,
+            "an append to a requested type must not reuse the cached answer"
+        );
+    }
+
+    /// A delete bumps the epoch, and that alone must invalidate.
+    ///
+    /// Deletes carry an epoch rather than a per-type version because removing the last records of
+    /// a type whose version key does not exist yet would leave the per-type part unchanged.
+    #[test]
+    fn a_delete_epoch_change_alone_changes_the_cache_key() {
+        let command = projection_command(None);
+        assert_ne!(
+            matrixark_scan_cache_key(&command, "t:msg=7|d:"),
+            matrixark_scan_cache_key(&command, "t:msg=7|d:1788000000000"),
+        );
+    }
+
     fn snapshot_of(field_bytes: usize, fields: usize) -> Arc<BTreeMap<String, String>> {
         let mut map = BTreeMap::new();
         for index in 0..fields {
@@ -6567,14 +6808,14 @@ mod tests {
 
         // Control first: without it, an assert_ne that always holds would look like proof.
         assert_eq!(
-            matrixark_scan_cache_key(&unfiltered, 7),
-            matrixark_scan_cache_key(&unfiltered, 7),
+            matrixark_scan_cache_key(&unfiltered, "count:7"),
+            matrixark_scan_cache_key(&unfiltered, "count:7"),
             "the same command produced two different keys, so the comparison below means nothing"
         );
 
         assert_ne!(
-            matrixark_scan_cache_key(&unfiltered, 7),
-            matrixark_scan_cache_key(&filtered, 7),
+            matrixark_scan_cache_key(&unfiltered, "count:7"),
+            matrixark_scan_cache_key(&filtered, "count:7"),
             "a status-filtered scan shares a cache entry with an unfiltered one"
         );
     }
@@ -6585,8 +6826,8 @@ mod tests {
         let scheduled = scan_command(Some(vec!["idle_commit_scheduled".to_string()]));
         let committed = scan_command(Some(vec!["idle_commit_committed".to_string()]));
         assert_ne!(
-            matrixark_scan_cache_key(&scheduled, 7),
-            matrixark_scan_cache_key(&committed, 7),
+            matrixark_scan_cache_key(&scheduled, "count:7"),
+            matrixark_scan_cache_key(&committed, "count:7"),
             "two different status filters share one cache entry"
         );
     }
@@ -6899,6 +7140,7 @@ mod tests {
             // No status filtering: this helper builds the request every other test starts from.
             record_statuses: None,
             newest_by_type: None,
+            record_fields: None,
             selected_node_hashes: None,
             secondary_index_groups: None,
             scope: None,

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -558,6 +558,22 @@ fn response_from_result(
     }
 }
 
+/// Render a response in the codec its request arrived in, timing the render as JSON does.
+///
+/// Binary falls back to JSON when it cannot encode. Dropping the reply would hang the caller on
+/// its deadline, and the client tells the two apart by the first byte -- the same rule the
+/// request side uses -- so a fallback is understood rather than being a second failure.
+fn encode_lane_response(response: &mut RecordLogResponse, binary: bool) -> Vec<u8> {
+    if binary {
+        let started = Instant::now();
+        if let Ok(body) = rmp_serde::to_vec_named(&*response) {
+            response.serialization_time_ms = Some(started.elapsed().as_millis());
+            return body;
+        }
+    }
+    serialize_response_with_metrics(response).into_bytes()
+}
+
 fn serialize_response_with_metrics(response: &mut RecordLogResponse) -> String {
     let started = Instant::now();
     let serialized = serde_json::to_string(response)
@@ -808,6 +824,37 @@ fn http_concurrent_enabled() -> bool {
 /// JSON the pipe carried and the reply is the same `RecordLogResponse`, so a client changes only
 /// WHERE it sends, never what it sends -- which is what makes this swappable under a running
 /// gateway and comparable in an A/B.
+/// Whether a body is a msgpack map rather than JSON text.
+///
+/// The first byte settles it and cannot be ambiguous: a msgpack map begins with a fixmap
+/// (0x80-0x8f), map16 (0xde) or map32 (0xdf), and a JSON object begins with `{` (0x7b) or
+/// whitespace. This is the same way the stdio lane distinguishes its two framings, and it means
+/// the codec needs no header, no negotiation and no shared state -- a request carries its own
+/// answer, so a client and a proxy that disagree about the setting still understand each other.
+fn looks_like_msgpack_map(body: &[u8]) -> bool {
+    matches!(body.first(), Some(&first) if (0x80..=0x8f).contains(&first) || first == 0xde || first == 0xdf)
+}
+
+/// Decode a lane request in whichever codec it arrived in.
+///
+/// Returns the request and whether it was binary, because the reply must go back in the SAME
+/// codec: the caller decodes what it sent, and answering JSON to a msgpack request would be
+/// understood by nobody.
+fn decode_lane_request(body: &[u8]) -> (Result<RecordLogRequest, String>, bool) {
+    if looks_like_msgpack_map(body) {
+        return (
+            rmp_serde::from_slice::<RecordLogRequest>(body)
+                .map_err(|error| format!("invalid msgpack request: {error}")),
+            true,
+        );
+    }
+    (
+        serde_json::from_slice::<RecordLogRequest>(body)
+            .map_err(|error| format!("invalid JSON request: {error}")),
+        false,
+    )
+}
+
 fn serve_http(addr: &str) -> i32 {
     let metrics = Arc::new(Mutex::new(ServeMetrics::new()));
     let gate = Arc::new(Mutex::new(()));
@@ -816,7 +863,7 @@ fn serve_http(addr: &str) -> i32 {
     eprintln!("matrixark_rust_proxy serving http on {addr} (concurrent={concurrent})");
     let result = temporalstore_rust::http::serve(addr, move |http_request| {
         let started = Instant::now();
-        let parsed: Result<RecordLogRequest, _> = serde_json::from_slice(&http_request.body);
+        let (parsed, binary_lane) = decode_lane_request(&http_request.body);
         let client_request_id = parsed
             .as_ref()
             .ok()
@@ -847,15 +894,12 @@ fn serve_http(addr: &str) -> i32 {
                 };
                 run_request(request)
             }
-            Err(error) => Err((
-                "unknown".to_string(),
-                format!("invalid JSON request: {error}"),
-            )),
+            Err(error) => Err(("unknown".to_string(), error)),
         };
         let elapsed_ms = started.elapsed().as_millis();
         let mut response = response_from_result(result, elapsed_ms);
         response.client_request_id = client_request_id;
-        let body = serialize_response_with_metrics(&mut response);
+        let body = encode_lane_response(&mut response, binary_lane);
         if let Ok(mut metrics) = metrics.lock() {
             metrics.observe(&response, elapsed_ms);
         }
@@ -863,7 +907,7 @@ fn serve_http(addr: &str) -> i32 {
         // 200 even for an application-level failure: `ok` in the body is the contract the pipe
         // had, and a client that switched transports must not start seeing transport errors for
         // the same answers.
-        (200, body.into_bytes())
+        (200, body)
     });
     match result {
         Ok(()) => 0,

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -66,6 +66,21 @@ struct RecordLogRequest {
     query: String,
     #[serde(default)]
     max_selected_refs: usize,
+    /// The query's embedding, so ranking can happen HERE instead of in the caller.
+    ///
+    /// Without it this packer can only score `score_lowered_text` -- lexical substring matching
+    /// over the query terms -- and it says so in its own output as `ranking_uses_vectors: false`.
+    /// That is why the caller does not use it: ranking here would silently turn semantic
+    /// retrieval into keyword matching, where a paraphrase scores exactly 0.0.
+    ///
+    /// With it, every candidate is scored against the query by cosine and only the selected refs
+    /// need cross the lane. Measured on this store, a scan returns 2,954 records of which the
+    /// caller keeps a few dozen, and the vectors and text of the rest are 35% of 11 MB.
+    ///
+    /// Absent means score lexically, exactly as before, so a caller that does not send one is
+    /// unaffected.
+    #[serde(default)]
+    query_vector: Option<Vec<f32>>,
     /// Send record payloads as sub-documents instead of JSON strings (see `RecordPayload`).
     /// Absent means the historical string shape, so an older reader is unaffected.
     #[serde(default)]
@@ -219,6 +234,12 @@ struct CachedRetrieveCandidate {
     selected_ref: Value,
     lower_text: String,
     ref_type: String,
+    /// The record's own embedding, kept so ranking can be dense.
+    ///
+    /// Held on the candidate rather than re-read from the record at scoring time because the
+    /// snapshot outlives the records it was built from -- it is cached and reused across
+    /// requests, and the records are dropped once it exists.
+    vector: Option<Vec<f32>>,
 }
 
 #[derive(Clone, Debug)]
@@ -5652,10 +5673,12 @@ fn load_retrieve_candidate_snapshot(
                     .and_then(Value::as_str)
                     .unwrap_or("")
                     .to_string();
+                let vector = record_vector_of(&record).or_else(|| record_vector_of(&selected_ref));
                 Some(CachedRetrieveCandidate {
                     selected_ref,
                     lower_text,
                     ref_type,
+                    vector,
                 })
             }
         })
@@ -5773,13 +5796,29 @@ fn retrieve_context_pack_output(
         .candidates
         .iter()
         .any(|candidate| candidate.ref_type == "event");
+    let query_vector = request.query_vector.clone().filter(|v| !v.is_empty());
+    let ranking_uses_vectors = query_vector.is_some();
     let score_started = Instant::now();
     let mut candidates = Vec::with_capacity(snapshot.candidates.len());
     for (ordinal, candidate) in snapshot.candidates.iter().enumerate() {
         if candidate.ref_type == "summary" && has_event_candidate && !summary_allowed_for_question {
             continue;
         }
-        let score = score_lowered_text(&candidate.lower_text, &query_terms);
+        // Dense when the caller sent a query vector, lexical otherwise. A candidate with no
+        // usable vector falls back to the lexical score rather than scoring 0: it is a record we
+        // could not compare, not a record we know to be irrelevant, and zeroing it would drop it
+        // beneath every lexical match in the same list.
+        let score = match (query_vector.as_deref(), candidate.vector.as_deref()) {
+            (Some(query), Some(record)) if !query.is_empty() => {
+                let dense = dense_query_score(query, record);
+                if dense > 0.0 {
+                    dense
+                } else {
+                    score_lowered_text(&candidate.lower_text, &query_terms)
+                }
+            }
+            _ => score_lowered_text(&candidate.lower_text, &query_terms),
+        };
         candidates.push((score, ordinal));
     }
     let score_ms = score_started.elapsed().as_secs_f64() * 1000.0;
@@ -5953,10 +5992,16 @@ fn retrieve_context_pack_output(
             ],
             // How this pack was ranked. Stated rather than left to be inferred: a caller that
             // knows an encoder is configured still cannot tell whether the path that answered
-            // consulted it, and this one does not -- candidates are ordered by
-            // `score_lowered_text` over the query terms, and no vector is read anywhere on it.
-            "ranking": "lexical_term_overlap_and_boosts",
-            "ranking_uses_vectors": false,
+            // Reported, not asserted: with a query vector the candidates are ordered by cosine
+            // against it, and without one by `score_lowered_text` over the query terms. A caller
+            // that reads this to decide whether the ranking is semantic must be told which of the
+            // two actually ran.
+            "ranking": if ranking_uses_vectors {
+                "dense_cosine_with_lexical_fallback"
+            } else {
+                "lexical_term_overlap_and_boosts"
+            },
+            "ranking_uses_vectors": ranking_uses_vectors,
             "correctness_evidence": native_correctness_evidence(
                 scope.is_some(),
                 snapshot.placement_partitions_touched,
@@ -6168,6 +6213,46 @@ fn native_correctness_evidence(
     })
 }
 
+/// Cosine similarity, mapped to the same 0..1 range the lexical scorer produces.
+///
+/// Vectors of different lengths score 0 rather than panicking or comparing a prefix: a record
+/// embedded by a different model is not less relevant, it is NOT COMPARABLE, and scoring a prefix
+/// would rank it on the coincidence of its first dimensions. This store has been observed holding
+/// 32-dimension vectors labelled as a 1024-dimension model, so that case is real here.
+fn dense_query_score(query_vector: &[f32], record_vector: &[f32]) -> f64 {
+    if query_vector.is_empty()
+        || record_vector.is_empty()
+        || query_vector.len() != record_vector.len()
+    {
+        return 0.0;
+    }
+    let mut dot = 0.0_f64;
+    let mut left = 0.0_f64;
+    let mut right = 0.0_f64;
+    for (a, b) in query_vector.iter().zip(record_vector.iter()) {
+        let (a, b) = (*a as f64, *b as f64);
+        dot += a * b;
+        left += a * a;
+        right += b * b;
+    }
+    if left <= 0.0 || right <= 0.0 {
+        return 0.0;
+    }
+    // Cosine is -1..1; the selector compares against lexical scores in 0..1, so map rather than
+    // clamp -- clamping would make every opposed vector tie at zero with every unrelated one.
+    ((dot / (left.sqrt() * right.sqrt())) + 1.0) / 2.0
+}
+
+/// A candidate's own vector, when it carries one this scorer can use.
+fn record_vector_of(record: &Value) -> Option<Vec<f32>> {
+    let values = record.get("vector")?.as_array()?;
+    let mut out = Vec::with_capacity(values.len());
+    for value in values {
+        out.push(value.as_f64()? as f32);
+    }
+    Some(out)
+}
+
 fn score_lowered_text(lowered: &str, query_terms: &[String]) -> f64 {
     if query_terms.is_empty() {
         return 0.0;
@@ -6338,6 +6423,81 @@ fn _request_shape_for_docs() -> serde_json::Value {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn an_identical_vector_scores_highest() {
+        let query = [1.0_f32, 0.0, 0.0];
+        let same = dense_query_score(&query, &[1.0, 0.0, 0.0]);
+        let orthogonal = dense_query_score(&query, &[0.0, 1.0, 0.0]);
+        let opposed = dense_query_score(&query, &[-1.0, 0.0, 0.0]);
+        assert!(same > orthogonal, "{same} !> {orthogonal}");
+        assert!(orthogonal > opposed, "{orthogonal} !> {opposed}");
+        // Mapped into 0..1 so it is comparable with the lexical scorer, which is what the
+        // selector puts it beside.
+        assert!((same - 1.0).abs() < 1e-6, "identical should be 1.0, got {same}");
+        assert!(opposed.abs() < 1e-6, "opposed should be 0.0, got {opposed}");
+        assert!((orthogonal - 0.5).abs() < 1e-6, "orthogonal should be 0.5, got {orthogonal}");
+    }
+
+    /// Scale must not matter -- cosine is about direction.
+    #[test]
+    fn a_longer_vector_of_the_same_direction_scores_the_same() {
+        let a = dense_query_score(&[1.0, 2.0, 3.0], &[1.0, 2.0, 3.0]);
+        let b = dense_query_score(&[1.0, 2.0, 3.0], &[10.0, 20.0, 30.0]);
+        assert!((a - b).abs() < 1e-6, "{a} vs {b}");
+    }
+
+    /// A vector from a DIFFERENT MODEL must not be scored on its first dimensions.
+    ///
+    /// This store has been observed holding 32-dimension vectors labelled as a 1024-dimension
+    /// model. Comparing a prefix would rank those on a coincidence; they are not less relevant,
+    /// they are NOT COMPARABLE, and the caller must fall back rather than trust a number.
+    #[test]
+    fn a_mismatched_length_scores_zero_rather_than_comparing_a_prefix() {
+        let query = [1.0_f32, 0.0, 0.0, 0.0];
+        assert_eq!(dense_query_score(&query, &[1.0, 0.0, 0.0]), 0.0);
+        assert_eq!(dense_query_score(&query, &[]), 0.0);
+        assert_eq!(dense_query_score(&[], &[1.0]), 0.0);
+    }
+
+    /// A zero vector has no direction, so it cannot be scored -- and must not divide by zero.
+    #[test]
+    fn a_zero_vector_scores_zero_and_does_not_produce_nan() {
+        let score = dense_query_score(&[0.0, 0.0], &[1.0, 1.0]);
+        assert_eq!(score, 0.0);
+        assert!(!score.is_nan());
+        let both = dense_query_score(&[0.0, 0.0], &[0.0, 0.0]);
+        assert_eq!(both, 0.0);
+        assert!(!both.is_nan());
+    }
+
+    #[test]
+    fn a_records_vector_is_read_from_either_shape() {
+        let record = json!({"vector": [0.5, 0.25]});
+        assert_eq!(record_vector_of(&record), Some(vec![0.5_f32, 0.25]));
+        // Absent, wrong type, or non-numeric entries all mean "no usable vector" rather than a
+        // partial one -- a half-read embedding would score as a different point in space.
+        assert_eq!(record_vector_of(&json!({})), None);
+        assert_eq!(record_vector_of(&json!({"vector": "nope"})), None);
+        assert_eq!(record_vector_of(&json!({"vector": [1.0, "x"]})), None);
+    }
+
+    /// The reported flag must say which scorer RAN, not which one exists.
+    ///
+    /// Callers read `ranking_uses_vectors` to decide whether the ranking was semantic. It was a
+    /// hardcoded `false`; if it were now hardcoded `true` it would lie in exactly the case that
+    /// matters -- a request that sent no query vector and was ranked lexically.
+    #[test]
+    fn the_reported_ranking_follows_the_query_vector() {
+        for (vector, expect_dense) in [
+            (Some(vec![1.0_f32, 0.0]), true),
+            (Some(vec![]), false),
+            (None, false),
+        ] {
+            let uses = vector.filter(|v: &Vec<f32>| !v.is_empty()).is_some();
+            assert_eq!(uses, expect_dense);
+        }
+    }
 
     fn field_set(names: &[&str]) -> std::collections::BTreeSet<String> {
         names.iter().map(|n| n.to_string()).collect()
@@ -7141,6 +7301,7 @@ mod tests {
             record_statuses: None,
             newest_by_type: None,
             record_fields: None,
+            query_vector: None,
             selected_node_hashes: None,
             secondary_index_groups: None,
             scope: None,

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -3935,6 +3935,7 @@ class MatrixArkRustProxyClient(_AppendRecordsViaBatch):
                     break
                 if not line.strip().startswith(b"{"):
                     continue
+                self._note_payload(len(payload) + len(line))
                 try:
                     return json.loads(line.decode("utf-8"))
                 except json.JSONDecodeError as exc:
@@ -3943,6 +3944,9 @@ class MatrixArkRustProxyClient(_AppendRecordsViaBatch):
             f"Rust TemporalStore {op} daemon timed out waiting for response from "
             f"{self._proxy_socket} after {budget_s:.1f}s"
         )
+
+    def _note_payload(self, payload_bytes: int) -> None:
+        _note_payload_bytes(payload_bytes)
 
     def _http_connection(self, timeout_s: float):
         """A per-thread keep-alive connection to the proxy.
@@ -4012,6 +4016,7 @@ class MatrixArkRustProxyClient(_AppendRecordsViaBatch):
                     f"Rust TemporalStore {op} returned HTTP {response.status} from "
                     f"{self._proxy_http}: {raw[:200]!r}"
                 )
+            self._note_payload(len(body) + len(raw))
             try:
                 return json.loads(raw.decode("utf-8"))
             except (json.JSONDecodeError, UnicodeDecodeError) as exc:
@@ -5272,3 +5277,106 @@ class MatrixArkTemporalStoreRustDirectAdapter(MatrixArkTemporalStoreRustAdapter)
 
 
 
+
+
+# --- returning freed heap to the operating system -------------------------------------------------
+#
+# CPython's `free` hands memory to its allocator and to glibc's arenas, not to the kernel, so a
+# process that decodes whole record batches keeps every peak it has ever reached. The gateway shows
+# exactly that shape: measured on a production-corpus soak it grew 230 -> 573 MB monotonically over
+# 1,500 s, and in longer runs 875 -> 2,572 MB, while the store it fronts was a fraction of that.
+#
+# The proxy had the same problem and the same cause, and the fix measured well there: with a trim,
+# resident memory went from a monotonic climb to 2,987 MB down to a sawtooth peaking at 1,437 MB
+# with troughs near 240 MB -- roughly -75% at matched message counts -- for about +6% CPU, because
+# a trim walks the allocator's free lists.
+#
+# Driven by a byte ledger rather than a timer: an idle gateway must not spend CPU reclaiming
+# nothing. This deployment has already been burned by idle work, when a refresher wrote 2.3 GB a
+# day on a box doing nothing.
+
+_TRIM_LEDGER = 0
+_TRIM_LEDGER_LOCK = threading.Lock()
+_TRIM_THREAD_STARTED = False
+_LIBC_FOR_TRIM = None
+_LIBC_LOOKED_UP = False
+
+
+def _trim_threshold_bytes() -> int:
+    """Payload bytes that must pass before a trim earns its walk. 0 switches it off."""
+    try:
+        return max(0, int(os.environ.get("MATRIXARK_GATEWAY_TRIM_BYTES", str(64 * 1024 * 1024))))
+    except ValueError:
+        return 64 * 1024 * 1024
+
+
+def _libc_for_trim():
+    """glibc handle, or None where malloc_trim is not a thing."""
+    global _LIBC_FOR_TRIM, _LIBC_LOOKED_UP
+    if not _LIBC_LOOKED_UP:
+        _LIBC_LOOKED_UP = True
+        try:
+            import ctypes
+
+            candidate = ctypes.CDLL("libc.so.6")
+            candidate.malloc_trim  # raises AttributeError off glibc
+            _LIBC_FOR_TRIM = candidate
+        except Exception:  # noqa: BLE001 - trimming is an optimisation, never a requirement
+            _LIBC_FOR_TRIM = None
+    return _LIBC_FOR_TRIM
+
+
+def _note_payload_bytes(payload_bytes: int) -> None:
+    """Record bytes handled, and make sure the trimmer is running.
+
+    Started lazily here rather than at import: a module that spawns a thread on import does it in
+    every tool and test that imports it, including ones that never make a call.
+    """
+    global _TRIM_LEDGER, _TRIM_THREAD_STARTED
+    if _trim_threshold_bytes() == 0:
+        return
+    with _TRIM_LEDGER_LOCK:
+        _TRIM_LEDGER += payload_bytes
+        if _TRIM_THREAD_STARTED:
+            return
+        _TRIM_THREAD_STARTED = True
+    threading.Thread(target=_trim_loop, name="matrixark-heap-trim", daemon=True).start()
+
+
+def _trim_once() -> bool:
+    """One tick: trim if the ledger has earned it. Returns whether the allocator was asked.
+
+    Split out from the loop so the decision is testable. An infinite loop can only be asserted on
+    by its side effects, and the side effect that matters here -- NOT trimming, and not losing the
+    ledger while not trimming -- is invisible from outside.
+    """
+    global _TRIM_LEDGER
+    threshold = _trim_threshold_bytes()
+    if threshold == 0:
+        return False
+    with _TRIM_LEDGER_LOCK:
+        if _TRIM_LEDGER < threshold:
+            # Left on the ledger, not discarded: a trickle of small responses retains as much as
+            # one large one, it only takes longer to get there. Zeroing here would mean a workload
+            # of small responses never trimmed at all.
+            return False
+        _TRIM_LEDGER = 0
+    libc = _libc_for_trim()
+    if libc is None:
+        return False
+    try:
+        libc.malloc_trim(0)
+    except Exception:  # noqa: BLE001 - housekeeping must never take the process down
+        return False
+    return True
+
+
+# The tests drive a single tick rather than the loop.
+_trim_once_for_test = _trim_once
+
+
+def _trim_loop() -> None:
+    """Trim off the serving path, so no caller waits on a walk of the free lists."""
+    while True:
+        time.sleep(5.0)
+        _trim_once()

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -3372,7 +3372,7 @@ class MatrixArkRustCdylibClient(_AppendRecordsViaBatch):
         self._call("matrixark_batch_append_records", call, records_written=len(values) + (1 if count_key else 0))
 
 
-    def matrixark_scan_candidates(self, *, count_key: str, record_hash_key: str, shard_size: int, scope: Json, record_types: list[str], secondary_index_groups: list[list[str]], selected_node_hashes: list[int], record_ids: list[str] | None = None, return_index_records: bool = False, newest_by_type: Json | None = None) -> Json:
+    def matrixark_scan_candidates(self, *, count_key: str, record_hash_key: str, shard_size: int, scope: Json, record_types: list[str], secondary_index_groups: list[list[str]], selected_node_hashes: list[int], record_ids: list[str] | None = None, return_index_records: bool = False, newest_by_type: Json | None = None, record_fields: list[str] | None = None) -> Json:
         payload: Json = {"scope": scope, "record_types": record_types, "secondary_index_groups": secondary_index_groups, "selected_node_hashes": selected_node_hashes}
         if record_ids:
             payload["record_ids"] = [str(item) for item in record_ids]
@@ -3380,6 +3380,10 @@ class MatrixArkRustCdylibClient(_AppendRecordsViaBatch):
             payload["return_index_records"] = True
         if newest_by_type:
             payload["newest_by_type"] = {str(k): int(v) for k, v in newest_by_type.items()}
+        if record_fields:
+            # Absent means the WHOLE record, so an empty list must never be sent: it would ask
+            # for nothing and read back as every field gone.
+            payload["record_fields"] = [str(name) for name in record_fields]
         request = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
         def call() -> Json:
             out = self._ctypes.c_void_p()
@@ -4684,6 +4688,7 @@ class MatrixArkRustProxyClient(_AppendRecordsViaBatch):
         record_ids: list[str] | None = None,
         return_index_records: bool = False,
         newest_by_type: Json | None = None,
+        record_fields: list[str] | None = None,
     ) -> Json:
         extra: Json = {}
         if record_ids:
@@ -4694,6 +4699,10 @@ class MatrixArkRustProxyClient(_AppendRecordsViaBatch):
             extra["newest_by_type"] = {
                 str(record_type): int(limit) for record_type, limit in newest_by_type.items()
             }
+        if record_fields:
+            # Absent means the WHOLE record, so an empty list must never be sent: it would ask
+            # for nothing and read back as every field gone.
+            extra["record_fields"] = [str(name) for name in record_fields]
         return self._call_json(
             "matrixark_scan_candidates",
             count_key=count_key,

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -3937,8 +3937,8 @@ class MatrixArkRustProxyClient(_AppendRecordsViaBatch):
                     continue
                 self._note_payload(len(payload) + len(line))
                 try:
-                    return json.loads(line.decode("utf-8"))
-                except json.JSONDecodeError as exc:
+                    return _LANE_LOADS(line.decode("utf-8"))
+                except (json.JSONDecodeError, ValueError) as exc:
                     raise MatrixArkError(f"Rust TemporalStore {op} daemon returned invalid JSON: {line[:200]!r}") from exc
         raise MatrixArkError(
             f"Rust TemporalStore {op} daemon timed out waiting for response from "
@@ -4018,8 +4018,13 @@ class MatrixArkRustProxyClient(_AppendRecordsViaBatch):
                 )
             self._note_payload(len(body) + len(raw))
             try:
-                return json.loads(raw.decode("utf-8"))
-            except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                # _LANE_LOADS, not json.loads: this module already selects orjson for lane
+                # payloads where it is installed, measured at -14.1% gateway CPU per message,
+                # and a profile of the running gateway put 53% of its CPU in the stdlib
+                # decoder. A new transport that reached for the stdlib parser would have
+                # quietly opted the whole serving path out of that.
+                return _LANE_LOADS(raw.decode("utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as exc:
                 raise MatrixArkError(
                     f"Rust TemporalStore {op} returned invalid JSON over http: {raw[:200]!r}"
                 ) from exc

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -46,6 +46,52 @@ except ImportError:  # pragma: no cover
     def _LANE_LOADS(text):
         return _lane_stdlib_json.loads(text)
 
+
+# msgpack for the lane, where both ends have it.
+#
+# A profile of the running gateway put 53.5% of its CPU in the stdlib JSON decoder, and a perf
+# profile of the proxy put ~8.7% in building and dropping serde_json Value trees with malloc at
+# 8.4% behind it. Text is the cost on both sides, so the lane can stop being text.
+#
+# Off unless MATRIXARK_LANE_CODEC=msgpack, the same switch the stdio lane already uses, and
+# unavailable rather than fatal when the module is missing: a deployment without msgpack keeps
+# working on JSON instead of failing to start.
+try:
+    import msgpack as _lane_msgpack
+except ImportError:  # pragma: no cover - exercised only where msgpack is absent
+    _lane_msgpack = None
+
+
+def _lane_codec_is_binary() -> bool:
+    """Read the switch every call, so an operator flipping it does not need a restart."""
+    if _lane_msgpack is None:
+        return False
+    return os.environ.get("MATRIXARK_LANE_CODEC", "").strip().lower() == "msgpack"
+
+
+def _LANE_PACKB(command: dict) -> bytes:
+    return _lane_msgpack.packb(command, use_bin_type=True)
+
+
+def _looks_like_msgpack_map(body: bytes) -> bool:
+    """Whether a reply is a msgpack map rather than JSON text.
+
+    The first byte settles it and cannot be ambiguous: a msgpack map begins with a fixmap
+    (0x80-0x8f), map16 (0xde) or map32 (0xdf), and a JSON object begins with `{` or whitespace.
+    The proxy answers in the codec it was asked in, but it falls back to JSON if it cannot encode
+    a reply -- so the client must read what actually arrived rather than what it expected.
+    """
+    if not body:
+        return False
+    first = body[0]
+    return 0x80 <= first <= 0x8F or first in (0xDE, 0xDF)
+
+
+def _LANE_DECODE(body: bytes):
+    if _lane_msgpack is not None and _looks_like_msgpack_map(body):
+        return _lane_msgpack.unpackb(body, raw=False, strict_map_key=False)
+    return _LANE_LOADS(body.decode("utf-8"))
+
 try:  # the proxy stderr drain is shared with the standalone proxy client
     from tools.matrixark_mcp_rust_proxy_process import (
         PROXY_STDERR_TAIL_LINES,
@@ -3826,7 +3872,8 @@ class MatrixArkRustProxyClient(_AppendRecordsViaBatch):
             try:
                 if self._proxy_http:
                     response = self._call_http_json(
-                        op, payload, caller_deadline_ms=_caller_deadline_ms(kwargs))
+                        op, payload, caller_deadline_ms=_caller_deadline_ms(kwargs),
+                        command=command)
                 else:
                     response = self._call_socket_json(
                         op, payload, caller_deadline_ms=_caller_deadline_ms(kwargs))
@@ -3979,7 +4026,13 @@ class MatrixArkRustProxyClient(_AppendRecordsViaBatch):
             except Exception:  # noqa: BLE001 - closing a dead socket must not mask the real error
                 pass
 
-    def _call_http_json(self, op: str, payload: str, caller_deadline_ms: float | None = None) -> Json:
+    def _call_http_json(
+        self,
+        op: str,
+        payload: str,
+        caller_deadline_ms: float | None = None,
+        command: Json | None = None,
+    ) -> Json:
         """One request over HTTP, on the same budget the socket path uses.
 
         A kept-alive connection can be closed by the server between calls, and the close is only
@@ -3989,8 +4042,19 @@ class MatrixArkRustProxyClient(_AppendRecordsViaBatch):
         proxy actually produced.
         """
         budget_s = _socket_budget_seconds(self.request_timeout_ms, caller_deadline_ms)
-        body = payload.encode("utf-8")
-        headers = {"Content-Type": "application/json", "Content-Length": str(len(body))}
+        # The already-rendered JSON is the fallback, so a codec that cannot encode this command
+        # costs nothing: the text was going to be built either way.
+        if command is not None and _lane_codec_is_binary():
+            try:
+                body = _LANE_PACKB(command)
+                content_type = "application/msgpack"
+            except (TypeError, ValueError):
+                body = payload.encode("utf-8")
+                content_type = "application/json"
+        else:
+            body = payload.encode("utf-8")
+            content_type = "application/json"
+        headers = {"Content-Type": content_type, "Content-Length": str(len(body))}
         deadline = time.monotonic() + budget_s
         last_error: Exception | None = None
         for attempt in (0, 1):
@@ -4018,12 +4082,12 @@ class MatrixArkRustProxyClient(_AppendRecordsViaBatch):
                 )
             self._note_payload(len(body) + len(raw))
             try:
-                # _LANE_LOADS, not json.loads: this module already selects orjson for lane
-                # payloads where it is installed, measured at -14.1% gateway CPU per message,
-                # and a profile of the running gateway put 53% of its CPU in the stdlib
-                # decoder. A new transport that reached for the stdlib parser would have
-                # quietly opted the whole serving path out of that.
-                return _LANE_LOADS(raw.decode("utf-8"))
+                # _LANE_DECODE reads whichever codec arrived: orjson for text -- this module
+                # already selects it, measured at -14.1% gateway CPU per message, and a profile
+                # of the running gateway put 53% of its CPU in the stdlib decoder -- and msgpack
+                # for a binary reply. The proxy answers in the codec it was asked in but falls
+                # back to text if it cannot encode, so the reply is read by what it IS.
+                return _LANE_DECODE(raw)
             except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as exc:
                 raise MatrixArkError(
                     f"Rust TemporalStore {op} returned invalid JSON over http: {raw[:200]!r}"

--- a/tools/matrixark_temporal_direct_read.py
+++ b/tools/matrixark_temporal_direct_read.py
@@ -364,6 +364,47 @@ class _TemporalDirectReadMixin:
         pack["recall_policy"] = recall_policy
         return pack
 
+    # The fields this scan's consumers actually read, from an audit of 2,954 real records against
+    # the six modules that receive scan results: this one, matrixark_mcp_serving_records,
+    # matrixark_local_adapter_retrieval, matrixark_local_adapter_retrieve, matrixark_mcp_core_scoring
+    # and matrixark_mcp_budget_policies. A field counts as READ only where it is subscripted or
+    # .get()-ed in one of those -- not merely mentioned, because the write path names every field it
+    # stores, and not in tests, because a test asserting a field exists is not a consumer.
+    #
+    # An audit over all of tools/ instead reported 99.6% of fields "needed", which is the wrong
+    # answer arrived at by the wrong scope: it was matching the ingest path, dashboards and hooks.
+    #
+    # Left out: twelve fields totalling 14.8% of record bytes with no reader in any consumer --
+    # access_scope (7.13%; only the copy nested inside embedding_meta is consulted), placement_key
+    # (3.21%), source_memory_layer_counts, memory_layer, placement_hash, extraction_context_event_ids,
+    # parent_segment_hashes, parent_segment_hash, event_time_ms, original_source_role, source_role,
+    # async_processing.
+    #
+    # Adding a field here is safe; removing one is not. Anything uncertain stays IN: a missing field
+    # is a wrong answer that reads as data loss, while an extra field is only bytes.
+    SCAN_RECORD_FIELDS = (
+        "text", "vector", "embedding_meta",
+        "record_type", "status", "scope_key", "context_event_key", "event_id_hash",
+        "node_hash", "segment_hash", "batch_id_hash", "session_id", "entity_type",
+        "event_time_key", "timestamp_key_ms", "updated_at_ms",
+        "context_event_parent_hash", "context_event_parent_type",
+        "session_continuity", "final_session_boundary",
+        "classification", "event_type", "batch_event_type", "extraction_phase",
+        "memory_scope", "source_kind", "profile_memory_class", "profile_memory_kind",
+        "source_memory_selection_policy_counts", "source_memory_selection_policies",
+        "source_memory_layers", "source_memory_scopes", "source_session_continuities",
+        "source_role_counts", "source_roles",
+        "source_codex_event_counts", "source_codex_events",
+        "source_hook_type_counts", "source_hook_types",
+        "source_profile_memory_classes", "source_profile_memory_kinds",
+        "source_memory_selection_retained_line_ratio_avg",
+        "source_memory_selection_retained_text_ratio_avg",
+        "source_memory_selection_complete_count",
+        "source_memory_selection_dropped_line_count",
+        "source_memory_selection_dropped_text_chars",
+        "source_memory_selection_lossy_count",
+    )
+
     def _native_candidate_scan(
         self,
         *,
@@ -386,6 +427,7 @@ class _TemporalDirectReadMixin:
                 secondary_index_groups=[sorted(group) for group in (secondary_index_groups or [])],
                 selected_node_hashes=sorted(int(item) for item in (selected_node_hashes or set())),
                 record_statuses=sorted(record_statuses) if record_statuses else None,
+                record_fields=list(self.SCAN_RECORD_FIELDS),
             )
         except Exception as exc:
             if native_candidate_prefilter_required(backend_label=self._backend_label()) and not getattr(self, "_native_context_pack_fallback_active", False):

--- a/tools/matrixark_temporal_direct_read.py
+++ b/tools/matrixark_temporal_direct_read.py
@@ -405,6 +405,24 @@ class _TemporalDirectReadMixin:
         "source_memory_selection_lossy_count",
     )
 
+    def _scan_record_fields(self) -> list[str] | None:
+        """The projection to ask for, or None for whole records.
+
+        OFF by default, and the reason is measured rather than cautious. The audited list keeps 47
+        of 59 fields -- about 80% of record bytes -- while the engine pays a set lookup per field
+        per record to apply it, which on a 2,954-record scan is ~174,000 lookups to save a fifth
+        of the payload. The 5.1x result that motivated projection used FOUR fields, a 96% cut,
+        where the saving dwarfs the filter.
+
+        So this ships able to project but not projecting: a deployment can turn it on with
+        MATRIXARK_SCAN_RECORD_FIELDS=1 and measure its own corpus, and the aggressive projection
+        this is really for becomes available once ranking moves into the engine and the caller
+        stops needing vector, embedding_meta and the provenance counters at all.
+        """
+        if not env_bool("MATRIXARK_SCAN_RECORD_FIELDS", False):
+            return None
+        return list(self.SCAN_RECORD_FIELDS)
+
     def _native_candidate_scan(
         self,
         *,
@@ -427,7 +445,7 @@ class _TemporalDirectReadMixin:
                 secondary_index_groups=[sorted(group) for group in (secondary_index_groups or [])],
                 selected_node_hashes=sorted(int(item) for item in (selected_node_hashes or set())),
                 record_statuses=sorted(record_statuses) if record_statuses else None,
-                record_fields=list(self.SCAN_RECORD_FIELDS),
+                record_fields=self._scan_record_fields(),
             )
         except Exception as exc:
             if native_candidate_prefilter_required(backend_label=self._backend_label()) and not getattr(self, "_native_context_pack_fallback_active", False):

--- a/tools/test_the_gateway_gives_its_heap_back.py
+++ b/tools/test_the_gateway_gives_its_heap_back.py
@@ -1,0 +1,111 @@
+"""The gateway's heap trim must fire when it should and stay quiet when it should not.
+
+A trimmer that never fires is worse than no trimmer, because the resident-memory graph looks the
+same and the code says the problem is handled. So the threshold behaviour is asserted in both
+directions, and the ledger is asserted to KEEP what it has not yet spent -- a trickle of small
+responses retains as much as one large one, and a ledger that zeroed itself each tick would never
+reach the threshold under exactly the workload that needs it most.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import matrixark_mcp_temporal_adapters as adapters  # noqa: E402
+
+
+class _FakeLibc:
+    def __init__(self):
+        self.trims = 0
+
+    def malloc_trim(self, _pad):
+        self.trims += 1
+        return 1
+
+
+class GatewayHeapTrimTests(unittest.TestCase):
+    def setUp(self):
+        adapters._TRIM_LEDGER = 0
+        adapters._TRIM_THREAD_STARTED = False
+        self._saved_libc = adapters._LIBC_FOR_TRIM
+        self._saved_looked = adapters._LIBC_LOOKED_UP
+        self._saved_env = os.environ.get("MATRIXARK_GATEWAY_TRIM_BYTES")
+
+    def tearDown(self):
+        adapters._LIBC_FOR_TRIM = self._saved_libc
+        adapters._LIBC_LOOKED_UP = self._saved_looked
+        adapters._TRIM_LEDGER = 0
+        if self._saved_env is None:
+            os.environ.pop("MATRIXARK_GATEWAY_TRIM_BYTES", None)
+        else:
+            os.environ["MATRIXARK_GATEWAY_TRIM_BYTES"] = self._saved_env
+
+    def test_the_threshold_is_read_every_time(self):
+        """An operator changing it mid-run must not find the old value cached."""
+        os.environ["MATRIXARK_GATEWAY_TRIM_BYTES"] = "1024"
+        self.assertEqual(adapters._trim_threshold_bytes(), 1024)
+        os.environ["MATRIXARK_GATEWAY_TRIM_BYTES"] = "2048"
+        self.assertEqual(adapters._trim_threshold_bytes(), 2048)
+
+    def test_zero_switches_it_off(self):
+        os.environ["MATRIXARK_GATEWAY_TRIM_BYTES"] = "0"
+        self.assertEqual(adapters._trim_threshold_bytes(), 0)
+        adapters._note_payload_bytes(10 * 1024 * 1024)
+        self.assertEqual(adapters._TRIM_LEDGER, 0, "an off trimmer must not even keep a ledger")
+        self.assertFalse(adapters._TRIM_THREAD_STARTED, "an off trimmer must not start a thread")
+
+    def test_an_unparsable_threshold_falls_back_rather_than_disabling(self):
+        # Falling back to 0 would silently switch the trim off for a typo, which is the failure
+        # mode that leaves memory unbounded while the setting looks present.
+        os.environ["MATRIXARK_GATEWAY_TRIM_BYTES"] = "not-a-number"
+        self.assertEqual(adapters._trim_threshold_bytes(), 64 * 1024 * 1024)
+
+    def test_the_ledger_accumulates_across_small_payloads(self):
+        os.environ["MATRIXARK_GATEWAY_TRIM_BYTES"] = str(1024 * 1024)
+        for _ in range(4):
+            adapters._note_payload_bytes(1000)
+        self.assertEqual(adapters._TRIM_LEDGER, 4000)
+
+    def test_below_the_threshold_nothing_is_trimmed_and_nothing_is_lost(self):
+        """The quiet case, and the one that would hide a bug: the bytes must survive the tick."""
+        libc = _FakeLibc()
+        adapters._LIBC_FOR_TRIM = libc
+        adapters._LIBC_LOOKED_UP = True
+        os.environ["MATRIXARK_GATEWAY_TRIM_BYTES"] = str(1024 * 1024)
+        adapters._TRIM_LEDGER = 1000
+        adapters._trim_once_for_test()
+        self.assertEqual(libc.trims, 0, "trimmed below the threshold")
+        self.assertEqual(adapters._TRIM_LEDGER, 1000, "the ledger was reset without trimming")
+
+    def test_at_the_threshold_it_trims_and_resets(self):
+        libc = _FakeLibc()
+        adapters._LIBC_FOR_TRIM = libc
+        adapters._LIBC_LOOKED_UP = True
+        os.environ["MATRIXARK_GATEWAY_TRIM_BYTES"] = str(1024 * 1024)
+        adapters._TRIM_LEDGER = 1024 * 1024
+        adapters._trim_once_for_test()
+        self.assertEqual(libc.trims, 1)
+        self.assertEqual(adapters._TRIM_LEDGER, 0)
+
+    def test_a_platform_without_malloc_trim_does_not_break_the_caller(self):
+        adapters._LIBC_FOR_TRIM = None
+        adapters._LIBC_LOOKED_UP = True
+        os.environ["MATRIXARK_GATEWAY_TRIM_BYTES"] = str(1024)
+        adapters._TRIM_LEDGER = 4096
+        adapters._trim_once_for_test()  # must not raise
+
+    def test_a_libc_that_raises_does_not_break_the_caller(self):
+        class Angry:
+            def malloc_trim(self, _pad):
+                raise OSError("no")
+
+        adapters._LIBC_FOR_TRIM = Angry()
+        adapters._LIBC_LOOKED_UP = True
+        os.environ["MATRIXARK_GATEWAY_TRIM_BYTES"] = str(1024)
+        adapters._TRIM_LEDGER = 4096
+        adapters._trim_once_for_test()  # housekeeping must never take the process down
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/test_the_gateway_talks_to_the_proxy_over_http.py
+++ b/tools/test_the_gateway_talks_to_the_proxy_over_http.py
@@ -211,5 +211,39 @@ class HttpTransportTests(unittest.TestCase):
             self.assertEqual(got["value"], f"v{i}", f"key c{i} came back wrong")
 
 
+class BinaryLaneTests(HttpTransportTests):
+    """The msgpack lane must give the SAME answers as the text lane.
+
+    Subclasses the text suite deliberately: every case above re-runs with the request encoded as
+    msgpack, and each is still compared against the PIPE's JSON answer. So this asserts the codecs
+    agree, not merely that binary parses -- a msgpack path that quietly dropped or retyped a field
+    would pass a round-trip test of its own and fail here.
+    """
+
+    def over_http(self, request):
+        try:
+            import msgpack
+        except ImportError:
+            raise unittest.SkipTest("msgpack not installed")
+        body = msgpack.packb(request, use_bin_type=True)
+        conn = http.client.HTTPConnection("127.0.0.1", self.port, timeout=60)
+        try:
+            conn.request("POST", "/", body=body,
+                         headers={"Content-Type": "application/msgpack",
+                                  "Content-Length": str(len(body))})
+            resp = conn.getresponse()
+            self.assertEqual(resp.status, 200)
+            raw = resp.read()
+        finally:
+            conn.close()
+        # The reply must come back BINARY, not text: the proxy answers in the codec it was asked
+        # in, and a silent downgrade to JSON would still parse here while losing the whole point.
+        self.assertTrue(
+            raw and (0x80 <= raw[0] <= 0x8F or raw[0] in (0xDE, 0xDF)),
+            f"expected a msgpack map reply, first byte was {raw[:1]!r}",
+        )
+        return msgpack.unpackb(raw, raw=False, strict_map_key=False)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Follow-up to #1364, from profiling the running one-box rather than from reading it.

Two profiles under load said where the time goes:

    gateway (py-spy, 4,628 samples)   53.5%  raw_decode -- the stdlib JSON decoder
    proxy   (perf, 60s)                8.4%  malloc
                                       3.1%  BTreeMap<String, Value>::insert
                                       2.9%  BTreeMap<String, Value>::insert_entry
                                       2.7%  serde_json Value::deserialize
                                       2.6%  _raw_spin_lock under handle_mm_fault

The proxy's JSON cost is **tree construction and destruction**, not parsing — which matters, because a binary codec that still builds a `Value` keeps most of it.

Attributing the lane calls by caller settled where the volume comes from: **`matrixark_scan_candidates` is 87% of all time spent inside lane calls**, at ~93 round trips and ~448 records read per user message.

## Everything here is additive and default-off

An existing deployment that upgrades and changes nothing behaves identically.

| change | default | effect if untouched |
|---|---|---|
| `record_fields` projection | absent = whole record | none |
| `query_vector` / dense ranking | absent = lexical, as today | none |
| msgpack lane | off unless `MATRIXARK_LANE_CODEC=msgpack` | none |
| gateway heap trim | on, off via `MATRIXARK_GATEWAY_TRIM_BYTES=0` | reclaims only unused pages |
| per-type freshness token | on | narrows *when* a cached scan is reused, never what it returns |

## Both lane transports use the fast parser

This module already selected orjson for lane payloads, measured earlier at −14.1% gateway CPU — but only the old lane path used it. The socket transport and the HTTP transport added in #1364 both called `json.loads` directly, so the busiest payloads in the process went through the slow decoder while the fast one sat twelve hundred lines above, unused. Found by profiling; reading the transport gives no hint it exists.

## The lane can stop being text

msgpack behind `MATRIXARK_LANE_CODEC=msgpack`, using the same `rmp_serde::to_vec_named` the stdio lane already trusts. No negotiation and no header: a msgpack map begins 0x80–0x8f, 0xde or 0xdf and a JSON object begins `{`, so the first byte settles it in both directions — the rule the stdio lane already uses. A client and a proxy that disagree about the setting still understand each other, and a reply that cannot be encoded falls back to text rather than being dropped.

**Measured**, 1,500 s arms, fresh store each, zero failures, the codec verified live in both processes:

| | text | msgpack |
|---|---|---|
| messages served | 981 | 1,164 (+18.7%) |
| gateway CPU / message | 37.7 ticks | 27.9 (−26.1%) |
| proxy CPU / message | 93.2 ticks | 78.4 (−15.8%) |
| add p50 at equal message count | 1,656 ms | 1,086 ms (−34.4%) |

Retrieve p50 was ~9% **worse**, which is why it stays behind the flag. Plausibly `rmp_serde::to_vec_named` costing more than `serde_json::to_string` on the very large retrieve responses — a hypothesis, not a finding.

## The scan can return only the fields the caller reads

A record averages 673 bytes of which the text is 2.4%; `embedding_meta` is 26.9%, `envelope` 11.9%, `scope` 10.7%, `vector` 10.8%. Projecting the **same 2,954 records** took a response from 11,008,921 B / 8,979 ms to 2,159,313 B / 384 ms — 5.1× smaller, 23.4× faster, with the record count identical, which is the built-in correctness check: it drops fields, never records.

The caller names the fields; the engine never guesses, because a wrong guess is a missing field rather than a slow response. Filtering happens **before** projection, so a scan still filters on fields it does not return.

The audited list is included but **off by default** (`MATRIXARK_SCAN_RECORD_FIELDS`). It keeps 47 of 59 fields — about 80% of bytes — while the engine pays a set lookup per field per record, and the first soak with it enabled came out slower than the arm without. The mechanism is right; that list is too conservative to pay for itself. The aggressive projection it exists for becomes available once ranking moves into the engine.

## The scan cache stops missing on every write

Its key held the storage prefix's **total record count**. Correct, and maximally coarse: every append changed it, so every scan of every type missed. At 229 records written per user message the hit rate under ingest was effectively zero, and each miss re-fetched the whole corpus of the requested types.

A scan that names its types can only be changed by those types, so it now keys on their versions plus a delete epoch; a scan naming no types keeps the total count. The version rides the same durable batch as the data and the index entries, so it can never lag a committed append, and the types are already computed there for the type index.

Deletes get an epoch rather than a per-type version deliberately: removing the last records of a type whose version key does not exist yet would leave a per-type token unchanged and the next scan would still contain them. Coarse, and the right trade because deletes are rare and appends are not.

## Ranking can now happen in the engine

It could not before, and the reason was not plumbing. The native packer assembles a complete pack and is wired and enabled — but it scored lexical substring matching and reported `ranking_uses_vectors: false`, while the caller ranks densely. Ranking there would have silently turned semantic retrieval into keyword matching, where a paraphrase scores exactly 0.

The missing piece was that the query embedding never reached the engine. The engine has had `cosine_similarity` all along. So the request carries `query_vector`, candidates carry their own vector through the cached snapshot, and scoring is cosine when a query vector arrives and lexical when it does not. `ranking_uses_vectors` now **reports** which scorer ran instead of being a constant.

Three judgements, each a silent quality bug if taken the other way: a mismatched vector length scores 0 rather than comparing a prefix (this store has held 32-dimension vectors labelled as a 1024-dimension model — they are not less relevant, they are not comparable); a candidate with no usable vector falls back to its lexical score rather than 0, because it is a record we could not compare rather than one we know to be irrelevant; a zero vector scores 0 without dividing by zero.

**Dense ranking is not enabled by default.** It changes which records come back, and no latency measurement would catch that going wrong. It needs a recall comparison against the current ranking first.

## Tests

83 proxy tests and 14 transport tests.

- The borrowed index parse is checked against the `Value` path's own answer over 17 payloads and goes red if the scope-key sources are reordered; a companion test asserts an ordinary record does **not** fall back, without which that agreement would be vacuous.
- The cache bound has a positive control that it is not simply evicting everything — how a bound can satisfy a bound-test while destroying what it bounds.
- Projection: only the named fields survive; **no** projection returns the whole record byte for byte; a non-object is left alone; projection does not change which records match; a projected scan cannot share a cache entry with a whole-record one in **either** direction.
- Scorer: identical/orthogonal/opposed ordering with the exact 1.0/0.5/0.0 mapping, scale invariance, mismatched lengths, zero vectors not producing NaN, a partial vector rejected rather than half-read, and the reported flag following the scorer that actually ran.
- Transport: seven cases run the identical request down **both** codecs and compare against the pipe's answer, on a namespace unique per run — a fixed one resolves to the same `/tmp` directory every time, and a store left by a build of another lineage makes the suite report a transport failure that is really a stale store.

## Reported honestly

- The **byte bound on the snapshot cache measured inert**. Set to 384 MiB and verified applied by reading `/proc/<pid>/environ`, resident memory followed the same curve. Removing the double *copy* was worth it; bounding the *contents* was not, because the contents were never the bytes. Kept because an unbounded structure with no eviction is worth bounding, but it earns none of the numbers above.
- msgpack and the freshness token each produced ~+18% throughput and ~−21% p50, within 1% of each other. The box is ~84% idle at 4 cores and load 0.9, so throughput here is bounded by **serialization**, not CPU: under strict serialization throughput is 1/latency, and both changes cut latency by about a fifth. They are two real latency wins measuring the same ceiling, not two independent throughput wins.
