### PR TITLE
Rank in the engine on the retrieve path the gateway actually uses

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -81,6 +81,17 @@ struct RecordLogRequest {
     /// unaffected.
     #[serde(default)]
     query_vector: Option<Vec<f32>>,
+    /// How to combine the dense and lexical scores, and what an index hint is worth.
+    ///
+    /// The CALLER owns ranking policy and the engine executes it. That is deliberate: the caller
+    /// already computes these weights from its own configuration -- on the one-box they are 1.00
+    /// dense and 0.00 lexical, elsewhere 0.72 and 0.28 -- and an engine that hardcoded its own
+    /// would silently rank differently from the caller that used to do it, which is the failure
+    /// this whole change has to avoid.
+    ///
+    /// Absent means dense-only (1.0 / 0.0 / 0.0), which is what this engine already did.
+    #[serde(default)]
+    ranking_weights: Option<RankingWeights>,
     /// Send record payloads as sub-documents instead of JSON strings (see `RecordPayload`).
     /// Absent means the historical string shape, so an older reader is unaffected.
     #[serde(default)]
@@ -5798,6 +5809,14 @@ fn retrieve_context_pack_output(
         .any(|candidate| candidate.ref_type == "event");
     let query_vector = request.query_vector.clone().filter(|v| !v.is_empty());
     let ranking_uses_vectors = query_vector.is_some();
+    let weights = request.ranking_weights.unwrap_or_default();
+    // The caller's own prefilter already named the nodes it believes in; the hint is what that
+    // belief is worth in the score, and the caller sets its size.
+    let hinted: std::collections::HashSet<u64> = request
+        .selected_node_hashes
+        .as_ref()
+        .map(|v| v.iter().copied().collect())
+        .unwrap_or_default();
     let score_started = Instant::now();
     let mut candidates = Vec::with_capacity(snapshot.candidates.len());
     for (ordinal, candidate) in snapshot.candidates.iter().enumerate() {
@@ -5808,17 +5827,22 @@ fn retrieve_context_pack_output(
         // usable vector falls back to the lexical score rather than scoring 0: it is a record we
         // could not compare, not a record we know to be irrelevant, and zeroing it would drop it
         // beneath every lexical match in the same list.
-        let score = match (query_vector.as_deref(), candidate.vector.as_deref()) {
-            (Some(query), Some(record)) if !query.is_empty() => {
-                let dense = dense_query_score(query, record);
-                if dense > 0.0 {
-                    dense
-                } else {
-                    score_lowered_text(&candidate.lower_text, &query_terms)
-                }
-            }
-            _ => score_lowered_text(&candidate.lower_text, &query_terms),
-        };
+        let lexical = score_lowered_text(&candidate.lower_text, &query_terms);
+        let score = candidate_score(
+            &weights,
+            query_vector.as_deref(),
+            candidate.vector.as_deref(),
+            lexical,
+            // Lazy: the lexical path must not pay for a hint lookup it will not use.
+            || {
+                candidate
+                    .selected_ref
+                    .get("node_hash")
+                    .and_then(Value::as_u64)
+                    .map(|h| hinted.contains(&h))
+                    .unwrap_or(false)
+            },
+        );
         candidates.push((score, ordinal));
     }
     let score_ms = score_started.elapsed().as_secs_f64() * 1000.0;
@@ -6213,6 +6237,82 @@ fn native_correctness_evidence(
     })
 }
 
+/// The caller's ranking policy: `dense * normalized_cosine + sparse * lexical + hint`.
+///
+/// Mirrors what the caller computes today, so the engine can reproduce its answer rather than
+/// approximate it. The hint is added for candidates the caller named in `selected_node_hashes`,
+/// which is how the caller's own prefilter marks a node it already believes in.
+#[derive(Debug, Clone, Copy, Deserialize)]
+struct RankingWeights {
+    #[serde(default = "one_f64")]
+    dense: f64,
+    #[serde(default)]
+    sparse: f64,
+    #[serde(default)]
+    index_hint: f64,
+}
+
+fn one_f64() -> f64 {
+    1.0
+}
+
+impl Default for RankingWeights {
+    fn default() -> Self {
+        // Dense-only, which is what this engine did before it could blend at all.
+        Self {
+            dense: 1.0,
+            sparse: 0.0,
+            index_hint: 0.0,
+        }
+    }
+}
+
+fn clamp01(value: f64) -> f64 {
+    value.clamp(0.0, 1.0)
+}
+
+/// One candidate's score under the caller's policy.
+///
+/// `dense` is already the 0..1 mapping of cosine, so this is the caller's formula term for term.
+/// A candidate with no usable vector contributes 0 to the dense term rather than being dropped:
+/// it is a record we could not compare, not one we know to be irrelevant, and with a non-zero
+/// sparse weight its lexical score still speaks for it.
+/// One candidate's score, choosing the scorer by what the caller actually sent.
+///
+/// Pulled out of the scoring loop so the no-vector case can be tested. It carries a hazard worth
+/// stating: the caller sends `ranking_weights` UNCONDITIONALLY but only sends `query_vector` when
+/// dense ranking is enabled, and on a one-box those weights are dense 1.00 / sparse 0.00. Blending
+/// with an absent dense term would therefore compute 1.00 * 0 + 0.00 * lexical = 0 for EVERY
+/// candidate and rank the whole corpus flat -- silently, with no error and a full-looking pack.
+/// So a missing query vector must bypass the blend entirely rather than pass a zero into it.
+fn candidate_score<F: FnOnce() -> bool>(
+    weights: &RankingWeights,
+    query_vector: Option<&[f32]>,
+    record_vector: Option<&[f32]>,
+    lexical: f64,
+    index_hinted: F,
+) -> f64 {
+    match (query_vector, record_vector) {
+        (Some(query), Some(record)) if !query.is_empty() => {
+            let dense = dense_query_score(query, record);
+            blended_candidate_score(weights, Some(dense), lexical, index_hinted())
+        }
+        // No query vector means no dense term to blend, so this is the lexical ranking the engine
+        // has always done -- not the blend with a zero, which the weights would scale.
+        _ => lexical,
+    }
+}
+
+fn blended_candidate_score(
+    weights: &RankingWeights,
+    dense: Option<f64>,
+    lexical: f64,
+    index_hinted: bool,
+) -> f64 {
+    let hint = if index_hinted { weights.index_hint } else { 0.0 };
+    clamp01(weights.dense * dense.unwrap_or(0.0) + weights.sparse * lexical + hint)
+}
+
 /// Cosine similarity, mapped to the same 0..1 range the lexical scorer produces.
 ///
 /// Vectors of different lengths score 0 rather than panicking or comparing a prefix: a record
@@ -6423,6 +6523,145 @@ fn _request_shape_for_docs() -> serde_json::Value {
 
 #[cfg(test)]
 mod tests {
+
+    /// Weights WITHOUT a query vector must not zero the ranking.
+    ///
+    /// This is the default-off path in production: Python sends ranking_weights on every request
+    /// but withholds the query vector unless dense ranking is enabled. With one-box weights
+    /// (dense 1.00, sparse 0.00) a blend against an absent dense term scores every candidate 0,
+    /// which does not error -- it returns a pack whose ordering is meaningless. The engine must
+    /// fall through to lexical instead.
+    #[test]
+    fn weights_without_a_query_vector_do_not_zero_the_ranking() {
+        let onebox = RankingWeights { dense: 1.0, sparse: 0.0, index_hint: 0.08 };
+        let record = [1.0_f32, 0.0];
+        for query in [None, Some(&[][..])] {
+            let got = candidate_score(&onebox, query, Some(&record), 0.75, || false);
+            assert!(
+                (got - 0.75).abs() < 1e-9,
+                "query {query:?}: got {got}, expected the lexical score 0.75"
+            );
+        }
+    }
+
+    /// A candidate the engine cannot compare keeps its lexical score too.
+    #[test]
+    fn a_candidate_with_no_vector_is_scored_lexically() {
+        let onebox = RankingWeights { dense: 1.0, sparse: 0.0, index_hint: 0.08 };
+        let query = [1.0_f32, 0.0];
+        let got = candidate_score(&onebox, Some(&query), None, 0.6, || false);
+        assert!((got - 0.6).abs() < 1e-9, "got {got}, expected 0.6");
+    }
+
+    /// The positive control: when BOTH vectors are present the blend really does run, so the two
+    /// tests above are asserting a fallback that something else would otherwise have taken.
+    #[test]
+    fn both_vectors_present_takes_the_dense_blend() {
+        let onebox = RankingWeights { dense: 1.0, sparse: 0.0, index_hint: 0.0 };
+        let query = [1.0_f32, 0.0];
+        let record = [1.0_f32, 0.0];
+        // Identical unit vectors: cosine 1.0 -> normalized 1.0, and the lexical 0.0 is ignored.
+        let got = candidate_score(&onebox, Some(&query), Some(&record), 0.0, || false);
+        assert!(got > 0.99, "got {got}, expected the dense term to dominate");
+    }
+
+    /// The hint must stay lazy: the lexical path must not evaluate it at all.
+    #[test]
+    fn the_lexical_path_never_evaluates_the_index_hint() {
+        let onebox = RankingWeights { dense: 1.0, sparse: 0.0, index_hint: 0.08 };
+        let mut evaluated = false;
+        let got = candidate_score(&onebox, None, None, 0.4, || {
+            evaluated = true;
+            true
+        });
+        assert!((got - 0.4).abs() < 1e-9, "got {got}");
+        assert!(!evaluated, "the lexical path paid for a hint lookup it did not use");
+    }
+
+    /// The one-box policy, term for term against the caller's own formula.
+    ///
+    /// The caller computes, with _ONEBOX_DENSE_ONLY true:
+    ///     _DENSE_W = 1.00, _SPARSE_W = 0.00
+    ///     score = clamp01(_DENSE_W * normalized_dense_score(cosine)
+    ///                   + _SPARSE_W * sparse + index_hint_boost)
+    ///     normalized_dense_score(v) = clamp01((v + 1) / 2)
+    ///
+    /// So the engine must return exactly (cosine + 1) / 2 and ignore the lexical score entirely.
+    /// If this ever fails, the engine and the caller are ranking differently and the engine must
+    /// not be the default -- which is the whole reason this test exists rather than a benchmark.
+    #[test]
+    fn the_dense_only_policy_reproduces_the_callers_score() {
+        let dense_only = RankingWeights { dense: 1.0, sparse: 0.0, index_hint: 0.0 };
+        // cosine = 1.0 -> normalized 1.0; cosine = 0.0 -> 0.5; cosine = -1.0 -> 0.0
+        for (cosine, expect) in [(1.0, 1.0), (0.0, 0.5), (-1.0, 0.0), (0.5, 0.75)] {
+            let normalized = (cosine + 1.0) / 2.0;
+            let got = blended_candidate_score(&dense_only, Some(normalized), 1.0, false);
+            assert!(
+                (got - expect).abs() < 1e-9,
+                "cosine {cosine}: got {got}, caller would produce {expect}"
+            );
+        }
+    }
+
+    /// With a zero sparse weight the lexical score must not reach the result AT ALL.
+    ///
+    /// The positive control for the test above: if the engine quietly added lexical, the first
+    /// test would still pass for lexical == 1.0 by coincidence of the numbers.
+    #[test]
+    fn a_zero_sparse_weight_ignores_the_lexical_score() {
+        let dense_only = RankingWeights { dense: 1.0, sparse: 0.0, index_hint: 0.0 };
+        let high = blended_candidate_score(&dense_only, Some(0.5), 1.0, false);
+        let low = blended_candidate_score(&dense_only, Some(0.5), 0.0, false);
+        assert_eq!(high, low, "lexical changed a dense-only score");
+    }
+
+    /// The non-one-box policy: 0.72 dense, 0.28 lexical.
+    #[test]
+    fn the_blended_policy_weights_both_terms() {
+        let blended = RankingWeights { dense: 0.72, sparse: 0.28, index_hint: 0.0 };
+        // The caller's arithmetic: 0.72 * 0.5 + 0.28 * 1.0 = 0.36 + 0.28 = 0.64
+        let got = blended_candidate_score(&blended, Some(0.5), 1.0, false);
+        assert!((got - 0.64).abs() < 1e-9, "got {got}, expected 0.64");
+    }
+
+    /// The index hint is worth what the caller says and applies only to hinted candidates.
+    #[test]
+    fn the_index_hint_applies_only_where_the_caller_hinted() {
+        let weights = RankingWeights { dense: 1.0, sparse: 0.0, index_hint: 0.08 };
+        let hinted = blended_candidate_score(&weights, Some(0.5), 0.0, true);
+        let plain = blended_candidate_score(&weights, Some(0.5), 0.0, false);
+        assert!((hinted - 0.58).abs() < 1e-9, "hinted got {hinted}, expected 0.58");
+        assert!((plain - 0.50).abs() < 1e-9, "unhinted got {plain}, expected 0.50");
+    }
+
+    /// clamp01, because the caller clamps and an unclamped engine would order ties differently
+    /// at the top of the list -- exactly where selection happens.
+    #[test]
+    fn the_score_is_clamped_like_the_callers() {
+        let weights = RankingWeights { dense: 1.0, sparse: 1.0, index_hint: 0.5 };
+        assert_eq!(blended_candidate_score(&weights, Some(1.0), 1.0, true), 1.0);
+        let negative = RankingWeights { dense: -5.0, sparse: 0.0, index_hint: 0.0 };
+        assert_eq!(blended_candidate_score(&negative, Some(1.0), 0.0, false), 0.0);
+    }
+
+    /// A candidate with no usable vector contributes 0 to the DENSE term but keeps its lexical
+    /// one, so a blended policy can still rank it. Dropping it to 0 outright would sink every
+    /// record the engine could not compare beneath every record it could.
+    #[test]
+    fn a_candidate_without_a_vector_keeps_its_lexical_score() {
+        let blended = RankingWeights { dense: 0.72, sparse: 0.28, index_hint: 0.0 };
+        let got = blended_candidate_score(&blended, None, 1.0, false);
+        assert!((got - 0.28).abs() < 1e-9, "got {got}, expected 0.28");
+    }
+
+    /// Absent weights must mean what the engine did BEFORE it could blend: dense-only.
+    #[test]
+    fn absent_weights_are_dense_only() {
+        let d = RankingWeights::default();
+        assert_eq!(d.dense, 1.0);
+        assert_eq!(d.sparse, 0.0);
+        assert_eq!(d.index_hint, 0.0);
+    }
 
     #[test]
     fn an_identical_vector_scores_highest() {
@@ -7302,6 +7541,7 @@ mod tests {
             newest_by_type: None,
             record_fields: None,
             query_vector: None,
+            ranking_weights: None,
             selected_node_hashes: None,
             secondary_index_groups: None,
             scope: None,

--- a/tools/matrixark_local_adapter_retrieve.py
+++ b/tools/matrixark_local_adapter_retrieve.py
@@ -1017,6 +1017,24 @@ class _LocalAdapterRetrieveMixin:
             "reference_time_ms": reference_time_ms,
             "include_superseded_resources": bool(args.get("include_superseded_resources", False) or args.get("historical_replay", False)),
             "audit_mode": audit_mode,
+            # Ranking policy and the query embedding, for the backend that assembles this pack.
+            #
+            # These used to be attached in _try_native_context_pack, which belongs to the OTHER
+            # retrieve on this object. The one-box gateway resolves retrieve() to this one, so the
+            # engine was handed a pack request with no vector and no weights and had nothing to
+            # rank densely with -- the flag that was supposed to enable it changed nothing at all,
+            # and an A/B across it measured noise between two identical arms.
+            #
+            # hasattr rather than a bare call: a backend class without the temporal read mixin
+            # should degrade to the lexical ranking it has always done, not raise inside retrieve.
+            "query_vector": (
+                self._native_query_vector(query)
+                if hasattr(self, "_native_query_vector") else None
+            ),
+            "ranking_weights": (
+                self._native_ranking_weights()
+                if hasattr(self, "_native_ranking_weights") else None
+            ),
         })
         if native_pack is not None:
             recall_policy = native_pack.get("recall_policy") if isinstance(native_pack.get("recall_policy"), dict) else {}

--- a/tools/matrixark_temporal_direct_read.py
+++ b/tools/matrixark_temporal_direct_read.py
@@ -405,6 +405,32 @@ class _TemporalDirectReadMixin:
         "source_memory_selection_lossy_count",
     )
 
+    def _native_ranking_weights(self) -> dict | None:
+        """The ranking policy to hand the engine, so it cannot drift from this one.
+
+        These are the same weights the local packer uses: on a one-box that ranks
+        embedding-first they are 1.00 dense and 0.00 lexical, elsewhere 0.72 and 0.28, and an
+        index hint is worth 0.08. Sending them rather than letting the engine hold its own copy
+        is the point -- two hardcoded copies of a ranking policy diverge silently, and the symptom
+        is worse answers rather than an error.
+        """
+        try:
+            from matrixark_mcp_core import onebox_embedding_first
+        except ImportError:  # pragma: no cover - import shape differs when run as a package
+            try:
+                from tools.matrixark_mcp_core import onebox_embedding_first
+            except ImportError:
+                return None
+        try:
+            dense_only = bool(onebox_embedding_first())
+        except Exception:  # noqa: BLE001 - ranking policy must never fail a retrieve
+            return None
+        return {
+            "dense": 1.00 if dense_only else 0.72,
+            "sparse": 0.00 if dense_only else 0.28,
+            "index_hint": 0.08,
+        }
+
     def _native_query_vector(self, query: str) -> list[float] | None:
         """The query embedding to hand the engine, or None to leave ranking here.
 
@@ -1127,6 +1153,7 @@ class _TemporalDirectReadMixin:
             # The engine ranks by cosine when this is present and lexically when it is not, and
             # reports which it did as `ranking_uses_vectors`.
             "query_vector": self._native_query_vector(query),
+            "ranking_weights": self._native_ranking_weights(),
             "question_type": question_type,
             "scope": scope,
             "session_scope": retrieval_session_scope,


### PR DESCRIPTION
## The flag never reached the path it was meant to change

`MATRIXARK_NATIVE_DENSE_RANKING` attached the query vector and the ranking policy in
`_try_native_context_pack`, which belongs to one `retrieve` implementation. The one-box gateway
resolves `retrieve()` to the local adapter's, which builds its **own** native-pack request and
carried neither field. So the engine received a pack request with nothing to rank densely with,
the flag changed nothing, and an A/B across it compared two identical arms.

This was confirmed at runtime rather than inferred. Instrumenting both branches on a copy of the
tools tree, with the flag on and 10/10 retrieves served, **neither** the query-vector helper nor
the pack call site was entered. The probe was not blind: the gateway's `PYTHONPATH` and cwd both
pointed at the patched copy and both modules had fresh `.pyc` files.

After the fix the same probe shows the flag flipping behaviour — ten query vectors computed with
it on, none with it off.

## The flag stays off by default

At equal elapsed time the arms return the same refs per retrieve (21.2 against 21.3) and the
engine arm's retrieve p50 is worse (541 ms against 617 ms) on a single sample. There is no
measurement here that justifies changing a default, so this only makes the flag *work* — it does
not turn it on.

Worth recording separately: the query embedding handed to the engine is **32-dimensional** while
the encoder service answers with 1024, so this ranking is cosine over hash vectors. That is
pre-existing and shared with the Python packer — the same vector is requested moments later — but
it caps what any ranking change can achieve on this box.

## A hazard the fix exposes, now held by tests

The caller sends `ranking_weights` on **every** request but sends `query_vector` only when the flag
is on, and on a one-box those weights are dense 1.00 / sparse 0.00. Blending an absent dense term
would compute `1.00 * 0 + 0.00 * lexical = 0` for every candidate and rank the whole corpus flat —
silently, with no error and a full-looking pack.

The engine already fell through to lexical instead. `candidate_score` now states that in one place
and four tests hold it, including a positive control that the blend genuinely runs when both
vectors are present, so the fallback tests are not asserting a branch nothing else would take. The
index hint is a lazy closure so the lexical path does not pay for a lookup it discards, and one
test asserts that laziness.

## Gate

`cargo test -p temporalstore-rust --bin matrixark_rust_proxy` — **94 passed, 0 failed**.

That specific target matters: this file is reached through `src/bin/`, so `cargo test --lib`
contains none of its tests and reports `ok` while running zero of them. `--bins` also misses it,
because cargo stops after the first failing test binary. Seven Python test files covering the
native-pack request also pass.
