### PR TITLE
Hand the engine the query vector, so ranking can move there

### DIFF
--- a/tools/matrixark_temporal_direct_read.py
+++ b/tools/matrixark_temporal_direct_read.py
@@ -405,6 +405,37 @@ class _TemporalDirectReadMixin:
         "source_memory_selection_lossy_count",
     )
 
+    def _native_query_vector(self, query: str) -> list[float] | None:
+        """The query embedding to hand the engine, or None to leave ranking here.
+
+        Off unless MATRIXARK_NATIVE_DENSE_RANKING=1. With it, the engine scores candidates by
+        cosine and returns only the refs it selected, so the vectors and text of everything it
+        rejected never cross the lane -- on this corpus a scan returns 2,954 records to select a
+        few dozen. Without it the engine scores lexically, which is what it has always done.
+
+        Computing the embedding here is not extra work when ranking stays local: the same call is
+        cached, and the local packer asks for the identical vector moments later.
+        """
+        if not env_bool("MATRIXARK_NATIVE_DENSE_RANKING", False):
+            return None
+        text = (query or "").strip()
+        if not text:
+            return None
+        try:
+            from matrixark_mcp_embeddings import embedding_for_text
+        except ImportError:  # pragma: no cover - import shape differs when run as a package
+            try:
+                from tools.matrixark_mcp_embeddings import embedding_for_text
+            except ImportError:
+                return None
+        try:
+            vector = embedding_for_text(text, role="query")
+        except Exception:  # noqa: BLE001 - ranking must never be the reason a retrieve fails
+            return None
+        if not isinstance(vector, list) or not vector:
+            return None
+        return [float(value) for value in vector]
+
     def _scan_record_fields(self) -> list[str] | None:
         """The projection to ask for, or None for whole records.
 
@@ -1093,6 +1124,9 @@ class _TemporalDirectReadMixin:
             "skill_status_watermark": skill_status_watermark,
             "index_posting_watermark": watermark_count,
             "query": query,
+            # The engine ranks by cosine when this is present and lexically when it is not, and
+            # reports which it did as `ranking_uses_vectors`.
+            "query_vector": self._native_query_vector(query),
             "question_type": question_type,
             "scope": scope,
             "session_scope": retrieval_session_scope,


### PR DESCRIPTION
The engine has had `cosine_similarity` all along, and the caller has computed a query embedding all along. The two were never introduced.

Without the vector, the native packer can only score lexical substring overlap — it reports this itself as `ranking_uses_vectors: false` — so it **declines every call**, and the whole candidate set crosses the lane to be ranked in Python. On this corpus that is 2,954 records shipped to select a few dozen, and `matrixark_scan_candidates` is 87% of all time spent inside lane calls.

This is the last connection. The request now carries `query_vector`.

## Default off, deliberately

Behind `MATRIXARK_NATIVE_DENSE_RANKING`, default false. Enabling it moves ranking into the engine, which changes **which records come back** — and no latency measurement would catch that going wrong. It needs a recall comparison against the current ranking first. This codebase has been bitten before by a selection change that cut recall from 40/80 while every timing looked healthy.

## Cheap and fail-soft

Computing the embedding here costs nothing when ranking stays local: the call is cached, and the local packer asks for the identical vector moments later. Any import or embedding failure returns `None` and ranking stays where it is — ranking must never be the reason a retrieve fails.

## Verified behaviour-neutral

The full 449-module suite, run before and after on the same tree:

    baseline failing modules: 31
    after    failing modules: 31
    NEW failures:  (empty)
    newly green:   (empty)

This tree carries known red, so the **name diff** is the signal, not the count.

## Why this rather than more projection

The companion result, measured on the same corpus and shipped off in #1366: projecting **47 of 59** fields *costs* 12.5% throughput and +17%/+23% CPU per message, while projecting **4** fields gives 5.1× payload and 23.4× latency. The filter cost is per-field-per-record and does not scale with how much you drop, so there is no useful middle — a conservative projection pays full price for a fraction of the benefit.

That makes "audit which fields are read, then return only those" the wrong shape: the safe list is large, and a large list loses. The right shape is to stop sending candidates at all, which is what ranking in the engine unlocks — a few dozen refs instead of three thousand records, projected hard. It is also the safer contract, since the caller of a finished pack has an explicit one while the caller of raw records has an implicit one spread across six modules.
