### PR TITLE
A self-hosted encoder takes no key, so stop silencing it

### DIFF
--- a/tools/matrixark_mcp_embeddings.py
+++ b/tools/matrixark_mcp_embeddings.py
@@ -346,13 +346,33 @@ def require_model_embeddings(path: str) -> bool:
     return _truthy_env("MATRIXARK_REQUIRE_MODEL_EMBEDDINGS") or _truthy_env(path)
 
 
+def _api_base_is_explicit() -> bool:
+    """Did the operator point this at their own endpoint?
+
+    A self-hosted OpenAI-compatible encoder -- vLLM, Ollama, TEI -- takes no key. "No key" only
+    means "cannot call" for the hosted defaults; against an endpoint the operator named, it is the
+    normal configuration. Reading the variable rather than comparing the URL to a default keeps one
+    source of truth: whatever `_api_embedding_config` used as the base, this asks whether that came
+    from the environment.
+    """
+    return bool(os.environ.get("MATRIXARK_EMBEDDING_API_BASE", "").strip())
+
+
 def api_embedding_for_texts(texts: list[str], provider: str) -> list[list[float]]:
     """Embed via an OpenAI-compatible or Voyage embeddings API. Falls back to the deterministic
     encoder on missing key / network error unless MATRIXARK_REQUIRE_API_EMBEDDINGS is set (then it
-    raises, so production fails fast instead of silently poisoning the store with mismatched-dim vectors)."""
+    raises, so production fails fast instead of silently poisoning the store with mismatched-dim vectors).
+
+    A missing key skips the call only for the HOSTED defaults. When MATRIXARK_EMBEDDING_API_BASE
+    names an endpoint, the call is made without an Authorization header, because a self-hosted
+    encoder takes no key -- and treating that as "cannot call" is how a whole production run came
+    to be served by 32-dimension token hashes while a healthy 1024-dimension encoder answered on
+    the same host. The gateway returned 200 throughout and the results looked plausible; the only
+    outward sign was that the encoder burned no CPU.
+    """
     endpoint, api_key, model, key_env = _api_embedding_config(provider)
     require = require_model_embeddings("MATRIXARK_REQUIRE_API_EMBEDDINGS")
-    if not api_key:
+    if not api_key and not _api_base_is_explicit():
         if require:
             raise MatrixArkError(f"API embeddings require {key_env} for provider '{provider}'")
         _mark_embedding_fallback()
@@ -362,11 +382,12 @@ def api_embedding_for_texts(texts: list[str], provider: str) -> list[list[float]
         import urllib.request as _urlreq
 
         body = _json.dumps({"model": model, "input": list(texts)}).encode("utf-8")
-        request = _urlreq.Request(
-            endpoint,
-            data=body,
-            headers={"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"},
-        )
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            # Omitted rather than sent empty: some servers reject a malformed Authorization header
+            # outright, which would turn a working keyless endpoint into the silent hash fallback.
+            headers["Authorization"] = f"Bearer {api_key}"
+        request = _urlreq.Request(endpoint, data=body, headers=headers)
         timeout = float(os.environ.get("MATRIXARK_EMBEDDING_API_TIMEOUT_S", "30"))
         with _urlreq.urlopen(request, timeout=timeout) as response:  # noqa: S310 - fixed provider endpoint
             payload = _json.loads(response.read().decode("utf-8"))

--- a/tools/test_a_self_hosted_encoder_takes_no_key.py
+++ b/tools/test_a_self_hosted_encoder_takes_no_key.py
@@ -1,0 +1,137 @@
+"""A self-hosted encoder takes no key, so a missing key must not silence it.
+
+Measured twice on a live one-box: every vector in the store was a 32-dimension token hash while a
+healthy 1024-dimension e5-large answered on the same network. The gateway returned 200 throughout,
+retrieval looked plausible, and the only outward sign was that the encoder burned no CPU. The cause
+was `if not api_key: return deterministic` -- correct for api.openai.com, wrong for an endpoint the
+operator named themselves.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import matrixark_mcp_embeddings as embeddings  # noqa: E402
+
+FAILURES = []
+
+
+def check(condition, message):
+    if not condition:
+        FAILURES.append(message)
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def read(self):
+        import json
+        return json.dumps(self._payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def run_with_stub(dims=1024):
+    """Capture the request the module would send, and answer it with a wide vector."""
+    seen = {}
+
+    import urllib.request as real_urlreq
+
+    def fake_urlopen(request, timeout=None):
+        # Record what the module WOULD have sent. Patching the attribute on the real module, not
+        # sys.modules: the function does  at call time, which
+        # rebinds from the package either way, so a sys.modules swap is simply not seen -- the
+        # first version of this test swapped sys.modules, the real urlopen ran, the connection was
+        # refused, and the generic except returned the hash fallback. The test then read that as
+        # "the endpoint was never called" when the endpoint HAD been called.
+        seen["headers"] = dict(getattr(request, "headers", {}) or {})
+        seen["url"] = getattr(request, "full_url", "")
+        return FakeResponse({"data": [{"index": 0, "embedding": [0.01] * dims}]})
+
+    original = real_urlreq.urlopen
+    real_urlreq.urlopen = fake_urlopen
+    try:
+        vector = embeddings.api_embedding_for_texts(["hello"], "openai")[0]
+    finally:
+        real_urlreq.urlopen = original
+    return vector, seen
+
+
+def clear_env():
+    for name in ("OPENAI_API_KEY", "MATRIXARK_EMBEDDING_API_KEY", "MATRIXARK_REQUIRE_API_EMBEDDINGS"):
+        os.environ.pop(name, None)
+
+
+def a_named_endpoint_is_called_even_with_no_key():
+    clear_env()
+    os.environ["MATRIXARK_EMBEDDING_API_BASE"] = "http://127.0.0.1:8081/v1"
+    try:
+        vector, seen = run_with_stub(dims=1024)
+        check("url" in seen, "the encoder was never called: a named endpoint must be reached")
+        check(len(vector) == 1024,
+              "expected the encoder's 1024 dims, got %d (the hash fallback is 32)" % len(vector))
+        auth = [k for k in seen.get("headers", {}) if k.lower() == "authorization"]
+        check(not auth, "no key was configured, so no Authorization header may be sent: %r" % auth)
+    finally:
+        os.environ.pop("MATRIXARK_EMBEDDING_API_BASE", None)
+
+
+def the_hosted_default_still_needs_a_key():
+    """Positive control. Without this, "always call" would fire blind requests at api.openai.com,
+    which only 401 -- the missing-key fallback is correct THERE and must stay."""
+    clear_env()
+    os.environ.pop("MATRIXARK_EMBEDDING_API_BASE", None)
+    vector = embeddings.api_embedding_for_texts(["hello"], "openai")[0]
+    check(len(vector) == embeddings.EMBEDDING_DIM,
+          "with no key and no named endpoint the deterministic encoder must still answer, got %d"
+          % len(vector))
+
+
+def a_configured_key_is_still_sent():
+    clear_env()
+    os.environ["MATRIXARK_EMBEDDING_API_BASE"] = "http://127.0.0.1:8081/v1"
+    os.environ["OPENAI_API_KEY"] = "sk-test-value"
+    try:
+        _, seen = run_with_stub()
+        auth = {k.lower(): v for k, v in seen.get("headers", {}).items()}.get("authorization", "")
+        check("sk-test-value" in str(auth), "a configured key must still be sent, got %r" % (auth,))
+    finally:
+        os.environ.pop("OPENAI_API_KEY", None)
+        os.environ.pop("MATRIXARK_EMBEDDING_API_BASE", None)
+
+
+def the_require_flag_still_fails_fast_on_the_hosted_default():
+    clear_env()
+    os.environ.pop("MATRIXARK_EMBEDDING_API_BASE", None)
+    os.environ["MATRIXARK_REQUIRE_API_EMBEDDINGS"] = "1"
+    try:
+        embeddings.api_embedding_for_texts(["hello"], "openai")
+        check(False, "with the require flag and no key, it must raise rather than fall back")
+    except Exception as exc:  # noqa: BLE001
+        check("require" in str(exc).lower() or "api embeddings" in str(exc).lower(),
+              "it must say a key is required, got %r" % (exc,))
+    finally:
+        os.environ.pop("MATRIXARK_REQUIRE_API_EMBEDDINGS", None)
+
+
+for test in (
+    a_named_endpoint_is_called_even_with_no_key,
+    the_hosted_default_still_needs_a_key,
+    a_configured_key_is_still_sent,
+    the_require_flag_still_fails_fast_on_the_hosted_default,
+):
+    test()
+    print("  ran %s" % test.__name__)
+
+if FAILURES:
+    print("FAILED:")
+    for item in FAILURES:
+        print("  - %s" % item)
+    raise SystemExit(1)
+print("all checks pass")


### PR DESCRIPTION
## A missing key silenced self-hosted encoders

`api_embedding_for_texts` returned the 32-dimension token-hash fallback whenever no API key was
set — including when `MATRIXARK_EMBEDDING_API_BASE` named a self-hosted OpenAI-compatible endpoint
(vLLM, Ollama, TEI), which takes no key at all. "No key" only means "cannot call" for the hosted
defaults.

Measured twice on a live one-box: **every vector in the store was a 32-dimension hash** while a
healthy **1024-dimension** e5-large answered on the same network — a direct probe of that endpoint
returned 1024 dims on request. The gateway returned 200 throughout and retrieval looked plausible.
The only outward sign was that the encoder burned no CPU.

## What changed

A missing key now skips the call only for the hosted defaults. With an endpoint named in the
environment the request goes out **without** an `Authorization` header. A configured key is still
sent, and the header is omitted rather than sent empty — some servers reject a malformed one
outright, which would land straight back in the silent fallback.

Unchanged on purpose, each with a test:

| case | behaviour |
|---|---|
| hosted default, no key | deterministic encoder, as before — calling `api.openai.com` unauthenticated only 401s |
| `MATRIXARK_REQUIRE_API_EMBEDDINGS`, no key, hosted | still raises, fails fast |
| key configured | still sent |
| network error | still falls back |

## For anyone already running this way

**Fixing the encoder does not fix the store.** Vectors already written are 32-dimension hashes, and
a stored vector whose width disagrees with the query's is not scored — so a corpus embedded under
the fallback needs re-ingesting before it retrieves densely.

## Tests

`tools/test_a_self_hosted_encoder_takes_no_key.py` — four checks, all pass, and the suite **fails on
unpatched code** (`rc=1`, reporting "the encoder was never called" and "got 32"), so it discriminates
rather than passing both ways. The hosted-default case is the positive control: without it, "always
call" would fire blind unauthenticated requests at `api.openai.com`.

The first version of this test swapped `sys.modules["urllib.request"]`, which the module's
call-time `import` never sees — the real `urlopen` ran, the connection was refused, and the generic
`except` returned the hash fallback, which the test then read as "the endpoint was never called"
when it had in fact been called. It now patches the attribute on the real module.

Neighbouring suites: 15 pass; 3 fail and are red on `main` too, verified by name-diff.
