### PR TITLE
Say when a scoped scan gives up and reads the whole store

### DIFF
--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -534,27 +534,59 @@ def _shadow_log_path(operation: str) -> str:
     return _os.environ.get("MATRIXARK_SHADOW_LOG", "/tmp/matrixark_%s_shadow.log" % operation)
 
 
-def _note_full_read_fallback(where: str, reason: BaseException) -> None:
-    """Say which scoped scan gave up and why, when the answer is to read the whole store.
+_FULL_READ_FALLBACKS: dict[str, int] = {}
+
+
+def full_read_fallback_counts() -> dict[str, int]:
+    """How many times each scoped scan gave up and read the whole store instead.
+
+    Counted in this process since start. Exposed because the fallback is otherwise undetectable
+    from outside: a measured degraded window did TEN whole-corpus reads and wrote nothing at all,
+    and from the caller it looked like a normal request that was merely slow.
+    """
+    return dict(_FULL_READ_FALLBACKS)
+
+
+def _note_full_read_fallback(where: str | None = None,
+                             reason: BaseException | None = None) -> None:
+    """Say which scoped scan gave up, when the answer is to read the whole store.
 
     Each of these replaces a scan of the records a request needs with a read of every record
     there is, on every turn it happens. Silent, that is invisible from outside: a scan path that
     has stopped working looks exactly like one that was never taken, and the cost shows up only as
     a store that got slower.
 
