### PR TITLE
A shard counts its inventory once per write, and the counts are summed

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -1462,6 +1462,11 @@ struct SnapshotEntry {
     /// Keyed by scope because the filter is: one caller means one key, and a second scope pays its
     /// own build once per shard per write rather than on every retrieve.
     prepared: BTreeMap<String, Arc<Vec<CachedRetrieveCandidate>>>,
+    /// The shard's inventory counts, or `None` until something asks.
+    ///
+    /// No scope key, unlike `prepared`: the counters are scope-free, and the scope only enters
+    /// when counts are finished into an inventory, once per rebuild rather than once per shard.
+    counts: Option<Value>,
     /// The payload bytes. `decoded` is charged separately, so this stays comparable to `weigh`.
     bytes: usize,
     /// What the decoded records and the prepared candidates are charged at, or 0 for none.
@@ -1587,6 +1592,23 @@ impl SnapshotCache {
         entry.prepared.get(signature).cloned()
     }
 
+    /// The shard's inventory counts, if this entry still has them.
+    fn counts_for(&mut self, key: &str) -> Option<Value> {
+        self.clock += 1;
+        let clock = self.clock;
+        let entry = self.entries.get_mut(key)?;
+        entry.used = clock;
+        entry.counts.clone()
+    }
+
+    /// Attach a shard's inventory counts. Not charged: this is a fixed handful of integers per
+    /// shard, and charging it would cost more in bookkeeping than it accounts for.
+    fn set_counts(&mut self, key: &str, counts: Value) {
+        if let Some(entry) = self.entries.get_mut(key) {
+            entry.counts = Some(counts);
+        }
+    }
+
     /// Attach a shard's candidates for a scope, and charge them.
     ///
     /// Charged at the payload bytes rather than a multiple: the candidates are a filtered subset
@@ -1640,6 +1662,7 @@ impl SnapshotCache {
                 map,
                 decoded: None,
                 prepared: BTreeMap::new(),
+                counts: None,
                 bytes,
                 decoded_bytes: 0,
                 used: self.clock,
@@ -1674,6 +1697,7 @@ impl SnapshotCache {
         let dropped = entry.decoded_bytes;
         entry.decoded = None;
         entry.prepared.clear();
+        entry.counts = None;
         entry.decoded_bytes = 0;
         let was = entry.bytes;
         let now = Self::weigh(&entry.map);
@@ -1701,6 +1725,9 @@ impl SnapshotCache {
             self.decoded_bytes = self.decoded_bytes.saturating_sub(entry.decoded_bytes);
             entry.decoded = None;
             entry.prepared.clear();
+            // The counts are a handful of integers; they are dropped with the rest so an evicted
+            // shard has nothing derived left behind, not because they are large.
+            entry.counts = None;
             entry.decoded_bytes = 0;
         }
     }
@@ -5874,6 +5901,46 @@ fn read_record_count(engine: &RecordStore, key: &str) -> Result<String, String> 
     Ok(value)
 }
 
+/// One shard's inventory counts, built at most once per shard per write.
+///
+/// Scope-free, so unlike the candidates there is one entry per shard rather than one per scope.
+fn shard_inventory_counts(engine: &RecordStore, key: String) -> Result<Value, String> {
+    if let Ok(mut cache) = hgetall_snapshot_cache().lock() {
+        if let Some(counts) = cache.counts_for(&key) {
+            return Ok(counts);
+        }
+    }
+    let records = hgetall_decoded(engine, key.clone())?;
+    let borrowed: Vec<&Value> = records.iter().collect();
+    let mut counts = empty_inventory_counts();
+    count_records_into(&mut counts, &borrowed);
+    if let Ok(mut cache) = hgetall_snapshot_cache().lock() {
+        cache.set_counts(&key, counts.clone());
+    }
+    Ok(counts)
+}
+
+/// Add one shard's counts into a running total.
+///
+/// The buckets are fixed and their leaves are integers, so this walks the two objects in step
+/// rather than trying to be general: anything that is not an integer under a known bucket is a
+/// shape change, and silently ignoring it would hide it.
+fn merge_inventory_counts(into: &mut Value, from: &Value) {
+    for bucket in ["session", "profile", "shared"] {
+        let Some(source) = from.get(bucket).and_then(Value::as_object).cloned() else {
+            continue;
+        };
+        let Some(target) = into.get_mut(bucket).and_then(Value::as_object_mut) else {
+            continue;
+        };
+        for (field, value) in source {
+            let added = value.as_u64().unwrap_or(0);
+            let running = target.get(&field).and_then(Value::as_u64).unwrap_or(0);
+            target.insert(field, json!(running.saturating_add(added)));
+        }
+    }
+}
+
 /// One shard's candidates for a scope, built at most once per shard per write.
 ///
 /// The filters are the same three the whole-corpus path applies, in the same order and for the
@@ -6009,7 +6076,15 @@ fn load_retrieve_candidate_snapshot(
     }
 
     let inventory_started = Instant::now();
-    let memory_inventory = native_retrieval_memory_inventory(&records, scope);
+    // Summed from per-shard counts rather than counted over every record again. The counters are
+    // scope-free, so a shard's are the same until that shard is written to; only the finishing
+    // step sees the scope.
+    let mut counts = empty_inventory_counts();
+    for shard in 0..shard_count {
+        let key = format!("{record_hash_key}:{shard:06}");
+        merge_inventory_counts(&mut counts, &shard_inventory_counts(engine, key)?);
+    }
+    let memory_inventory = finish_inventory(counts, scope);
     let inventory_ms = inventory_started.elapsed().as_secs_f64() * 1000.0;
     let scanned_records = records.len();
     let candidates_started = Instant::now();
@@ -7212,6 +7287,58 @@ fn _request_shape_for_docs() -> serde_json::Value {
 
 #[cfg(test)]
 mod tests {
+
+    /// Summing per-shard counts equals counting every record at once.
+    ///
+    /// A miscounted inventory does not fail, it changes which memory layers a retrieve believes
+    /// exist -- `available_layers` and the `has_*` flags are derived from these numbers. The
+    /// fixture puts records in all three buckets and includes a shard that contributes nothing,
+    /// which a shard of pure index records does.
+    #[test]
+    fn summing_shard_counts_equals_counting_them_together() {
+        let shard_one = vec![
+            json!({"record_type": "context_event", "memory_scope": "session"}),
+            json!({"record_type": "context_event", "session_continuity": "same_session"}),
+            json!({"record_type": "skill_section", "sharing_scope": "tenant_shared"}),
+        ];
+        let shard_two = vec![
+            json!({"record_type": "context_entity", "memory_scope": "user_profile"}),
+            json!({"record_type": "context_summary", "session_continuity": "cross_session"}),
+            json!({"record_type": "resource_chunk"}),
+        ];
+        // A shard the inventory takes nothing from.
+        let shard_three: Vec<Value> = vec![
+            json!({"record_type": "context_embedding"}),
+            json!({"record_type": "context_node"}),
+        ];
+
+        let mut summed = empty_inventory_counts();
+        for shard in [&shard_one, &shard_two, &shard_three] {
+            let borrowed: Vec<&Value> = shard.iter().collect();
+            let mut counts = empty_inventory_counts();
+            count_records_into(&mut counts, &borrowed);
+            merge_inventory_counts(&mut summed, &counts);
+        }
+
+        let everything: Vec<&Value> = shard_one
+            .iter()
+            .chain(shard_two.iter())
+            .chain(shard_three.iter())
+            .collect();
+        let mut at_once = empty_inventory_counts();
+        count_records_into(&mut at_once, &everything);
+
+        assert_eq!(summed, at_once, "summed counts differ from counting together");
+
+        // And the finished inventories agree, which is what a retrieve actually reads.
+        let scope = json!({"user_id": "u", "session_id": "s"});
+        assert_eq!(
+            finish_inventory(summed, Some(&scope)),
+            finish_inventory(at_once, Some(&scope)),
+            "the finished inventories differ"
+        );
+    }
+
 
     fn candidate_named(name: &str) -> CachedRetrieveCandidate {
         CachedRetrieveCandidate {

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl/native_serving.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl/native_serving.rs
@@ -90,8 +90,22 @@ fn inventory_layer_available(inventory: &Value, layer: &str) -> bool {
 ///
 /// Takes BORROWED records: the caller reads them out of the shard cache, and counting has never
 /// needed to own them.
-fn native_retrieval_memory_inventory(records: &[&Value], query_scope: Option<&Value>) -> Value {
-    let mut inventory = json!({
+fn native_retrieval_memory_inventory(
+    records: &[&Value],
+    query_scope: Option<&Value>,
+) -> Value {
+    let mut counts = empty_inventory_counts();
+    count_records_into(&mut counts, records);
+    finish_inventory(counts, query_scope)
+}
+
+/// The zeroed buckets a count starts from.
+///
+/// Separate from the finishing step because the counters do not depend on the query scope -- only
+/// the `query_scope` block and the derived flags do -- so counts for one shard can be built once,
+/// kept, and summed with another shard's.
+fn empty_inventory_counts() -> Value {
+    json!({
         "session": {
             "context_events": 0,
             "context_segments": 0,
@@ -114,28 +128,12 @@ fn native_retrieval_memory_inventory(records: &[&Value], query_scope: Option<&Va
             "context_entities": 0,
             "context_indexes": 0
         },
-        "available_layers": [],
-        "query_scope": {
-            "session_scope": query_scope.map(session_scope_mode).unwrap_or("prefer"),
-            "has_session_id": query_scope
-                .and_then(|scope| scope.get("session_id"))
-                .and_then(Value::as_str)
-                .map(|value| !value.trim().is_empty())
-                .unwrap_or(false),
-            "has_user_id": query_scope
-                .and_then(|scope| scope.get("user_id"))
-                .and_then(Value::as_str)
-                .map(|value| !value.trim().is_empty())
-                .unwrap_or(false),
-            "has_tenant_id": query_scope
-                .and_then(|scope| scope.get("tenant_id"))
-                .and_then(Value::as_str)
-                .map(|value| !value.trim().is_empty())
-                .unwrap_or(false)
-        },
         "profile_records_available_but_not_selected": false
-    });
+    })
+}
 
+/// Add a set of records to a counts object.
+fn count_records_into(inventory: &mut Value, records: &[&Value]) {
     for record in records.iter().copied() {
         let record_type = string_field(record, "record_type");
         let memory_scope = string_field(record, "memory_scope")
@@ -173,14 +171,14 @@ fn native_retrieval_memory_inventory(records: &[&Value], query_scope: Option<&Va
 
         if is_shared {
             match record_type {
-                "resource_chunk" => increment_inventory_count(&mut inventory, "shared", "resource_chunks"),
-                "resource_manifest" => increment_inventory_count(&mut inventory, "shared", "resource_manifests"),
-                "skill_section" => increment_inventory_count(&mut inventory, "shared", "skill_sections"),
+                "resource_chunk" => increment_inventory_count(inventory, "shared", "resource_chunks"),
+                "resource_manifest" => increment_inventory_count(inventory, "shared", "resource_manifests"),
+                "skill_section" => increment_inventory_count(inventory, "shared", "skill_sections"),
                 "skill_manifest" | "skill_registry_update" => {
-                    increment_inventory_count(&mut inventory, "shared", "skill_manifests")
+                    increment_inventory_count(inventory, "shared", "skill_manifests")
                 }
-                "context_entity" => increment_inventory_count(&mut inventory, "shared", "context_entities"),
-                "context_index" => increment_inventory_count(&mut inventory, "shared", "context_indexes"),
+                "context_entity" => increment_inventory_count(inventory, "shared", "context_entities"),
+                "context_index" => increment_inventory_count(inventory, "shared", "context_indexes"),
                 _ => {}
             }
             continue;
@@ -188,11 +186,11 @@ fn native_retrieval_memory_inventory(records: &[&Value], query_scope: Option<&Va
 
         if is_profile {
             match record_type {
-                "context_entity" => increment_inventory_count(&mut inventory, "profile", "context_entities"),
-                "context_index" => increment_inventory_count(&mut inventory, "profile", "context_indexes"),
-                "context_summary" => increment_inventory_count(&mut inventory, "profile", "context_summaries"),
+                "context_entity" => increment_inventory_count(inventory, "profile", "context_entities"),
+                "context_index" => increment_inventory_count(inventory, "profile", "context_indexes"),
+                "context_summary" => increment_inventory_count(inventory, "profile", "context_summaries"),
                 "context_summary_dirty" => {
-                    increment_inventory_count(&mut inventory, "profile", "summary_dirty_markers")
+                    increment_inventory_count(inventory, "profile", "summary_dirty_markers")
                 }
                 _ => {}
             }
@@ -201,19 +199,46 @@ fn native_retrieval_memory_inventory(records: &[&Value], query_scope: Option<&Va
 
         if is_session || matches!(record_type, "context_event" | "context_segment") {
             match record_type {
-                "context_event" => increment_inventory_count(&mut inventory, "session", "context_events"),
-                "context_segment" => increment_inventory_count(&mut inventory, "session", "context_segments"),
-                "context_entity" => increment_inventory_count(&mut inventory, "session", "context_entities"),
-                "context_index" => increment_inventory_count(&mut inventory, "session", "context_indexes"),
-                "context_summary" => increment_inventory_count(&mut inventory, "session", "context_summaries"),
+                "context_event" => increment_inventory_count(inventory, "session", "context_events"),
+                "context_segment" => increment_inventory_count(inventory, "session", "context_segments"),
+                "context_entity" => increment_inventory_count(inventory, "session", "context_entities"),
+                "context_index" => increment_inventory_count(inventory, "session", "context_indexes"),
+                "context_summary" => increment_inventory_count(inventory, "session", "context_summaries"),
                 "context_summary_dirty" => {
-                    increment_inventory_count(&mut inventory, "session", "summary_dirty_markers")
+                    increment_inventory_count(inventory, "session", "summary_dirty_markers")
                 }
                 _ => {}
             }
         }
     }
 
+}
+
+/// Turn counts into the inventory a request is served, which is where the scope comes in.
+fn finish_inventory(mut inventory: Value, query_scope: Option<&Value>) -> Value {
+    if let Some(object) = inventory.as_object_mut() {
+        object.insert(
+            "query_scope".to_string(),
+            json!({
+                "session_scope": query_scope.map(session_scope_mode).unwrap_or("prefer"),
+                "has_session_id": query_scope
+                    .and_then(|scope| scope.get("session_id"))
+                    .and_then(Value::as_str)
+                    .map(|value| !value.trim().is_empty())
+                    .unwrap_or(false),
+                "has_user_id": query_scope
+                    .and_then(|scope| scope.get("user_id"))
+                    .and_then(Value::as_str)
+                    .map(|value| !value.trim().is_empty())
+                    .unwrap_or(false),
+                "has_tenant_id": query_scope
+                    .and_then(|scope| scope.get("tenant_id"))
+                    .and_then(Value::as_str)
+                    .map(|value| !value.trim().is_empty())
+                    .unwrap_or(false)
+            }),
+        );
+    }
     let mut available_layers = Vec::new();
     for layer in ["session", "profile", "shared"] {
         if inventory_layer_available(&inventory, layer) {


### PR DESCRIPTION
With the parse and the candidates cached per shard, the rebuild was read 0.1 / **inventory
22.8–26.9** / candidates 2.4 — the inventory was what was left, and it had the same shape
everything else did: a pass over every record on every rebuild, producing what it produced last
time for every shard but the newest.

It is cacheable because **the counters do not depend on the query scope.** Only three things do,
and all three are derived at the end from the counts: the `query_scope` block, `available_layers`,
and the `has_*` flags. So counting is per shard and scope-free; finishing is per request.

### The split

`native_retrieval_memory_inventory` becomes `empty_inventory_counts` + `count_records_into` +
`finish_inventory`, and still exists with the same signature and the same output for its other
caller. The loader sums per-shard counts and finishes once.

Unlike the candidates there is no scope key on this cache — the scope never reaches the counting.

### Measured, in one run on one store

| stage | building | from cache |
|---|---:|---:|
| inventory | 35.9 ms | **0.1 – 1.2 ms** |

The rebuild as a whole, on the same 22,628-record store: **read 18.0 / inventory 1.2 /
candidates 3.2 = 22.4 ms**, with the retrieve at 39 ms.

Across this run of work, the rebuild after a write on a store of this size:

| | rebuild |
|---|---:|
| before any of it | 1,134.9 ms |
| after the parse budget fix | 153 ms |
| after the candidate cache | 42–50 ms |
| after this | **22.4 ms** |

### One thing worth knowing, and it is a limitation

The candidate cache is keyed by scope signature. In this run one rebuild still shows
`candidates 70.6` — a signature it had not prepared before. If a deployment's scope varies per
request (a session id inside it, say), the candidate cache will miss on every retrieve while the
parse and the inventory still hit. That is worth measuring on a real workload before assuming the
candidate half helps there; the inventory half is unaffected, because it has no scope key at all.

### Tests

`summing_shard_counts_equals_counting_them_together` is the one that matters. A miscounted
inventory does not fail — it changes which memory layers a retrieve believes exist, since
`available_layers` and the `has_*` flags are derived from these numbers. It asserts summed counts
against counting everything at once, over records landing in all three buckets, including a shard
that contributes nothing (a shard of pure index records does exactly that), and then asserts the
*finished* inventories match too, which is what a retrieve actually reads.

`merge_inventory_counts` walks the fixed buckets in step rather than trying to be general: anything
that is not an integer under a known bucket is a shape change, and quietly ignoring it would hide
it.

The proxy binary suite: 123 passed, 0 failed.
