### PR TITLE
A full read that goes back to the refused backend is not a fallback

### DIFF
--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -536,6 +536,13 @@ def _shadow_log_path(operation: str) -> str:
 
 _FULL_READ_FALLBACKS: dict[str, int] = {}
 
+# Why the most recent scoped scan in THIS thread gave up, or None if it simply could not be asked.
+#
+# Thread-local rather than an attribute on the adapter: one adapter serves every request, so an
+# instance attribute would let one thread's backend error decide another thread's fallback. Reset
+# at the top of every scan, so what it holds is always the scan the caller is reacting to.
+_SCAN_STATE = threading.local()
+
 
 def full_read_fallback_counts() -> dict[str, int]:
     """How many times each scoped scan gave up and read the whole store instead.
@@ -1346,6 +1353,10 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         """
         # An adapter with no client at all (partial construction, stubs) is the same answer as
         # a client without the scan: the question cannot be asked here.
+        # Absence and failure are different answers and the caller now acts on the difference:
+        # no scanner means the full read is the correct path, a FAILED scan means the backend could
+        # not answer -- and the full read goes back to that same backend.
+        _SCAN_STATE.last_error = None
         scanner = getattr(getattr(self, "_client", None), "matrixark_scan_candidates", None)
         if not callable(scanner):
             return None
@@ -1382,10 +1393,12 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
                         record_types, record_ids=record_ids, scope=scope, newest_by_type=None
                     )
                 except Exception as fallback_reason:  # noqa: BLE001 - the caller reads everything.
+                    _SCAN_STATE.last_error = fallback_reason
                     _note_full_read_fallback("_scan_records_of_types", fallback_reason)
                     return None
             return None
-        except Exception:  # noqa: BLE001 - an unanswered question means "do the full read".
+        except Exception as scan_error:  # noqa: BLE001 - the caller decides what an outage means.
+            _SCAN_STATE.last_error = scan_error
             return None
         if not isinstance(response, dict):
             return None
@@ -1397,6 +1410,55 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             record for record in records
             if isinstance(record, dict) and str(record.get("record_type") or "") in wanted
         ]
+
+    def _full_read_can_answer_offline(self) -> bool:
+        """Could a full read answer without the backend that just failed?
+
+        Two ways it can. The Python hot cache may already hold the records -- but
+        `python_hot_cache_allowed` returns `backend_label == "local"`, so on a native backend it is
+        off by design, because serving is meant to read through native pushdown. Or a disk fallback
+        store may be configured, which `read_all` recovers from before reading.
+
+        With neither, `read_all` calls `_get_count()` on the same client that just failed, so the
+        full read is guaranteed to fail too. Unsure counts as "yes": an unexpected answer here must
+        leave the old behaviour in place rather than turn a served request into an error.
+        """
+        try:
+            if self.python_hot_cache_enabled() and getattr(self, "_records_cache", None) is not None:
+                return True
+        except Exception:  # noqa: BLE001 - if the policy cannot be read, keep the full read.
+            return True
+        try:
+            return bool(disk_fallback_store_path())
+        except Exception:  # noqa: BLE001
+            return True
+
+    def _read_all_after_scoped_scan(self) -> list[Json]:
+        """The full read a scoped scan falls back to -- unless it provably cannot help.
+
+        Measured 2026-09-09 on a native one-box: one request with the backend down did TEN
+        whole-corpus reads and returned 500 anyway. Each of those went back to the same client that
+        had just refused the scan, so none of them could ever have answered; they only delayed the
+        error and, on a large store, would have done it expensively.
+
+        So when the scan FAILED and no offline source exists, re-raise the scan's own error instead.
+        The request fails exactly as it did before, with the real reason -- a refused connection
+        reads as a refused connection rather than as a slow request that eventually gave up.
+
+        When the scan could not be ASKED (no scanner on this client) there is no error and this is
+        the ordinary full read, unchanged.
+        """
+        import sys as _sys
+        where = "unknown"
+        try:
+            where = _sys._getframe(1).f_code.co_name
+        except Exception:  # noqa: BLE001
+            pass
+        _note_full_read_fallback(where)
+        error = getattr(_SCAN_STATE, "last_error", None)
+        if error is not None and not self._full_read_can_answer_offline():
+            raise error
+        return self.read_all()
 
     def _memory_tombstone_records(self) -> list[Json] | None:
         """Every memory tombstone in the store. None = could not ask (see _scan_records_of_types)."""