-    Written only when MATRIXARK_MCP_DEBUG_LOG names a file, so the normal path costs one lookup --
-    against a fallback that is about to read everything. Never raises: a channel that reports a
-    problem must not become one.
+    The COUNT is kept unconditionally -- a dict increment, against a caller that is about to read
+    every record in the store, so the cost is not worth a flag. The detailed line is still written
+    only when MATRIXARK_MCP_DEBUG_LOG names a file.
+
+    `where` defaults to the calling function's name, so the branches that have no exception to
+    report can announce themselves without each one restating its own name. `reason` is optional
+    for the same branches: `subset is None` means the scan could not answer, which is not an error
+    anything raised.
+
+    Never raises: a channel that reports a problem must not become one.
     """
+    try:
+        if where is None:
+            import sys as _sys
+            try:
+                where = _sys._getframe(1).f_code.co_name
+            except Exception:  # noqa: BLE001 - naming the caller must not fail the caller.
+                where = "unknown"
+        _FULL_READ_FALLBACKS[where] = _FULL_READ_FALLBACKS.get(where, 0) + 1
+    except Exception:  # noqa: BLE001
+        pass
     try:
         import os as _os
 
         debug_path = _os.environ.get("MATRIXARK_MCP_DEBUG_LOG")
         if not debug_path:
             return
+        detail = "scoped scan unavailable" if reason is None else "%s: %s" % (
+            reason.__class__.__name__, reason)
         with open(debug_path, "a", encoding="utf-8") as handle:
-            handle.write("%s fell back to the full read: %s: %s%s"
-                         % (where, reason.__class__.__name__, reason, chr(10)))
+            handle.write("%s fell back to the full read: %s%s" % (where, detail, chr(10)))
     except OSError:
         pass
 
@@ -1468,6 +1500,10 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             scope=engine_scope,
         )
         if subset is None:
+            # The scan could not answer, so this is about to read every record in the store.
+            # Counted rather than silent: this branch, not the exception one below, is what fires
+            # when the backend is unreachable, and it used to report nothing at all.
+            _note_full_read_fallback()
             return self.read_all()
         try:
             latest_state = self._load_latest_context_state_records()
@@ -1587,6 +1623,10 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             scope=engine_scope,
         )
         if subset is None:
+            # The scan could not answer, so this is about to read every record in the store.
+            # Counted rather than silent: this branch, not the exception one below, is what fires
+            # when the backend is unreachable, and it used to report nothing at all.
+            _note_full_read_fallback()
             return self.read_all()
         try:
             latest_state = self._load_latest_context_state_records()
@@ -1685,6 +1725,10 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         ]
         subset = self._scan_records_of_types(wanted)
         if subset is None:
+            # The scan could not answer, so this is about to read every record in the store.
+            # Counted rather than silent: this branch, not the exception one below, is what fires
+            # when the backend is unreachable, and it used to report nothing at all.
+            _note_full_read_fallback()
             return self.read_all()
         try:
             latest_state = self._load_latest_context_state_records()
@@ -1804,6 +1848,10 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             else self._scan_records_of_types(kept_types, record_ids=sorted(identity_ids))
         )
         if subset is None:
+            # The scan could not answer, so this is about to read every record in the store.
+            # Counted rather than silent: this branch, not the exception one below, is what fires
+            # when the backend is unreachable, and it used to report nothing at all.
+            _note_full_read_fallback()
             return self.read_all()
         try:
             latest_state = self._load_latest_context_state_records()
@@ -1945,6 +1993,10 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             else self._scan_records_of_types(kept_types, record_ids=sorted(identity_ids))
         )
         if subset is None:
+            # The scan could not answer, so this is about to read every record in the store.
+            # Counted rather than silent: this branch, not the exception one below, is what fires
+            # when the backend is unreachable, and it used to report nothing at all.
+            _note_full_read_fallback()
             return self.read_all()
         try:
             latest_state = self._load_latest_context_state_records()
@@ -2117,6 +2169,10 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
                 newest_by_type=({"context_event": newest_events} if newest_events else None),
             )
         if subset is None:
+            # The scan could not answer, so this is about to read every record in the store.
+            # Counted rather than silent: this branch, not the exception one below, is what fires
+            # when the backend is unreachable, and it used to report nothing at all.
+            _note_full_read_fallback()
             return self.read_all()
         # Summaries and other compact records can live in the latest-state HASH rather than the
         # append log, and the scan walks only the log -- the shadow compare caught exactly this:

--- a/tools/test_a_scoped_scan_that_gives_up_says_so.py
+++ b/tools/test_a_scoped_scan_that_gives_up_says_so.py
@@ -1,0 +1,105 @@
+"""A scoped scan that gives up and reads the whole store must say so.
+
+Measured 2026-09-09: a degraded window did TEN whole-corpus reads and wrote nothing anywhere. Two
+reasons, both fixed here and both asserted below -- the notifier returned early unless a debug log
+was configured, and the `subset is None` branch (the one that actually fires when the backend
+cannot answer) never called the notifier at all.
+"""
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from matrixark_mcp_temporal_adapters import (  # noqa: E402
+    _note_full_read_fallback,
+    full_read_fallback_counts,
+)
+
+FAILURES = []
+
+
+def check(condition, message):
+    if not condition:
+        FAILURES.append(message)
+
+
+def a_named_fallback_is_counted_without_any_debug_log():
+    os.environ.pop("MATRIXARK_MCP_DEBUG_LOG", None)
+    before = full_read_fallback_counts().get("records_for_session_buffer", 0)
+    _note_full_read_fallback("records_for_session_buffer", RuntimeError("backend away"))
+    after = full_read_fallback_counts().get("records_for_session_buffer", 0)
+    check(after == before + 1,
+          "counting must not depend on a debug log: %d -> %d" % (before, after))
+
+
+def an_unnamed_fallback_takes_the_calling_functions_name():
+    """The `subset is None` branches call this with no arguments at all."""
+    def records_for_a_made_up_thing():
+        _note_full_read_fallback()
+
+    before = full_read_fallback_counts().get("records_for_a_made_up_thing", 0)
+    records_for_a_made_up_thing()
+    after = full_read_fallback_counts().get("records_for_a_made_up_thing", 0)
+    check(after == before + 1,
+          "an unnamed fallback must be attributed to its caller, got %d -> %d" % (before, after))
+
+
+def counting_a_fallback_never_raises():
+    """A channel that reports a problem must not become one."""
+    try:
+        _note_full_read_fallback(None, None)
+    except Exception as exc:  # noqa: BLE001
+        check(False, "the notifier raised: %r" % (exc,))
+
+
+def the_detail_line_still_needs_the_debug_log():
+    """The positive control: without this, 'counts always' could mean 'writes always' too, and the
+    detail line would start appearing in deployments that never asked for it."""
+    os.environ.pop("MATRIXARK_MCP_DEBUG_LOG", None)
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "debug.log")
+        _note_full_read_fallback("quiet_case", None)
+        check(not os.path.exists(path), "no debug log configured, so nothing may be written")
+
+        os.environ["MATRIXARK_MCP_DEBUG_LOG"] = path
+        try:
+            _note_full_read_fallback("loud_case", None)
+            check(os.path.exists(path), "with the log configured the line must be written")
+            body = open(path, encoding="utf-8").read()
+            check("loud_case" in body, "the line must name the caller, got %r" % body)
+            check("scoped scan unavailable" in body,
+                  "a fallback with no exception must still say why, got %r" % body)
+        finally:
+            os.environ.pop("MATRIXARK_MCP_DEBUG_LOG", None)
+
+
+def every_silent_branch_now_announces():
+    """The six `subset is None` branches must each call the notifier before reading everything."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    source = open(os.path.join(here, "matrixark_mcp_temporal_adapters.py"), encoding="utf-8").read()
+    silent = "        if subset is None:\n            return self.read_all()"
+    check(source.count(silent) == 0,
+          "%d 'subset is None' branches still read the whole store silently" % source.count(silent))
+    announced = "_note_full_read_fallback()\n            return self.read_all()"
+    check(source.count(announced) == 6,
+          "expected 6 announcing branches, found %d" % source.count(announced))
+
+
+for test in (
+    a_named_fallback_is_counted_without_any_debug_log,
+    an_unnamed_fallback_takes_the_calling_functions_name,
+    counting_a_fallback_never_raises,
+    the_detail_line_still_needs_the_debug_log,
+    every_silent_branch_now_announces,
+):
+    test()
+    print("  ran %s" % test.__name__)
+
+if FAILURES:
+    print("FAILED:")
+    for f in FAILURES:
+        print("  - %s" % f)
+    raise SystemExit(1)
+print("all fallback-visibility checks pass")


