### PR TITLE
A catalog dump keeps a minimum interval

### DIFF
--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -382,11 +382,21 @@ impl TemporalEngine {
 
     /// MANIFEST-CONFORMANCE FOLD threshold check: dump the index catalog when the undumped index-log
     /// gap has crossed `index_dump_wal_gap_bytes` (the index-meta dump gap
-    /// cadence). Returns whether a dump fired.
+    /// cadence) AND `index_dump_min_interval_ms` has passed since this shard last dumped.
+    /// Returns whether a dump fired.
+    ///
+    /// This caller has no cadence of its own -- it checks on every background round it runs --
+    /// so without the interval, a burst that keeps crossing the gap gets a whole-index
+    /// serialize every time it does.
     pub fn maybe_dump_index_catalog(&self, shard_id: ShardId) -> bool {
         let gap = crate::storage_config::index_dump_wal_gap_bytes();
         let undumped = self.index_log_store.undumped_len_since_dump(shard_id);
-        if !crate::index_log::should_dump_index_catalog(undumped, gap) {
+        if !crate::index_log::should_dump_index_catalog_now(
+            undumped,
+            gap,
+            self.index_log_store.ms_since_catalog_dump(shard_id),
+            crate::storage_config::index_dump_min_interval_ms(),
+        ) {
             return false;
         }
         self.dump_index_catalog(shard_id)
@@ -400,9 +410,15 @@ impl TemporalEngine {
         &self,
         shard_id: ShardId,
         gap_bytes: u64,
+        min_interval_ms: u64,
     ) -> bool {
         let undumped = self.index_log_store.undumped_len_since_dump(shard_id);
-        if !crate::index_log::should_dump_index_catalog(undumped, gap_bytes) {
+        if !crate::index_log::should_dump_index_catalog_now(
+            undumped,
+            gap_bytes,
+            self.index_log_store.ms_since_catalog_dump(shard_id),
+            min_interval_ms,
+        ) {
             return false;
         }
         self.dump_index_catalog(shard_id)
@@ -506,7 +522,12 @@ impl TemporalEngine {
     ) -> Option<super::reports::CatalogDumpReclaimReport> {
         let gap = crate::storage_config::index_dump_wal_gap_bytes();
         let undumped = self.index_log_store.undumped_len_since_dump(shard_id);
-        if !crate::index_log::should_dump_index_catalog(undumped, gap) {
+        if !crate::index_log::should_dump_index_catalog_now(
+            undumped,
+            gap,
+            self.index_log_store.ms_since_catalog_dump(shard_id),
+            crate::storage_config::index_dump_min_interval_ms(),
+        ) {
             return None;
         }
         self.dump_and_reclaim_index_logs(shard_id)
@@ -602,9 +623,15 @@ impl TemporalEngine {
         &self,
         shard_id: ShardId,
         gap_bytes: u64,
+        min_interval_ms: u64,
     ) -> Option<super::reports::CatalogDumpReclaimReport> {
         let undumped = self.index_log_store.undumped_len_since_dump(shard_id);
-        if !crate::index_log::should_dump_index_catalog(undumped, gap_bytes) {
+        if !crate::index_log::should_dump_index_catalog_now(
+            undumped,
+            gap_bytes,
+            self.index_log_store.ms_since_catalog_dump(shard_id),
+            min_interval_ms,
+        ) {
             return None;
         }
         self.dump_and_reclaim_index_logs(shard_id)

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -2261,7 +2261,7 @@ fn manifest_fold_threshold_dump_fires_only_past_the_gap_and_folds_the_catalog() 
     write_string(&engine, "k0", b"v0");
     // A gap far larger than the current index-log must NOT dump.
     assert!(
-        !engine.maybe_dump_index_catalog_with_gap_for_test(1, u64::MAX),
+        !engine.maybe_dump_index_catalog_with_gap_for_test(1, u64::MAX, 0),
         "no dump below the threshold"
     );
     assert!(
@@ -2273,7 +2273,7 @@ fn manifest_fold_threshold_dump_fires_only_past_the_gap_and_folds_the_catalog() 
         write_string(&engine, &format!("k{i}"), b"value");
     }
     assert!(
-        engine.maybe_dump_index_catalog_with_gap_for_test(1, 1),
+        engine.maybe_dump_index_catalog_with_gap_for_test(1, 1, 0),
         "dump fires once the undumped gap crosses the threshold"
     );
     let catalog = engine.index_log_store().latest_band_catalog(1).unwrap();
@@ -2284,8 +2284,63 @@ fn manifest_fold_threshold_dump_fires_only_past_the_gap_and_folds_the_catalog() 
     );
     // The watermark advanced: the undumped gap reset, so an immediate re-check does not re-dump.
     assert!(
-        !engine.maybe_dump_index_catalog_with_gap_for_test(1, u64::MAX),
+        !engine.maybe_dump_index_catalog_with_gap_for_test(1, u64::MAX, 0),
         "the dumped watermark advanced; no immediate re-dump"
+    );
+}
+
+/// A dump that just happened holds the next one off; one that never happened holds nothing.
+///
+/// The unit test pins the rule. This pins the WIRING: that the engine reads how long ago this
+/// shard dumped, that a completed dump is what sets it, and that a shard which has not dumped
+/// reports no time at all rather than zero. A rule can be right while nothing consults it.
+///
+/// The gap stays at 1 byte throughout, so the byte half of the decision is satisfied at every
+/// step and only the interval can change the answer. Without that, a "no dump" could just as
+/// well be the gap having reset -- which is exactly what the second assertion would otherwise
+/// be observing.
+#[test]
+fn a_catalog_dump_waits_out_the_interval_before_the_next_one() {
+    let dir = tempfile::tempdir().unwrap();
+    let page_dir = dir.path().join("pages");
+    let index_dir = dir.path().join("indexes");
+    let engine =
+        TemporalEngine::with_local_dirs(1 << 20, dir.path().join("cache"), &page_dir, &index_dir);
+    engine.load_shard(1);
+    for i in 0..8 {
+        write_string(&engine, &format!("k{i}"), b"value");
+    }
+    assert_eq!(
+        engine.index_log_store().ms_since_catalog_dump(1),
+        None,
+        "a shard that has not dumped has no elapsed time, not an elapsed time of zero"
+    );
+    // Never dumped, so a minute-long floor holds nothing off.
+    assert!(
+        engine.maybe_dump_index_catalog_with_gap_for_test(1, 1, 60_000),
+        "the first dump is never delayed"
+    );
+    assert!(
+        engine.index_log_store().ms_since_catalog_dump(1).is_some(),
+        "a completed dump records when it happened"
+    );
+
+    // Enough new deltas to cross a 1-byte gap again -- the byte half says yes.
+    for i in 8..16 {
+        write_string(&engine, &format!("k{i}"), b"value");
+    }
+    assert!(
+        engine.index_log_store().undumped_len_since_dump(1) >= 1,
+        "the second dump must be refused by the CLOCK, not by an empty gap"
+    );
+    assert!(
+        !engine.maybe_dump_index_catalog_with_gap_for_test(1, 1, 60_000),
+        "a dump moments after the last one waits for the interval"
+    );
+    // Same state, no floor: it fires. So what held it back was the interval and nothing else.
+    assert!(
+        engine.maybe_dump_index_catalog_with_gap_for_test(1, 1, 0),
+        "with no floor the same gap dumps immediately"
     );
 }
 
@@ -2305,7 +2360,7 @@ fn catalog_dump_reclaim_shrinks_both_logs_and_reload_stays_exact() {
         write_string(&engine, &format!("key-{i}"), format!("val-{i}").as_bytes());
     }
     let report = engine
-        .maybe_dump_and_reclaim_with_gap_for_test(1, 1)
+        .maybe_dump_and_reclaim_with_gap_for_test(1, 1, 0)
         .expect("past the gap, the dump + reclaim must fire");
     assert!(
         report.index_log_bytes_after < report.index_log_bytes_before,
@@ -2333,12 +2388,12 @@ fn catalog_dump_reclaim_shrinks_both_logs_and_reload_stays_exact() {
     // The watermark was re-marked at the post-reclaim length: no immediate re-dump, and the
     // cadence fires again once new writes regrow the gap (it must not wait for the file to
     // regrow past its PRE-reclaim size).
-    assert!(engine.maybe_dump_and_reclaim_with_gap_for_test(1, u64::MAX).is_none());
+    assert!(engine.maybe_dump_and_reclaim_with_gap_for_test(1, u64::MAX, 0).is_none());
     for i in 60..70 {
         write_string(&engine, &format!("key-{i}"), format!("val-{i}").as_bytes());
     }
     assert!(
-        engine.maybe_dump_and_reclaim_with_gap_for_test(1, 1).is_some(),
+        engine.maybe_dump_and_reclaim_with_gap_for_test(1, 1, 0).is_some(),
         "the cadence must keep firing after a reclaim shrank the log"
     );
     drop(engine);
@@ -2394,7 +2449,7 @@ fn catalog_dump_reclaim_pins_wal_records_holding_block_in_wal_pages() {
         write_string(&engine, &format!("sync-{i}"), format!("val-{i}").as_bytes());
     }
     let report = engine
-        .maybe_dump_and_reclaim_with_gap_for_test(1, 1)
+        .maybe_dump_and_reclaim_with_gap_for_test(1, 1, 0)
         .expect("dump + reclaim must fire");
     let floor = report
         .wal_retention_floor

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -1036,6 +1036,14 @@ struct IndexLogInner {
     /// on process restart, so the first post-restart cycle may dump once -- harmless (a dump only
     /// materializes durable state that is already recoverable).
     last_dumped_len_by_shard: HashMap<ShardId, u64>,
+    /// When the last catalog dump of a shard completed. Read by `ms_since_catalog_dump` to hold
+    /// the next dump off until the minimum interval has passed.
+    ///
+    /// An `Instant`, not a wall clock, because the question is "how long since", and a wall
+    /// clock that steps backwards would hold a dump off for as long as the step, while one that
+    /// steps forward would release it early. A shard never dumped in this process has no entry,
+    /// and no entry means no floor: the first dump after a restart is never delayed.
+    last_dumped_at_by_shard: HashMap<ShardId, std::time::Instant>,
     // Set only by Default: the store owns its minted scratch directory, and the last
     // clone's drop removes it. Never set for a caller-supplied root.
     scratch: Option<std::sync::Arc<crate::scratch::ScratchDirGuard>>,
@@ -1085,6 +1093,30 @@ pub fn should_dump_index_catalog(undumped_bytes: u64, gap_bytes: u64) -> bool {
     gap_bytes > 0 && undumped_bytes >= gap_bytes
 }
 
+/// The threshold decision above, with a floor on how often it may say yes.
+///
+/// `ms_since_dump` is `None` for a shard this process has never dumped, which is not a dump
+/// "0 ms ago" -- it is no dump at all, and nothing to wait behind. Getting that backwards would
+/// silence the first dump after every restart for the length of the interval, on exactly the
+/// engine that has the most to reclaim.
+///
+/// A zero interval is no floor at all, so the byte gap alone decides. That is what a test which
+/// is not exercising the timer passes, and it says so by passing it.
+pub fn should_dump_index_catalog_now(
+    undumped_bytes: u64,
+    gap_bytes: u64,
+    ms_since_dump: Option<u64>,
+    min_interval_ms: u64,
+) -> bool {
+    if !should_dump_index_catalog(undumped_bytes, gap_bytes) {
+        return false;
+    }
+    match ms_since_dump {
+        Some(elapsed) => elapsed >= min_interval_ms,
+        None => true,
+    }
+}
+
 impl LocalIndexLogStore {
     /// On-disk byte length of a shard's index-log file (0 if absent). Used as the "undumped
     /// length" signal for the threshold-dump cadence: the growth of this file since the last
@@ -1102,6 +1134,16 @@ impl LocalIndexLogStore {
     /// the undumped WAL length, and is the signal compared against `index_dump_wal_gap_bytes`
     /// to decide a threshold dump. A shard never dumped this process (or freshly restarted)
     /// reports the whole current length.
+    /// Milliseconds since this shard's last catalog dump, or `None` if it has not dumped in
+    /// this process. Feeds `should_dump_index_catalog_now`'s interval check.
+    pub fn ms_since_catalog_dump(&self, shard_id: ShardId) -> Option<u64> {
+        let inner = self.inner.lock().expect("index log lock poisoned");
+        inner
+            .last_dumped_at_by_shard
+            .get(&shard_id)
+            .map(|at| at.elapsed().as_millis() as u64)
+    }
+
     pub fn undumped_len_since_dump(&self, shard_id: ShardId) -> u64 {
         let inner = self.inner.lock().expect("index log lock poisoned");
         let current = index_log_path(&inner.root, shard_id)
@@ -1127,6 +1169,11 @@ impl LocalIndexLogStore {
             .map(|metadata| metadata.len())
             .unwrap_or(0);
         inner.last_dumped_len_by_shard.insert(shard_id, current);
+        // Stamped in the same call as the length, so the two halves of the cadence -- how much
+        // has accumulated, and how long ago -- can never disagree about which dump they describe.
+        inner
+            .last_dumped_at_by_shard
+            .insert(shard_id, std::time::Instant::now());
     }
 
     /// The most recent `MetaItem` anchor carrying a folded band catalog, or `None` if no
@@ -1156,6 +1203,7 @@ impl LocalIndexLogStore {
                 stats: IndexLogStats::default(),
                 last_sequence_by_shard: HashMap::new(),
                 last_dumped_len_by_shard: HashMap::new(),
+                last_dumped_at_by_shard: HashMap::new(),
                 scratch: None,
             })),
             flush_gates: Arc::new(crate::flush_gate::FlushRegistry::default()),
@@ -2680,6 +2728,29 @@ mod tests {
             .append_delta(6, Vec::new(), Vec::new(), Some(9), Some(newer.clone()), false, true)
             .unwrap();
         assert_eq!(store.latest_band_catalog(6).unwrap().unwrap(), newer);
+    }
+
+    /// The interval holds a second dump off, and a shard that has never dumped is not held.
+    ///
+    /// Both halves matter and neither alone is enough. A rule that only checked the gap would
+    /// satisfy "fires when enough has accumulated"; a rule that treated "never dumped" as
+    /// "dumped just now" would satisfy "holds a second dump off" while silencing the FIRST dump
+    /// of every restart -- the case with the most to reclaim and the one no interval should
+    /// ever cover.
+    #[test]
+    fn the_dump_interval_holds_off_a_second_dump_but_never_the_first() {
+        // Never dumped: no floor to wait behind, however long the interval.
+        assert!(should_dump_index_catalog_now(4096, 1024, None, 60_000));
+        // Dumped recently: the gap is crossed and the dump still waits.
+        assert!(!should_dump_index_catalog_now(4096, 1024, Some(200), 1_500));
+        // Waited long enough: it fires. The boundary itself counts as waited.
+        assert!(should_dump_index_catalog_now(4096, 1024, Some(1_500), 1_500));
+        assert!(should_dump_index_catalog_now(4096, 1024, Some(9_000), 1_500));
+        // A zero interval is no floor -- the gap alone decides, in both directions.
+        assert!(should_dump_index_catalog_now(4096, 1024, Some(0), 0));
+        assert!(!should_dump_index_catalog_now(512, 1024, Some(0), 0));
+        // And the interval never SUBSTITUTES for the gap: waiting is not accumulating.
+        assert!(!should_dump_index_catalog_now(512, 1024, Some(9_000), 1_500));
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/storage_config.rs
+++ b/crates/temporalstore-rust/src/storage_config.rs
@@ -14,6 +14,9 @@ pub const TS_INDEX_DUMP_WAL_GAP_BYTES: &str = "TS_INDEX_DUMP_WAL_GAP_BYTES";
 /// Previous name for [`TS_INDEX_DUMP_WAL_GAP_BYTES`], still honoured so a deployment that
 /// sets it keeps working. Read only when the current name is unset.
 pub const TS_INDEX_DUMP_GAP_BYTES_PREVIOUS_NAME: &str = "TS_INDEX_DUMP_OPLOG_GAP_BYTES";
+/// Shortest time between two catalog dumps of the same shard. The byte gap says a dump is
+/// WORTH doing; this says it is not worth doing AGAIN yet.
+pub const TS_INDEX_DUMP_MIN_INTERVAL_MS: &str = "TS_INDEX_DUMP_MIN_INTERVAL_MS";
 
 /// Previous name for [`TS_BLOCK_SLAB_TARGET_BYTES`], still honoured so a deployment that sets it
 /// keeps working. Read only when the current name is unset.
@@ -40,6 +43,25 @@ pub const DEFAULT_BLOCK_INDEX_CACHE_BYTES: u64 = 64 * 1024 * 1024;
 // MANIFEST-CONFORMANCE FOLD (TS_INDEX_CATALOG_FOLD). Matches the
 // default of 1 MiB.
 pub const DEFAULT_INDEX_DUMP_WAL_GAP_BYTES: u64 = 1024 * 1024;
+/// Shortest time between two catalog dumps of the same shard, in milliseconds.
+///
+/// The byte gap alone leaves the cadence in the hands of whoever calls the threshold check. One
+/// caller has a cadence of its own -- the proxy's reclaim thread polls on a timer -- and the
+/// other, the background storage cycle, has none: it checks on every round it runs. So under a
+/// write burst the gap can be crossed again immediately and the dump fires back to back, and a
+/// dump is not cheap: it serializes the whole served index, writes it durably, appends a folded
+/// anchor and then rewrites both logs.
+///
+/// A floor in TIME belongs with the threshold rather than with its callers, so that a caller
+/// that polls quickly cannot dump quickly. Waiting also makes each dump worth MORE: the deltas
+/// that arrive during the wait fold into the same base rather than into the next one -- the
+/// same reason the design being followed delays a dump until its log has accumulated.
+///
+/// 1.5 s, against the 1 s that design allows between two index-meta updates. Half a second more
+/// because what we do on a dump is the heavier of the two -- a whole-index serialize where
+/// theirs writes one meta record -- and because 1.5 s still bounds the extra log growth this
+/// costs to one and a half seconds of writes.
+pub const DEFAULT_INDEX_DUMP_MIN_INTERVAL_MS: u64 = 1_500;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StorageTuningConfig {
@@ -52,6 +74,7 @@ pub struct StorageTuningConfig {
     pub page_index_cache_bytes: u64,
     pub block_index_cache_bytes: u64,
     pub index_dump_wal_gap_bytes: u64,
+    pub index_dump_min_interval_ms: u64,
 }
 
 impl Default for StorageTuningConfig {
@@ -65,6 +88,7 @@ impl Default for StorageTuningConfig {
             page_index_cache_bytes: DEFAULT_PAGE_INDEX_CACHE_BYTES,
             block_index_cache_bytes: DEFAULT_BLOCK_INDEX_CACHE_BYTES,
             index_dump_wal_gap_bytes: DEFAULT_INDEX_DUMP_WAL_GAP_BYTES,
+            index_dump_min_interval_ms: DEFAULT_INDEX_DUMP_MIN_INTERVAL_MS,
         }
     }
 }
@@ -114,6 +138,10 @@ impl StorageTuningConfig {
                     .or_else(|| get(TS_INDEX_DUMP_GAP_BYTES_PREVIOUS_NAME)),
                 defaults.index_dump_wal_gap_bytes,
             ),
+            index_dump_min_interval_ms: parse_u64(
+                get(TS_INDEX_DUMP_MIN_INTERVAL_MS),
+                defaults.index_dump_min_interval_ms,
+            ),
         }
     }
 
@@ -127,7 +155,7 @@ impl StorageTuningConfig {
             .max(self.stream_max_blob_size)
     }
 
-    pub fn env_names() -> [&'static str; 10] {
+    pub fn env_names() -> [&'static str; 11] {
         [
             TS_CONTEXT_PAGE_TARGET_BYTES,
             TS_BLOCK_SLAB_TARGET_BYTES,
@@ -139,6 +167,7 @@ impl StorageTuningConfig {
             TS_BLOCK_INDEX_CACHE_BYTES,
             TS_INDEX_DUMP_WAL_GAP_BYTES,
             TS_INDEX_DUMP_GAP_BYTES_PREVIOUS_NAME,
+            TS_INDEX_DUMP_MIN_INTERVAL_MS,
         ]
     }
 }
@@ -157,6 +186,12 @@ pub fn effective_block_slab_target_bytes() -> u64 {
 /// default. Only consulted by the catalog fold's threshold dump.
 pub fn index_dump_wal_gap_bytes() -> u64 {
     StorageTuningConfig::from_env().index_dump_wal_gap_bytes
+}
+
+/// Shortest time (ms) between two catalog dumps of the same shard. A zero disables the floor,
+/// which is what every test that is not exercising the timer passes.
+pub fn index_dump_min_interval_ms() -> u64 {
+    StorageTuningConfig::from_env().index_dump_min_interval_ms
 }
 
 fn parse_u64(value: Option<String>, default: u64) -> u64 {
@@ -217,6 +252,7 @@ mod tests {
             DEFAULT_INDEX_DUMP_WAL_GAP_BYTES
         );
         assert_eq!(config.index_dump_wal_gap_bytes, 1024 * 1024);
+        assert_eq!(config.index_dump_min_interval_ms, 1_500);
     }
 
     #[test]
@@ -235,6 +271,7 @@ mod tests {
                 "TS_BLOCK_INDEX_CACHE_BYTES",
                 "TS_INDEX_DUMP_WAL_GAP_BYTES",
                 "TS_INDEX_DUMP_OPLOG_GAP_BYTES",
+                "TS_INDEX_DUMP_MIN_INTERVAL_MS",
             ]
         );
     }


### PR DESCRIPTION
The catalog dump fired on one signal: how much index log had accumulated since the last one. That left the cadence in the hands of whoever called the check — and one caller has no cadence of its own.

| caller | how often it checks |
|---|---|
| the proxy's log-reclaim thread | sleeps a second between polls |
| the background storage cycle | **every round it runs** |

A dump is not cheap: it serializes the whole served index, writes it durably, appends a folded anchor and then rewrites both logs. So a write burst that crosses the byte threshold again immediately got a dump again immediately.

## What changed

A floor in **time**, on the threshold itself rather than on its callers, so a caller that polls quickly cannot dump quickly. Waiting also makes each dump worth more: the deltas that arrive during the wait fold into the same base rather than into the next one.

`TS_INDEX_DUMP_MIN_INTERVAL_MS`, default **1500 ms**. It is a monotonic `Instant`, not a wall clock — the question is how long *since*, and a clock that steps backwards would hold a dump off for the length of the step while one that steps forward would release it early. It is stamped in `mark_catalog_dumped`, in the same call as the dumped-length watermark, so the two halves of the cadence can never disagree about which dump they describe.

**A shard this process has never dumped has no stamp, and no stamp means no floor.** That is not the same as a dump zero milliseconds ago; inverting it would silence the *first* dump after every restart, on exactly the engine that has the most to reclaim.

The four existing callers of the two test-only threshold variants now pass a zero interval explicitly. They were relying on there being no floor at all; saying so is honest, and it leaves the floor to the tests written for it.

## Evidence

Four mutations, all killed — and the last two each kill exactly one of the two tests, which is the discrimination the pair exists to give: the unit test owns the rule, the engine test owns the wiring.

```
KILLED   no floor at all: the interval is never consulted     0 passed; 2 failed
KILLED   never dumped is read as dumped just now              0 passed; 2 failed
KILLED   the boundary itself does not count as waited         1 passed; 1 failed
KILLED   a completed dump does not record when it happened    1 passed; 1 failed
```

Full library suite, single-threaded: **1718 passed, 2 failed**. Both failures — `storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_flags` and `durable_bytes_never_exceed_the_bytes_the_log_holds` — fail identically on a clean `main` worktree at the same assertions, and the first also fails with this change's default set to 0 (behaviourally inert). No new failures.

## Scope

This is the base-index dump, and only that one. The bucket dump already picks its round: dirty buckets sorted by how long since each last dumped, truncated to a per-round budget, and skipped entirely while too little has accumulated to be worth coalescing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
