### PR TITLE
Shard size is part of the on-disk contract, so agree on it

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -1779,7 +1779,7 @@ fn matrixark_scan_cache_key(command: &RecordLogRequest, freshness: &str) -> Stri
     serde_json::to_string(&json!({
         "count_key": command.count_key,
         "record_hash_key": command.record_hash_key,
-        "shard_size": command.shard_size.unwrap_or(1024).max(1),
+        "shard_size": command.shard_size.unwrap_or(DEFAULT_RECORD_LOG_SHARD_SIZE).max(1),
         "freshness": freshness,
         "record_types": command.record_types,
         // A status-filtered scan is a SUBSET of the same question, exactly like
@@ -2872,7 +2872,11 @@ fn scan_matrixark_candidates(
 ) -> Result<Value, String> {
     let count_key = required_option(command.count_key.clone(), "count_key")?;
     let record_hash_key = required_option(command.record_hash_key.clone(), "record_hash_key")?;
-    let shard_size = command.shard_size.unwrap_or(1024).max(1);
+    // 256, matching the writer. Guessing 1024 against a store written at 256 computes
+    // max_shard = (count - 1) / 1024, enumerates a quarter of the shards, and returns a
+    // partial store as though it were the whole one. Over-enumerating is the safe direction:
+    // extra shard keys simply do not exist and read back empty.
+    let shard_size = command.shard_size.unwrap_or(DEFAULT_RECORD_LOG_SHARD_SIZE).max(1);
     let count_text = read_record_count(engine, &count_key)?;
     let count = count_text.parse::<u64>().unwrap_or(0);
     let freshness = scan_freshness_token(engine, command, &record_hash_key, count);
@@ -6501,6 +6505,12 @@ fn blended_candidate_score(
 /// a token budget -- the fill is then bounded by tokens and this is never consulted -- or enables
 /// `MATRIXARK_RETURN_ALL_CANDIDATES`, which lifts the limit to the candidate count.
 const DEFAULT_MAX_SELECTED_REFS: usize = 1000;
+
+/// Records per shard, mirroring DIRECT_RECORD_LOG_SHARD_SIZE on the writing side.
+///
+/// A reader that assumes a LARGER shard size than the writer used enumerates too few shards
+/// and silently returns part of the store. This was 1024 here against a writer at 256.
+const DEFAULT_RECORD_LOG_SHARD_SIZE: u64 = 256;
 
 /// Which candidates a token budget and a set of per-layer floors admit.
 ///

--- a/tools/matrixark_context_backfill.py
+++ b/tools/matrixark_context_backfill.py
@@ -46,7 +46,9 @@ from matrixark_raw_message_storage_contract import (  # noqa: E402
 
 Json = dict[str, Any]
 SourceRef = tuple[int, str | None] | tuple[int, str | None, str | None]
-DIRECT_RECORD_LOG_SHARD_SIZE = int(os.environ.get("MATRIXARK_DIRECT_RECORD_LOG_SHARD_SIZE", "4096"))
+# 256, matching the serving modules. This said 4096: the backfill wrote 4096 records per shard
+# while serving read 256 per shard, so the two disagreed about where a record lives.
+DIRECT_RECORD_LOG_SHARD_SIZE = int(os.environ.get("MATRIXARK_DIRECT_RECORD_LOG_SHARD_SIZE", "256"))
 
 VOLATILE_SERVING_FINGERPRINT_FIELDS = {
     'context_event_key',

--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -80,7 +80,12 @@ try:  # package path
     from tools.matrixark_mcp_embeddings import EMBEDDING_DIM  # noqa: F401
 except ImportError:  # top-level path (direct tools/ execution)
     from matrixark_mcp_embeddings import EMBEDDING_DIM  # noqa: F401
-DIRECT_RECORD_LOG_SHARD_SIZE = 256
+# Records per shard. This decides PLACEMENT: a record lands in shard index // shard_size, so a
+# reader that assumes a LARGER size than the writer used enumerates too few shards and silently
+# reads a fraction of the store. It was 256 here, 4096 in the backfill (the only module that
+# honoured the environment variable) and 1024 in the engine, so which records a scan could see
+# depended on which module opened it.
+DIRECT_RECORD_LOG_SHARD_SIZE = int(os.environ.get("MATRIXARK_DIRECT_RECORD_LOG_SHARD_SIZE", "256"))
 DIRECT_RECORD_BUNDLE_MAX_BYTES = int(os.environ.get("MATRIXARK_DIRECT_RECORD_BUNDLE_MAX_BYTES", "65536"))
 DIRECT_RECORD_HOT_CACHE_MAX_RECORDS = int(os.environ.get("MATRIXARK_DIRECT_RECORD_HOT_CACHE_MAX_RECORDS", "20000"))
 DIRECT_WRITE_RETRIES = int(os.environ.get("MATRIXARK_DIRECT_WRITE_RETRIES", "3"))

--- a/tools/matrixark_mcp_runtime_config.py
+++ b/tools/matrixark_mcp_runtime_config.py
@@ -17,7 +17,12 @@ import os
 MAX_PRIOR_MESSAGES = 8
 MAX_PRIOR_CHARS = 4096
 
-DIRECT_RECORD_LOG_SHARD_SIZE = 256
+# Records per shard. This decides PLACEMENT: a record lands in shard index // shard_size, so a
+# reader that assumes a LARGER size than the writer used enumerates too few shards and silently
+# reads a fraction of the store. It was 256 here, 4096 in the backfill (the only module that
+# honoured the environment variable) and 1024 in the engine, so which records a scan could see
+# depended on which module opened it.
+DIRECT_RECORD_LOG_SHARD_SIZE = int(os.environ.get("MATRIXARK_DIRECT_RECORD_LOG_SHARD_SIZE", "256"))
 DIRECT_RECORD_BUNDLE_MAX_BYTES = int(os.environ.get("MATRIXARK_DIRECT_RECORD_BUNDLE_MAX_BYTES", "65536"))
 DIRECT_RECORD_HOT_CACHE_MAX_RECORDS = int(os.environ.get("MATRIXARK_DIRECT_RECORD_HOT_CACHE_MAX_RECORDS", "20000"))
 DIRECT_WRITE_RETRIES = int(os.environ.get("MATRIXARK_DIRECT_WRITE_RETRIES", "3"))

--- a/tools/test_the_shard_size_has_one_value.py
+++ b/tools/test_the_shard_size_has_one_value.py
@@ -1,0 +1,103 @@
+"""Shard size is part of the on-disk contract, so every surface must agree on it.
+
+A record lands in shard `arrival_index // shard_size`. The asymmetry is what makes this dangerous:
+a reader assuming a LARGER shard size than the writer used computes `max_shard = (count - 1) / size`,
+enumerates too few shards, and returns part of the store while reporting success. The other
+direction is harmless -- surplus shard keys simply do not exist and read back empty.
+
+It was 256 in the two serving modules, 4096 in the backfill (the only module that honoured the
+environment variable), and 1024 in the engine's fallback. The engine guessing 1024 against a store
+written at 256 would have read a quarter of it.
+"""
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+sys.path.insert(0, HERE)
+sys.path.insert(0, ROOT)
+
+FAILURES = []
+
+
+def check(condition, message):
+    if not condition:
+        FAILURES.append(message)
+
+
+def python_defaults():
+    found = {}
+    for name in (
+        "matrixark_mcp_core.py",
+        "matrixark_mcp_runtime_config.py",
+        "matrixark_context_backfill.py",
+    ):
+        body = open(os.path.join(HERE, name), encoding="utf-8").read()
+        match = re.search(
+            r'DIRECT_RECORD_LOG_SHARD_SIZE = int\(os\.environ\.get\(\s*"MATRIXARK_DIRECT_RECORD_LOG_SHARD_SIZE",\s*"(\d+)"\s*\)\)',
+            body,
+        )
+        found[name] = int(match.group(1)) if match else None
+    return found
+
+
+def rust_default():
+    path = os.path.join(ROOT, "crates", "temporalstore-rust", "src", "matrixark_rust_proxy_impl.rs")
+    body = open(path, encoding="utf-8").read()
+    match = re.search(r"const DEFAULT_RECORD_LOG_SHARD_SIZE: u64 = (\d+);", body)
+    return int(match.group(1)) if match else None
+
+
+def every_surface_agrees_on_the_shard_size():
+    values = python_defaults()
+    values["rust"] = rust_default()
+    for name, value in values.items():
+        check(value is not None, "%s no longer declares the shard size the expected way" % name)
+    distinct = {v for v in values.values() if v is not None}
+    check(len(distinct) == 1, "shard size disagrees across surfaces: %s" % (values,))
+
+
+def every_surface_honours_the_environment_variable():
+    """It was hardcoded in the two serving modules, so the knob existed and only the backfill read
+    it -- which is how the writer and the reader came to disagree in the first place."""
+    for name in ("matrixark_mcp_core.py", "matrixark_mcp_runtime_config.py"):
+        body = open(os.path.join(HERE, name), encoding="utf-8").read()
+        check(
+            "MATRIXARK_DIRECT_RECORD_LOG_SHARD_SIZE" in body,
+            "%s hardcodes the shard size instead of reading the variable" % name,
+        )
+
+
+def the_engine_does_not_guess_a_larger_size():
+    """The engine's fallback must never exceed the writer's default.
+
+    Larger is the losing direction: it under-enumerates shards and silently drops records. This
+    asserts the relationship, not just the number, so raising the writer's default later cannot
+    quietly leave the engine reading a fraction of the store.
+    """
+    writer = python_defaults().get("matrixark_mcp_core.py")
+    engine = rust_default()
+    if writer is None or engine is None:
+        return
+    check(
+        engine <= writer,
+        "the engine assumes %d records per shard against a writer at %d, so it would enumerate "
+        "too few shards and read part of the store" % (engine, writer),
+    )
+
+
+for test in (
+    every_surface_agrees_on_the_shard_size,
+    every_surface_honours_the_environment_variable,
+    the_engine_does_not_guess_a_larger_size,
+):
+    test()
+    print("  ran %s" % test.__name__)
+
+if FAILURES:
+    print("FAILED:")
+    for item in FAILURES:
+        print("  - %s" % item)
+    raise SystemExit(1)
+print("all shard-size checks pass")


### PR DESCRIPTION
## Shard size decides placement, and three surfaces disagreed about it

A record lands in shard `arrival_index // shard_size`.

| surface | was | now |
|---|---|---|
| `matrixark_mcp_core.py` | 256, hardcoded | **256**, from the variable |
| `matrixark_mcp_runtime_config.py` | 256, hardcoded | **256**, from the variable |
| `matrixark_context_backfill.py` | **4096** (the only module reading the variable) | **256** |
| the engine fallback | **1024** | **256** |

## Why the direction matters

A reader assuming a **larger** shard size than the writer used computes
`max_shard = (count - 1) / size`, enumerates **too few shards**, and returns part of the store while
reporting success. The engine guessing 1024 against a store written at 256 would have read a quarter
of it and raised nothing.

The other direction is harmless: surplus shard keys simply do not exist and read back empty. So the
engine's fallback moves **1024 → 256**, deliberately the over-enumerating side.

## The guard

`tools/test_the_shard_size_has_one_value.py` pins the four surfaces together, checks the two serving
modules actually honour `MATRIXARK_DIRECT_RECORD_LOG_SHARD_SIZE` (they hardcoded it, which is how
writer and reader drifted apart), and asserts the **relationship** rather than only the number:

> the engine's fallback must never exceed the writer's default

so raising the writer's default later cannot quietly leave the engine reading a fraction of the
store.

Both failures it exists to catch were checked:

- engine back to 1024 → fails, reporting every surface *and* "would enumerate too few shards and
  read part of the store"
- backfill back to 4096 → fails, naming the disagreement

## Tests

108 pass in the proxy binary; Python compiles and the neighbouring suites are unchanged.

## Context

Found while answering how context records are placed. The larger question is filed as #1383 —
records are placed by arrival order rather than by scope, so nothing is co-located by tenant,
session or layer, and a distributed deployment has to settle that before it can route by scope.
