### PR TITLE
A compaction round is bounded, and resumes instead of rolling again

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -131,6 +131,18 @@ pub struct TemporalEngine {
     /// which is why the tests that measure both sides had to be serialised against each other: a
     /// baseline could otherwise observe a window its sibling had opened. Shared across clones,
     /// because a clone is the same engine.
+    /// The slab an unfinished compaction round is still filling, per shard, with the slab it
+    /// rolled away from.
+    ///
+    /// A round rolls a fresh slab and relocates live pages onto it. Once a round is BOUNDED it
+    /// can stop before every page has moved -- and rolling again next round would re-move
+    /// everything the last one moved, so the next round continues filling this slab instead.
+    /// That is what makes a bounded round make progress rather than shuffle the same pages.
+    /// Absent means no round is in flight, so the next one rolls.
+    ///
+    /// Not durable: a restart loses at most the knowledge that a round was open, and the next
+    /// round then rolls, which is correct if wasteful once.
+    compaction_rounds: Arc<RwLock<HashMap<ShardId, (u64, u64)>>>,
     concurrent_commit: Arc<std::sync::atomic::AtomicBool>,
     /// Whether loading a shard warms the in-memory cache tier from the page store as part of
     /// the load, rather than leaving it to be warmed in the background.

--- a/crates/temporalstore-rust/src/engine/compaction.rs
+++ b/crates/temporalstore-rust/src/engine/compaction.rs
@@ -4,6 +4,18 @@
 //! Compaction utility/policy/layout reporting helpers, split from engine.rs.
 use super::*;
 
+/// How many bytes one compaction round may relocate.
+///
+/// Compaction used to relocate EVERY live page of every model in one pass, holding the shard
+/// write lock throughout, so the stall grew with the store. A bound makes the round's cost a
+/// property of the constant rather than of the corpus.
+///
+/// Large enough that a store whose live pages fit inside it still compacts in a single round --
+/// which is every store the suite builds, so the existing assertions about what one compaction
+/// leaves behind are unchanged. A store bigger than this takes several rounds, and each one
+/// relocates pages that have not moved yet rather than re-moving the last round's work.
+pub(super) const COMPACTION_ROUND_BYTES: u64 = 256 * 1024 * 1024;
+
 pub(super) fn compaction_utility_report(
     page_store: &LocalBlockStore,
     shard: &ShardState,
@@ -212,6 +224,13 @@ pub(super) struct CompactionRewriteStats {
     pub(super) rewritten_page_refs: usize,
     pub(super) cold_page_rewrite_refs: usize,
     by_model: BTreeMap<String, ModelCompactionRewriteStats>,
+    /// The slab this round is filling. A page already there does not move.
+    target_block_slab_id: u64,
+    /// Bytes this round may still relocate. Saturates at zero, and a round that reaches zero
+    /// leaves the rest where it is for the next one.
+    budget_bytes: u64,
+    pub(super) skipped_by_budget: usize,
+    pub(super) skipped_by_budget_bytes: u64,
 }
 
 #[derive(Debug, Default)]
@@ -221,6 +240,40 @@ pub(super) struct ModelCompactionRewriteStats {
 }
 
 impl CompactionRewriteStats {
+    /// A round that relocates onto `target_block_slab_id` and may spend `budget_bytes`.
+    pub(super) fn for_round(target_block_slab_id: u64, budget_bytes: u64) -> Self {
+        Self {
+            target_block_slab_id,
+            budget_bytes,
+            ..Self::default()
+        }
+    }
+
+    /// Whether this address should move, charging the budget when it should.
+    ///
+    /// Two reasons not to move one: it is already on the slab this round is filling, which is
+    /// how a resumed round avoids redoing its predecessor's work; or the round has spent its
+    /// budget, which is how it stays bounded. Charged BEFORE the page is read, since reading is
+    /// the expensive half and the length is known from the address.
+    pub(super) fn should_relocate(&mut self, address: &BlockAddress) -> bool {
+        if address.block_slab_id == self.target_block_slab_id {
+            return false;
+        }
+        if address.length > self.budget_bytes {
+            self.skipped_by_budget = self.skipped_by_budget.saturating_add(1);
+            self.skipped_by_budget_bytes =
+                self.skipped_by_budget_bytes.saturating_add(address.length);
+            return false;
+        }
+        self.budget_bytes = self.budget_bytes.saturating_sub(address.length);
+        true
+    }
+
+    /// Whether the round stopped early, so the engine keeps it open for the next one.
+    pub(super) fn left_work_behind(&self) -> bool {
+        self.skipped_by_budget > 0
+    }
+
     fn record(&mut self, model_id: &str, cold_page: bool) {
         self.rewritten_page_refs = self.rewritten_page_refs.saturating_add(1);
         let model = self.by_model.entry(model_id.to_string()).or_default();
@@ -478,6 +531,9 @@ pub(super) fn compact_page_addresses<'a>(
     rewrite_stats: &mut CompactionRewriteStats,
 ) -> Result<(), Status> {
     for address in addresses {
+        if !rewrite_stats.should_relocate(address) {
+            continue;
+        }
         let cold_page = !page_memory_resident(cache, shard_id, address);
         let bytes = read_page_bytes(cache, page_store, shard_id, address).ok_or_else(|| {
             Status::error(
@@ -525,6 +581,9 @@ pub(super) fn compact_feature_page_addresses(
     let unique_addresses = unique_feature_page_addresses(series);
     let mut rewritten = HashMap::<BlockAddress, BlockAddress>::new();
     for old_address in unique_addresses {
+        if !rewrite_stats.should_relocate(&old_address) {
+            continue;
+        }
         let cold_page = !page_memory_resident(cache, shard_id, &old_address);
         let bytes =
             read_page_bytes(cache, page_store, shard_id, &old_address).ok_or_else(|| {

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -73,6 +73,7 @@ impl TemporalEngine {
             replay_installs: Arc::default(),
             maintenance_mirror: Arc::default(),
             quotas: Arc::new(RwLock::new(crate::engine::quota::QuotaTable::default())),
+            compaction_rounds: Arc::default(),
             concurrent_commit: Arc::new(std::sync::atomic::AtomicBool::new(true)),
             evict_sampled_lru: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             eager_cache_warm: Arc::new(std::sync::atomic::AtomicBool::new(

--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -372,6 +372,21 @@ fn expiry_scan_budget(limit: usize) -> usize {
     }
 
     pub fn compact_shard_pages(&self, shard_id: ShardId) -> Result<ShardCompactionReport, Status> {
+        self.compact_shard_pages_with_budget(shard_id, COMPACTION_ROUND_BYTES)
+    }
+
+    /// Compact, relocating at most `budget_bytes` of pages this round.
+    ///
+    /// The budget is a parameter and not only a constant so a test can force MANY rounds over a
+    /// handful of pages. A boundary that only appears once a store passes 256 MiB is a boundary
+    /// no test would reach, and the rules that make a bounded round correct -- a round resumes
+    /// onto the slab it was filling rather than rolling again, and rounds together still move
+    /// every page -- all live at that boundary.
+    pub(crate) fn compact_shard_pages_with_budget(
+        &self,
+        shard_id: ShardId,
+        budget_bytes: u64,
+    ) -> Result<ShardCompactionReport, Status> {
         let (start_routing_bucket, end_routing_bucket) = self
             .infos
             .read()
@@ -401,11 +416,31 @@ fn expiry_scan_budget(limit: usize) -> usize {
         let object_manager_before =
             object_manager_runtime_report(shard_id, shard, start_routing_bucket, end_routing_bucket);
         let bucket_layout_transition_count_before = object_manager_before.layout_transition_count;
-        let roll = self
-            .page_store
-            .roll_slab()
-            .map_err(|err| Status::error("page_compaction_failed", err.to_string()))?;
-        let mut rewrite_stats = CompactionRewriteStats::default();
+        // Start a round, or continue the one a budget cut short.
+        //
+        // A round rolls a fresh slab and relocates live pages onto it. Rolling AGAIN while a
+        // round is unfinished would re-move everything the last round moved -- the pages it just
+        // relocated would no longer be on the newest slab -- so a bounded round would shuffle
+        // rather than progress. Continuing to fill the same slab is what makes each round move
+        // pages that have not moved yet.
+        let resumed = self
+            .compaction_rounds
+            .read()
+            .expect("compaction round lock poisoned")
+            .get(&shard_id)
+            .copied();
+        let (previous_block_slab_id, target_block_slab_id) = match resumed {
+            Some(round) => round,
+            None => {
+                let roll = self
+                    .page_store
+                    .roll_slab()
+                    .map_err(|err| Status::error("page_compaction_failed", err.to_string()))?;
+                (roll.previous_block_slab_id, roll.new_block_slab_id)
+            }
+        };
+        let mut rewrite_stats =
+            CompactionRewriteStats::for_round(target_block_slab_id, budget_bytes);
 
         // Relocate every model's live pages onto the freshly rolled slab. A mid-way failure
         // (append ENOSPC / an unreadable torn page) is caught below so we can durably commit the
@@ -593,6 +628,20 @@ fn expiry_scan_budget(limit: usize) -> usize {
             return Err(err);
         }
 
+        // A round that spent its budget stays open, so the next one fills the same slab instead
+        // of rolling a new one and re-moving what this one moved. A round that relocated
+        // everything closes, and the next starts fresh.
+        {
+            let mut rounds = self
+                .compaction_rounds
+                .write()
+                .expect("compaction round lock poisoned");
+            if rewrite_stats.left_work_behind() {
+                rounds.insert(shard_id, (previous_block_slab_id, target_block_slab_id));
+            } else {
+                rounds.remove(&shard_id);
+            }
+        }
         rebuild_bucket_first_index(shard_id, shard, 0, u32::MAX);
         refresh_bucket_runtime_flags(shard);
         let after_slabs = collect_live_block_slab_ids(shard);
@@ -690,8 +739,10 @@ fn expiry_scan_budget(limit: usize) -> usize {
                 "stale segments left behind by moved indexes are reported as reclaimable".to_string(),
             ],
             model_layout_compaction_blockers,
-            previous_block_slab_id: roll.previous_block_slab_id,
-            compacted_block_slab_id: roll.new_block_slab_id,
+            previous_block_slab_id,
+            compacted_block_slab_id: target_block_slab_id,
+            pages_left_by_budget: rewrite_stats.skipped_by_budget,
+            bytes_left_by_budget: rewrite_stats.skipped_by_budget_bytes,
             rewritten_page_refs: rewrite_stats.rewritten_page_refs,
             cold_page_rewrite_refs: rewrite_stats.cold_page_rewrite_refs,
             object_page_pack_group_count: before

--- a/crates/temporalstore-rust/src/engine/reports.rs
+++ b/crates/temporalstore-rust/src/engine/reports.rs
@@ -63,6 +63,15 @@ pub struct ShardCompactionReport {
     #[serde(rename = "compacted_page_slab_id")]
     pub compacted_block_slab_id: u64,
     pub rewritten_page_refs: usize,
+    /// Pages this round left where they were because it spent its byte budget.
+    ///
+    /// Non-zero means the round did NOT finish, and the next one continues filling the same slab
+    /// rather than rolling a new one. Zero means compaction completed inside one round, which is
+    /// what every store small enough for the default budget does.
+    #[serde(default)]
+    pub pages_left_by_budget: usize,
+    #[serde(default)]
+    pub bytes_left_by_budget: u64,
     #[serde(default)]
     pub cold_page_rewrite_refs: usize,
     #[serde(default)]

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -8259,6 +8259,107 @@ fn what_a_thousand_records_hides() {
 /// dropping anything is flat, and walking everything is correct.
 ///
 ///   cargo test -p temporalstore-rust --lib emptied_buckets_are_dropped_without_walking_the_map -- --nocapture
+/// A bounded compaction round stops at its budget, RESUMES onto the same slab, and the rounds
+/// together still move every page.
+///
+/// The resume is what makes bounding work at all. A round rolls a fresh slab and relocates onto
+/// it; rolling AGAIN while a round is unfinished would re-move everything the last round moved,
+/// because those pages would no longer be on the newest slab. A budget without a resume shuffles
+/// the same pages and the tail never moves.
+///
+/// Note what "finished" means here, because it is not what it first appears: compaction relocates
+/// every live page BY DESIGN, so a completed compaction is followed by another that moves them
+/// all again. A round is finished when it left nothing behind for want of budget, which is what
+/// `pages_left_by_budget` reports.
+///
+/// Two controls. Every value must still read after EACH round -- a partial compaction that loses
+/// a page is the risk bounding introduces -- and the unbounded round must finish in ONE, which is
+/// what keeps the default behaviour of every store small enough for the real budget.
+#[test]
+fn a_bounded_compaction_round_resumes_instead_of_rolling_again() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        4 * 1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    const KEYS: u64 = 40;
+    for index in 0..KEYS {
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("bounded-{index}"),
+                value: vec![b'v'; 256],
+            },
+        });
+        assert!(response.status.ok, "write {index}: {:?}", response.status);
+    }
+
+    let reads_all_hold = |stage: &str| {
+        for index in 0..KEYS {
+            let response = engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringGet {
+                    key: format!("bounded-{index}"),
+                },
+            });
+            assert_eq!(
+                response.response,
+                CommandResponse::Bytes {
+                    value: Some(vec![b'v'; 256])
+                },
+                "{stage}: bounded-{index} did not read back"
+            );
+        }
+    };
+
+    // A tiny budget: several rounds before one finishes.
+    let mut rounds = 0;
+    let mut slabs_filled = std::collections::BTreeSet::new();
+    let mut relocated = 0usize;
+    loop {
+        let report = engine
+            .compact_shard_pages_with_budget(1, 300)
+            .expect("a bounded round succeeds");
+        rounds += 1;
+        relocated += report.rewritten_page_refs;
+        slabs_filled.insert(report.compacted_block_slab_id);
+        reads_all_hold(&format!("after round {rounds}"));
+        if report.pages_left_by_budget == 0 {
+            break;
+        }
+        assert!(rounds < 100, "the rounds are not converging: {rounds} of them");
+    }
+
+    assert!(
+        rounds > 2,
+        "a 300-byte budget should have taken several rounds, took {rounds}"
+    );
+    assert_eq!(
+        slabs_filled.len(),
+        1,
+        "every round of ONE compaction must fill the SAME slab; rolling again each round is what \
+         re-moves the previous round's work: {slabs_filled:?}"
+    );
+    assert!(
+        relocated >= KEYS as usize,
+        "the rounds together must move at least every key's page, moved {relocated}"
+    );
+
+    // The control: with the real budget a compaction finishes in one round, leaving nothing
+    // behind. This is what keeps every existing assertion about a single compaction true.
+    let whole = engine
+        .compact_shard_pages(1)
+        .expect("an unbounded round succeeds");
+    assert_eq!(
+        whole.pages_left_by_budget, 0,
+        "the shipped budget must finish a store this size in one round"
+    );
+    reads_all_hold("after the unbounded round");
+}
+
 #[test]
 fn emptied_buckets_are_dropped_without_walking_the_map() {
     use crate::types::ContextNode;


### PR DESCRIPTION
Compaction relocated **every** live page of every model in one pass, holding the shard write lock
throughout, so the stall grew with the store. A round now spends at most `COMPACTION_ROUND_BYTES`
and leaves the rest for the next one.

## A budget alone would not have worked

This is the whole design. A round rolls a fresh slab and relocates onto it. Rolling **again** while
a round is unfinished re-moves everything the last round moved — those pages are no longer on the
newest slab — so a budget without a resume shuffles the same pages and the tail never moves. It is
not merely inefficient; it makes no progress at all.

So the engine remembers the slab an unfinished round was filling, and the next round continues
filling it. A round that leaves nothing behind closes, and the next one rolls.

Two reasons a page does not move, and they are different: it already sits on the slab this round is
filling — which is how a resumed round avoids redoing its predecessor's work — or the round has
spent its budget. Charged from `address.length` **before** the page is read, since reading is the
expensive half and the length is already in hand.

## The partial state needed no new machinery

The success path already rebuilds the secondary views, takes the durability barrier and persists.
The failure path beside it already commits a consistent partial, with a comment saying *a later run
retries the not-yet-moved pages*. A budget stop is that, without the error.

## Observability

The report gains `pages_left_by_budget` / `bytes_left_by_budget`, so a caller can tell "nothing to
reclaim" from "not yet" — the reclaim path already reports its own `skipped_by_budget_count` this
way.

256 MiB is chosen so every store the suite builds still compacts in **one** round, which is why the
existing assertions about what a single compaction leaves behind are untouched.

## The test earned its keep twice

It first failed because I had assumed a converged compaction relocates *nothing*. It does not:
compaction relocates every live page by design, so a completed one is followed by another that
moves them all again — the observed cycle was rounds 1-5 filling slab 1 and draining slab 0, then
round 6 rolling to slab 2 and starting over. "Finished" can only mean *the round left nothing behind
for want of budget*, which is why the report field had to exist before the test could be written.

Then both mutations — ignoring the stored round, and never keeping one open — fail it on
**non-convergence**, which is exactly the shuffle-forever the resume prevents.

Its controls: every value must still read after **each** round, and the unbounded round must finish
in one.

## Gates

- compaction 23 passed, block store 61 passed, crash recovery 8 passed
- library: 1715 passed, 2 failed — both already failing on main

A first gate on this commit also showed `distributed_raft_chunks_large_sequence_add_under_default_entry_limit`.
It did not reproduce in isolation (0 of 8) and did not recur on a second full run; it is a
suite-interaction flake, not this change.
