### PR TITLE
A band is a slab

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::storage_config::{effective_block_slab_target_bytes, storage_band_size_bytes};
+use crate::storage_config::effective_block_slab_target_bytes;
 
 mod paths;
 mod band_manifest;
@@ -89,7 +89,6 @@ const ADDRESS_HAS_PAGE_ID: u8 = 1 << 0;
 const ADDRESS_HAS_OBJECT_ID: u8 = 1 << 1;
 const ADDRESS_HAS_ROUTING_BUCKET: u8 = 1 << 2;
 const ADDRESS_HAS_GENERATION: u8 = 1 << 3;
-const ADDRESS_HAS_BAND_ID: u8 = 1 << 4;
 
 /// The address as it travels on the wire and on disk.
 ///
@@ -140,14 +139,6 @@ struct BlockAddressWire {
     )]
     generation: Option<u64>,
     #[serde(
-        rename = "b",
-        alias = "band_id",
-        alias = "extent_id",
-        alias = "zone_id",
-        default
-    )]
-    band_id: Option<u64>,
-    #[serde(
         rename = "h",
         alias = "sha256",
         alias = "checksum",
@@ -167,7 +158,6 @@ impl From<BlockAddressWire> for BlockAddress {
             wire.object_id,
             wire.routing_bucket,
             wire.generation,
-            wire.band_id,
         )
     }
 }