@@ -1500,11 +1562,10 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             scope=engine_scope,
         )
         if subset is None:
-            # The scan could not answer, so this is about to read every record in the store.
-            # Counted rather than silent: this branch, not the exception one below, is what fires
-            # when the backend is unreachable, and it used to report nothing at all.
-            _note_full_read_fallback()
-            return self.read_all()
+            # The scan could not answer, so this is about to read every record in the store --
+            # unless the scan FAILED and nothing offline can serve it, in which case the full read
+            # would go back to the same backend and fail too. Counted either way.
+            return self._read_all_after_scoped_scan()
         try:
             latest_state = self._load_latest_context_state_records()
         except Exception as fallback_reason:  # noqa: BLE001 - the full read is the fallback.
@@ -1623,11 +1684,10 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             scope=engine_scope,
         )
         if subset is None:
-            # The scan could not answer, so this is about to read every record in the store.
-            # Counted rather than silent: this branch, not the exception one below, is what fires
-            # when the backend is unreachable, and it used to report nothing at all.
-            _note_full_read_fallback()
-            return self.read_all()
+            # The scan could not answer, so this is about to read every record in the store --
+            # unless the scan FAILED and nothing offline can serve it, in which case the full read
+            # would go back to the same backend and fail too. Counted either way.
+            return self._read_all_after_scoped_scan()
         try:
             latest_state = self._load_latest_context_state_records()
         except Exception as fallback_reason:  # noqa: BLE001 - full read is the fallback.
@@ -1725,11 +1785,10 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         ]
         subset = self._scan_records_of_types(wanted)
         if subset is None:
-            # The scan could not answer, so this is about to read every record in the store.
-            # Counted rather than silent: this branch, not the exception one below, is what fires
-            # when the backend is unreachable, and it used to report nothing at all.
-            _note_full_read_fallback()
-            return self.read_all()
+            # The scan could not answer, so this is about to read every record in the store --
+            # unless the scan FAILED and nothing offline can serve it, in which case the full read
+            # would go back to the same backend and fail too. Counted either way.
+            return self._read_all_after_scoped_scan()
         try:
             latest_state = self._load_latest_context_state_records()
         except Exception as fallback_reason:  # noqa: BLE001 - full read is the fallback.
@@ -1848,11 +1907,10 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             else self._scan_records_of_types(kept_types, record_ids=sorted(identity_ids))
         )
         if subset is None:
-            # The scan could not answer, so this is about to read every record in the store.
-            # Counted rather than silent: this branch, not the exception one below, is what fires
-            # when the backend is unreachable, and it used to report nothing at all.
-            _note_full_read_fallback()
-            return self.read_all()
+            # The scan could not answer, so this is about to read every record in the store --
+            # unless the scan FAILED and nothing offline can serve it, in which case the full read
+            # would go back to the same backend and fail too. Counted either way.
+            return self._read_all_after_scoped_scan()
         try:
             latest_state = self._load_latest_context_state_records()
         except Exception as fallback_reason:  # noqa: BLE001 - full read is the fallback.
@@ -1993,11 +2051,10 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             else self._scan_records_of_types(kept_types, record_ids=sorted(identity_ids))
         )
         if subset is None:
