### PR TITLE
The lane has two modules and the faster decoder reached one

### DIFF
--- a/tools/matrixark_json_lane.py
+++ b/tools/matrixark_json_lane.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""The lane's JSON decoder, in one place.
+
+A sampled profile of the running gateway put **53.5%** of its CPU in the stdlib JSON decoder, and
+orjson parses the same text materially faster -- measured at -14.1% gateway CPU per message on an
+identical corpus, with proxy CPU flat, which is the right control for a Python-side change.
+
+That change was made in `matrixark_mcp_temporal_adapters`, and `matrixark_mcp_rust_proxy_client`
+kept calling `json.loads` -- including for the whole context pack on every retrieve, which is the
+largest payload on that path. Two modules serve the lane and the faster decoder reached one, so the
+profile kept reporting `raw_decode` after the fix was supposedly in.
+
+One behaviour differs and accepting it is deliberate: integers beyond u64 decode as floats rather
+than exact ints. JSON guarantees no integer precision beyond 2**53 -- most parsers lose it far
+earlier -- so a value that large is already outside what an interoperable consumer round-trips, and
+every hash this system stores is within u64 and exact.
+
+`orjson.JSONDecodeError` subclasses `json.JSONDecodeError`, so callers catching the stdlib error
+catch this one unchanged. Optional by design: without orjson the stdlib parser is used and nothing
+about the lane changes.
+"""
+from __future__ import annotations
+
+try:  # pragma: no cover - whichever is installed is the one exercised
+    import orjson as _orjson
+
+    def lane_loads(text):
+        """Parse lane JSON. Accepts str or bytes, as both parsers do."""
+        return _orjson.loads(text)
+
+    LANE_DECODER = "orjson"
+
+except ImportError:  # pragma: no cover
+    import json as _stdlib_json
+
+    def lane_loads(text):
+        """Parse lane JSON. Accepts str or bytes, as both parsers do."""
+        if isinstance(text, (bytes, bytearray)):
+            text = text.decode("utf-8")
+        return _stdlib_json.loads(text)
+
+    LANE_DECODER = "stdlib"

--- a/tools/matrixark_mcp_rust_proxy_client.py
+++ b/tools/matrixark_mcp_rust_proxy_client.py
@@ -14,6 +14,14 @@ import threading
 import time
 from typing import Any
 
+# The lane decoder, shared with matrixark_mcp_temporal_adapters. This module decodes the whole
+# context pack on every retrieve -- the largest payload on the path -- and did so with the stdlib
+# parser while the faster one was already wired up next door.
+try:  # pragma: no cover - import shape differs when run as a package
+    from matrixark_json_lane import lane_loads as _lane_loads
+except ImportError:  # pragma: no cover
+    from tools.matrixark_json_lane import lane_loads as _lane_loads
+
 try:
     from tools.matrixark_mcp_core import Json, MatrixArkError
     from tools.matrixark_mcp_rust_proxy_coalesce import (
@@ -208,7 +216,7 @@ class MatrixArkRustProxyClient(MatrixArkRustProxyCacheMixin):
             if not line.strip().startswith("{"):
                 continue
             try:
-                parsed = json.loads(line)
+                parsed = _lane_loads(line)
             except json.JSONDecodeError as exc:
                 raise MatrixArkError(f"Rust TemporalStore {op} returned invalid JSON: {line[:200]!r}") from exc
             # The proxy answers strictly in order on one stdout, so the late response of a
@@ -613,7 +621,7 @@ class MatrixArkRustProxyClient(MatrixArkRustProxyCacheMixin):
             result = response
             value = response.get("value")
             if isinstance(value, str) and value:
-                decoded = json.loads(value)
+                decoded = _lane_loads(value)
                 if isinstance(decoded, dict):
                     result = decoded
             self._context_pack_response_cache_put(cache_key, result)

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -34,17 +34,14 @@ from pathlib import PurePosixPath
 #
 # Optional by design: where orjson is not installed the stdlib parser is used and nothing about
 # the lane changes.
-try:  # pragma: no cover - whichever is installed is the one exercised
-    import orjson as _lane_orjson
-
-    def _LANE_LOADS(text):
-        return _lane_orjson.loads(text)
-
+# One decoder, shared with matrixark_mcp_rust_proxy_client. Two modules serve this lane, and when
+# the faster parser lived here only, the client went on decoding the whole context pack with the
+# stdlib one -- so a profile taken after the change still reported the decoder it was meant to
+# replace.
+try:  # pragma: no cover - import shape differs when run as a package
+    from matrixark_json_lane import lane_loads as _LANE_LOADS
 except ImportError:  # pragma: no cover
-    import json as _lane_stdlib_json
-
-    def _LANE_LOADS(text):
-        return _lane_stdlib_json.loads(text)
+    from tools.matrixark_json_lane import lane_loads as _LANE_LOADS
 
 
 # msgpack for the lane, where both ends have it.

--- a/tools/test_the_lane_has_one_decoder.py
+++ b/tools/test_the_lane_has_one_decoder.py
@@ -1,0 +1,91 @@
+"""The lane has one decoder, and both modules that serve the lane use it.
+
+A profile put 53.5% of gateway CPU in the stdlib JSON decoder. orjson was wired into
+`matrixark_mcp_temporal_adapters` and measured at -14.1% gateway CPU per message -- but
+`matrixark_mcp_rust_proxy_client`, which is the client the one-box HTTP path uses, went on calling
+`json.loads`, including for the whole context pack on every retrieve. Two modules serve the lane;
+the faster parser reached one; the profile kept naming the decoder that was supposedly replaced.
+"""
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+sys.path.insert(0, HERE)
+sys.path.insert(0, ROOT)
+
+from matrixark_json_lane import LANE_DECODER, lane_loads  # noqa: E402
+
+FAILURES = []
+
+
+def check(condition, message):
+    if not condition:
+        FAILURES.append(message)
+
+
+def the_decoder_reads_both_str_and_bytes():
+    """Both parsers accept both; the stdlib branch has to decode bytes itself."""
+    check(lane_loads('{"a": 1}') == {"a": 1}, "str input failed")
+    check(lane_loads(b'{"a": 1}') == {"a": 1}, "bytes input failed")
+    check(lane_loads('[1, 2]') == [1, 2], "array failed")
+
+
+def orjson_is_used_when_it_is_installed():
+    """The whole point is the faster parser. If orjson is present and we are not using it, the
+    measured win is not being taken."""
+    try:
+        import orjson  # noqa: F401
+    except ImportError:
+        print("    (orjson absent here; stdlib branch is correct)")
+        return
+    check(LANE_DECODER == "orjson", "orjson is installed but the lane reports %r" % LANE_DECODER)
+
+
+def both_lane_modules_share_one_decoder():
+    """The property that was missing. Same function object, not merely similar code."""
+    import matrixark_json_lane
+    try:
+        from matrixark_mcp_rust_proxy_client import _lane_loads as client_loads
+    except Exception as exc:  # noqa: BLE001
+        FAILURES.append("could not import the client's decoder: %r" % (exc,))
+        return
+    check(
+        client_loads is matrixark_json_lane.lane_loads,
+        "the client uses a different decoder object from the shared one",
+    )
+
+
+def the_client_does_not_decode_the_lane_with_the_stdlib_parser():
+    """Source-level, because an import can be shadowed by a later local call."""
+    body = open(os.path.join(HERE, "matrixark_mcp_rust_proxy_client.py"), encoding="utf-8").read()
+    hits = re.findall(r"^\s*\w*\s*=?\s*json\.loads\(", body, re.M)
+    check(not hits, "the client still calls stdlib json.loads on the lane: %d site(s)" % len(hits))
+
+
+def the_context_pack_is_decoded_by_the_shared_decoder():
+    """The hot one: the pack is the largest payload on the retrieve path."""
+    body = open(os.path.join(HERE, "matrixark_mcp_rust_proxy_client.py"), encoding="utf-8").read()
+    check(
+        "decoded = _lane_loads(value)" in body,
+        "the context pack is no longer decoded by the shared decoder",
+    )
+
+
+for test in (
+    the_decoder_reads_both_str_and_bytes,
+    orjson_is_used_when_it_is_installed,
+    both_lane_modules_share_one_decoder,
+    the_client_does_not_decode_the_lane_with_the_stdlib_parser,
+    the_context_pack_is_decoded_by_the_shared_decoder,
+):
+    test()
+    print("  ran %s" % test.__name__)
+
+if FAILURES:
+    print("FAILED:")
+    for item in FAILURES:
+        print("  - %s" % item)
+    raise SystemExit(1)
+print("all lane-decoder checks pass")


### PR DESCRIPTION
## The faster decoder reached one of the two modules that serve the lane

A sampled profile put **53.5% of gateway CPU** in the stdlib JSON decoder. orjson was wired into
`matrixark_mcp_temporal_adapters` and measured at **-14.1% gateway CPU per message** on an identical
corpus, with proxy CPU flat — the right control for a Python-side change.

`matrixark_mcp_rust_proxy_client` — the client the one-box HTTP path uses — kept calling
`json.loads`:

| site | what it decodes |
|---|---|
| the stdio lane reader | every proxy response line |
| `decoded = json.loads(value)` | **the whole context pack, on every retrieve** |

The second is the largest payload on that path. So a profile taken *after* the change still named
the decoder the change was meant to replace.

## One decoder

`matrixark_json_lane.lane_loads` is now the only one, and the adapters **delegate** to it rather
than keeping a second copy, so the two cannot drift apart again.

## What is measured, and what is not

The **-14.1%** is the earlier measurement of this parser on the *adapters* path. This applies the
same parser to the *client* path. The effect on that path is **not yet measured**, and this PR does
not claim a number for it.

## Behaviour is unchanged

- `orjson.JSONDecodeError` subclasses `json.JSONDecodeError`, so the handlers around both call sites
  catch it exactly as before
- without orjson the stdlib parser is used, unchanged
- integers beyond u64 decode as floats rather than exact ints — the same tradeoff already accepted
  on the adapters path, and every hash this system stores is within u64 and exact

## Tests

`tools/test_the_lane_has_one_decoder.py` — five checks. The load-bearing one asserts the two modules
resolve to the **same function object**, not merely to similar code, since "both use orjson" is
exactly the kind of claim that was true of one module and not the other. It also pins that orjson is
used when installed, and that the context pack specifically goes through the shared decoder.
