### PR TITLE
A block record is named for the block it holds

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -26,10 +26,11 @@ mod record;
 
 /// Bytes a block record spends on its header, before the block's own bytes.
 ///
-/// Reachable outside the block store because a log that CARRIES a block can work out the length
-/// its address will hold, rather than being told it: the address covers the header and the
-/// payload together.
-pub(crate) const BLOCK_RECORD_HEADER_LEN: usize = record::PAGE_RECORD_HEADER_LEN;
+/// Re-exported rather than redefined. This was a second constant whose entire body was the
+/// first one, written to widen a `pub(super)` definition so a log that CARRIES a block could
+/// work out the length its address will hold. Now that both spell the record the same way, two
+/// constants of one name in two modules is a thing to trip over rather than a bridge.
+pub(crate) use record::BLOCK_RECORD_HEADER_LEN;
 
 pub(crate) use record::block_index_checksums_enabled;
 
@@ -48,7 +49,7 @@ use record::{
 use self::band_manifest::*;
 pub(crate) use slab_ids::*;
 #[cfg(test)]
-use record::{PAGE_RECORD_COMPRESSION_NONE, PAGE_RECORD_COMPRESSION_ZSTD};
+use record::{BLOCK_RECORD_COMPRESSION_NONE, BLOCK_RECORD_COMPRESSION_ZSTD};
 
 #[derive(Debug, Error)]
 pub enum BlockStoreError {
@@ -2658,8 +2659,8 @@ mod tests {
         let slab = fs::read(&path).unwrap();
         let start = address.offset as usize;
         let record = &slab[start..start + address.length as usize];
-        let at = record::PAGE_RECORD_CHECKSUM_OFFSET;
-        let field = &record[at..at + record::PAGE_RECORD_CHECKSUM_LEN];
+        let at = record::BLOCK_RECORD_CHECKSUM_OFFSET;
+        let field = &record[at..at + record::BLOCK_RECORD_CHECKSUM_LEN];
 
         assert_ne!(
             hex::encode(field),
@@ -2672,7 +2673,7 @@ mod tests {
             "the field is the crc32c of the payload"
         );
         assert_eq!(
-            record::PAGE_RECORD_CHECKSUM_LEN,
+            record::BLOCK_RECORD_CHECKSUM_LEN,
             4,
             "the field is the checksum and nothing else: no padding, no marker"
         );
@@ -3224,8 +3225,8 @@ mod tests {
         let second = store.append(&second_payload).unwrap();
         let raw = store.read_slab(first.block_slab_id).unwrap();
 
-        assert!(first.length < (record::PAGE_RECORD_HEADER_LEN + first_payload.len()) as u64);
-        assert!(second.length < (record::PAGE_RECORD_HEADER_LEN + second_payload.len()) as u64);
+        assert!(first.length < (record::BLOCK_RECORD_HEADER_LEN + first_payload.len()) as u64);
+        assert!(second.length < (record::BLOCK_RECORD_HEADER_LEN + second_payload.len()) as u64);
         assert_eq!(store.read(&first).unwrap(), first_payload);
         assert_eq!(store.read(&second).unwrap(), second_payload);
 
@@ -3237,7 +3238,7 @@ mod tests {
         expected.extend_from_slice(&first_payload[first_payload.len() - 3..]);
         expected.extend_from_slice(&second_payload[..9]);
         assert_eq!(logical, expected);
-        assert_eq!(record::page_record_compression_byte(&raw), PAGE_RECORD_COMPRESSION_ZSTD);
+        assert_eq!(record::page_record_compression_byte(&raw), BLOCK_RECORD_COMPRESSION_ZSTD);
 
         let stats = store.stats();
         assert_eq!(stats.writes, 2);
@@ -3498,17 +3499,17 @@ mod tests {
 
         // Stated from the values that went in, because a varint header has no fixed length: it
         // is the fixed part, one varint per number, and the compression codec.
-        let expected_header = record::PAGE_RECORD_HEADER_LEN;
+        let expected_header = record::BLOCK_RECORD_HEADER_LEN;
         assert_eq!(
             disabled_address.length,
             (expected_header + payload.len()) as u64
         );
         assert_eq!(
             expected_header,
-            record::PAGE_RECORD_HEADER_LEN,
+            record::BLOCK_RECORD_HEADER_LEN,
             "one header size, whatever the values"
         );
-        assert_eq!(record::page_record_compression_byte(&disabled_raw), PAGE_RECORD_COMPRESSION_NONE);
+        assert_eq!(record::page_record_compression_byte(&disabled_raw), BLOCK_RECORD_COMPRESSION_NONE);
         assert_eq!(disabled_store.read(&disabled_address).unwrap(), payload);
         assert_eq!(disabled_store.stats().compressed_records_written, 0);
         assert_eq!(disabled_store.stats().compression_bytes_saved, 0);
@@ -3526,12 +3527,12 @@ mod tests {
             .read_slab(threshold_address.block_slab_id)
             .unwrap();
 
-        let threshold_header = record::PAGE_RECORD_HEADER_LEN;
+        let threshold_header = record::BLOCK_RECORD_HEADER_LEN;
         assert_eq!(
             threshold_address.length,
             (threshold_header + payload.len()) as u64
         );
-        assert_eq!(record::page_record_compression_byte(&threshold_raw), PAGE_RECORD_COMPRESSION_NONE);
+        assert_eq!(record::page_record_compression_byte(&threshold_raw), BLOCK_RECORD_COMPRESSION_NONE);
         assert_eq!(threshold_store.read(&threshold_address).unwrap(), payload);
         assert_eq!(threshold_store.stats().compressed_records_written, 0);
         assert_eq!(threshold_store.stats().compression_bytes_saved, 0);
@@ -3564,7 +3565,7 @@ mod tests {
         // Make the block say it is far larger than the record holds. The size sits at a
         // constant offset now, so this corrupts the number itself rather than payload bytes,
         // which would only be caught by the checksum.
-        let size_at = record::PAGE_RECORD_LENGTH_OFFSET;
+        let size_at = record::BLOCK_RECORD_LENGTH_OFFSET;
         slab[size_at] = 0xFF;
         slab[size_at + 1] = 0xFF;
         slab[size_at + 2] = 0xFF;

--- a/crates/temporalstore-rust/src/block_store/record.rs
+++ b/crates/temporalstore-rust/src/block_store/record.rs
@@ -32,25 +32,25 @@ use super::{
 /// have `install_slab`, which puts arbitrary bytes in a slab -- a restore path, and thirty test
 /// sites -- so "is this a record" is a real question here and something has to answer it. Two
 /// bytes answer it; the checksum catches anything that gets past them.
-pub(super) const PAGE_RECORD_MAGIC: &[u8; 2] = b"TB";
+pub(super) const BLOCK_RECORD_MAGIC: &[u8; 2] = b"TB";
 
-pub(super) const PAGE_RECORD_CHECKSUM_OFFSET: usize = PAGE_RECORD_MAGIC.len();
+pub(super) const BLOCK_RECORD_CHECKSUM_OFFSET: usize = BLOCK_RECORD_MAGIC.len();
 
 /// Length and codec share a word, the way the comparison design packs its status bits rather
 /// than spending a byte on each. Thirty bits of length is a gigabyte per block.
-pub(super) const PAGE_RECORD_LENGTH_OFFSET: usize = PAGE_RECORD_CHECKSUM_OFFSET + 4;
+pub(super) const BLOCK_RECORD_LENGTH_OFFSET: usize = BLOCK_RECORD_CHECKSUM_OFFSET + 4;
 
 /// Which block of its object this is.
 ///
 /// Two bytes, because a block id is an index INSIDE an object rather than a number handed out
 /// across the whole store. An object with more than 65,535 blocks is not a case this design
 /// serves; one with a handful is every case it does.
-pub(super) const PAGE_RECORD_BLOCK_ID_OFFSET: usize = PAGE_RECORD_LENGTH_OFFSET + 4;
-pub(super) const PAGE_RECORD_LENGTH_MASK: u32 = 0x3FFF_FFFF;
-pub(super) const PAGE_RECORD_CODEC_SHIFT: u32 = 30;
+pub(super) const BLOCK_RECORD_BLOCK_ID_OFFSET: usize = BLOCK_RECORD_LENGTH_OFFSET + 4;
+pub(super) const BLOCK_RECORD_LENGTH_MASK: u32 = 0x3FFF_FFFF;
+pub(super) const BLOCK_RECORD_CODEC_SHIFT: u32 = 30;
 
 /// The header is one size, always.
-pub(super) const PAGE_RECORD_HEADER_LEN: usize = PAGE_RECORD_BLOCK_ID_OFFSET + 2;
+pub(crate) const BLOCK_RECORD_HEADER_LEN: usize = BLOCK_RECORD_BLOCK_ID_OFFSET + 2;
 
 /// The checksum is a CRC32C and nothing else, so the field is exactly its width.
 ///
@@ -59,14 +59,14 @@ pub(super) const PAGE_RECORD_HEADER_LEN: usize = PAGE_RECORD_BLOCK_ID_OFFSET + 2
 /// format there is nothing to tell apart, so the marker is gone and the field is the checksum.
 /// A page checksum guards against a page that corrupted into something still decodable, not
 /// against a forged one, and CRC32C is the right tool for that.
-pub(super) const PAGE_RECORD_CHECKSUM_LEN: usize = 4;
+pub(super) const BLOCK_RECORD_CHECKSUM_LEN: usize = 4;
 
 /// What the walks use to decide whether what is left can still be a record.
 ///
 /// One header length now, so this is that length. It was a separate constant while the header
 /// was variable, and set too high it made a walk read a short record as the end of the slab and
 /// lose every record behind it -- which happened twice.
-pub(super) const PAGE_RECORD_SMALLEST_HEADER_LEN: usize = PAGE_RECORD_HEADER_LEN;
+pub(super) const BLOCK_RECORD_SMALLEST_HEADER_LEN: usize = BLOCK_RECORD_HEADER_LEN;
 
 /// The compression codec byte of a record this code writes, found by walking the header.
 ///
@@ -75,11 +75,11 @@ pub(super) const PAGE_RECORD_SMALLEST_HEADER_LEN: usize = PAGE_RECORD_HEADER_LEN
 #[cfg(test)]
 pub(super) fn page_record_compression_byte(record: &[u8]) -> u8 {
     let sized = u32::from_le_bytes(
-        record[PAGE_RECORD_LENGTH_OFFSET..PAGE_RECORD_LENGTH_OFFSET + 4]
+        record[BLOCK_RECORD_LENGTH_OFFSET..BLOCK_RECORD_LENGTH_OFFSET + 4]
             .try_into()
             .expect("block size slice"),
     );
-    (sized >> PAGE_RECORD_CODEC_SHIFT) as u8
+    (sized >> BLOCK_RECORD_CODEC_SHIFT) as u8
 }
 
 /// How many bytes `value` takes as a varint.
@@ -134,21 +134,21 @@ fn read_page_record_varint(
         }
     }
 }
-pub(super) const PAGE_RECORD_COMPRESSION_MIN_BYTES: usize = 256;
-pub(super) const PAGE_RECORD_COMPRESSION_LEVEL: i32 = 0;
-pub(super) const PAGE_RECORD_COMPRESSION_NONE: u8 = 0;
-pub(super) const PAGE_RECORD_COMPRESSION_ZSTD: u8 = 1;
+pub(super) const BLOCK_RECORD_COMPRESSION_MIN_BYTES: usize = 256;
+pub(super) const BLOCK_RECORD_COMPRESSION_LEVEL: i32 = 0;
+pub(super) const BLOCK_RECORD_COMPRESSION_NONE: u8 = 0;
+pub(super) const BLOCK_RECORD_COMPRESSION_ZSTD: u8 = 1;
 
 pub(super) fn default_page_record_compression_enabled() -> bool {
     true
 }
 
 pub(super) fn default_page_record_compression_min_bytes() -> usize {
-    PAGE_RECORD_COMPRESSION_MIN_BYTES
+    BLOCK_RECORD_COMPRESSION_MIN_BYTES
 }
 
 pub(super) fn default_page_record_compression_level() -> i32 {
-    PAGE_RECORD_COMPRESSION_LEVEL
+    BLOCK_RECORD_COMPRESSION_LEVEL
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -162,7 +162,7 @@ struct PageRecordHeader {
     header_len: usize,
     payload_len: usize,
     pub(super) stored_len: usize,
-    checksum: [u8; PAGE_RECORD_CHECKSUM_LEN],
+    checksum: [u8; BLOCK_RECORD_CHECKSUM_LEN],
     page_id: Option<u64>,
     object_id: Option<u64>,
     routing_bucket: Option<u32>,
@@ -216,7 +216,7 @@ pub(super) fn encode_page_record(
         }
     };
     let block_size = stored_payload.len();
-    if block_size as u64 > u64::from(PAGE_RECORD_LENGTH_MASK) {
+    if block_size as u64 > u64::from(BLOCK_RECORD_LENGTH_MASK) {
         return Err(corrupt_page_envelope(
             &BlockAddress::default(),
             format!("block of {block_size} bytes does not fit a block size field"),
@@ -226,12 +226,12 @@ pub(super) fn encode_page_record(
     // derivable from the slab on top of that. None of them are written here any more.
     let _ = (object_id, routing_bucket, band_id);
     let codec = match compression {
-        PageRecordCompression::None => u32::from(PAGE_RECORD_COMPRESSION_NONE),
-        PageRecordCompression::Zstd => u32::from(PAGE_RECORD_COMPRESSION_ZSTD),
+        PageRecordCompression::None => u32::from(BLOCK_RECORD_COMPRESSION_NONE),
+        PageRecordCompression::Zstd => u32::from(BLOCK_RECORD_COMPRESSION_ZSTD),
     };
-    let sized = (codec << PAGE_RECORD_CODEC_SHIFT) | (block_size as u32);
-    let mut record = Vec::with_capacity(PAGE_RECORD_HEADER_LEN + block_size);
-    record.extend_from_slice(PAGE_RECORD_MAGIC);
+    let sized = (codec << BLOCK_RECORD_CODEC_SHIFT) | (block_size as u32);
+    let mut record = Vec::with_capacity(BLOCK_RECORD_HEADER_LEN + block_size);
+    record.extend_from_slice(BLOCK_RECORD_MAGIC);
     record.extend_from_slice(&checksum_field);
     record.extend_from_slice(&sized.to_le_bytes());
     if page_id > u64::from(u16::MAX) {
@@ -241,7 +241,7 @@ pub(super) fn encode_page_record(
         ));
     }
     record.extend_from_slice(&(page_id as u16).to_le_bytes());
-    debug_assert_eq!(record.len(), PAGE_RECORD_HEADER_LEN, "the header is one size");
+    debug_assert_eq!(record.len(), BLOCK_RECORD_HEADER_LEN, "the header is one size");
     let stored_len = block_size;
     record.extend_from_slice(&stored_payload);
     Ok(EncodedPageRecord {
@@ -265,7 +265,7 @@ fn encode_page_record_payload(
     // compressor allocates its working buffers up front. Measured by sweeping value sizes
     // through a write: cost is flat at 2.0 B allocated per payload byte on both sides of a
     // step between 192 and 256 bytes worth 32,535 B per write -- and 256 is
-    // `PAGE_RECORD_COMPRESSION_MIN_BYTES`, so the step IS this call. At the 1,244-byte average
+    // `BLOCK_RECORD_COMPRESSION_MIN_BYTES`, so the step IS this call. At the 1,244-byte average
     // of a soak corpus that is about 80% of everything a write allocates.
     //
     // The level is per-call rather than fixed, so it is set on the held compressor each time;
@@ -294,14 +294,14 @@ pub(super) fn decode_page_record(
     record: &[u8],
     address: &BlockAddress,
 ) -> Result<DecodedPageRecord, BlockStoreError> {
-    if record.len() < PAGE_RECORD_HEADER_LEN || !record.starts_with(PAGE_RECORD_MAGIC) {
+    if record.len() < BLOCK_RECORD_HEADER_LEN || !record.starts_with(BLOCK_RECORD_MAGIC) {
         return Ok(DecodedPageRecord {
             payload: record.to_vec(),
             logical_len: record.len(),
             compression: PageRecordCompression::None,
         });
     }
-    if record.len() < PAGE_RECORD_SMALLEST_HEADER_LEN {
+    if record.len() < BLOCK_RECORD_SMALLEST_HEADER_LEN {
         return Err(corrupt_page_envelope(address, "short header"));
     }
     let header = parse_page_record_header(record, address)?;
@@ -374,7 +374,7 @@ pub(super) fn logical_range_from_slab(
             compressed_records_read: 0,
         });
     }
-    if slab.len() < PAGE_RECORD_HEADER_LEN || !slab.starts_with(PAGE_RECORD_MAGIC) {
+    if slab.len() < BLOCK_RECORD_HEADER_LEN || !slab.starts_with(BLOCK_RECORD_MAGIC) {
         let start = offset as usize;
         let end = start.saturating_add(size as usize).min(slab.len());
         let bytes = if start >= slab.len() {
@@ -398,13 +398,13 @@ pub(super) fn logical_range_from_slab(
     while physical_offset < slab.len() && out.len() < size as usize {
         let remaining = &slab[physical_offset..];
         let address = BlockAddress::from_parts(block_slab_id, physical_offset as u64, 0, None, None, None, None);
-        if remaining.len() < PAGE_RECORD_HEADER_LEN || !remaining.starts_with(PAGE_RECORD_MAGIC) {
+        if remaining.len() < BLOCK_RECORD_HEADER_LEN || !remaining.starts_with(BLOCK_RECORD_MAGIC) {
             return Err(corrupt_page_envelope(
                 &address,
                 "mixed raw bytes after page envelope",
             ));
         }
-        if remaining.len() < PAGE_RECORD_SMALLEST_HEADER_LEN {
+        if remaining.len() < BLOCK_RECORD_SMALLEST_HEADER_LEN {
             return Err(corrupt_page_envelope(&address, "short header"));
         }
         let header = parse_page_record_header(remaining, &address)?;
@@ -452,30 +452,30 @@ fn parse_page_record_header(
     record: &[u8],
     address: &BlockAddress,
 ) -> Result<PageRecordHeader, BlockStoreError> {
-    if !record.starts_with(PAGE_RECORD_MAGIC) {
+    if !record.starts_with(BLOCK_RECORD_MAGIC) {
         return Err(corrupt_page_envelope(address, "not a block record"));
     }
-    if record.len() < PAGE_RECORD_HEADER_LEN {
+    if record.len() < BLOCK_RECORD_HEADER_LEN {
         return Err(corrupt_page_envelope(address, "short header"));
     }
-    let checksum = record[PAGE_RECORD_CHECKSUM_OFFSET..PAGE_RECORD_CHECKSUM_OFFSET + PAGE_RECORD_CHECKSUM_LEN]
+    let checksum = record[BLOCK_RECORD_CHECKSUM_OFFSET..BLOCK_RECORD_CHECKSUM_OFFSET + BLOCK_RECORD_CHECKSUM_LEN]
         .try_into()
         .expect("block checksum slice");
     let sized = u32::from_le_bytes(
-        record[PAGE_RECORD_LENGTH_OFFSET..PAGE_RECORD_LENGTH_OFFSET + 4]
+        record[BLOCK_RECORD_LENGTH_OFFSET..BLOCK_RECORD_LENGTH_OFFSET + 4]
             .try_into()
             .expect("block size slice"),
     );
-    let block_size = (sized & PAGE_RECORD_LENGTH_MASK) as usize;
-    let codec = (sized >> PAGE_RECORD_CODEC_SHIFT) as u8;
+    let block_size = (sized & BLOCK_RECORD_LENGTH_MASK) as usize;
+    let codec = (sized >> BLOCK_RECORD_CODEC_SHIFT) as u8;
     let block_id = u16::from_le_bytes(
-        record[PAGE_RECORD_BLOCK_ID_OFFSET..PAGE_RECORD_BLOCK_ID_OFFSET + 2]
+        record[BLOCK_RECORD_BLOCK_ID_OFFSET..BLOCK_RECORD_BLOCK_ID_OFFSET + 2]
             .try_into()
             .expect("block id slice"),
     );
     let compression = match codec {
-        PAGE_RECORD_COMPRESSION_NONE => PageRecordCompression::None,
-        PAGE_RECORD_COMPRESSION_ZSTD => PageRecordCompression::Zstd,
+        BLOCK_RECORD_COMPRESSION_NONE => PageRecordCompression::None,
+        BLOCK_RECORD_COMPRESSION_ZSTD => PageRecordCompression::Zstd,
         codec => {
             return Err(corrupt_page_envelope(
                 address,
@@ -491,7 +491,7 @@ fn parse_page_record_header(
     let payload_len = match compression {
         PageRecordCompression::None => block_size,
         PageRecordCompression::Zstd => {
-            let at = PAGE_RECORD_HEADER_LEN;
+            let at = BLOCK_RECORD_HEADER_LEN;
             if record.len() < at + 4 {
                 return Err(corrupt_page_envelope(
                     address,
@@ -506,7 +506,7 @@ fn parse_page_record_header(
         }
     };
     Ok(PageRecordHeader {
-        header_len: PAGE_RECORD_HEADER_LEN,
+        header_len: BLOCK_RECORD_HEADER_LEN,
         payload_len,
         stored_len: block_size,
         checksum,
@@ -609,14 +609,14 @@ fn decode_page_record_payload(
 
 /// Build the 32-byte checksum field for a new (v7) record: CRC32C little-endian in the first
 /// four bytes, a marker so the field is self-describing, then zero padding.
-fn page_record_checksum_field(payload: &[u8]) -> [u8; PAGE_RECORD_CHECKSUM_LEN] {
+fn page_record_checksum_field(payload: &[u8]) -> [u8; BLOCK_RECORD_CHECKSUM_LEN] {
     crate::checksum::crc32c(payload).to_le_bytes()
 }
 
 /// Verify a page record's payload against its stored CRC32C.
 fn verify_page_record_checksum(
     payload: &[u8],
-    expected_checksum: &[u8; PAGE_RECORD_CHECKSUM_LEN],
+    expected_checksum: &[u8; BLOCK_RECORD_CHECKSUM_LEN],
     address: &BlockAddress,
 ) -> Result<(), BlockStoreError> {
     let stored = u32::from_le_bytes(*expected_checksum);
@@ -667,7 +667,7 @@ pub(super) fn summarize_slab(
     slab: &[u8],
     block_slab_id: u64,
 ) -> Result<SlabSummary, BlockStoreError> {
-    if slab.len() < PAGE_RECORD_HEADER_LEN || !slab.starts_with(PAGE_RECORD_MAGIC) {
+    if slab.len() < BLOCK_RECORD_HEADER_LEN || !slab.starts_with(BLOCK_RECORD_MAGIC) {
         return Ok(SlabSummary {
             logical_bytes: slab.len() as u64,
             first_page_id: None,
@@ -679,13 +679,13 @@ pub(super) fn summarize_slab(
     while physical_offset < slab.len() {
         let remaining = &slab[physical_offset..];
         let address = BlockAddress::from_parts(block_slab_id, physical_offset as u64, 0, None, None, None, None);
-        if remaining.len() < PAGE_RECORD_HEADER_LEN || !remaining.starts_with(PAGE_RECORD_MAGIC) {
+        if remaining.len() < BLOCK_RECORD_HEADER_LEN || !remaining.starts_with(BLOCK_RECORD_MAGIC) {
             return Err(corrupt_page_envelope(
                 &address,
                 "mixed raw bytes after page envelope",
             ));
         }
-        if remaining.len() < PAGE_RECORD_SMALLEST_HEADER_LEN {
+        if remaining.len() < BLOCK_RECORD_SMALLEST_HEADER_LEN {
             return Err(corrupt_page_envelope(&address, "short header"));
         }
         let header = parse_page_record_header(remaining, &address)?;
@@ -717,14 +717,14 @@ pub(super) fn summarize_slab(
 }
 
 /// The scan reads a prefix big enough to hold a header. There is one header size now.
-const PAGE_RECORD_WIDEST_HEADER_LEN: usize = PAGE_RECORD_HEADER_LEN;
+const BLOCK_RECORD_WIDEST_HEADER_LEN: usize = BLOCK_RECORD_HEADER_LEN;
 
 /// Read buffer for the page-id scan.
 ///
 /// Sized so a bufferful spans many records rather than one: at the ~300-byte records the live
 /// store holds, this is ~800 per fill, which is the difference between thousands of reads for a
 /// slab and millions.
-const PAGE_RECORD_SCAN_BUFFER_BYTES: usize = 256 * 1024;
+const BLOCK_RECORD_SCAN_BUFFER_BYTES: usize = 256 * 1024;
 
 /// TS_BLOCK_INDEX_CHECKSUMS: recompute and record a hex digest per page record while inspecting.
 ///
@@ -760,7 +760,7 @@ pub(super) fn inspect_slab(slab: &[u8], block_slab_id: u64) -> BlockStoreSlabRep
     if slab.is_empty() {
         return report;
     }
-    if slab.len() < PAGE_RECORD_HEADER_LEN || !slab.starts_with(PAGE_RECORD_MAGIC) {
+    if slab.len() < BLOCK_RECORD_HEADER_LEN || !slab.starts_with(BLOCK_RECORD_MAGIC) {
         report.logical_bytes = slab.len() as u64;
         report.page_count = 1;
         report.readable_prefix_physical_bytes = slab.len() as u64;
@@ -771,7 +771,7 @@ pub(super) fn inspect_slab(slab: &[u8], block_slab_id: u64) -> BlockStoreSlabRep
     while physical_offset < slab.len() {
         let remaining = &slab[physical_offset..];
         let mut address = BlockAddress::from_parts(block_slab_id, physical_offset as u64, 0, None, None, None, None);
-        if remaining.len() < PAGE_RECORD_HEADER_LEN || !remaining.starts_with(PAGE_RECORD_MAGIC) {
+        if remaining.len() < BLOCK_RECORD_HEADER_LEN || !remaining.starts_with(BLOCK_RECORD_MAGIC) {
             record_slab_inspection_error(
                 &mut report,
                 address.offset,
@@ -779,7 +779,7 @@ pub(super) fn inspect_slab(slab: &[u8], block_slab_id: u64) -> BlockStoreSlabRep
             );
             break;
         }
-        if remaining.len() < PAGE_RECORD_SMALLEST_HEADER_LEN {
+        if remaining.len() < BLOCK_RECORD_SMALLEST_HEADER_LEN {
             record_slab_inspection_error(
                 &mut report,
                 address.offset,
@@ -922,7 +922,7 @@ mod page_record_format_tests {
         .expect("encode");
         assert_eq!(
             encoded.bytes.len(),
-            PAGE_RECORD_HEADER_LEN + payload.len(),
+            BLOCK_RECORD_HEADER_LEN + payload.len(),
             "one header size, whatever the values"
         );
         let header = parse_page_record_header(&encoded.bytes, &address()).expect("parse");
@@ -945,7 +945,7 @@ mod page_record_format_tests {
             encode_page_record(payload, block_id, None, None, 0, BlockStoreOptions::default())
                 .expect("encode");
 
-        let at = PAGE_RECORD_BLOCK_ID_OFFSET;
+        let at = BLOCK_RECORD_BLOCK_ID_OFFSET;
         let read_directly = u16::from_le_bytes(encoded.bytes[at..at + 2].try_into().unwrap());
         assert_eq!(
             u64::from(read_directly),
@@ -953,12 +953,12 @@ mod page_record_format_tests {
             "the block id is one slice at a constant offset"
         );
 
-        let at = PAGE_RECORD_LENGTH_OFFSET;
+        let at = BLOCK_RECORD_LENGTH_OFFSET;
         let sized = u32::from_le_bytes(encoded.bytes[at..at + 4].try_into().unwrap());
-        assert_eq!((sized & PAGE_RECORD_LENGTH_MASK) as usize, payload.len());
+        assert_eq!((sized & BLOCK_RECORD_LENGTH_MASK) as usize, payload.len());
         assert_eq!(
-            (sized >> PAGE_RECORD_CODEC_SHIFT) as u8,
-            PAGE_RECORD_COMPRESSION_NONE,
+            (sized >> BLOCK_RECORD_CODEC_SHIFT) as u8,
+            BLOCK_RECORD_COMPRESSION_NONE,
             "the codec shares the size word rather than taking a byte of its own"
         );
     }
@@ -970,14 +970,14 @@ mod page_record_format_tests {
         let encoded =
             encode_page_record(payload, 7, None, None, 3, BlockStoreOptions::default())
                 .expect("encode");
-        let at = PAGE_RECORD_CHECKSUM_OFFSET;
+        let at = BLOCK_RECORD_CHECKSUM_OFFSET;
         let stored = u32::from_le_bytes(
-            encoded.bytes[at..at + PAGE_RECORD_CHECKSUM_LEN]
+            encoded.bytes[at..at + BLOCK_RECORD_CHECKSUM_LEN]
                 .try_into()
                 .unwrap(),
         );
         assert_eq!(stored, crate::checksum::crc32c(payload));
-        assert_eq!(PAGE_RECORD_CHECKSUM_LEN, 4, "the field is the checksum, nothing more");
+        assert_eq!(BLOCK_RECORD_CHECKSUM_LEN, 4, "the field is the checksum, nothing more");
     }
 
     /// A record whose payload was altered after the fact is refused.
@@ -1003,7 +1003,7 @@ mod page_record_format_tests {
         let encoded =
             encode_page_record(payload, 1, None, None, 0, BlockStoreOptions::default())
                 .expect("encode");
-        for keep in [0, 1, PAGE_RECORD_HEADER_LEN - 1] {
+        for keep in [0, 1, BLOCK_RECORD_HEADER_LEN - 1] {
             let err = parse_page_record_header(&encoded.bytes[..keep], &address())
                 .expect_err("a short record must be refused");
             assert!(
@@ -1021,10 +1021,10 @@ mod reused_zstd_context_tests {
 
     fn zstd_header(payload_len: usize, stored_len: usize) -> PageRecordHeader {
         PageRecordHeader {
-            header_len: PAGE_RECORD_HEADER_LEN,
+            header_len: BLOCK_RECORD_HEADER_LEN,
             payload_len,
             stored_len,
-            checksum: [0_u8; PAGE_RECORD_CHECKSUM_LEN],
+            checksum: [0_u8; BLOCK_RECORD_CHECKSUM_LEN],
             page_id: Some(1),
             // The record no longer carries these; the index does.
             object_id: None,
@@ -1051,7 +1051,7 @@ mod reused_zstd_context_tests {
 
     /// Round-trip at several sizes through the shared thread-local context.
     ///
-    /// Sizes straddle PAGE_RECORD_COMPRESSION_MIN_BYTES (256) so both the compressed and the
+    /// Sizes straddle BLOCK_RECORD_COMPRESSION_MIN_BYTES (256) so both the compressed and the
     /// uncompressed branch are exercised, and the largest is well past any single decompress
     /// buffer -- a bulk decompressor given the wrong capacity truncates rather than erroring, so
     /// "it worked for the size I tried" is not evidence.
@@ -1063,7 +1063,7 @@ mod reused_zstd_context_tests {
             let original: Vec<u8> = (0..len).map(|i| (i % 7) as u8).collect();
             let compressed = zstd::stream::encode_all(
                 std::io::Cursor::new(&original[..]),
-                PAGE_RECORD_COMPRESSION_LEVEL,
+                BLOCK_RECORD_COMPRESSION_LEVEL,
             )
             .expect("compresses");
             let stored = stored_bytes(original.len(), &compressed);
@@ -1086,7 +1086,7 @@ mod reused_zstd_context_tests {
                 let original: Vec<u8> = (0..len).map(|i| (i % 11) as u8).collect();
                 let compressed = zstd::stream::encode_all(
                     std::io::Cursor::new(&original[..]),
-                    PAGE_RECORD_COMPRESSION_LEVEL,
+                    BLOCK_RECORD_COMPRESSION_LEVEL,
                 )
                 .expect("compresses");
                 let stored = stored_bytes(original.len(), &compressed);
@@ -1109,7 +1109,7 @@ mod reused_zstd_context_tests {
         let original: Vec<u8> = (0..1000).map(|i| (i % 5) as u8).collect();
         let compressed = zstd::stream::encode_all(
             std::io::Cursor::new(&original[..]),
-            PAGE_RECORD_COMPRESSION_LEVEL,
+            BLOCK_RECORD_COMPRESSION_LEVEL,
         )
         .expect("compresses");
         // The frame really holds 1000 bytes; the block says 4242.

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -8054,7 +8054,7 @@ fn what_one_write_spends() {
 ///
 /// Write cost is flat at ~2 B per payload byte on both sides of a sharp step between 192 and 256
 /// bytes worth 32,535 B per write (`what_one_write_spends`). 256 is
-/// `PAGE_RECORD_COMPRESSION_MIN_BYTES`, and the encoder above it is `zstd::stream::encode_all`,
+/// `BLOCK_RECORD_COMPRESSION_MIN_BYTES`, and the encoder above it is `zstd::stream::encode_all`,
 /// which builds a compressor, uses it once and drops it. Records in the soak corpus average 1,244
 /// bytes, so essentially every real write is above the threshold and pays this.
 ///


### PR DESCRIPTION
A block record is named for the block it holds

101 constants describing the on-disk record's own layout still spelled it a
page: PAGE_RECORD_MAGIC, PAGE_RECORD_HEADER_LEN, PAGE_RECORD_CHECKSUM_OFFSET
and the rest. They live in a module called block_store, in a file called
record.rs, describing a record the rest of this tree calls a block.

Not a byte moves on disk. None of these names is serde- or wire-visible --
the diff changes zero lines carrying serde, rename or alias -- so the magic
is still "TB", the offsets are where they were, and the header is still
twelve bytes: two magic, four checksum, four length-and-codec packed into a
word, two block id.

One name was not mechanical. BLOCK_RECORD_HEADER_LEN already existed, as a
pub(crate) constant in block_store.rs whose entire body was
record::PAGE_RECORD_HEADER_LEN -- a bridge added to widen a pub(super)
definition so a log that carries a block could work out the length its
address will hold. Renaming blindly would have left two constants of the same
name in two modules, one defined as the other. So the bridge collapses into a
re-export and the definition moves up to pub(crate): one name, one
definition, and the five callers outside the module keep the path they use.

That is the third rename this session where grepping for the TARGET name
before touching anything changed the answer. Twice it stopped the rename
(model_id onto kind, which IndexItem already uses for something else;
tombstone onto deleted, which has 66 declarations meaning the live flag
rather than the marker). Here it turned a mechanical rename into a small
cleanup.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