@@ -182,7 +172,6 @@ impl From<BlockAddress> for BlockAddressWire {
             object_id: address.object_id(),
             routing_bucket: address.routing_bucket(),
             generation: address.generation(),
-            band_id: address.band_id(),
             // The index no longer holds a digest, so it cannot write one. An index written
             // before this still LOADS -- the field is accepted and ignored -- but one written
             // now omits it. That is a content change, not a schema change: the field was always
@@ -201,7 +190,6 @@ pub struct BlockAddress {
     page_id: u64,
     object_id: u64,
     generation: u64,
-    band_id: u64,
     routing_bucket: u32,
     /// Which of the five above are actually set. See `ADDRESS_HAS_*`.
     present: u8,
@@ -223,7 +211,6 @@ impl BlockAddress {
         object_id: Option<u64>,
         routing_bucket: Option<u32>,
         generation: Option<u64>,
-        band_id: Option<u64>,
     ) -> Self {
         let mut present = 0u8;
         if page_id.is_some() {
@@ -238,9 +225,6 @@ impl BlockAddress {
         if generation.is_some() {
             present |= ADDRESS_HAS_GENERATION;
         }
-        if band_id.is_some() {
-            present |= ADDRESS_HAS_BAND_ID;
-        }
         Self {
             block_slab_id,
             offset,
@@ -248,7 +232,6 @@ impl BlockAddress {
             page_id: page_id.unwrap_or_default(),
             object_id: object_id.unwrap_or_default(),
             generation: generation.unwrap_or_default(),
-            band_id: band_id.unwrap_or_default(),
             routing_bucket: routing_bucket.unwrap_or_default(),
             present,
         }
@@ -270,8 +253,17 @@ impl BlockAddress {
         (self.present & ADDRESS_HAS_GENERATION != 0).then_some(self.generation)
     }
 
+    /// The band this address is in, which is the slab it is in.
+    ///
+    /// Derived rather than stored. It was a function of the slab AND two configuration sizes,
+    /// which is what made it unsafe to derive: a reader whose configuration had moved would
+    /// reconstruct a different band than the writer meant. With one size there is nothing to
+    /// disagree about, so the band is a fact about the address instead of a field beside it.
+    ///
+    /// Still an `Option` because every caller reads it as one, and it now answers `Some` for
+    /// every address -- a slab is always known.
     pub fn band_id(&self) -> Option<u64> {
-        (self.present & ADDRESS_HAS_BAND_ID != 0).then_some(self.band_id)
+        Some(self.block_slab_id)
     }
 
     pub fn set_page_id(&mut self, value: Option<u64>) {
@@ -292,11 +284,6 @@ impl BlockAddress {
     pub fn set_generation(&mut self, value: Option<u64>) {
         self.generation = value.unwrap_or_default();
         self.set_present(ADDRESS_HAS_GENERATION, value.is_some());
-    }
-
-    pub fn set_band_id(&mut self, value: Option<u64>) {
-        self.band_id = value.unwrap_or_default();
-        self.set_present(ADDRESS_HAS_BAND_ID, value.is_some());
     }
 
     fn set_present(&mut self, bit: u8, on: bool) {
@@ -359,7 +346,6 @@ impl BlockAddress {
             compact_extract_band_id(compact_slab_address) as u64,
             compact_extract_band_offset(compact_slab_address) as u64,
             length,
-            None,
             None,
             None,
             None,
@@ -1713,25 +1699,30 @@ mod address_size_tests {
         assert!(packed <= 104, "address grew to {packed} bytes");
     }
 
-    /// A presence bit is not the same as a zero value. `0` is a legitimate `band_id` and a
-    /// legitimate `routing_slot`, so "zero means absent" would erase real values -- this is why
-    /// the byte exists instead of a sentinel.
+    /// A presence bit is not the same as a zero value. `0` is a legitimate `routing_slot` and a
+    /// legitimate `generation`, so "zero means absent" would erase real values -- this is why the
+    /// byte exists instead of a sentinel.
+    ///
+    /// The band was a third example here and is no longer one: a band IS a slab, so it is always
+    /// known, never absent, and needs no bit.
     #[test]
     fn zero_is_distinguishable_from_absent() {
-        let zero = BlockAddress::from_parts(1, 0, 0, None, None, Some(0), None, Some(0));
-        let absent = BlockAddress::from_parts(1, 0, 0, None, None, None, None, None);
-        assert_eq!(zero.band_id(), Some(0));
+        let zero = BlockAddress::from_parts(1, 0, 0, None, None, Some(0), Some(0));
+        let absent = BlockAddress::from_parts(1, 0, 0, None, None, None, None);
         assert_eq!(zero.routing_bucket(), Some(0));
-        assert_eq!(absent.band_id(), None);
+        assert_eq!(zero.generation(), Some(0));
         assert_eq!(absent.routing_bucket(), None);
+        assert_eq!(absent.generation(), None);
         assert_ne!(zero, absent);
+        assert_eq!(zero.band_id(), Some(1), "the band is the slab, present either way");
+        assert_eq!(absent.band_id(), Some(1));
     }
 
     /// Clearing a value must clear its bit, or the next read reports a stale one as present.
     #[test]
     fn setters_track_presence_both_ways() {
         let mut address =
-            BlockAddress::from_parts(1, 0, 0, Some(7), None, None, None, None);
+            BlockAddress::from_parts(1, 0, 0, Some(7), None, None, None);
         assert_eq!(address.page_id(), Some(7));
         address.set_page_id(None);
         assert_eq!(address.page_id(), None);
@@ -1759,7 +1750,6 @@ mod address_size_tests {
             Some(2),
             Some(3),
             Some(4),
-            Some(0),
         );
         let json = serde_json::to_value(&address).unwrap();
         // What is written now: the short names, and nothing else.
@@ -1767,7 +1757,10 @@ mod address_size_tests {
         assert_eq!(json["o"], 64, "the offset");
         assert_eq!(json["l"], 128, "the length");
         assert_eq!(json["rs"], 3, "the routing bucket");
-        assert_eq!(json["b"], 0, "a present zero must still be written");
+        assert!(
+            json.get("b").is_none(),
+            "a band is the slab, so it is derived rather than written"
+        );
         for long in ["page_segment_id", "routing_slot", "band_id", "object_id", "generation"] {
             assert!(
                 json.get(long).is_none(),
@@ -1829,7 +1822,15 @@ mod tests {
         assert_eq!(address.object_id(), Some(122110326161599232));
         assert_eq!(address.routing_bucket(), Some(545210715));
         assert_eq!(address.generation(), Some(2));
-        assert_eq!(address.band_id(), Some(4), "`zone_id` is the older spelling of this one");
+        // A band is the slab now, so a band STORED against a different slab is accepted and
+        // ignored rather than believed. This record says slab 3 and zone 4, which could only have
+        // been written under a configuration that sized bands and slabs differently -- one the
+        // tree never set, and no longer has a knob for.
+        assert_eq!(
+            address.band_id(),
+            Some(3),
+            "the band answers the slab, whatever an older record stored beside it"
+        );
         // And the digest is accepted and dropped rather than rejected: an index written before the
         // address stopped carrying one still loads, which is the whole point of keeping the alias.
         // The page envelope holds the digest that verifies the bytes.
@@ -1847,7 +1848,6 @@ mod tests {
             Some(122110326161599232),
             Some(545210715),
             Some(2),
-            Some(4),
         );
         let encoded = serde_json::to_string(&address).unwrap();
         // Not vacuous: the values must still be there before the size claim means anything.
@@ -2299,7 +2299,9 @@ mod tests {
             4,
             "the field is the checksum and nothing else: no padding, no marker"
         );
-        assert_eq!(std::mem::size_of::<BlockAddress>(), 64);
+        // Six u64, one u32 and the presence byte. It was 64 while a band was a seventh
+        // field; a band is a slab, so it is read off `block_slab_id` instead of stored.
+        assert_eq!(std::mem::size_of::<BlockAddress>(), 56);
     }
 
     #[test]
@@ -3203,7 +3205,7 @@ mod tests {
     fn page_address_without_checksum_keeps_legacy_read_compatibility() {
         let dir = tempfile::tempdir().unwrap();
         let store = LocalBlockStore::new(dir.path());
-        let legacy_address = BlockAddress::from_parts(0, 0, b"alteredpage".len() as u64, None, None, None, None, None);
+        let legacy_address = BlockAddress::from_parts(0, 0, b"alteredpage".len() as u64, None, None, None, None);
         fs::write(
             slab_path(dir.path(), legacy_address.block_slab_id),
             b"alteredpage",

--- a/crates/temporalstore-rust/src/block_store/append.rs
+++ b/crates/temporalstore-rust/src/block_store/append.rs
@@ -88,7 +88,7 @@ impl LocalBlockStore {
         }
         let path = slab_path(&inner.root, inner.block_slab_id);
         let mut file = OpenOptions::new().create(true).append(true).open(path)?;
-        let address = BlockAddress::from_parts(inner.block_slab_id, inner.write_offset, record.bytes.len() as u64, Some(page_id), object_id, routing_bucket, Some(page_id), Some(band_id));
+        let address = BlockAddress::from_parts(inner.block_slab_id, inner.write_offset, record.bytes.len() as u64, Some(page_id), object_id, routing_bucket, Some(page_id));
         file.write_all(&record.bytes)?;
         file.flush()?;
         // Two INDEPENDENT relaxations:
@@ -185,7 +185,7 @@ impl LocalBlockStore {
                 let path = slab_path(&inner.root, inner.block_slab_id);
                 file = Some(OpenOptions::new().create(true).append(true).open(path)?);
             }
-            let address = BlockAddress::from_parts(inner.block_slab_id, inner.write_offset, record.bytes.len() as u64, Some(page_id), object_id, routing_bucket, Some(page_id), Some(band_id));
+            let address = BlockAddress::from_parts(inner.block_slab_id, inner.write_offset, record.bytes.len() as u64, Some(page_id), object_id, routing_bucket, Some(page_id));
             if let Some(current) = file.as_mut() {
                 current.write_all(&record.bytes)?;
             }

--- a/crates/temporalstore-rust/src/block_store/record.rs
+++ b/crates/temporalstore-rust/src/block_store/record.rs
@@ -397,7 +397,7 @@ pub(super) fn logical_range_from_slab(
 
     while physical_offset < slab.len() && out.len() < size as usize {
         let remaining = &slab[physical_offset..];
-        let address = BlockAddress::from_parts(block_slab_id, physical_offset as u64, 0, None, None, None, None, None);
+        let address = BlockAddress::from_parts(block_slab_id, physical_offset as u64, 0, None, None, None, None);
         if remaining.len() < PAGE_RECORD_HEADER_LEN || !remaining.starts_with(PAGE_RECORD_MAGIC) {
             return Err(corrupt_page_envelope(
                 &address,
@@ -415,7 +415,7 @@ pub(super) fn logical_range_from_slab(
                 "payload length mismatch".to_string(),
             ));
         }
-        let address = BlockAddress::from_parts(0, 0, record_len as u64, header.page_id, header.object_id, header.routing_bucket, header.page_id.or(header.object_id), header.band_id);
+        let address = BlockAddress::from_parts(0, 0, record_len as u64, header.page_id, header.object_id, header.routing_bucket, header.page_id.or(header.object_id));
         let payload = decode_page_record_payload(
             &remaining[header.header_len..record_len],
             &header,
@@ -678,7 +678,7 @@ pub(super) fn summarize_slab(
     let mut summary = SlabSummary::default();
     while physical_offset < slab.len() {
         let remaining = &slab[physical_offset..];
-        let address = BlockAddress::from_parts(block_slab_id, physical_offset as u64, 0, None, None, None, None, None);
+        let address = BlockAddress::from_parts(block_slab_id, physical_offset as u64, 0, None, None, None, None);
         if remaining.len() < PAGE_RECORD_HEADER_LEN || !remaining.starts_with(PAGE_RECORD_MAGIC) {
             return Err(corrupt_page_envelope(
                 &address,
@@ -770,7 +770,7 @@ pub(super) fn inspect_slab(slab: &[u8], block_slab_id: u64) -> BlockStoreSlabRep
     let mut physical_offset = 0usize;
     while physical_offset < slab.len() {
         let remaining = &slab[physical_offset..];
-        let mut address = BlockAddress::from_parts(block_slab_id, physical_offset as u64, 0, None, None, None, None, None);
+        let mut address = BlockAddress::from_parts(block_slab_id, physical_offset as u64, 0, None, None, None, None);
         if remaining.len() < PAGE_RECORD_HEADER_LEN || !remaining.starts_with(PAGE_RECORD_MAGIC) {
             record_slab_inspection_error(
                 &mut report,
@@ -807,7 +807,6 @@ pub(super) fn inspect_slab(slab: &[u8], block_slab_id: u64) -> BlockStoreSlabRep
         address.set_page_id(header.page_id);
         address.set_object_id(header.object_id);
         address.set_routing_bucket(header.routing_bucket);
-        address.set_band_id(header.band_id);
         match decode_page_record(&remaining[..record_len], &address) {
             Ok(decoded) => {
                 report.page_count = report.page_count.saturating_add(1);
@@ -1047,7 +1046,7 @@ mod reused_zstd_context_tests {
     }
 
     fn address_for(payload_len: usize) -> BlockAddress {
-        BlockAddress::from_parts(1, 0, payload_len as u64, Some(1), Some(1), Some(0), None, None)
+        BlockAddress::from_parts(1, 0, payload_len as u64, Some(1), Some(1), Some(0), None)
     }
 
     /// Round-trip at several sizes through the shared thread-local context.

--- a/crates/temporalstore-rust/src/block_store/slab_ids.rs
+++ b/crates/temporalstore-rust/src/block_store/slab_ids.rs
@@ -75,12 +75,19 @@ pub(crate) fn delayed_destroy_slab_id_from_name(name: &std::ffi::OsStr) -> Optio
     id.parse::<u64>().ok()
 }
 
+/// A band IS a slab.
+///
+/// This divided the slab's byte range by a separate band size, so a band could group several
+/// slabs. Nothing ever configured the two differently -- the one configuration that set them
+/// set both to the same value -- and the grouping was never exercised: the band map is keyed
+/// by slab id, one descriptor per slab, with the band id a computed label inside it.
+///
+/// Collapsing them is what makes the id DERIVABLE rather than merely equal. While it was a
+/// function of two configuration sizes, a reader whose configuration had moved would
+/// reconstruct a different band than the writer meant, so it had to be written down. A band
+/// that is a slab is a fact about the address.
 pub(crate) fn band_id_for_slab(block_slab_id: u64) -> u64 {
-    let slab_target_bytes = effective_block_slab_target_bytes().max(1);
-    let storage_band_size = storage_band_size_bytes().max(1);
     block_slab_id
-        .saturating_mul(slab_target_bytes)
-        .saturating_div(storage_band_size)
 }
 
 pub(crate) fn compact_slab_address_from_parts(block_slab_id: u64, offset: u64) -> Option<u64> {

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -3572,7 +3572,7 @@ fn append_value(
         }
         return page_store.append_with_page_metadata(bytes, object_id, routing_bucket);
     }
-    let address = BlockAddress::from_parts(HOT_BLOCK_SLAB_ID, HOT_PAGE_OFFSET.fetch_add(1, Ordering::Relaxed), bytes.len() as u64, None, object_id, routing_bucket, object_id, None);
+    let address = BlockAddress::from_parts(HOT_BLOCK_SLAB_ID, HOT_PAGE_OFFSET.fetch_add(1, Ordering::Relaxed), bytes.len() as u64, None, object_id, routing_bucket, object_id);
     // Put the page aside for this write's record. It is often derived state rather than the
     // command's own bytes, so the record has to carry it for a read to serve it back.
     if page_store.block_in_wal() {

--- a/crates/temporalstore-rust/src/engine/reports.rs
+++ b/crates/temporalstore-rust/src/engine/reports.rs
@@ -11,7 +11,7 @@ use crate::block_store::{
 use crate::storage_config::{
     StorageTuningConfig, TS_BLOCK_INDEX_CACHE_BYTES, TS_BLOCK_SLAB_TARGET_BYTES,
     TS_COLD_SCAN_NO_CACHE_FILL, TS_COMPACTION_WATERMARK_BYTES, TS_CONTEXT_PAGE_TARGET_BYTES,
-    TS_PAGE_INDEX_CACHE_BYTES, TS_STORAGE_ZONE_SIZE, TS_STREAM_MAX_BLOB_SIZE,
+    TS_PAGE_INDEX_CACHE_BYTES, TS_STREAM_MAX_BLOB_SIZE,
 };
 use crate::types::{ShardId, Status};
 use matrixcache::{CacheEntryInfo, CacheStats};
@@ -2272,10 +2272,6 @@ pub fn effective_storage_tuning_from_env() -> BTreeMap<String, StorageContractVa
     values.insert(
         TS_BLOCK_SLAB_TARGET_BYTES.to_string(),
         contract_u64(tuning.block_slab_target_bytes),
-    );
-    values.insert(
-        TS_STORAGE_ZONE_SIZE.to_string(),
-        contract_u64(tuning.storage_band_size),
     );
     values.insert(
         TS_STREAM_MAX_BLOB_SIZE.to_string(),

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -1718,7 +1718,7 @@ mod component_lookup_tests {
             object_key: Arc::from(object.to_string()),
             model_id: Arc::from("hash".to_string()),
             component: component.map(str::to_string).map(Arc::from),
-            address: BlockAddress::from_parts(0, 0, 0, None, Some(0), None, None, None),
+            address: BlockAddress::from_parts(0, 0, 0, None, Some(0), None, None),
             dirty: false,
             deleted: false,
             log_backed: false,

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -240,7 +240,7 @@ pub(super) fn storage_page_address_sample(
 ) -> StoragePageAddressSample {
     StoragePageAddressSample {
         shard_id,
-        band_id: address.band_id().unwrap_or(address.block_slab_id),
+        band_id: address.block_slab_id,
         slab_id: address.block_slab_id,
         page_id: address.page_id().unwrap_or(address.block_slab_id),
         offset: address.offset,
@@ -255,7 +255,7 @@ pub(super) fn storage_block_address_sample(
 ) -> StorageBlockAddressSample {
     StorageBlockAddressSample {
         shard_id,
-        band_id: address.band_id().unwrap_or(address.block_slab_id),
+        band_id: address.block_slab_id,
         block_id: address.block_slab_id,
         offset: address.offset,
         length: address.length,

--- a/crates/temporalstore-rust/src/engine/storage_reporting.rs
+++ b/crates/temporalstore-rust/src/engine/storage_reporting.rs
@@ -266,7 +266,7 @@ pub(super) fn native_packed_page_index_bytes(
     bytes[4] = u8::from(page.dirty) | (u8::from(page.log_backed) << 1);
     let page_size = if page.deleted { 0 } else { page.length as u32 };
     bytes[5..9].copy_from_slice(&page_size.to_le_bytes());
-    let address = physical_address_word(&BlockAddress::from_parts(page.block_slab_id, page.offset, page.length, page.page_id, page.object_id, Some(page.routing_bucket), page.page_id.or(page.object_id), page.band_id));
+    let address = physical_address_word(&BlockAddress::from_parts(page.block_slab_id, page.offset, page.length, page.page_id, page.object_id, Some(page.routing_bucket), page.page_id.or(page.object_id)));
     bytes[9..17].copy_from_slice(&address.to_le_bytes());
     bytes
 }

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -1411,15 +1411,15 @@ fn live_block_slab_ids_scan_all_index_backed_data_models() {
     let mut shard = ShardState::default();
     shard.strings.insert(
         "string".to_string(),
-        BlockAddress::from_parts(7, 0, 1, None, None, None, None, None),
+        BlockAddress::from_parts(7, 0, 1, None, None, None, None),
     );
     shard.hashes.entry("hash".to_string()).or_default().insert(
         "field".to_string(),
-        BlockAddress::from_parts(8, 0, 1, None, None, None, None, None),
+        BlockAddress::from_parts(8, 0, 1, None, None, None, None),
     );
     shard.sets.entry("set".to_string()).or_default().insert(
         b"member".to_vec(),
-        BlockAddress::from_parts(9, 0, 1, None, None, None, None, None),
+        BlockAddress::from_parts(9, 0, 1, None, None, None, None),
     );
     shard
         .features
@@ -1427,7 +1427,7 @@ fn live_block_slab_ids_scan_all_index_backed_data_models() {
         .or_default()
         .insert(
             10,
-            BlockAddress::from_parts(10, 0, 1, None, None, None, None, None),
+            BlockAddress::from_parts(10, 0, 1, None, None, None, None),
         );
     shard
         .features
@@ -1435,7 +1435,7 @@ fn live_block_slab_ids_scan_all_index_backed_data_models() {
         .or_default()
         .insert(
             11,
-            BlockAddress::from_parts(11, 0, 1, None, None, None, None, None),
+            BlockAddress::from_parts(11, 0, 1, None, None, None, None),
         );
     shard
         .control_state
@@ -3443,7 +3443,7 @@ fn served_index_container_round_trips_and_still_reads_plain_json() {
     let mut shard = ShardState::default();
     shard.strings.insert(
         "container-probe".to_string(),
-        BlockAddress::from_parts(7, 11, 13, None, None, None, None, None),
+        BlockAddress::from_parts(7, 11, 13, None, None, None, None),
     );
 
     // Raw JSON, which is what an older binary wrote. Nothing in production produces this any
@@ -3482,12 +3482,12 @@ fn binary_index_payload_round_trips_and_refuses_a_shape_it_cannot_read() {
     for i in 0..64u64 {
         shard.strings.insert(
             format!("object-{i}"),
-            BlockAddress::from_parts(i, i * 7, i + 1, Some(i), Some(i * 3), Some((i % 8) as u32), Some(i), None),
+            BlockAddress::from_parts(i, i * 7, i + 1, Some(i), Some(i * 3), Some((i % 8) as u32), Some(i)),
         );
     }
     shard.hashes.entry("hash-object".to_string()).or_default().insert(
         "component".to_string(),
-        BlockAddress::from_parts(9, 1, 2, None, None, None, None, None),
+        BlockAddress::from_parts(9, 1, 2, None, None, None, None),
     );
     shard.applied_wal_sequence = Some(4242);
 

--- a/crates/temporalstore-rust/src/engine/tests/part3.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part3.rs
@@ -1892,7 +1892,7 @@ fn rebuild_bucket_page_ownership_preserves_dirty_watermarks() {
     let mut shard = ShardState::default();
     shard.strings.insert(
         "k".to_string(),
-        BlockAddress::from_parts(1, 0, 4, Some(1), Some(30), Some(3), Some(1), None),
+        BlockAddress::from_parts(1, 0, 4, Some(1), Some(30), Some(3), Some(1)),
     );
     shard.bucket_index.bucket_map.insert(
         3,
@@ -2376,7 +2376,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                     object_key: Arc::from("k".to_string()),
                     model_id: Arc::from("string".to_string()),
                     component: None,
-                    address: BlockAddress::from_parts(1, 0, 4, Some(1), Some(30), Some(3), Some(1), None),
+                    address: BlockAddress::from_parts(1, 0, 4, Some(1), Some(30), Some(3), Some(1)),
                     dirty: false,
                     deleted: false,
                     log_backed: true,
@@ -2404,7 +2404,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                         object_key: Arc::from("feature-key".to_string()),
                         model_id: Arc::from("feature".to_string()),
                         component: None,
-                        address: BlockAddress::from_parts(2, 0, 4, Some(2), Some(40), Some(4), Some(2), None),
+                        address: BlockAddress::from_parts(2, 0, 4, Some(2), Some(40), Some(4), Some(2)),
                         dirty: false,
                         deleted: false,
                         log_backed: true,
@@ -2416,7 +2416,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                         object_key: Arc::from("feature-key".to_string()),
                         model_id: Arc::from("feature".to_string()),
                         component: None,
-                        address: BlockAddress::from_parts(2, 4, 4, Some(3), Some(40), Some(4), Some(3), None),
+                        address: BlockAddress::from_parts(2, 4, 4, Some(3), Some(40), Some(4), Some(3)),
                         dirty: false,
                         deleted: false,
                         log_backed: true,
@@ -2444,7 +2444,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                         object_key: Arc::from("hash-key".to_string()),
                         model_id: Arc::from("hash".to_string()),
                         component: Some(Arc::from("a".to_string())),
-                        address: BlockAddress::from_parts(3, 0, 1, Some(4), Some(50), Some(5), Some(4), None),
+                        address: BlockAddress::from_parts(3, 0, 1, Some(4), Some(50), Some(5), Some(4)),
                         dirty: false,
                         deleted: false,
                         log_backed: true,
@@ -2456,7 +2456,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                         object_key: Arc::from("hash-key".to_string()),
                         model_id: Arc::from("hash".to_string()),
                         component: Some(Arc::from("b".to_string())),
-                        address: BlockAddress::from_parts(3, 1, 1, Some(5), Some(51), Some(5), Some(5), None),
+                        address: BlockAddress::from_parts(3, 1, 1, Some(5), Some(51), Some(5), Some(5)),
                         dirty: false,
                         deleted: false,
                         log_backed: true,

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -4991,7 +4991,7 @@ fn a_page_whose_address_carries_no_object_id_still_reports_one() {
         let mut shards = engine.shards.write().expect("shards lock poisoned");
         let shard = shards.get_mut(&1).expect("shard 1 loaded");
         // Deliberately no object id, and no routing slot either.
-        let address = BlockAddress::from_parts(0, 0, 16, Some(7), None, None, None, None);
+        let address = BlockAddress::from_parts(0, 0, 16, Some(7), None, None, None);
         assert!(address.object_id().is_none(), "the case under test");
         crate::engine::storage_bucket_internals::upsert_bucket_index_page(
             shard,
@@ -5178,7 +5178,7 @@ fn installing_the_same_page_twice_replaces_it() {
         object_key: Arc::from("twice".to_string()),
         model_id: Arc::from("string".to_string()),
         component: None,
-        address: BlockAddress::from_parts(1, 0, 4, Some(1), Some(30), Some(3), Some(1), None),
+        address: BlockAddress::from_parts(1, 0, 4, Some(1), Some(30), Some(3), Some(1)),
         dirty: false,
         deleted: false,
         log_backed: true,
@@ -5193,7 +5193,7 @@ fn installing_the_same_page_twice_replaces_it() {
 
     // A page differing in one identity field is a different page and keeps its own slot.
     let mut moved = page();
-    moved.address = BlockAddress::from_parts(1, 64, 4, Some(1), Some(30), Some(3), Some(1), None);
+    moved.address = BlockAddress::from_parts(1, 64, 4, Some(1), Some(30), Some(3), Some(1));
     let third = map.insert(moved);
     assert_ne!(first, third, "a page at another offset is not the same page");
     assert_eq!(map.len(), 2);
@@ -5900,7 +5900,10 @@ fn the_index_wire_keys_are_what_they_were() {
         listed,
         vec![
             "address",
-            "b",
+            // "b", the band, is gone: a band IS a slab, so an address derives it from
+            // `block_slab_id` rather than carrying it. An index written before this still has the
+            // key and still loads -- the wire struct does not deny unknown fields, so the stored
+            // value is read and ignored.
             "component",
             "deleted",
             "deleted_object_index",

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -3192,11 +3192,11 @@ mod tests {
         let cases = [
             ("no address", None),
             ("address repeats both", Some(crate::block_store::BlockAddress::from_parts(
-                42, 1_048_576, 4096, Some(7), Some(object_id), Some(bucket), Some(3), Some(9)))),
+                42, 1_048_576, 4096, Some(7), Some(object_id), Some(bucket), Some(3)))),
             ("address holds a DIFFERENT object", Some(crate::block_store::BlockAddress::from_parts(
-                42, 0, 0, None, Some(object_id + 1), Some(bucket + 1), None, None))),
+                42, 0, 0, None, Some(object_id + 1), Some(bucket + 1), None))),
             ("address holds neither", Some(crate::block_store::BlockAddress::from_parts(
-                42, 0, 0, None, None, None, None, None))),
+                42, 0, 0, None, None, None, None))),
         ];
 
         for (label, address) in cases {
@@ -3250,11 +3250,11 @@ mod tests {
 
         // As written today: the address repeats the item's object id and routing bucket.
         let repeats = item(Some(crate::block_store::BlockAddress::from_parts(
-            42, 1_048_576, 4096, Some(7), Some(object_id), Some(bucket), Some(3), Some(9),
+            42, 1_048_576, 4096, Some(7), Some(object_id), Some(bucket), Some(3),
         )));
         // The same address with the two the item already states left out.
         let deduped = item(Some(crate::block_store::BlockAddress::from_parts(
-            42, 1_048_576, 4096, Some(7), None, None, Some(3), Some(9),
+            42, 1_048_576, 4096, Some(7), None, None, Some(3),
         )));
 
         let a = encode_index_payload(&repeats, INDEX_LOG_SHAPE_DELTA).expect("encode").len();
@@ -3290,7 +3290,7 @@ mod tests {
             page_id: 7,
             address: Some(crate::block_store::BlockAddress::from_parts(
                 42, 1_048_576, 4096, Some(7), Some(12_345_678_901_234_567), Some(8539),
-                Some(3), Some(9),
+                Some(3),
             )),
             size: 4096,
             in_log: false,

--- a/crates/temporalstore-rust/src/storage_config.rs
+++ b/crates/temporalstore-rust/src/storage_config.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 
 pub const TS_CONTEXT_PAGE_TARGET_BYTES: &str = "TS_CONTEXT_PAGE_TARGET_BYTES";
 pub const TS_BLOCK_SLAB_TARGET_BYTES: &str = "TS_BLOCK_SLAB_TARGET_BYTES";
-pub const TS_STORAGE_ZONE_SIZE: &str = "TS_STORAGE_ZONE_SIZE";
 pub const TS_STREAM_MAX_BLOB_SIZE: &str = "TS_STREAM_MAX_BLOB_SIZE";
 pub const TS_COMPACTION_WATERMARK_BYTES: &str = "TS_COMPACTION_WATERMARK_BYTES";
 pub const TS_COLD_SCAN_NO_CACHE_FILL: &str = "TS_COLD_SCAN_NO_CACHE_FILL";
@@ -47,8 +46,6 @@ pub struct StorageTuningConfig {
     pub context_page_target_bytes: usize,
     #[serde(alias = "block_segment_target_bytes")]
     pub block_slab_target_bytes: u64,
-    #[serde(rename = "storage_zone_size")]
-    pub storage_band_size: u64,
     pub stream_max_blob_size: u64,
     pub compaction_watermark_bytes: u64,
     pub cold_scan_no_cache_fill: bool,
@@ -62,7 +59,6 @@ impl Default for StorageTuningConfig {
         Self {
             context_page_target_bytes: DEFAULT_CONTEXT_PAGE_TARGET_BYTES,
             block_slab_target_bytes: DEFAULT_BLOCK_SLAB_TARGET_BYTES,
-            storage_band_size: DEFAULT_STORAGE_BAND_SIZE,
             stream_max_blob_size: DEFAULT_STREAM_MAX_BLOB_SIZE,
             compaction_watermark_bytes: DEFAULT_COMPACTION_WATERMARK_BYTES,
             cold_scan_no_cache_fill: DEFAULT_COLD_SCAN_NO_CACHE_FILL,
@@ -92,8 +88,6 @@ impl StorageTuningConfig {
                 defaults.block_slab_target_bytes,
             )
             .max(1024),
-            storage_band_size: parse_u64(get(TS_STORAGE_ZONE_SIZE), defaults.storage_band_size)
-                .max(1024),
             stream_max_blob_size: parse_u64(
                 get(TS_STREAM_MAX_BLOB_SIZE),
                 defaults.stream_max_blob_size,
@@ -133,12 +127,11 @@ impl StorageTuningConfig {
             .max(self.stream_max_blob_size)
     }
 
-    pub fn env_names() -> [&'static str; 11] {
+    pub fn env_names() -> [&'static str; 10] {
         [
             TS_CONTEXT_PAGE_TARGET_BYTES,
             TS_BLOCK_SLAB_TARGET_BYTES,
             TS_BLOCK_SLAB_TARGET_BYTES_PREVIOUS_NAME,
-            TS_STORAGE_ZONE_SIZE,
             TS_STREAM_MAX_BLOB_SIZE,
             TS_COMPACTION_WATERMARK_BYTES,
             TS_COLD_SCAN_NO_CACHE_FILL,
@@ -156,10 +149,6 @@ pub fn context_page_target_bytes() -> usize {
 
 pub fn effective_block_slab_target_bytes() -> u64 {
     StorageTuningConfig::from_env().effective_slab_target_bytes()
-}
-
-pub fn storage_band_size_bytes() -> u64 {
-    StorageTuningConfig::from_env().storage_band_size
 }
 
 /// Undumped index-log-gap threshold (bytes) that triggers a background catalog/index dump under
@@ -208,7 +197,6 @@ mod tests {
             config.block_slab_target_bytes,
             DEFAULT_BLOCK_SLAB_TARGET_BYTES
         );
-        assert_eq!(config.storage_band_size, DEFAULT_STORAGE_BAND_SIZE);
         assert_eq!(config.stream_max_blob_size, DEFAULT_STREAM_MAX_BLOB_SIZE);
         assert_eq!(
             config.compaction_watermark_bytes,
@@ -240,7 +228,6 @@ mod tests {
                 "TS_CONTEXT_PAGE_TARGET_BYTES",
                 "TS_BLOCK_SLAB_TARGET_BYTES",
                 "TS_BLOCK_SEGMENT_TARGET_BYTES",
-                "TS_STORAGE_ZONE_SIZE",
                 "TS_STREAM_MAX_BLOB_SIZE",
                 "TS_COMPACTION_WATERMARK_BYTES",
                 "TS_COLD_SCAN_NO_CACHE_FILL",
@@ -315,7 +302,6 @@ mod tests {
         let env = HashMap::from([
             (TS_CONTEXT_PAGE_TARGET_BYTES, "32768"),
             (TS_BLOCK_SLAB_TARGET_BYTES, "10485760"),
-            (TS_STORAGE_ZONE_SIZE, "10485760"),
             (TS_STREAM_MAX_BLOB_SIZE, "8388608"),
             (TS_COMPACTION_WATERMARK_BYTES, "4096"),
             (TS_COLD_SCAN_NO_CACHE_FILL, "false"),
@@ -326,7 +312,6 @@ mod tests {
         let config = StorageTuningConfig::from_getter(|name| env.get(name).map(|v| v.to_string()));
         assert_eq!(config.context_page_target_bytes, 32 * 1024);
         assert_eq!(config.block_slab_target_bytes, 10 * 1024 * 1024);
-        assert_eq!(config.storage_band_size, 10 * 1024 * 1024);
         assert_eq!(config.stream_max_blob_size, 8 * 1024 * 1024);
         // Seal = max(block_slab_target 10MiB, max_blob 8MiB) = 10MiB (blob is a floor).
         assert_eq!(config.effective_slab_target_bytes(), 10 * 1024 * 1024);

--- a/crates/temporalstore-rust/src/wal_proto.rs
+++ b/crates/temporalstore-rust/src/wal_proto.rs
@@ -373,7 +373,8 @@ fn address_to_proto(address: &BlockAddress, implied_length: Option<u64>) -> v1::
         // anything currently reads the difference.
         routing_bucket: None,
         generation: address.generation(),
-        band_id: address.band_id(),
+        // Derivable from the slab now that a band IS one, so the log stops restating it.
+        band_id: None,
         // The digest, not its transcription. Half the bytes, same value.
         checksum: None,
         // In memory the digest is already the 32 bytes this field wants, so there is no
@@ -397,7 +398,6 @@ fn address_from_proto(address: v1::WalBlockAddress, implied_length: Option<u64>)
         address.object_id,
         address.routing_bucket,
         address.generation,
-        address.band_id,
     )
 }
 /// The numeric key a component is carrying, if it is carrying one.
@@ -1366,11 +1366,11 @@ mod tests {
             None,
             // object_id repeats the item's, so `item_to_proto` drops it from the address.
             Some(crate::block_store::BlockAddress::from_parts(
-                42, 1_048_576, 4096, Some(7), Some(9), Some(8539), Some(3), Some(9),
+                42, 1_048_576, 4096, Some(7), Some(9), Some(8539), Some(3),
             )),
             // and one that does not repeat it, so it stays.
             Some(crate::block_store::BlockAddress::from_parts(
-                42, 0, 0, None, Some(4_242), None, None, None,
+                42, 0, 0, None, Some(4_242), None, None,
             )),
         ];
 
@@ -1828,7 +1828,6 @@ mod tests {
                 stored,
                 Some(1),
                 Some(0x1234_5678_9ABC_DEF0),
-                None,
                 None,
                 None,
             )),

--- a/crates/temporalstore-rust/src/wal_record.rs
+++ b/crates/temporalstore-rust/src/wal_record.rs
@@ -110,7 +110,6 @@ pub fn block_address_from_item(log_id: u64, log_size: u64, item: &WalItem) -> Bl
         Some(u64::from(item.object_id)),
         u32::try_from(item.routing_bucket).ok(),
         None,
-        None,
     )
 }
 

--- a/tools/matrixark_load_config.py
+++ b/tools/matrixark_load_config.py
@@ -78,7 +78,6 @@ ENV_MAP: Dict[str, str] = {
     "storage.object_store_bucket": "TS_MATRIXOBJECT_BUCKET",
     "storage.object_store_dir": "TS_MATRIXOBJECT_STORE_DIR",
     "storage.shared_store_dir": "TS_SHARED_STORE_DIR",
-    "storage.zone_size_bytes": "TS_STORAGE_ZONE_SIZE",
     "storage.context_page_target_bytes": "TS_CONTEXT_PAGE_TARGET_BYTES",
     "storage.block_slab_target_bytes": "TS_BLOCK_SLAB_TARGET_BYTES",
     "storage.stream_max_blob_size": "TS_STREAM_MAX_BLOB_SIZE",


### PR DESCRIPTION
A block address carried a slab **and** a band, where the band was
`slab * block_slab_target_bytes / storage_band_size` — a grouping that let one band span several
slabs.

Nothing ever used it. The band map is keyed by **slab** id, one descriptor per slab, with the band
id a computed label inside it; both sizes default to 1 GiB; and the one configuration that sets
them sets both to the same value. So the grouping existed in the code and collapsed to one-to-one
in every configuration we ship.

## Collapsing it is what makes the id derivable

While the band was a function of two configuration sizes, a reader whose configuration had moved
would reconstruct a **different** band than the writer meant — so it had to be written down beside
the slab. A band that *is* a slab is a fact about the address, so the address derives it and
neither log writes it.

```
BlockAddress          64 -> 56 bytes
WAL                  127 -> 125 bytes per record
total                265 -> 263, write amplification 3.39x -> 3.37x
```

`storage_band_size` is retired rather than left accepted-and-ignored, which is the trap a knob that
reads but does nothing sets for the next person. It was read in exactly one place: inside the
derivation this removes.

## One behaviour change, stated because a test had to move for it

An address whose **stored** band disagrees with its slab now answers the slab. Such a record could
only have been written under a configuration that sized bands and slabs differently — one the tree
never set and no longer has a knob for.

Every older spelling still **loads**. The wire struct does not deny unknown fields, so a record
carrying `b` / `band_id` / `extent_id` / `zone_id` reads exactly as before and the value is ignored.
Compatibility runs the direction the format already promises — the module says *"Old to new is
safe; new to old is not."*

`the_index_wire_keys_are_what_they_were` caught the `b` key leaving the shard index, which is what
that guard is for; the list is updated with the reason rather than quietly.

## Gates

- block store 61 passed, index log 46 passed, crash recovery 8 passed
- library: 1712 passed, 2 failed — both already failing on main