-            # The scan could not answer, so this is about to read every record in the store.
-            # Counted rather than silent: this branch, not the exception one below, is what fires
-            # when the backend is unreachable, and it used to report nothing at all.
-            _note_full_read_fallback()
-            return self.read_all()
+            # The scan could not answer, so this is about to read every record in the store --
+            # unless the scan FAILED and nothing offline can serve it, in which case the full read
+            # would go back to the same backend and fail too. Counted either way.
+            return self._read_all_after_scoped_scan()
         try:
             latest_state = self._load_latest_context_state_records()
         except Exception as fallback_reason:  # noqa: BLE001 - full read is the fallback.
@@ -2169,11 +2226,10 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
                 newest_by_type=({"context_event": newest_events} if newest_events else None),
             )
         if subset is None:
-            # The scan could not answer, so this is about to read every record in the store.
-            # Counted rather than silent: this branch, not the exception one below, is what fires
-            # when the backend is unreachable, and it used to report nothing at all.
-            _note_full_read_fallback()
-            return self.read_all()
+            # The scan could not answer, so this is about to read every record in the store --
+            # unless the scan FAILED and nothing offline can serve it, in which case the full read
+            # would go back to the same backend and fail too. Counted either way.
+            return self._read_all_after_scoped_scan()
         # Summaries and other compact records can live in the latest-state HASH rather than the
         # append log, and the scan walks only the log -- the shadow compare caught exactly this:
         # the subset was missing every refresher-written context_summary. Fold the latest-state