### PR DESCRIPTION
## A degraded window did ten whole-corpus reads and reported nothing

Measured on a native one-box: with the proxy killed, one request produced **10** `read_all` calls
and wrote nothing anywhere. From outside it was indistinguishable from a request that was merely
slow.

Two causes, both fixed here:

1. `_note_full_read_fallback` returned early unless `MATRIXARK_MCP_DEBUG_LOG` named a file, which
   it does not by default.
2. The branch that actually fires when the backend cannot answer — `subset is None` — **never
   called the notifier at all**. All nine existing calls sit on the exception path beside it. Six
   such branches read every record in the store and said nothing.

## What changed

The count is now kept unconditionally: a dict increment against a caller about to read the entire
store, so it is not worth a flag to skip. `full_read_fallback_counts()` exposes it. The detailed
line still requires the debug log, so no deployment starts writing lines it did not ask for — and a
test asserts that, because "counts always" quietly becoming "writes always" is the obvious way this
change could go wrong.

`where` defaults to the calling function name so a branch with no exception can announce itself,
and `reason` is optional because "the scan could not answer" is not something anything raised.

## Why this, and not deleting read_all

`read_all` is already off the healthy serving path. Measured on a native one-box with the stack
verified healthy first — ingest 202, and ingest 500 with the proxy killed, which proves the gateway
was really on the backend under test rather than quietly serving from a local adapter:

| traffic | `read_all` calls |
|---|---|
| 30 ingests + 20 retrieves, healthy | **2** (one-time init, not per-request) |
| one request, proxy down | **10** |

So what is left to retire is the fallback, not the serving path. A fallback nobody can see firing
cannot be retired safely — this makes it visible first.

## Tests

`tools/test_a_scoped_scan_that_gives_up_says_so.py`, five checks, all pass. It fails on unpatched
code. Being precise about that: it fails there by `ImportError` on the new symbol, so the assertion
that genuinely discriminates is the source-level one — six silent branches must become zero.
