### PR TITLE
The redundancy sweep searches a few joined haystacks, not hundreds of texts

### DIFF
--- a/tools/matrixark_mcp_context_pack.py
+++ b/tools/matrixark_mcp_context_pack.py
@@ -1367,6 +1367,60 @@ def _normalized_item_text(item: Json) -> str:
     return " ".join(text.split()).strip().lower().rstrip(".")
 
 
+# Joined between pack texts so a match cannot span two of them. Normalized record text is
+# whitespace-collapsed lowercase prose and never contains a NUL.
+_PACK_TEXT_SEPARATOR = "\x00"
+
+# How much text to seal into one haystack. Larger means fewer searches per item and more bytes
+# rescanned by each; 64 KiB keeps a full 1,000-ref pack to a handful of searches per item.
+_PACK_HAYSTACK_BYTES = 65536
+
+
+def _drop_redundant_pairwise(
+    groups: list[Json],
+    items: list[Json],
+    texts: list[str],
+    lengths: list[int],
+    order: list[int],
+) -> list[Json]:
+    """The one-text-at-a-time sweep, for a pack that cannot use a joined haystack.
+
+    Same answer, and the same length pruning; it simply compares against each longer text on its
+    own instead of against several joined together.
+    """
+    count = len(items)
+    negated = [-lengths[index] for index in order]
+    redundant = [False] * count
+    any_redundant = False
+    for index in range(count):
+        text = texts[index]
+        length = lengths[index]
+        if not text or length < 8:
+            continue
+        longer = bisect.bisect_left(negated, -length)
+        for position in range(longer):
+            other = order[position]
+            if redundant[other]:
+                continue
+            if text in texts[other]:
+                redundant[index] = True
+                any_redundant = True
+                break
+    if not any_redundant:
+        return groups
+    dropped = {id(items[index]) for index in range(count) if redundant[index]}
+    surviving: list[Json] = []
+    for group in groups:
+        kept = [item for item in (group.get("items") or []) if id(item) not in dropped]
+        if not kept:
+            continue
+        trimmed = dict(group)
+        trimmed["items"] = kept
+        trimmed["n"] = len(kept)
+        surviving.append(trimmed)
+    return surviving
+
+
 def drop_redundant_pack_items(groups: list[Json]) -> list[Json]:
     """Remove items whose content a LONGER item elsewhere in the pack already carries.
 
@@ -1404,29 +1458,56 @@ def drop_redundant_pack_items(groups: list[Json]) -> list[Json]:
 
     count = len(items)
     lengths = [len(text) for text in texts]
-    # Longest first, and negated so the same ordering is ascending for ``bisect``: the scan for an
-    # item of length L covers exactly the entries whose length exceeds L.
+    # Longest first. Everything already in the haystack is then strictly longer than whatever is
+    # being tested, which is the only thing that can contain it.
     order = sorted(range(count), key=lambda index: -lengths[index])
-    negated = [-lengths[index] for index in order]
+
+    # A text carrying the separator could let a match span two of them, which would drop an item
+    # nothing actually contains. Normalized record text does not contain a NUL; if one ever does,
+    # the pack takes the pairwise path rather than the risk.
+    if any(_PACK_TEXT_SEPARATOR in text for text in texts):
+        return _drop_redundant_pairwise(groups, items, texts, lengths, order)
 
     redundant = [False] * count
     any_redundant = False
-    for index in range(count):
-        text = texts[index]
-        length = lengths[index]
-        if not text or length < 8:
-            continue
-        longer = bisect.bisect_left(negated, -length)
-        for position in range(longer):
-            other = order[position]
-            # A container that is redundant itself cannot change the answer (see the note above);
-            # skipping it is only cheaper than searching its text.
-            if redundant[other]:
-                continue
-            if text in texts[other]:
-                redundant[index] = True
-                any_redundant = True
-                break
+    sealed: list[str] = []          # joined haystacks, each ~_PACK_HAYSTACK_BYTES
+    pending: list[str] = []         # not yet sealed
+    pending_text = ""               # pending, joined once per length group rather than per item
+    pending_bytes = 0
+
+    position = 0
+    while position < count:
+        # One whole length group at a time: an item of the same length cannot contain another.
+        group_length = lengths[order[position]]
+        end = position
+        while end < count and lengths[order[end]] == group_length:
+            end += 1
+
+        if group_length >= 8:
+            for slot in range(position, end):
+                index = order[slot]
+                text = texts[index]
+                if not text:
+                    continue
+                if (pending_text and text in pending_text) or any(
+                    text in chunk for chunk in sealed
+                ):
+                    redundant[index] = True
+                    any_redundant = True
+
+        for slot in range(position, end):
+            text = texts[order[slot]]
+            pending.append(text)
+            pending_bytes += len(text) + 1
+        if pending_bytes >= _PACK_HAYSTACK_BYTES:
+            sealed.append(_PACK_TEXT_SEPARATOR.join(pending))
+            pending = []
+            pending_text = ""
+            pending_bytes = 0
+        else:
+            pending_text = _PACK_TEXT_SEPARATOR.join(pending)
+        position = end
+
     if not any_redundant:
         return groups
 

--- a/tools/test_pack_redundancy.py
+++ b/tools/test_pack_redundancy.py
@@ -152,5 +152,34 @@ class PackRedundancyCase(unittest.TestCase):
                 sorted(got_kept), sorted(expected_kept), "disagreed at seed %d" % seed
             )
 
+    def test_a_text_carrying_the_separator_still_gets_the_plain_answer(self):
+        """A NUL in a text sends the pack down the pairwise path, with the same result.
+
+        The joined haystack is only sound while no text contains the separator -- a match could
+        otherwise span two texts and drop an item nothing actually carries. The guard prevents its
+        own hazard, which means nothing else will ever exercise it.
+        """
+        contained = "drink is matcha"
+        container = "user: my favorite drink is matcha, noted at step 9"
+        packed = [group("event", container, "unrelated sentence about a page cache"),
+                  group("entity", "k = %s" % contained)]
+        without_nul = drop_redundant_pack_items(packed)
+
+        # The same pack, with a NUL riding along in one text.
+        packed_with_nul = [
+            group("event", container + "\x00tail", "unrelated sentence about a page cache"),
+            group("entity", "k = %s" % contained),
+        ]
+        with_nul = drop_redundant_pack_items(packed_with_nul)
+
+        kept_without = sorted(i["text"] for g in without_nul for i in g["items"])
+        kept_with = sorted(i["text"].replace("\x00tail", "") for g in with_nul for i in g["items"])
+        self.assertEqual(kept_with, kept_without)
+        self.assertNotIn(
+            "k = %s" % contained,
+            [i["text"] for g in with_nul for i in g["items"]],
+            "the projection is still dropped on the fallback path",
+        )
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The previous change pruned the sweep to strictly longer items and took it from 98.4 ms to 26.4 ms
on a 1,000-ref pack. Re-profiling the gateway moved the cost onto the substring test itself --
41.8% of gateway on-CPU time on one line -- so what is left is the NUMBER of searches, about 500
per item, each its own call.

Joining the longer texts into a handful of large haystacks does the same byte scanning in a handful
of calls. On the same 1,000-ref pack: **26.4 ms to 8.4 ms**, and 98.4 ms to 8.4 ms against where
this started.

### Why it can be this simple

An item is redundant iff some LONGER item contains it, whether or not that container is itself
redundant -- containment is transitive and carries the length condition with it. So the haystack is
exactly "every text longer than this one", with no per-item bookkeeping to keep in step.

Two things it has to get right, both structural:

- **A match must not span two texts.** They are joined with a NUL, which normalized record text --
  whitespace-collapsed lowercase prose -- never contains. A pack that somehow carries one takes the
  pairwise path instead of the risk.
- **Equal-length texts must not count as containers.** A whole length group is tested before any of
  that group joins the haystack.

The pending haystack is joined once per length group rather than once per item; joining per item
would reintroduce a cost proportional to the haystack on every candidate.

### Measured end to end

A warm retrieve, with the proxy reporting its own time separately:

| | wall | of which proxy | gateway |
|---|---:|---:|---:|
| before the sweep changes | 224 ms | 14 ms | ~205 ms |
| after the length pruning | 119 ms | 14 ms | ~105 ms |
| after this | **85 ms** | 16 ms | **~68 ms** |

Single-request timings on each side, not a run-to-run comparison: this hardware spreads 350%
between identical arms, so no soak percentage is claimed.

### Tests

 covers the fallback, which is
otherwise unreachable -- the guard prevents its own hazard, so nothing in normal data will ever
exercise it. The randomised agreement test from the previous change still compares the sweep
against the plain definition over 60 packs. 10 tests, all green.