--- a/tools/test_a_full_read_that_cannot_answer_is_not_a_fallback.py
+++ b/tools/test_a_full_read_that_cannot_answer_is_not_a_fallback.py
@@ -1,0 +1,146 @@
+"""A full read that goes back to the backend that just refused is not a fallback.
+
+Measured 2026-09-09 on a native one-box: one request with the backend down did TEN whole-corpus
+reads and returned 500 anyway. Every one of them called the same client that had refused the scan,
+so none could have answered. These tests pin the difference between the two ways a scoped scan
+returns None -- it could not be ASKED (full read is correct) versus it was asked and FAILED (the
+full read goes back to the same backend).
+"""
+import os
+import sys
+import threading
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import matrixark_mcp_temporal_adapters as adapters  # noqa: E402
+
+CLASS = adapters.MatrixArkTemporalStoreDirectAdapter
+FAILURES = []
+
+
+def check(condition, message):
+    if not condition:
+        FAILURES.append(message)
+
+
+class Stub:
+    """Only the methods under test, so no store or client is needed."""
+
+    _read_all_after_scoped_scan = CLASS._read_all_after_scoped_scan
+    _full_read_can_answer_offline = CLASS._full_read_can_answer_offline
+
+    def __init__(self, hot_cache=False, cache=None):
+        self._hot = hot_cache
+        self._records_cache = cache
+        self.read_all_calls = 0
+
+    def python_hot_cache_enabled(self):
+        return self._hot
+
+    def read_all(self):
+        self.read_all_calls += 1
+        return [{"record_type": "context_event"}]
+
+
+def a_scan_that_could_not_be_asked_still_reads_everything():
+    """No scanner on the client means no error: the full read is the correct path and must run."""
+    adapters._SCAN_STATE.last_error = None
+    os.environ.pop("MATRIXARK_TEMPORALSTORE_LOCAL_STORE", None)
+    stub = Stub()
+    out = stub._read_all_after_scoped_scan()
+    check(stub.read_all_calls == 1, "the full read must still run when the scan was never asked")
+    check(out == [{"record_type": "context_event"}], "it must return the records, got %r" % (out,))
+
+
+def a_failed_scan_with_nowhere_offline_reraises_instead_of_reading_everything():
+    """The retirement: no hot cache, no disk fallback, so the full read cannot answer."""
+    adapters._SCAN_STATE.last_error = ConnectionRefusedError("backend down")
+    os.environ.pop("MATRIXARK_TEMPORALSTORE_LOCAL_STORE", None)
+    stub = Stub()
+    try:
+        stub._read_all_after_scoped_scan()
+        check(False, "a failed scan with no offline source must re-raise, not read the store")
+    except ConnectionRefusedError as exc:
+        check("backend down" in str(exc), "it must re-raise the SCAN's own error, got %r" % (exc,))
+    check(stub.read_all_calls == 0,
+          "the full read must not run at all, ran %d times" % stub.read_all_calls)
+
+
+def a_failed_scan_still_reads_when_a_disk_fallback_is_configured():
+    """The full read recovers from disk first, so there it can genuinely answer."""
+    adapters._SCAN_STATE.last_error = ConnectionRefusedError("backend down")
+    os.environ["MATRIXARK_TEMPORALSTORE_LOCAL_STORE"] = "/tmp/some-local-store"
+    try:
+        stub = Stub()
+        stub._read_all_after_scoped_scan()
+        check(stub.read_all_calls == 1,
+              "a configured disk fallback must still get its full read")
+    except Exception as exc:  # noqa: BLE001
+        check(False, "it must not raise when a disk fallback exists: %r" % (exc,))
+    finally:
+        os.environ.pop("MATRIXARK_TEMPORALSTORE_LOCAL_STORE", None)
+
+
+def a_failed_scan_still_reads_when_a_warm_hot_cache_can_serve():
+    adapters._SCAN_STATE.last_error = ConnectionRefusedError("backend down")
+    os.environ.pop("MATRIXARK_TEMPORALSTORE_LOCAL_STORE", None)
+    stub = Stub(hot_cache=True, cache=[{"record_type": "context_event"}])
+    try:
+        stub._read_all_after_scoped_scan()
+        check(stub.read_all_calls == 1, "a warm hot cache must still get its full read")
+    except Exception as exc:  # noqa: BLE001
+        check(False, "it must not raise when the hot cache holds records: %r" % (exc,))
+
+
+def an_empty_hot_cache_cannot_serve_so_it_does_not_count():
+    """Positive control for the test above: hot cache ON but holding nothing is not an offline
+    source, and treating it as one would restore the futile read this change removes."""
+    adapters._SCAN_STATE.last_error = ConnectionRefusedError("backend down")
+    os.environ.pop("MATRIXARK_TEMPORALSTORE_LOCAL_STORE", None)
+    stub = Stub(hot_cache=True, cache=None)
+    try:
+        stub._read_all_after_scoped_scan()
+        check(False, "an empty hot cache must not count as an offline source")
+    except ConnectionRefusedError:
+        check(stub.read_all_calls == 0, "and the full read must not run")
+
+
+def one_threads_outage_does_not_decide_another_threads_fallback():
+    """_SCAN_STATE is thread-local because ONE adapter serves every request."""
+    adapters._SCAN_STATE.last_error = ConnectionRefusedError("this thread is down")
+    os.environ.pop("MATRIXARK_TEMPORALSTORE_LOCAL_STORE", None)
+    seen = {}
+
+    def other_thread():
+        stub = Stub()
+        try:
+            stub._read_all_after_scoped_scan()
+            seen["ok"] = stub.read_all_calls
+        except Exception as exc:  # noqa: BLE001
+            seen["raised"] = repr(exc)
+
+    thread = threading.Thread(target=other_thread)
+    thread.start()
+    thread.join()
+    check(seen.get("ok") == 1,
+          "a clean thread must read normally, not inherit another thread's outage: %r" % (seen,))
+
+
+for test in (
+    a_scan_that_could_not_be_asked_still_reads_everything,
+    a_failed_scan_with_nowhere_offline_reraises_instead_of_reading_everything,
+    a_failed_scan_still_reads_when_a_disk_fallback_is_configured,
+    a_failed_scan_still_reads_when_a_warm_hot_cache_can_serve,
+    an_empty_hot_cache_cannot_serve_so_it_does_not_count,
+    one_threads_outage_does_not_decide_another_threads_fallback,
+):
+    test()
+    print("  ran %s" % test.__name__)
+
+if FAILURES:
+    print("FAILED:")
+    for item in FAILURES:
+        print("  - %s" % item)
+    raise SystemExit(1)
+print("all checks pass")

