### PR TITLE
A node returns a thousand by default, and a caller can ask for all

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -6492,10 +6492,15 @@ fn blended_candidate_score(
 /// irrelevant". An Option makes the distinction one the caller has to handle.
 /// What the engine selects when the caller names no limit.
 ///
-/// Mirrors `DEFAULT_MAX_SELECTED_REFS` on the calling side. This was a bare `24` here while the
-/// caller's own default was 64 and its request built a third `24` inline, so one setting had three
-/// numbers and the guard that checks for exactly this only scans environment defaults.
-const DEFAULT_MAX_SELECTED_REFS: usize = 64;
+/// 1000, which is what `config/temporalstore.toml` has declared all along -- the code was the half
+/// that disagreed. This was a bare `24` here while the caller defaulted to 64, its request builder
+/// wrote a third `24` inline, and the config asked for 1000: four numbers for one setting, and the
+/// guard that exists to catch that only scans environment defaults.
+///
+/// A node returns up to this many refs unless told otherwise. To return EVERYTHING, a caller sends
+/// a token budget -- the fill is then bounded by tokens and this is never consulted -- or enables
+/// `MATRIXARK_RETURN_ALL_CANDIDATES`, which lifts the limit to the candidate count.
+const DEFAULT_MAX_SELECTED_REFS: usize = 1000;
 
 /// Which candidates a token budget and a set of per-layer floors admit.
 ///

--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -249,7 +249,10 @@ DEFAULT_RETRIEVAL_MIN_SCORE = float(os.environ.get("MATRIXARK_RETRIEVAL_MIN_SCOR
 DEFAULT_TOP_K_PER_LAYER = int(os.environ.get("MATRIXARK_TOP_K_PER_LAYER", "8"))
 DEFAULT_MAX_CANDIDATES_PER_NODE = int(os.environ.get("MATRIXARK_MAX_CANDIDATES_PER_NODE", "1024"))
 DEFAULT_MAX_GLOBAL_CANDIDATES = int(os.environ.get("MATRIXARK_MAX_GLOBAL_CANDIDATES", "512"))
-DEFAULT_MAX_SELECTED_REFS = int(os.environ.get("MATRIXARK_MAX_SELECTED_REFS", "64"))
+# 1000, matching config/temporalstore.toml. The config declared 1000 while this said 64 and
+# the engine used 24, so the number a deployment got depended on which surface it came from.
+# test_the_ref_cap_has_one_value pins all of them together.
+DEFAULT_MAX_SELECTED_REFS = int(os.environ.get("MATRIXARK_MAX_SELECTED_REFS", "1000"))
 DEFAULT_BUDGET_FILL_POLICY = os.environ.get("MATRIXARK_BUDGET_FILL_POLICY", "quality_first").strip().lower()
 # Near-duplicate suppression threshold (see matrixark_mcp_runtime_config for the
 # canonical definition). Reused here so the ref-selection path shares one source

--- a/tools/matrixark_mcp_runtime_config.py
+++ b/tools/matrixark_mcp_runtime_config.py
@@ -182,7 +182,10 @@ DEFAULT_RETRIEVAL_MIN_SCORE = float(os.environ.get("MATRIXARK_RETRIEVAL_MIN_SCOR
 DEFAULT_TOP_K_PER_LAYER = int(os.environ.get("MATRIXARK_TOP_K_PER_LAYER", "8"))
 DEFAULT_MAX_CANDIDATES_PER_NODE = int(os.environ.get("MATRIXARK_MAX_CANDIDATES_PER_NODE", "1024"))
 DEFAULT_MAX_GLOBAL_CANDIDATES = int(os.environ.get("MATRIXARK_MAX_GLOBAL_CANDIDATES", "512"))
-DEFAULT_MAX_SELECTED_REFS = int(os.environ.get("MATRIXARK_MAX_SELECTED_REFS", "64"))
+# 1000, matching config/temporalstore.toml. The config declared 1000 while this said 64 and
+# the engine used 24, so the number a deployment got depended on which surface it came from.
+# test_the_ref_cap_has_one_value pins all of them together.
+DEFAULT_MAX_SELECTED_REFS = int(os.environ.get("MATRIXARK_MAX_SELECTED_REFS", "1000"))
 DEFAULT_BUDGET_FILL_POLICY = os.environ.get("MATRIXARK_BUDGET_FILL_POLICY", "quality_first").strip().lower()
 # Near-duplicate suppression in ref selection. A candidate whose token set has a
 # Jaccard similarity >= this ratio with an already-selected (higher-ranked) ref

--- a/tools/test_the_ref_cap_has_one_value.py
+++ b/tools/test_the_ref_cap_has_one_value.py
@@ -1,0 +1,139 @@
+"""One setting, one number, across every surface that declares it.
+
+`max_selected_refs` carried FOUR values at once: config/temporalstore.toml said 1000, two Python
+modules defaulted to 64, the request builder wrote a bare 24 inline, and the engine used another 24
+under a ceiling of 128. Which one a deployment got depended on which surface it came through, and
+the existing numeric-defaults guard could not see it because that guard only scans
+`os.environ.get(VAR, literal)` reads -- not a config file, not Rust, not an inline fallback.
+
+This is the narrow guard for that one setting, checked where it is actually written.
+"""
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+sys.path.insert(0, HERE)
+sys.path.insert(0, ROOT)
+
+FAILURES = []
+
+
+def check(condition, message):
+    if not condition:
+        FAILURES.append(message)
+
+
+def config_value():
+    path = os.path.join(ROOT, "config", "temporalstore.toml")
+    for line in open(path, encoding="utf-8"):
+        match = re.match(r"\s*max_selected_refs\s*=\s*(\d+)", line)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def python_defaults():
+    found = {}
+    for name in ("matrixark_mcp_core.py", "matrixark_mcp_runtime_config.py"):
+        body = open(os.path.join(HERE, name), encoding="utf-8").read()
+        match = re.search(
+            r'DEFAULT_MAX_SELECTED_REFS = int\(os\.environ\.get\("MATRIXARK_MAX_SELECTED_REFS",\s*"(\d+)"\)\)',
+            body,
+        )
+        found[name] = int(match.group(1)) if match else None
+    return found
+
+
+def rust_default():
+    path = os.path.join(ROOT, "crates", "temporalstore-rust", "src", "matrixark_rust_proxy_impl.rs")
+    body = open(path, encoding="utf-8").read()
+    match = re.search(r"const DEFAULT_MAX_SELECTED_REFS: usize = (\d+);", body)
+    return int(match.group(1)) if match else None
+
+
+def every_surface_declares_the_same_cap():
+    config = config_value()
+    check(config is not None, "config/temporalstore.toml no longer declares max_selected_refs")
+    rust = rust_default()
+    check(rust is not None, "the engine no longer declares DEFAULT_MAX_SELECTED_REFS")
+    pythons = python_defaults()
+    for name, value in pythons.items():
+        check(value is not None, "%s no longer declares DEFAULT_MAX_SELECTED_REFS" % name)
+
+    values = {"config": config, "rust": rust}
+    values.update(pythons)
+    distinct = {v for v in values.values() if v is not None}
+    check(
+        len(distinct) == 1,
+        "max_selected_refs disagrees across surfaces: %s" % (values,),
+    )
+
+
+def the_request_builder_does_not_re_default_it():
+    """The inline fallback is what the environment-scanning guard cannot see.
+
+    `int(ranking.get(...) or args.get(...) or 24)` declares a fourth default in the middle of a
+    dict literal. It must use the named constant instead, so there is nothing to drift.
+    """
+    body = open(os.path.join(HERE, "matrixark_temporal_direct_read.py"), encoding="utf-8").read()
+    # Scan to the matching close paren rather than regexing it. A regex that stops at the first
+    # ")" reads `int(ranking.get("max_selected_refs")` as the whole expression and then reports the
+    # constant missing -- which is what the first version of this guard did, failing on correct
+    # code.
+    start = body.find('"max_selected_refs": int(')
+    check(start != -1, "the engine-request builder no longer sets max_selected_refs")
+    expression = None
+    if start != -1:
+        open_at = body.index("(", start + len('"max_selected_refs": int'))
+        brace_depth = 0
+        for index in range(open_at, len(body)):
+            if body[index] == "(":
+                brace_depth += 1
+            elif body[index] == ")":
+                brace_depth -= 1
+                if brace_depth == 0:
+                    expression = body[open_at + 1:index]
+                    break
+    if expression is not None:
+        check(
+            "DEFAULT_MAX_SELECTED_REFS" in expression,
+            "the request builder re-defaults max_selected_refs with a literal: %r"
+            % expression.strip()[:160],
+        )
+        bare = re.findall(r"\bor\s+(\d+)\b", expression)
+        check(not bare, "the request builder still falls back to a bare literal: %s" % bare)
+
+
+def a_caller_can_still_ask_for_everything():
+    """1000 is a DEFAULT, not a ceiling: the ways to say 'all' must remain."""
+    body = open(os.path.join(HERE, "matrixark_tenant_policy.py"), encoding="utf-8").read()
+    check(
+        "MATRIXARK_RETURN_ALL_CANDIDATES" in body,
+        "the return-all knob is gone, so 'configure as all' has no surface",
+    )
+    engine = open(
+        os.path.join(ROOT, "crates", "temporalstore-rust", "src", "matrixark_rust_proxy_impl.rs"),
+        encoding="utf-8",
+    ).read()
+    check(
+        ".clamp(1, 128)" not in engine,
+        "the engine has an artificial ceiling again, so 'all' cannot exceed it",
+    )
+
+
+for test in (
+    every_surface_declares_the_same_cap,
+    the_request_builder_does_not_re_default_it,
+    a_caller_can_still_ask_for_everything,
+):
+    test()
+    print("  ran %s" % test.__name__)
+
+if FAILURES:
+    print("FAILED:")
+    for item in FAILURES:
+        print("  - %s" % item)
+    raise SystemExit(1)
+print("all cap-value checks pass")


### PR DESCRIPTION
## One setting, four numbers

`max_selected_refs` carried four values at once, and which one a deployment got depended on which
surface the request came through:

| surface | was | now |
|---|---|---|
| `config/temporalstore.toml` | **1000** | 1000 |
| `matrixark_mcp_core.py` | 64 | **1000** |
| `matrixark_mcp_runtime_config.py` | 64 | **1000** |
| the request builder, inline | `or 24` | the named constant |
| the engine | 24, ceiling 128 | **1000**, no ceiling |

The config was the half that was right.

## 1000 is a default, not a ceiling

Both ways to ask for everything are unchanged:

- **send a token budget** — the fill is bounded by tokens and the cap is never consulted
  (pinned by mx#1379)
- **`MATRIXARK_RETURN_ALL_CANDIDATES`** — lifts the limit to however many candidates there are

## The guard

`tools/test_the_ref_cap_has_one_value.py` pins all four surfaces to the same number, including the
two the existing numeric-defaults guard **structurally cannot see**: a value in a config file, and a
bare literal inline in a dict literal. It also asserts the ways to say "all" still exist, so raising
the default can never quietly become a ceiling.

It was checked against both failures it exists to catch:

- revert the engine to 64 → fails, reporting
  `{'config': 1000, 'rust': 64, 'mcp_core': 1000, 'runtime_config': 1000}`
- re-introduce the bare `or 24` → fails, quoting the literal

Worth stating: the guard's **first version passed on correct code**. Its regex stopped at the first
close paren, so it read `int(ranking.get("max_selected_refs")` as the whole expression and reported
the constant missing. It now scans to the matching paren. A guard that fails on correct code is one
edit away from being "fixed" by weakening it until it cannot fail at all.

## Tests

108 pass in the proxy binary (`cargo test -p temporalstore-rust --bin matrixark_rust_proxy`).
