### PR TITLE
Choosing what to evict stops reading the whole shard

### DIFF
--- a/crates/temporalstore-rust/src/engine/eviction_sampler.rs
+++ b/crates/temporalstore-rust/src/engine/eviction_sampler.rs
@@ -197,12 +197,24 @@ pub(super) fn select_victims<S: BucketSource>(
     batch_limit: usize,
     source: S,
 ) -> EvictionSampleOutcome {
-    if batch_limit == 0 || source.bucket_count() == 0 {
+    if source.bucket_count() == 0 {
         return EvictionSampleOutcome {
             pool_size_after: state.pool.len(),
             ..EvictionSampleOutcome::default()
         };
     }
+    // A zero limit means NO limit, the same thing it means to the exhaustive path, which reads
+    // it as "do not truncate" and returns every eligible bucket. This read it as "take none" and
+    // returned immediately, so the one value a caller uses to say "everything" produced opposite
+    // answers depending on which path was running -- and which path runs is a default.
+    //
+    // Unlimited here is the whole bucket count: scan them all, keep them all. That makes the two
+    // paths agree at the boundary rather than agreeing only in the middle.
+    let batch_limit = if batch_limit == 0 {
+        source.bucket_count()
+    } else {
+        batch_limit
+    };
 
     let samples = config.samples.max(1);
     let scan_turns = config.scan_turns.max(1);
@@ -289,6 +301,73 @@ pub(super) fn select_victims<S: BucketSource>(
 
 #[cfg(test)]
 mod tests {
+    /// A zero batch limit means "no limit" here, because it means that to the path this one
+    /// replaced.
+    ///
+    /// The exhaustive path reads a zero as "do not truncate" and hands back every eligible
+    /// bucket. This one used to read the same zero as "take none" and return before scanning.
+    /// One value, two opposite answers, and which one a caller got depended on a default it
+    /// never set -- which is exactly how a caller asking for everything got nothing.
+    #[test]
+    fn a_zero_batch_limit_takes_everything_rather_than_nothing() {
+        use super::*;
+
+        struct AllEligible(usize);
+        impl BucketSource for AllEligible {
+            fn bucket_count(&self) -> usize {
+                self.0
+            }
+            fn scan(
+                &self,
+                _cursor: Option<u32>,
+                budget: usize,
+                visit: &mut dyn FnMut(&BucketSample) -> bool,
+            ) -> ScanResult {
+                let mut scanned = 0usize;
+                for routing_bucket in 0..self.0 as u32 {
+                    if scanned >= budget {
+                        break;
+                    }
+                    scanned += 1;
+                    let sample = BucketSample {
+                        routing_bucket,
+                        eligible: true,
+                        last_used_ms: routing_bucket as u64,
+                    };
+                    if !visit(&sample) {
+                        break;
+                    }
+                }
+                ScanResult {
+                    scanned,
+                    next_cursor: None,
+                    wrapped: true,
+                }
+            }
+            fn lookup(&self, routing_bucket: u32) -> Option<BucketSample> {
+                (routing_bucket < self.0 as u32).then(|| BucketSample {
+                    routing_bucket,
+                    eligible: true,
+                    last_used_ms: routing_bucket as u64,
+                })
+            }
+        }
+
+        let config = EvictionSamplerConfig::default();
+        let mut state = EvictionSamplerState::default();
+        let unlimited = select_victims(&mut state, config, 0, AllEligible(6));
+        assert_eq!(
+            unlimited.victims.len(),
+            6,
+            "a zero limit must take every eligible bucket, not none"
+        );
+
+        // And a real limit still limits, or the fix would just have removed the bound.
+        let mut state = EvictionSamplerState::default();
+        let limited = select_victims(&mut state, config, 2, AllEligible(6));
+        assert_eq!(limited.victims.len(), 2, "a stated limit must still be a limit");
+    }
+
     use super::*;
 
     fn buckets(count: u32) -> Vec<BucketSample> {
@@ -454,17 +533,26 @@ mod tests {
         assert_eq!(outcome.victims, vec![5, 6, 7]);
     }
 
+    /// An empty store yields no victims, whatever the limit.
+    ///
+    /// This used to assert a second thing: that a ZERO limit also yields nothing. It no longer
+    /// does, and the change is deliberate. The exhaustive path this sampler replaced reads a
+    /// zero as "do not truncate" and returns every eligible bucket, and so does every other
+    /// bound in this engine -- the dump round, the index-GC round, the dump interval, the
+    /// sweep threshold. The sampler was the one place where zero meant the opposite, and the
+    /// caller that asked for everything got nothing.
+    ///
+    /// `a_zero_batch_limit_takes_everything_rather_than_nothing` now owns that half.
     #[test]
-    fn an_empty_store_or_zero_batch_selects_nothing() {
+    fn an_empty_store_selects_nothing() {
         let mut state = EvictionSamplerState::default();
         let empty: Vec<BucketSample> = Vec::new();
         assert!(select_victims(&mut state, EvictionSamplerConfig::default(), 3, empty.as_slice())
             .victims
             .is_empty());
-        assert!(
-            select_victims(&mut state, EvictionSamplerConfig::default(), 0, buckets(10).as_slice())
-                .victims
-                .is_empty()
-        );
+        // Zero limit, still nothing -- because there is nothing, not because the limit is zero.
+        assert!(select_victims(&mut state, EvictionSamplerConfig::default(), 0, empty.as_slice())
+            .victims
+            .is_empty());
     }
 }

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -75,7 +75,16 @@ impl TemporalEngine {
             quotas: Arc::new(RwLock::new(crate::engine::quota::QuotaTable::default())),
             compaction_rounds: Arc::default(),
             concurrent_commit: Arc::new(std::sync::atomic::AtomicBool::new(true)),
-            evict_sampled_lru: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            // Sampled by default. The exhaustive alternative calls `bucket_storage_summaries`,
+            // which reads EVERY live page in the shard to rank every bucket, and then keeps at
+            // most `eviction_batch_limit` of them -- so the cost of choosing grew with the store
+            // while the work done stayed fixed. The sampler walks a bounded window from a cursor
+            // (`samples * batch_limit * scan_turns`) and resumes where it stopped, so a store
+            // twice the size costs the same to choose from.
+            //
+            // The sampled path was written, tested and measured, and the only thing that ever
+            // turned it on was a #[cfg(test)] helper.
+            evict_sampled_lru: Arc::new(std::sync::atomic::AtomicBool::new(true)),
             eager_cache_warm: Arc::new(std::sync::atomic::AtomicBool::new(
                 crate::engine::eager_cache_warm_on_load(),
             )),
@@ -115,11 +124,23 @@ impl TemporalEngine {
     /// Take the durable WAL barrier UNDER the `shards` write lock, for a test measuring what
     /// the other side of the lock costs. Scoped to this engine.
     #[cfg(test)]
-    /// Pick eviction victims by a sampled scan, for the test that measures what that costs.
+    /// Pick eviction victims by a sampled scan. The default, kept so a test can say it means
+    /// the sampled path rather than relying on what the default happens to be.
     #[cfg(test)]
     pub(crate) fn use_sampled_eviction_for_test(&self) {
         self.evict_sampled_lru
             .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Rank every bucket by reading every live page, instead of sampling a window.
+    ///
+    /// No longer the default. Kept because the measurement that justifies the default needs
+    /// something to measure against: a test that cannot produce the exhaustive scan cannot show
+    /// that the sampled one is cheaper.
+    #[cfg(test)]
+    pub(crate) fn use_full_scan_eviction_for_test(&self) {
+        self.evict_sampled_lru
+            .store(false, std::sync::atomic::Ordering::Relaxed);
     }
 
     pub(crate) fn commit_under_lock_for_test(&self) {

--- a/crates/temporalstore-rust/src/engine/reports.rs
+++ b/crates/temporalstore-rust/src/engine/reports.rs
@@ -3121,6 +3121,9 @@ pub struct StorageManagerCycleRequest {
     pub warm_cache: bool,
     #[serde(default = "default_storage_manager_eviction_threshold")]
     pub eviction_memory_pressure_threshold: u64,
+    /// Buckets evicted per round. **Zero means no limit**, as it does on every other bound in
+    /// this request -- not "evict nothing", which is what the sampled selection used to read it
+    /// as while the exhaustive selection read it as "evict everything".
     #[serde(default)]
     pub eviction_batch_limit: usize,
     #[serde(default)]

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -7673,8 +7673,13 @@ fn sampled_eviction_scan_volume_does_not_grow_with_the_store() {
             });
         }
 
+        // Both sides say what they mean. The default moved to the sampled path, so the
+        // full-scan arm has to ask for the exhaustive scan -- if it did not, both arms would
+        // sample and the comparison would compare one path against itself.
         if sampled {
             engine.use_sampled_eviction_for_test();
+        } else {
+            engine.use_full_scan_eviction_for_test();
         }
         crate::engine::reset_live_page_scan_entries();
         // Threshold 0 so the pressure gate always admits and the selection path actually runs.


### PR DESCRIPTION
Picking eviction victims ranked **every bucket in the shard**, and ranking a bucket meant reading its live pages — `collect_live_page_entries`, by way of `bucket_storage_summaries`. It then kept at most `eviction_batch_limit` of them. So the cost of *choosing* grew with the store while the work actually done stayed fixed: a store twice the size cost twice as much to pick four buckets out of.

A sampled alternative was already written, already tested, and already measured against the exhaustive one. It walks a bounded window from a cursor — `samples * batch_limit * scan_turns`, the same product the design being followed uses for its evicter — resumes where the last pass stopped, and computes byte totals only for the buckets it actually picked.

**The only thing that ever turned it on was a `#[cfg(test)]` helper.**

## The measurement

The existing test's, unchanged except that each arm now asks for its path by name:

```
full-scan    200 pages ->  200 live-page entries scanned
full-scan   1600 pages -> 1600 live-page entries scanned
sampled      200 pages ->    0 live-page entries scanned (4 victims)
sampled     1600 pages ->    0 live-page entries scanned (4 victims)
```

Eight times the store, the same four victims, and the sampled path never touches the live-page scan at all. That test already asserted both halves — that the full scan grows with the store and that the sampled one does not — so the guard for this default predates the default.

## What is given up

Exactness. The exhaustive scan ranks every bucket and takes the globally coldest; the sampler ranks a window and takes the coldest it saw.

Where the window covers the store the two agree — that is every store smaller than `samples * batch_limit * scan_turns` buckets. Beyond that the sampler can pass over a colder bucket, and reaches it on a later pass because the cursor advances. That is the same approximation the design being followed makes, and eviction is a pressure-relief heuristic rather than a correctness boundary: evicting the second-coldest bucket frees memory just as well.

The full scan stays reachable behind a test-only switch, because the measurement above needs something to measure against — a test that cannot produce the exhaustive scan cannot show the sampled one is cheaper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## A defect this surfaced

Switching the default exposed something sitting between the two paths: **a zero batch limit meant opposite things depending on which one ran.** The exhaustive path reads a zero as "do not truncate" and returns every eligible bucket; the sampled path read the same zero as "take none" and returned before scanning. Two tests each asserted one of the readings, and which one a caller got depended on a default it never set — so a caller asking for everything got nothing.

Zero now means *no limit* in both, which is what it means on every other bound in this engine — the dump round, the index-GC round, the dump interval, the sweep threshold. The field says so, and a test pins both ends: a zero limit takes every eligible bucket, and a stated limit still limits. The old test asserting the opposite is narrowed to the empty-store case it also covered, with a note recording which half moved.

Full library suite, single-threaded: **1722 passed, 3 failed** — the two deterministic pre-existing failures (both reproduce on a clean `main` worktree at the same assertions) and one known-flaky timing-ratio test that was green in the previous run and passes in isolation.
