### PR TITLE
The rebuild says which stage it spent, and the parse cache stops starving

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -293,6 +293,19 @@ struct CachedRetrieveCandidate {
     vector: Option<Vec<f32>>,
 }
 
+/// What building a snapshot cost, by stage, in milliseconds.
+///
+/// A retrieve after a write is nearly all rebuild, and the rebuild is three unrelated pieces of
+/// work: reading and parsing the shards, counting the inventory, and turning records into
+/// candidates. Each is fixed by a different change, so a total is not enough to act on. A snapshot
+/// served from cache reports the build it came from.
+#[derive(Clone, Copy, Debug, Default)]
+struct RetrieveBuildCost {
+    read_ms: f64,
+    inventory_ms: f64,
+    candidates_ms: f64,
+}
+
 #[derive(Clone, Debug)]
 struct RetrieveCandidateSnapshot {
     candidates: Vec<CachedRetrieveCandidate>,
@@ -300,6 +313,7 @@ struct RetrieveCandidateSnapshot {
     scanned_records: usize,
     placement_partitions_touched: usize,
     index_postings_read: usize,
+    build: RetrieveBuildCost,
 }
 
 struct NativeScoredCandidate {
@@ -1411,7 +1425,7 @@ struct SnapshotEntry {
 /// `BTreeMap` of `String` keys and every number is a `Value` -- and the exact factor varies by
 /// record shape, so this is a deliberate over-estimate: the cost of guessing low is an unbudgeted
 /// cache, which is what this type exists to prevent.
-const DECODED_BYTES_PER_PAYLOAD_BYTE: usize = 6;
+const DECODED_BYTES_PER_PAYLOAD_BYTE: usize = 4;
 
 struct SnapshotCache {
     entries: BTreeMap<String, SnapshotEntry>,
@@ -1438,10 +1452,18 @@ impl SnapshotCache {
             decoded_bytes: 0,
             clock: 0,
             budget,
-            // Half the payload budget. Parsed records are several times their payload, so this is
-            // a smaller share of shards than it looks -- deliberately, since a dropped decode is
-            // cheap to rebuild and the payload cache must not shrink to make room for it.
-            decoded_budget: budget / 2,
+            // The SAME budget as the payloads, not a fraction of it.
+            //
+            // This was half, while each parse was charged at six times its payload bytes -- so the
+            // parse cache could hold about a twelfth of the payload volume and evicted most of
+            // what it was given. Measured on a 27,186-record store, that left the rebuild's read
+            // stage at 367-540 ms; with this budget it is 0.1 ms, and the rebuild after a write
+            // went 662-720 ms to 153 ms, for 6% more resident memory.
+            //
+            // Evicting a parse still costs less than evicting a payload -- one re-parse against a
+            // re-read AND a re-parse -- which is why they keep separate budgets and separate LRUs
+            // rather than one shared pool.
+            decoded_budget: budget,
         }
     }
 
@@ -5772,12 +5794,14 @@ fn load_retrieve_candidate_snapshot(
     // Parsed at most once per shard per write, and then borrowed from the shard cache rather
     // than copied out of it: copying a record to own it costs ~23 us against the ~0.6 us that
     // owning it saves the ref build.
+    let read_started = Instant::now();
     let mut shards = Vec::with_capacity(shard_count);
     for shard in 0..shard_count {
         let key = format!("{record_hash_key}:{shard:06}");
         shards.push(hgetall_decoded(engine, key)?);
     }
     let records: Vec<&Value> = shards.iter().flat_map(|shard| shard.iter()).collect();
+    let read_ms = read_started.elapsed().as_secs_f64() * 1000.0;
 
     // Built only when something is going to read them. The single consumer is the secondary-group
     // filter below, which returns early on an empty group list -- so with no groups this was a
@@ -5818,8 +5842,11 @@ fn load_retrieve_candidate_snapshot(
         }
     }
 
+    let inventory_started = Instant::now();
     let memory_inventory = native_retrieval_memory_inventory(&records, scope);
+    let inventory_ms = inventory_started.elapsed().as_secs_f64() * 1000.0;
     let scanned_records = records.len();
+    let candidates_started = Instant::now();
     let candidates = records
         .into_iter()
         // Cheapest and most selective first. This is one `get` and a `matches!`, and it rejects
@@ -5862,12 +5889,18 @@ fn load_retrieve_candidate_snapshot(
             }
         })
         .collect::<Vec<_>>();
+    let candidates_ms = candidates_started.elapsed().as_secs_f64() * 1000.0;
     let snapshot = Arc::new(RetrieveCandidateSnapshot {
         candidates,
         memory_inventory,
         scanned_records,
         placement_partitions_touched: shard_count,
         index_postings_read: shard_count,
+        build: RetrieveBuildCost {
+            read_ms,
+            inventory_ms,
+            candidates_ms,
+        },
     });
     if let Ok(mut cache) = retrieve_candidate_cache().lock() {
         cache.insert(cache_key, Arc::clone(&snapshot));
@@ -6253,8 +6286,11 @@ fn retrieve_context_pack_output(
         // Phases, not just a total: a rebuild and a scoring pass are fixed by different work, and
         // "the retrieve took a second" has never been enough to tell them apart.
         eprintln!(
-            "slow retrieve: {elapsed_ms} ms total, snapshot {snapshot_ms:.1} ms              (cache_hit={candidate_cache_hit}), score {score_ms:.1} ms,              {} records scanned, {selected_count} refs selected",
-            snapshot.scanned_records
+            "slow retrieve: {elapsed_ms} ms total, snapshot {snapshot_ms:.1} ms (cache_hit={candidate_cache_hit}), score {score_ms:.1} ms, {} records scanned, {selected_count} refs selected; rebuild {:.1} read / {:.1} inventory / {:.1} candidates",
+            snapshot.scanned_records,
+            snapshot.build.read_ms,
+            snapshot.build.inventory_ms,
+            snapshot.build.candidates_ms
         );
     }
     let correctness = selected_count > 0;
@@ -7026,6 +7062,38 @@ fn _request_shape_for_docs() -> serde_json::Value {
 
 #[cfg(test)]
 mod tests {
+
+    /// A parse that fits its budget is kept.
+    ///
+    /// The parse cache was added and then starved: half the payload budget, with every parse
+    /// charged at six times its payload bytes, so it held about a twelfth of the payload volume
+    /// and evicted nearly everything. The rebuild went on re-parsing and the cache looked like it
+    /// had not helped. This asserts the relationship rather than the constants, so an edit that
+    /// halves the budget again fails here rather than quietly making a retrieve slow.
+    #[test]
+    fn a_parse_that_fits_is_kept() {
+        let mut cache = SnapshotCache::new();
+        assert!(
+            cache.decoded_budget >= cache.budget,
+            "parses get a smaller budget than payloads ({} against {}), which starves the cache \
+             the rebuild depends on",
+            cache.decoded_budget,
+            cache.budget
+        );
+
+        cache.insert("shard".to_string(), shard_payloads("one"));
+        cache.set_decoded("shard", Arc::new(vec![json!({"text": "one"})]));
+        assert!(
+            cache.decoded("shard").is_some(),
+            "a single small parse did not survive its own budget"
+        );
+
+        // And the charge stays a bounded multiple, so a parse cannot be free.
+        assert!(
+            cache.decoded_bytes >= cache.bytes,
+            "a parse charged less than its payload would make the budget meaningless"
+        );
+    }
 
     fn shard_payloads(text: &str) -> Arc<BTreeMap<String, String>> {
         let mut map = BTreeMap::new();


### PR DESCRIPTION
A retrieve reported the snapshot rebuild as one number, so a rebuild that took 700 ms could not say
which part took it. It now reports three: reading and parsing the shards, counting the inventory,
and turning records into candidates. Each is fixed by a different change.

The first thing it said was that the cache added two changes ago was **starving**.

### The split, and the bug it exposed

Cold rebuild over 26,756 records:

| stage | ms | share |
|---|---:|---:|
| read + parse shards | 367.5–540.5 | **55–75%** |
| candidates | 92.9–173.7 | 14–26% |
| inventory | 36.6 | 5% |

The read stage should have been near zero on a rebuild after a write: records are appended, so
every shard but the newest parses to what it parsed before, and that is exactly what the parse
cache exists for.

It was not, because of how I budgeted it. Each parse was charged at **six times** its payload bytes
against **half** the payload budget — so the parse cache could hold about a *twelfth* of the payload
volume and evicted nearly everything it was given. The rebuild kept re-parsing, and the cache
looked like it had not helped.

### Measured, nothing else changed

Same store, 27,186 records:

| | payload/2 budget, 6x charge | equal budget, 4x charge |
|---|---:|---:|
| rebuild **read** stage, after a write | 367–540 ms | **0.1 ms** |
| rebuild total, after a write | 662–720 ms | **153 ms** |
| retrieve after a write | 744 ms | **221 ms** |
| warm retrieve p50 | 78 ms | 56.5 ms |
| proxy RSS | 551 MB | 585 MB (**+6%**) |

The first rebuild on a cold process still pays the read — 618.9 ms with 501.7 ms of reading — and
always will; there is nothing cached yet. It is the rebuild *after a write* that this fixes, and
that is the one an ingesting store does on nearly every retrieve.

### Why the two budgets stay separate

Evicting a parse costs a re-parse. Evicting a payload costs a re-read *and* a re-parse. They are
not worth keeping on the same terms, so they keep separate budgets and separate LRUs rather than
sharing one pool — and the payload cache's behaviour is unchanged by this.

The charge is still a deliberate over-estimate, because the cost of guessing low is an unbudgeted
cache, which is the failure the whole type exists to prevent.

### Tests

`a_parse_that_fits_is_kept` asserts the *relationship*, not the constants: the decode budget may not
be smaller than the payload budget, a single small parse must survive, and a parse may not be
charged less than its payload. An edit that halves the budget again fails there rather than quietly
making a retrieve slow — which is precisely what happened here and what nothing caught.

The proxy binary suite: 121 passed, 0 failed.

The report line also lost the runs of spaces it was carrying: it had been written with line
continuations that ended up as literal whitespace in the output.
