### PR TITLE
A retrieve stops copying every ref it might not need

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -6140,12 +6140,15 @@ fn retrieve_context_pack_output(
         question_type,
         "current_state" | "latest" | "profile_memory"
     );
-    let all_candidate_refs: Vec<Value> = snapshot
-        .candidates
-        .iter()
-        .map(|candidate| candidate.selected_ref.clone())
-        .collect();
+    // Built inside the branch, and borrowed rather than copied: the consumer only reads them, and
+    // only sometimes. This used to clone the `selected_ref` of every candidate in the snapshot --
+    // the whole corpus -- before asking whether the one caller wanted them.
     let (profile_by_entity, profile_by_source_entity_hash) = if current_state_query {
+        let all_candidate_refs: Vec<&Value> = snapshot
+            .candidates
+            .iter()
+            .map(|candidate| &candidate.selected_ref)
+            .collect();
         profile_shadow_maps_from_selected_refs(&all_candidate_refs)
     } else {
         (HashMap::new(), HashMap::new())
@@ -7252,8 +7255,48 @@ mod tests {
         }
         assert_eq!(left, right, "both shapes build the same response");
 
+        // 4. Copying every candidate's ref, against borrowing them. A retrieve built the copy
+        // unconditionally for a consumer that runs only on a current-state query.
+        let refs: Vec<Value> = (0..20_000)
+            .map(|i| {
+                json!({
+                    "ref_type": "event",
+                    "ref_hash": format!("h{i}"),
+                    "text": "the storage manager reclaims the log once a durable dump completes",
+                    "token_estimate": 14,
+                    "memory_layer": "session",
+                    "memory_scope": "session",
+                    "session_continuity": "same_session",
+                    "source_roles": ["user", "assistant"],
+                    "source_session_ids": ["s1", "s2"],
+                })
+            })
+            .collect();
+
+        let started = Instant::now();
+        let mut copied_len = 0usize;
+        for _ in 0..5 {
+            let copied: Vec<Value> = refs.iter().cloned().collect();
+            copied_len = copied.len();
+        }
+        let refs_clone_ns = started.elapsed().as_nanos();
+
+        let started = Instant::now();
+        let mut borrowed_len = 0usize;
+        for _ in 0..5 {
+            let borrowed: Vec<&Value> = refs.iter().collect();
+            borrowed_len = borrowed.len();
+        }
+        let refs_borrow_ns = started.elapsed().as_nanos();
+        assert_eq!(copied_len, borrowed_len);
+
         println!(
             "  parse of 256 records x8:   {parse_ns} ns  (neither shape avoids this)"
+        );
+        println!(
+            "  candidate refs x5 over 20,000: clone {refs_clone_ns} ns, borrow {refs_borrow_ns} \
+             ns, {:.1}% saved",
+            pct(refs_clone_ns, refs_borrow_ns)
         );
         println!(
             "  extract 2048 records:      clone {clone_ns} ns, move {move_ns} ns, {:.1}% saved",

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl/native_serving.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl/native_serving.rs
@@ -666,12 +666,14 @@ fn profile_shadow_for_candidate(
         .map(|(_, profile_hash)| (profile_hash.clone(), "same_entity_identity"))
 }
 
+/// Takes BORROWED refs: it reads a handful of fields off each and never keeps one, and its caller
+/// holds them inside a snapshot that outlives the call.
 fn profile_shadow_maps_from_selected_refs(
-    selected_refs: &[Value],
+    selected_refs: &[&Value],
 ) -> (HashMap<String, (u64, String)>, HashMap<String, (u64, String)>) {
     let mut by_entity: HashMap<String, (u64, String)> = HashMap::new();
     let mut by_source_entity_hash: HashMap<String, (u64, String)> = HashMap::new();
-    for selected_ref in selected_refs {
+    for selected_ref in selected_refs.iter().copied() {
         if string_field(selected_ref, "memory_scope") != "user_profile"
             || string_field(selected_ref, "session_continuity") != "cross_session"
         {


### PR DESCRIPTION
A retrieve copied the ref of every candidate in the snapshot — the whole corpus — and then asked
whether anything wanted them:

```rust
let all_candidate_refs: Vec<Value> = snapshot.candidates.iter()
    .map(|candidate| candidate.selected_ref.clone()).collect();
let (by_entity, by_hash) = if current_state_query { … } else { (empty, empty) };
```

Two things wrong, fixed together. It is built unconditionally for a conditional consumer, so it now
lives inside the branch. And that consumer only *reads* the refs, so it takes borrows — which also
removes the copy from the branch that does run. The snapshot is shared behind an `Arc` and outlives
the call, so borrowing from it is free.

### What it is worth, honestly

The operation is expensive in isolation. `what_the_copies_on_the_retrieve_path_cost` now prices it:
cloning 20,000 refs costs **91.5 ms against 0.08 ms to borrow them — 4.6 µs per ref**.

**And removing it did not move the retrieve on this hardware: 15 ms either way**, across two runs
whose stores matched to 1.4% in record count. Whole-run CPU came out 10.7% lower on the proxy and
7.9% lower on the gateway, and I am not claiming those — this box spreads 350% between identical
arms, and one pair cannot carry a 10% effect.

So this ships on the mechanism rather than on a measured end-to-end win. It strictly removes work —
an unconditional O(corpus) allocation per request, for a branch that usually does not run — and
there is no configuration in which doing it is cheaper. On a corpus larger than this one it matters
more, and the price above says by how much.

### Tests

The proxy binary suite: 120 passed, 0 failed. That is the only command that reaches this file; both
of the usual whole-crate forms run zero of its tests and report ok.
