### PR TITLE
The post-dump index-log sweep earns its rewrite

### DIFF
--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -539,13 +539,31 @@ impl TemporalEngine {
         &self,
         shard_id: ShardId,
     ) -> Option<super::reports::CatalogDumpReclaimReport> {
+        self.dump_and_reclaim_index_logs_with_min_reclaimable(
+            shard_id,
+            crate::storage_config::index_gc_min_reclaimable_bytes(),
+        )
+    }
+
+    /// [`dump_and_reclaim_index_logs`](Self::dump_and_reclaim_index_logs) with the index-log
+    /// sweep's threshold given rather than read from configuration.
+    ///
+    /// A threshold that only ever comes from the environment cannot be varied by a test without
+    /// writing to the environment of the whole process, which is shared with every other test in
+    /// the binary. Passing it makes "this test is not exercising the threshold" something the
+    /// test says rather than something it assumes.
+    pub(crate) fn dump_and_reclaim_index_logs_with_min_reclaimable(
+        &self,
+        shard_id: ShardId,
+        min_reclaimable_bytes: u64,
+    ) -> Option<super::reports::CatalogDumpReclaimReport> {
         let (wal_anchor, meta_sequence) = self.dump_index_catalog_anchored(shard_id)?;
         // Index-log first: drop every record the durable base already reflects (per-record WAL
         // anchor at or below the dump's), keeping the folded catalog anchor and any delta a
         // concurrent writer landed after the dump serialized.
         let index_gc = self
             .index_log_store
-            .gc_reflected_before_anchor(shard_id, wal_anchor, meta_sequence)
+            .gc_reflected_before_anchor(shard_id, wal_anchor, meta_sequence, min_reclaimable_bytes)
             .ok();
         // The sweep rewrote (shrank) the log file; re-mark the dumped watermark so the next
         // threshold measures growth from the POST-reclaim length. Without this the gap signal
@@ -599,6 +617,10 @@ impl TemporalEngine {
                 .as_ref()
                 .map(|report| report.bytes_after)
                 .unwrap_or_default(),
+            index_log_rewrite_skipped: index_gc
+                .as_ref()
+                .map(|report| report.rewrite_skipped)
+                .unwrap_or_default(),
             wal_records_removed: wal_gc
                 .as_ref()
                 .map(|report| report.records_removed)
@@ -624,6 +646,7 @@ impl TemporalEngine {
         shard_id: ShardId,
         gap_bytes: u64,
         min_interval_ms: u64,
+        min_reclaimable_bytes: u64,
     ) -> Option<super::reports::CatalogDumpReclaimReport> {
         let undumped = self.index_log_store.undumped_len_since_dump(shard_id);
         if !crate::index_log::should_dump_index_catalog_now(
@@ -634,7 +657,7 @@ impl TemporalEngine {
         ) {
             return None;
         }
-        self.dump_and_reclaim_index_logs(shard_id)
+        self.dump_and_reclaim_index_logs_with_min_reclaimable(shard_id, min_reclaimable_bytes)
     }
 
     pub(super) fn persist_index_bytes(

--- a/crates/temporalstore-rust/src/engine/reports.rs
+++ b/crates/temporalstore-rust/src/engine/reports.rs
@@ -2888,6 +2888,11 @@ pub struct CatalogDumpReclaimReport {
     pub index_log_records_removed: usize,
     pub index_log_bytes_before: u64,
     pub index_log_bytes_after: u64,
+    /// The index-log sweep read the log and left it alone: nothing was reclaimable, or too
+    /// little was to be worth the rewrite. Without this a caller cannot tell a log that had
+    /// nothing to give from one that was rewritten for nothing -- they report identical bytes.
+    #[serde(default)]
+    pub index_log_rewrite_skipped: bool,
     pub wal_records_removed: usize,
     pub wal_bytes_before: u64,
     pub wal_bytes_after: u64,

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -2360,7 +2360,7 @@ fn catalog_dump_reclaim_shrinks_both_logs_and_reload_stays_exact() {
         write_string(&engine, &format!("key-{i}"), format!("val-{i}").as_bytes());
     }
     let report = engine
-        .maybe_dump_and_reclaim_with_gap_for_test(1, 1, 0)
+        .maybe_dump_and_reclaim_with_gap_for_test(1, 1, 0, 0)
         .expect("past the gap, the dump + reclaim must fire");
     assert!(
         report.index_log_bytes_after < report.index_log_bytes_before,
@@ -2388,12 +2388,12 @@ fn catalog_dump_reclaim_shrinks_both_logs_and_reload_stays_exact() {
     // The watermark was re-marked at the post-reclaim length: no immediate re-dump, and the
     // cadence fires again once new writes regrow the gap (it must not wait for the file to
     // regrow past its PRE-reclaim size).
-    assert!(engine.maybe_dump_and_reclaim_with_gap_for_test(1, u64::MAX, 0).is_none());
+    assert!(engine.maybe_dump_and_reclaim_with_gap_for_test(1, u64::MAX, 0, 0).is_none());
     for i in 60..70 {
         write_string(&engine, &format!("key-{i}"), format!("val-{i}").as_bytes());
     }
     assert!(
-        engine.maybe_dump_and_reclaim_with_gap_for_test(1, 1, 0).is_some(),
+        engine.maybe_dump_and_reclaim_with_gap_for_test(1, 1, 0, 0).is_some(),
         "the cadence must keep firing after a reclaim shrank the log"
     );
     drop(engine);
@@ -2449,7 +2449,7 @@ fn catalog_dump_reclaim_pins_wal_records_holding_block_in_wal_pages() {
         write_string(&engine, &format!("sync-{i}"), format!("val-{i}").as_bytes());
     }
     let report = engine
-        .maybe_dump_and_reclaim_with_gap_for_test(1, 1, 0)
+        .maybe_dump_and_reclaim_with_gap_for_test(1, 1, 0, 0)
         .expect("dump + reclaim must fire");
     let floor = report
         .wal_retention_floor

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -1015,6 +1015,15 @@ pub struct IndexLogGcReport {
     pub budget_exhausted: bool,
     pub bytes_before: u64,
     pub bytes_after: u64,
+    /// On-disk bytes the sweep found reclaimable, whether or not it rewrote the log for them.
+    #[serde(default)]
+    pub reclaimable_bytes: u64,
+    /// The sweep read the log, decided what was reclaimable, and did NOT rewrite it -- because
+    /// nothing was reclaimable, or too little was to be worth the barrier. Distinguishes a log
+    /// that had nothing to give from one that was rewritten and gave nothing, which otherwise
+    /// look identical: both report zero records removed and the same bytes before and after.
+    #[serde(default)]
+    pub rewrite_skipped: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -1672,9 +1681,10 @@ impl LocalIndexLogStore {
         let mut removed_this_round = 0usize;
         let mut removable_records_before_budget = 0usize;
         let mut retained = Vec::new();
+        let mut reclaimable_bytes = 0u64;
         // By frame, not by line: see the fold path above.
         let mut reader = reader;
-        while let Some((_, payload)) = crate::log_framing::read_frame(&mut reader)? {
+        while let Some((frame_bytes, payload)) = crate::log_framing::read_frame(&mut reader)? {
             if payload.iter().all(|byte| byte.is_ascii_whitespace()) {
                 continue;
             }
@@ -1697,6 +1707,7 @@ impl LocalIndexLogStore {
                 retained.push(payload);
             } else {
                 removed_this_round = removed_this_round.saturating_add(1);
+                reclaimable_bytes = reclaimable_bytes.saturating_add(frame_bytes as u64);
             }
         }
 
@@ -1725,6 +1736,10 @@ impl LocalIndexLogStore {
                 && removable_records_before_budget > max_entries_per_round,
             bytes_before,
             bytes_after,
+            reclaimable_bytes,
+            // This sweep is only reached once a caller has decided it is worth taking; the
+            // threshold that can decline one lives on the post-dump sweep.
+            rewrite_skipped: false,
         })
     }
 
@@ -1747,11 +1762,15 @@ impl LocalIndexLogStore {
     /// load-time catalog seed always survives. Position (`sequence < meta_sequence`) still
     /// bounds the sweep so a record appended AFTER the dump with a stale-looking anchor is never
     /// touched.
+    /// `min_reclaimable_bytes` is the least the sweep must be able to reclaim before it will
+    /// rewrite the log. Below it -- and always when nothing at all is reclaimable -- the log is
+    /// left exactly as it is and the report says so.
     pub fn gc_reflected_before_anchor(
         &self,
         shard_id: ShardId,
         wal_anchor: u64,
         meta_sequence: u64,
+        min_reclaimable_bytes: u64,
     ) -> Result<IndexLogGcReport, IndexLogError> {
         // A SECOND reader of the same on-disk record, so it has to know every spelling the
         // record has ever used. It previously named the long forms only; when those were
@@ -1783,7 +1802,11 @@ impl LocalIndexLogStore {
         let mut retained = Vec::new();
         // By frame, not by line: see the fold path above.
         let mut reader = reader;
-        while let Some((_, payload)) = crate::log_framing::read_frame(&mut reader)? {
+        // `read_frame` hands back how many bytes the record OCCUPIED, which this loop used to
+        // discard. It is the exact on-disk size of what a rewrite would drop, so the threshold
+        // below is measured in the same bytes the file is measured in rather than in payloads.
+        let mut reclaimable_bytes = 0u64;
+        while let Some((frame_bytes, payload)) = crate::log_framing::read_frame(&mut reader)? {
             if payload.iter().all(|byte| byte.is_ascii_whitespace()) {
                 continue;
             }
@@ -1794,7 +1817,30 @@ impl LocalIndexLogStore {
             let reflected = probe.applied_wal_sequence.unwrap_or(0) <= wal_anchor;
             if probe.sequence >= meta_sequence || !reflected {
                 retained.push(payload);
+            } else {
+                reclaimable_bytes = reclaimable_bytes.saturating_add(frame_bytes as u64);
             }
+        }
+
+        // Rewriting while retaining every record writes the file back byte for byte, so the
+        // barrier and the rename buy nothing at all -- that half is arithmetic, not policy. The
+        // threshold is the policy: a rewrite that reclaims a handful of bytes still costs a full
+        // read, a full write and an fsync, and the post-dump sweep runs on every dump.
+        let removable = records_before.saturating_sub(retained.len());
+        if removable == 0 || reclaimable_bytes < min_reclaimable_bytes {
+            return Ok(IndexLogGcReport {
+                shard_id,
+                retain_from_sequence: meta_sequence,
+                records_before,
+                records_after: records_before,
+                records_removed: 0,
+                removable_records_before_budget: removable,
+                bytes_before,
+                bytes_after: bytes_before,
+                reclaimable_bytes,
+                rewrite_skipped: true,
+                ..IndexLogGcReport::default()
+            });
         }
 
         let temp_path = path.with_extension("jsonl.tmp");
@@ -1821,6 +1867,8 @@ impl LocalIndexLogStore {
             budget_exhausted: false,
             bytes_before,
             bytes_after,
+            reclaimable_bytes,
+            rewrite_skipped: false,
         })
     }
 
@@ -2397,6 +2445,91 @@ mod tests {
         assert_eq!(records[1].meta.as_ref().unwrap().start_wal_sequence, 42);
     }
 
+    /// The sweep only rewrites the log when the rewrite is worth taking.
+    ///
+    /// The middle pair carries the weight: the SAME log, with the same records reclaimable, is
+    /// left alone one byte above what it can give and rewritten at exactly what it can give.
+    /// Without that pairing, "it did not rewrite" could just as well mean "there was nothing to
+    /// remove" -- which is the last state, and is asserted on its own terms -- and "enough"
+    /// could quietly mean "more than enough", which a mutation to a strict comparison survived
+    /// until those two thresholds sat either side of the boundary.
+    ///
+    /// The first two states are proved by the log itself and not only by the report: a rewrite
+    /// there removes three of four records, so the surviving count and the byte total say
+    /// plainly whether it happened. The third cannot be proved that way -- a rewrite retaining
+    /// every record writes the file back byte for byte -- which is why the field exists.
+    #[test]
+    fn a_sweep_rewrites_the_log_only_when_the_rewrite_is_worth_taking() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalIndexLogStore::new(dir.path());
+        for key in ["a", "b", "c"] {
+            store
+                .append_delta(9, vec![page_item(1, key, false)], Vec::new(), Some(2), None, false, true)
+                .unwrap();
+        }
+        let meta_sequence = store
+            .append_delta(9, Vec::new(), Vec::new(), Some(2), Some(MetaItem::default()), false, true)
+            .unwrap();
+
+        // 1. Reclaimable, but nowhere near a megabyte of it: the log is left exactly as it is.
+        let held = store
+            .gc_reflected_before_anchor(9, 2, meta_sequence, 1 << 20)
+            .unwrap();
+        assert!(held.rewrite_skipped, "a sweep this small must not rewrite the log");
+        assert_eq!(held.records_removed, 0);
+        assert_eq!(
+            held.removable_records_before_budget, 3,
+            "and it must still report what it COULD have removed, or the skip is unreadable"
+        );
+        assert!(
+            held.reclaimable_bytes > 0,
+            "the bytes it declined to reclaim are the reason it declined"
+        );
+        assert_eq!(held.bytes_after, held.bytes_before);
+        assert_eq!(
+            store.read_delta_records(9, 0).unwrap().len(),
+            4,
+            "every record is still there"
+        );
+
+        // 1b. One byte more than it can reclaim is still too much to ask: the near side of the
+        //     boundary, without which "enough" could quietly mean "strictly more than enough".
+        let short = store
+            .gc_reflected_before_anchor(9, 2, meta_sequence, held.reclaimable_bytes + 1)
+            .unwrap();
+        assert!(
+            short.rewrite_skipped,
+            "one byte short of the threshold is short of the threshold"
+        );
+
+        // 2. The same log, the same records reclaimable, and a threshold it meets EXACTLY: it
+        //    rewrites. Reaching the threshold is enough; it does not have to be exceeded.
+        let swept = store
+            .gc_reflected_before_anchor(9, 2, meta_sequence, held.reclaimable_bytes)
+            .unwrap();
+        assert!(
+            !swept.rewrite_skipped,
+            "a sweep that meets the threshold exactly must rewrite"
+        );
+        assert_eq!(swept.records_removed, 3);
+        assert!(swept.bytes_after < swept.bytes_before);
+        assert_eq!(
+            swept.reclaimable_bytes, held.reclaimable_bytes,
+            "the same log offers the same bytes either way -- only the decision changed"
+        );
+        assert_eq!(store.read_delta_records(9, 0).unwrap().len(), 1);
+
+        // 3. Nothing left to reclaim: skipped even with the threshold turned off, because a
+        //    rewrite that retains every record writes the file back byte for byte.
+        let empty = store.gc_reflected_before_anchor(9, 2, meta_sequence, 0).unwrap();
+        assert!(
+            empty.rewrite_skipped,
+            "a sweep with nothing to remove must not take a barrier for it"
+        );
+        assert_eq!(empty.removable_records_before_budget, 0);
+        assert_eq!(empty.reclaimable_bytes, 0);
+    }
+
     #[test]
     fn gc_reflected_before_anchor_keeps_unreflected_deltas_and_the_catalog_anchor() {
         // Content-based post-dump sweep: records whose WAL anchor the durable base already
@@ -2426,7 +2559,7 @@ mod tests {
             .append_delta(7, Vec::new(), Vec::new(), Some(2), Some(meta), false, true)
             .unwrap();
 
-        let report = store.gc_reflected_before_anchor(7, 2, meta_sequence).unwrap();
+        let report = store.gc_reflected_before_anchor(7, 2, meta_sequence, 0).unwrap();
         assert_eq!(report.records_before, 4);
         assert_eq!(report.records_removed, 2, "the whole-index line and the covered delta go");
         assert!(report.bytes_after < report.bytes_before);

--- a/crates/temporalstore-rust/src/storage_config.rs
+++ b/crates/temporalstore-rust/src/storage_config.rs
@@ -17,6 +17,9 @@ pub const TS_INDEX_DUMP_GAP_BYTES_PREVIOUS_NAME: &str = "TS_INDEX_DUMP_OPLOG_GAP
 /// Shortest time between two catalog dumps of the same shard. The byte gap says a dump is
 /// WORTH doing; this says it is not worth doing AGAIN yet.
 pub const TS_INDEX_DUMP_MIN_INTERVAL_MS: &str = "TS_INDEX_DUMP_MIN_INTERVAL_MS";
+/// How many reclaimable bytes the index log must be carrying before the post-dump sweep is worth
+/// rewriting it for.
+pub const TS_INDEX_GC_MIN_RECLAIMABLE_BYTES: &str = "TS_INDEX_GC_MIN_RECLAIMABLE_BYTES";
 
 /// Previous name for [`TS_BLOCK_SLAB_TARGET_BYTES`], still honoured so a deployment that sets it
 /// keeps working. Read only when the current name is unset.
@@ -62,6 +65,20 @@ pub const DEFAULT_INDEX_DUMP_WAL_GAP_BYTES: u64 = 1024 * 1024;
 /// theirs writes one meta record -- and because 1.5 s still bounds the extra log growth this
 /// costs to one and a half seconds of writes.
 pub const DEFAULT_INDEX_DUMP_MIN_INTERVAL_MS: u64 = 1_500;
+/// Reclaimable bytes the index log must hold before the post-dump sweep rewrites it.
+///
+/// The sweep reads the whole log, decides which records the durable base already reflects, and
+/// writes the survivors to a temp file which it fsyncs and renames over the original. The READ
+/// is what decides; the write, the barrier and the rename are what it costs. When little is
+/// reclaimable that cost buys almost nothing, and it is paid on every dump.
+///
+/// 768 KiB, against the 1 MiB the design being followed requires before its index GC runs. Below
+/// its own threshold that design skips the round entirely, for the same reason.
+///
+/// A zero disables the threshold, so any reclaimable byte at all triggers a rewrite. Nothing
+/// reclaimable NEVER triggers one regardless: rewriting a log while retaining every record
+/// produces the same bytes it started with, so that is arithmetic rather than policy.
+pub const DEFAULT_INDEX_GC_MIN_RECLAIMABLE_BYTES: u64 = 768 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StorageTuningConfig {
@@ -75,6 +92,7 @@ pub struct StorageTuningConfig {
     pub block_index_cache_bytes: u64,
     pub index_dump_wal_gap_bytes: u64,
     pub index_dump_min_interval_ms: u64,
+    pub index_gc_min_reclaimable_bytes: u64,
 }
 
 impl Default for StorageTuningConfig {
@@ -89,6 +107,7 @@ impl Default for StorageTuningConfig {
             block_index_cache_bytes: DEFAULT_BLOCK_INDEX_CACHE_BYTES,
             index_dump_wal_gap_bytes: DEFAULT_INDEX_DUMP_WAL_GAP_BYTES,
             index_dump_min_interval_ms: DEFAULT_INDEX_DUMP_MIN_INTERVAL_MS,
+            index_gc_min_reclaimable_bytes: DEFAULT_INDEX_GC_MIN_RECLAIMABLE_BYTES,
         }
     }
 }
@@ -142,6 +161,10 @@ impl StorageTuningConfig {
                 get(TS_INDEX_DUMP_MIN_INTERVAL_MS),
                 defaults.index_dump_min_interval_ms,
             ),
+            index_gc_min_reclaimable_bytes: parse_u64(
+                get(TS_INDEX_GC_MIN_RECLAIMABLE_BYTES),
+                defaults.index_gc_min_reclaimable_bytes,
+            ),
         }
     }
 
@@ -155,7 +178,7 @@ impl StorageTuningConfig {
             .max(self.stream_max_blob_size)
     }
 
-    pub fn env_names() -> [&'static str; 11] {
+    pub fn env_names() -> [&'static str; 12] {
         [
             TS_CONTEXT_PAGE_TARGET_BYTES,
             TS_BLOCK_SLAB_TARGET_BYTES,
@@ -168,6 +191,7 @@ impl StorageTuningConfig {
             TS_INDEX_DUMP_WAL_GAP_BYTES,
             TS_INDEX_DUMP_GAP_BYTES_PREVIOUS_NAME,
             TS_INDEX_DUMP_MIN_INTERVAL_MS,
+            TS_INDEX_GC_MIN_RECLAIMABLE_BYTES,
         ]
     }
 }
@@ -192,6 +216,12 @@ pub fn index_dump_wal_gap_bytes() -> u64 {
 /// which is what every test that is not exercising the timer passes.
 pub fn index_dump_min_interval_ms() -> u64 {
     StorageTuningConfig::from_env().index_dump_min_interval_ms
+}
+
+/// Reclaimable bytes the index log must hold before the post-dump sweep rewrites it. A zero
+/// disables the threshold, which is what a test that is not exercising it passes.
+pub fn index_gc_min_reclaimable_bytes() -> u64 {
+    StorageTuningConfig::from_env().index_gc_min_reclaimable_bytes
 }
 
 fn parse_u64(value: Option<String>, default: u64) -> u64 {
@@ -253,6 +283,7 @@ mod tests {
         );
         assert_eq!(config.index_dump_wal_gap_bytes, 1024 * 1024);
         assert_eq!(config.index_dump_min_interval_ms, 1_500);
+        assert_eq!(config.index_gc_min_reclaimable_bytes, 768 * 1024);
     }
 
     #[test]
@@ -272,6 +303,7 @@ mod tests {
                 "TS_INDEX_DUMP_WAL_GAP_BYTES",
                 "TS_INDEX_DUMP_OPLOG_GAP_BYTES",
                 "TS_INDEX_DUMP_MIN_INTERVAL_MS",
+                "TS_INDEX_GC_MIN_RECLAIMABLE_BYTES",
             ]
         );
     }


### PR DESCRIPTION
The sweep that runs after a catalog dump read the whole index log, worked out which records the durable base already reflects, and then wrote the survivors to a temp file, fsynced it, and renamed it over the original. **Always** — even when the survivors were every record it had just read.

That case is not rare, it is the steady state: a dump that captured nothing new leaves nothing to remove, and the sweep then writes the file back byte for byte and takes a barrier for it. The read is what decides; the write, the fsync and the rename are what it costs.

## Two rules, different in kind

| rule | why |
|---|---|
| nothing reclaimable → never rewrite | arithmetic: retaining every record reproduces the file exactly |
| below `TS_INDEX_GC_MIN_RECLAIMABLE_BYTES` → do not rewrite | policy: **768 KiB**, against the megabyte the design being followed requires before its own index GC runs a round |

The measure was already there and being discarded — `read_frame` hands back how many bytes each record occupied and the loop bound it to an underscore. The threshold is now counted in the same bytes the file is measured in, not in payload lengths that omit the framing.

## Reports

`IndexLogGcReport` gained `reclaimable_bytes` and `rewrite_skipped`, because the old shape could not tell two outcomes apart: a sweep that found nothing to remove and a sweep that ran for nothing both reported zero records removed and identical bytes on either side. `CatalogDumpReclaimReport` carries the skip up to its caller.

The budgeted sweep reports `reclaimable_bytes` too. It measures the same thing over the same records, and a zero there would have had to mean "not measured".

## Testing

The threshold is passed in rather than read from configuration inside the sweep — a value that only ever comes from the environment cannot be varied by a test without writing to the environment of a process shared with every other test in the binary. Four existing call sites now pass a zero, which *says* they are not exercising the threshold rather than assuming there is none.

```
KILLED   the sweep always rewrites
KILLED   only nothing-to-do is skipped, the threshold is ignored
KILLED   only the threshold is honoured, a no-op rewrite still runs
KILLED   a skipped sweep reports that it rewrote
KILLED   the threshold is a strict greater-than
```

The last one **survived the first version of the test**, because both thresholds it used sat far from the boundary. It is killed now by a pair that straddles it: one byte more than the log can give must decline, and exactly what it can give must rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
