### PR TITLE
Every maintenance round gets a bound it actually uses

### DIFF
--- a/crates/temporalstore-rust/src/engine/reports.rs
+++ b/crates/temporalstore-rust/src/engine/reports.rs
@@ -3177,6 +3177,51 @@ pub struct StorageManagerCycleRequest {
     pub page_gc_min_band_garbage_basis_points: u64,
 }
 
+/// Per-round bounds for the background storage cycle.
+///
+/// Every one of these was 0, and 0 means "no bound" in each of the places it is read: the expiry
+/// window walks the whole deadline map, the eviction sampler keeps every victim it finds, the
+/// index-log sweep removes every removable record, and both index-GC triggers fire whatever the
+/// log looks like. The enforcement was there and tested the whole time; nothing set it, so a
+/// cycle did as much work as there was work to do.
+///
+/// The values are the same order as the design being followed, deliberately not identical --
+/// they are our bounds, chosen against our own costs, not copied numbers:
+///
+/// | bound | theirs | ours | why ours differs |
+/// |---|---|---|---|
+/// | index-log records per round | 200 | 256 | the same order; a round number here |
+/// | index-log size before a sweep | 1 MiB | 768 KiB | agrees with the post-dump sweep's own threshold |
+/// | removable share before a sweep | 50% | 40% | our sweep rewrites a log, theirs rewrites a zone's live pages -- ours is the cheaper one, so it can fire sooner |
+/// | hot buckets expired per round | 100 | 128 | the same order |
+/// | cold buckets expired per round | 5 | 8 | small on purpose either way: a cold bucket has to be loaded before it can be expired |
+/// | eviction victims per round | 10 | 16 | the same order |
+/// | band garbage before reclaim | 50% | 40% | see the note on the constant |
+pub const DEFAULT_INDEX_GC_MAX_ENTRIES_PER_ROUND: usize = 256;
+/// Index-log size below which a sweep is not worth running. Matches the post-dump sweep's
+/// reclaimable-bytes threshold, so the two things that rewrite this log agree about when it is
+/// too small to bother with.
+pub const DEFAULT_INDEX_GC_INDEX_LOG_BYTES_THRESHOLD: u64 = 768 * 1024;
+/// Share of the log's records that must be removable before a sweep runs, in basis points.
+pub const DEFAULT_INDEX_GC_USAGE_RATIO_TRIGGER_BASIS_POINTS: u64 = 4_000;
+/// Buckets whose deadlines are examined per expiry round, in memory and on the store.
+///
+/// Cold is much smaller than hot because a cold bucket has to be LOADED before its records can
+/// be expired, so a cold round costs I/O a hot one does not. That is the same reason the design
+/// being followed scans 5 on-store slots against 100 in-memory ones.
+pub const DEFAULT_MAX_EXPIRE_HOT_BUCKETS_PER_ROUND: usize = 128;
+pub const DEFAULT_MAX_EXPIRE_COLD_BUCKETS_PER_ROUND: usize = 8;
+/// Buckets evicted per round once the cache is over its memory pressure threshold.
+pub const DEFAULT_EVICTION_BATCH_LIMIT: usize = 16;
+/// Garbage share a band must carry before GC will reclaim it, in basis points.
+///
+/// Expected to be INERT today, and set anyway so the policy is stated rather than implied: our
+/// GC only destroys bands with no live refs at all, and a band with no live refs is 10 000 basis
+/// points of garbage, which clears any threshold below it. It binds only if a future GC starts
+/// offering partially-live bands as candidates -- which is exactly when a threshold should
+/// already be in place rather than being added in a hurry.
+pub const DEFAULT_PAGE_GC_MIN_BAND_GARBAGE_BASIS_POINTS: u64 = 4_000;
+
 impl Default for StorageManagerCycleRequest {
     fn default() -> Self {
         Self {
@@ -3194,11 +3239,11 @@ impl Default for StorageManagerCycleRequest {
             min_undumped_wal_records: 0,
             warm_cache: false,
             eviction_memory_pressure_threshold: default_storage_manager_eviction_threshold(),
-            eviction_batch_limit: 0,
+            eviction_batch_limit: DEFAULT_EVICTION_BATCH_LIMIT,
             eviction_dump_before_evict: false,
             eviction_delete_drop: false,
-            max_expire_hot_buckets_per_round: 0,
-            max_expire_cold_buckets_per_round: 0,
+            max_expire_hot_buckets_per_round: DEFAULT_MAX_EXPIRE_HOT_BUCKETS_PER_ROUND,
+            max_expire_cold_buckets_per_round: DEFAULT_MAX_EXPIRE_COLD_BUCKETS_PER_ROUND,
             expire_hot_cursor: None,
             expire_cold_cursor: None,
             load_cold_buckets_for_expire: false,
@@ -3208,11 +3253,13 @@ impl Default for StorageManagerCycleRequest {
             page_gc_checkpoint_floor_slab_id: None,
             page_gc_raft_install_floor_slab_id: None,
             page_gc_delayed_destroy_grace_ms: 0,
-            index_gc_index_log_bytes_threshold: 0,
-            index_gc_usage_ratio_trigger_basis_points: 0,
-            index_gc_max_entries_per_round: 0,
+            index_gc_index_log_bytes_threshold: DEFAULT_INDEX_GC_INDEX_LOG_BYTES_THRESHOLD,
+            index_gc_usage_ratio_trigger_basis_points:
+                DEFAULT_INDEX_GC_USAGE_RATIO_TRIGGER_BASIS_POINTS,
+            index_gc_max_entries_per_round: DEFAULT_INDEX_GC_MAX_ENTRIES_PER_ROUND,
             index_gc_commit_dirty_buckets_before_truncation: true,
-            page_gc_min_band_garbage_basis_points: 0,
+            page_gc_min_band_garbage_basis_points:
+                DEFAULT_PAGE_GC_MIN_BAND_GARBAGE_BASIS_POINTS,
         }
     }
 }

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -9061,6 +9061,99 @@ fn what_one_expiry_round_costs_as_deadlines_accumulate() {
     }
 }
 
+/// Every per-round bound on the background cycle is set, and none of them is zero.
+///
+/// Zero is not a small bound in any of these, it is NO bound: the expiry window walks the whole
+/// deadline map, the eviction sampler keeps every victim it finds, the index-log sweep removes
+/// every removable record, and both index-GC triggers fire whatever the log looks like. They were
+/// all zero, with the enforcement written and tested around them, so a cycle did as much work as
+/// there was work to do.
+///
+/// Asserted as exact values AND as non-zero. The exact values keep the numbers deliberate; the
+/// non-zero assertions say what the test is really defending, which is that none of these
+/// silently goes back to meaning "unbounded" -- the state they were all in.
+#[test]
+fn every_maintenance_round_is_bounded_by_default() {
+    let request = StorageManagerCycleRequest::default();
+
+    assert_eq!(request.index_gc_max_entries_per_round, 256);
+    assert_eq!(request.index_gc_index_log_bytes_threshold, 768 * 1024);
+    assert_eq!(request.index_gc_usage_ratio_trigger_basis_points, 4_000);
+    assert_eq!(request.max_expire_hot_buckets_per_round, 128);
+    assert_eq!(request.max_expire_cold_buckets_per_round, 8);
+    assert_eq!(request.eviction_batch_limit, 16);
+    assert_eq!(request.page_gc_min_band_garbage_basis_points, 4_000);
+
+    for (name, bound) in [
+        ("index_gc_max_entries_per_round", request.index_gc_max_entries_per_round as u64),
+        ("index_gc_index_log_bytes_threshold", request.index_gc_index_log_bytes_threshold),
+        (
+            "index_gc_usage_ratio_trigger_basis_points",
+            request.index_gc_usage_ratio_trigger_basis_points,
+        ),
+        ("max_expire_hot_buckets_per_round", request.max_expire_hot_buckets_per_round as u64),
+        ("max_expire_cold_buckets_per_round", request.max_expire_cold_buckets_per_round as u64),
+        ("eviction_batch_limit", request.eviction_batch_limit as u64),
+        (
+            "page_gc_min_band_garbage_basis_points",
+            request.page_gc_min_band_garbage_basis_points,
+        ),
+    ] {
+        assert!(bound > 0, "{name} is zero, which is not a bound at all");
+    }
+
+    // Cold is deliberately much smaller than hot: a cold bucket has to be LOADED before its
+    // records can be expired, so a cold round costs I/O a hot one does not.
+    assert!(
+        request.max_expire_cold_buckets_per_round < request.max_expire_hot_buckets_per_round,
+        "a cold expiry round must stay smaller than a hot one"
+    );
+}
+
+/// The default hot-expiry bound actually truncates a round, and the round after it resumes.
+///
+/// Pinning the constant proves the number; this proves the number reaches the mechanism. A bound
+/// that is set but never read is the state this whole change is about, so asserting the value
+/// alone would assert exactly the thing that was already true.
+#[test]
+fn the_default_expiry_bound_truncates_a_round_and_the_next_one_resumes() {
+    use std::collections::BTreeMap;
+
+    let request = StorageManagerCycleRequest::default();
+    let limit = request.max_expire_hot_buckets_per_round;
+    let mut deadlines: BTreeMap<String, u64> = BTreeMap::new();
+    for index in 0..(limit as u64 * 3) {
+        deadlines.insert(format!("key-{index:05}"), index);
+    }
+
+    let (first, cursor) = crate::engine::expiry_window(
+        &deadlines,
+        None,
+        limit,
+        limit.saturating_mul(8).max(64),
+        |_| true,
+    );
+    assert_eq!(first.len(), limit, "the round must stop at the bound");
+    assert!(
+        first.len() < deadlines.len(),
+        "and the bound must be smaller than the work, or this proves nothing"
+    );
+    let cursor = cursor.expect("an unfinished round must hand back where to resume");
+
+    let (second, _) = crate::engine::expiry_window(
+        &deadlines,
+        Some(cursor.as_str()),
+        limit,
+        limit.saturating_mul(8).max(64),
+        |_| true,
+    );
+    assert_eq!(second.len(), limit, "the next round takes another full window");
+    assert!(
+        second[0].0 > first[first.len() - 1].0,
+        "and it resumes past the first round rather than re-walking it"
+    );
+}
+
 /// Paging by cursor reaches every deadline exactly once.
 ///
 /// The window is read from an ordered set, so paging only works if the cursor advances past


### PR DESCRIPTION
Seven per-round bounds on the background storage cycle were implemented, enforced and tested — and every one of them defaulted to `0`. In each place `0` is read it does not mean a small bound, it means **no bound**: the expiry window walks the whole deadline map (`expiry_scan_budget(0)` declines to cap the walk either), the eviction sampler keeps every victim it finds, the index-log sweep removes every removable record, and both index-GC triggers fire whatever the log looks like.

None of the three production constructors — the server, the data node, the proxy — names any of them. Only tests do, and every test that names one passes `0`. The enforcement has been carrying its own weight with nothing on the other end of it.

## The numbers

Same order as the design being followed, deliberately not identical, because they are ours and chosen against our costs.

| bound | theirs | ours | why ours differs |
|---|---|---|---|
| index-log records per round | 200 | **256** | the same order |
| index-log size before a sweep | 1 MiB | **768 KiB** | agrees with the post-dump sweep's own threshold, so the two things that rewrite this log agree about when it is too small to bother with |
| removable share before a sweep | 50% | **40%** | ours rewrites a log, theirs rewrites a zone's live pages — ours is the cheaper one, so it can fire sooner |
| hot buckets expired per round | 100 | **128** | the same order |
| cold buckets expired per round | 5 | **8** | small on purpose either way: a cold bucket has to be *loaded* before it can be expired, so a cold round costs I/O a hot one does not |
| eviction victims per round | 10 | **16** | the same order |
| band garbage before reclaim | 50% | **40%** | expected **inert** today |

The last one is set even though it cannot change an outcome today, and the constant says so rather than leaving a reader to work it out: our GC only destroys bands with no live refs at all, and a band with no live refs is 10 000 basis points of garbage, which clears any threshold below it. It binds only if a future GC starts offering partially-live bands — which is exactly when a threshold should already be in place rather than being added in a hurry.

## Testing

Two tests, because the value and the wiring are different claims.

- **The values.** Each number is pinned, and each is separately asserted non-zero. The exact values keep the numbers deliberate; the non-zero assertions say what is really being defended, which is that none of these quietly goes back to meaning unbounded.
- **The wiring.** A round over three windows' worth of deadlines stops at the bound, hands back a cursor, and the next round resumes *past* the first rather than re-walking it. A bound that is set but never read is the state this whole change is about, so asserting the value alone would have asserted the thing that was already true.

Full library suite, single-threaded: **1720 passed, 3 failed**, none attributable to this diff:

- `storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_flags` and `durable_bytes_never_exceed_the_bytes_the_log_holds` fail identically on a clean `main` worktree, at the same assertions, deterministically.
- `emptied_buckets_are_dropped_without_walking_the_map` asserts a **timing ratio** — 2.34x measured against a 2.0 threshold. It was green in the previous run of this same suite and passes 3/3 in isolation here at ~105 s each. Its own panic message states that it asserts a ratio and cannot say what caused it, and that the mechanism it guards is intact.

## What this does not do

It does not bound what a round **surveys** to decide. The plan phase still reads every live page in the shard to find which buckets are dirty, which is now the dominant cost of a cycle precisely *because* the rounds after it are bounded. That is a change in where dirtiness is recorded, not a default to set, and it is not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