--- a/tools/test_a_scoped_scan_that_gives_up_says_so.py
+++ b/tools/test_a_scoped_scan_that_gives_up_says_so.py
@@ -76,15 +76,22 @@ def the_detail_line_still_needs_the_debug_log():
 
 
 def every_silent_branch_now_announces():
-    """The six `subset is None` branches must each call the notifier before reading everything."""
+    """No `subset is None` branch may read the whole store without announcing it.
+
+    Written first as a literal match on the announcing lines, which broke the moment those branches
+    were routed through a helper -- the invariant is "nothing reads everything silently", not "this
+    exact text appears six times". Asserted as a property now: no branch goes straight to
+    read_all(), and every one of them goes through the helper that counts.
+    """
     here = os.path.dirname(os.path.abspath(__file__))
     source = open(os.path.join(here, "matrixark_mcp_temporal_adapters.py"), encoding="utf-8").read()
     silent = "        if subset is None:\n            return self.read_all()"
     check(source.count(silent) == 0,
           "%d 'subset is None' branches still read the whole store silently" % source.count(silent))
-    announced = "_note_full_read_fallback()\n            return self.read_all()"
-    check(source.count(announced) == 6,
-          "expected 6 announcing branches, found %d" % source.count(announced))
+    routed = source.count("return self._read_all_after_scoped_scan()")
+    check(routed == 6, "expected 6 branches routed through the counting helper, found %d" % routed)
+    check("_note_full_read_fallback(where)" in source,
+          "the helper must still count the fallback it takes")
 
 
 for test in (


### PR DESCRIPTION
## Two different answers, treated as one

A scoped scan returns `None` for two unrelated reasons and every caller treated them identically:

- it could not be **asked** — this client has no scanner, so the full read is the correct path
- it was asked and **failed** — in which case the full read calls the very client that just refused

Measured on a native one-box: one request with the backend down did **10** whole-corpus reads and
returned 500 anyway. None of them could have answered. On a large store they would have been
expensive as well as useless.

## What changed

`_scan_records_of_types` now records *why* it gave up, and the six branches route through
`_read_all_after_scoped_scan`, which re-raises the scan's own error when the full read provably
cannot help. The request fails exactly as it did before, with the real reason — a refused
connection reads as a refused connection rather than as a slow request that eventually gave up.

"Provably cannot help" is deliberately narrow, and both escapes keep today's behaviour:

| escape | still does the full read |
|---|---|
| warm Python hot cache | yes — off by default on native backends (`python_hot_cache_allowed` returns `backend_label == "local"`), but honoured wherever it is on and holding records |
| configured disk fallback store | yes — `read_all` recovers from disk before reading |

Anything unexpected counts as "it can help": if the policy cannot be read, the full read happens as
before. Turning a served request into an error is the one outcome this must not cause.

The state is **thread-local**. One adapter serves every request, so an attribute on the instance
would let one thread's outage decide another thread's fallback — a test covers exactly that.

## Why this is what "retire read_all" comes down to

`read_all` is already off the healthy serving path (mx#1338/1340), confirmed by measurement with
the stack verified healthy first:

| traffic | `read_all` calls |
|---|---|
| 30 ingests + 20 retrieves, healthy | **2** — one-time init, not per-request |
| one request, backend down | **10** |

So the remaining calls were all on paths where it could not work. This removes those; it does not
remove the fallback where the fallback can genuinely serve.

## Tests

`tools/test_a_full_read_that_cannot_answer_is_not_a_fallback.py` — six checks, all pass, including
a positive control that an **empty** hot cache does not count as an offline source (treating it as
one would quietly restore the futile read) and the thread-locality check.

Also fixes a test shipped in the previous change: it asserted a literal source string, which broke
the moment those branches were routed through a helper. The invariant is that nothing reads
everything silently, not that a particular line appears six times.

Neighbouring suites: 25 pass. Four `backend_policy` suites fail by `SkipTest` at import and are red
on main too — verified by name-diff, not by comparing red counts.
