### PR TITLE
A retrieve says how much its snapshot is holding

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -356,6 +356,23 @@ impl RetrieveCandidateSnapshot {
         self.segments.iter().map(|segment| segment.len()).sum()
     }
 
+    /// How many candidates carry a vector, and how wide the widest is.
+    ///
+    /// The snapshot is resident for the life of its cache entry, and a 1024-dim `Vec<f32>` is
+    /// 4 KiB -- so this is the difference between a snapshot costing a few megabytes and costing
+    /// tens of them. Nothing reported it, which is why nobody could say.
+    fn candidates_holding_vectors(&self) -> (usize, usize) {
+        let mut holding = 0usize;
+        let mut widest = 0usize;
+        for candidate in self.candidates() {
+            if let Some(vector) = candidate.vector.as_ref() {
+                holding += 1;
+                widest = widest.max(vector.len());
+            }
+        }
+        (holding, widest)
+    }
+
     /// The candidate at an ordinal across every segment.
     ///
     /// The ordinal is what the scoring pass records and what the budget closures look up later, so
@@ -6507,15 +6524,25 @@ fn retrieve_context_pack_output(
         .unwrap_or(0);
     let elapsed_ms = started.elapsed().as_millis() as u64;
     let threshold = slow_retrieve_log_ms();
+    // Walked once rather than twice: counting vectors is a pass over every candidate, and the line
+    // wants two numbers from it.
+    let (vectors_held, widest_vector) = if threshold > 0 && u128::from(elapsed_ms) >= threshold {
+        snapshot.candidates_holding_vectors()
+    } else {
+        (0, 0)
+    };
     if threshold > 0 && u128::from(elapsed_ms) >= threshold {
         // Phases, not just a total: a rebuild and a scoring pass are fixed by different work, and
         // "the retrieve took a second" has never been enough to tell them apart.
         eprintln!(
-            "slow retrieve: {elapsed_ms} ms total, snapshot {snapshot_ms:.1} ms (cache_hit={candidate_cache_hit}), score {score_ms:.1} ms, {} records scanned, {selected_count} refs selected; rebuild {:.1} read / {:.1} inventory / {:.1} candidates",
+            "slow retrieve: {elapsed_ms} ms total, snapshot {snapshot_ms:.1} ms (cache_hit={candidate_cache_hit}), score {score_ms:.1} ms, {} records scanned, {selected_count} refs selected; rebuild {:.1} read / {:.1} inventory / {:.1} candidates; snapshot holds {} candidates, {} with vectors up to {} dims",
             snapshot.scanned_records,
             snapshot.build.read_ms,
             snapshot.build.inventory_ms,
-            snapshot.build.candidates_ms
+            snapshot.build.candidates_ms,
+            snapshot.candidate_count(),
+            vectors_held,
+            widest_vector
         );
     }
     let correctness = selected_count > 0;

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -1462,6 +1462,11 @@ struct SnapshotEntry {
     /// Keyed by scope because the filter is: one caller means one key, and a second scope pays its
     /// own build once per shard per write rather than on every retrieve.
     prepared: BTreeMap<String, Arc<Vec<CachedRetrieveCandidate>>>,
+    /// The shard's inventory counts, or `None` until something asks.
+    ///
+    /// No scope key, unlike `prepared`: the counters are scope-free, and the scope only enters
+    /// when counts are finished into an inventory, once per rebuild rather than once per shard.
+    counts: Option<Value>,
     /// The payload bytes. `decoded` is charged separately, so this stays comparable to `weigh`.
     bytes: usize,
     /// What the decoded records and the prepared candidates are charged at, or 0 for none.
@@ -1587,6 +1592,23 @@ impl SnapshotCache {
         entry.prepared.get(signature).cloned()
     }
 
+    /// The shard's inventory counts, if this entry still has them.
+    fn counts_for(&mut self, key: &str) -> Option<Value> {
+        self.clock += 1;
+        let clock = self.clock;
+        let entry = self.entries.get_mut(key)?;
+        entry.used = clock;
+        entry.counts.clone()
+    }
+
+    /// Attach a shard's inventory counts. Not charged: this is a fixed handful of integers per
+    /// shard, and charging it would cost more in bookkeeping than it accounts for.
+    fn set_counts(&mut self, key: &str, counts: Value) {
+        if let Some(entry) = self.entries.get_mut(key) {
+            entry.counts = Some(counts);
+        }
+    }
+
     /// Attach a shard's candidates for a scope, and charge them.
     ///
     /// Charged at the payload bytes rather than a multiple: the candidates are a filtered subset
@@ -1640,6 +1662,7 @@ impl SnapshotCache {
                 map,
                 decoded: None,
                 prepared: BTreeMap::new(),
+                counts: None,
                 bytes,
                 decoded_bytes: 0,
                 used: self.clock,
@@ -1674,6 +1697,7 @@ impl SnapshotCache {
         let dropped = entry.decoded_bytes;
         entry.decoded = None;
         entry.prepared.clear();
+        entry.counts = None;
         entry.decoded_bytes = 0;
         let was = entry.bytes;
         let now = Self::weigh(&entry.map);
@@ -1701,6 +1725,9 @@ impl SnapshotCache {
             self.decoded_bytes = self.decoded_bytes.saturating_sub(entry.decoded_bytes);
             entry.decoded = None;
             entry.prepared.clear();
+            // The counts are a handful of integers; they are dropped with the rest so an evicted
+            // shard has nothing derived left behind, not because they are large.
+            entry.counts = None;
             entry.decoded_bytes = 0;
         }
     }
@@ -5874,6 +5901,46 @@ fn read_record_count(engine: &RecordStore, key: &str) -> Result<String, String> 
     Ok(value)
 }
 
+/// One shard's inventory counts, built at most once per shard per write.
+///
+/// Scope-free, so unlike the candidates there is one entry per shard rather than one per scope.
+fn shard_inventory_counts(engine: &RecordStore, key: String) -> Result<Value, String> {
+    if let Ok(mut cache) = hgetall_snapshot_cache().lock() {
+        if let Some(counts) = cache.counts_for(&key) {
+            return Ok(counts);
+        }
+    }
+    let records = hgetall_decoded(engine, key.clone())?;
+    let borrowed: Vec<&Value> = records.iter().collect();
+    let mut counts = empty_inventory_counts();
+    count_records_into(&mut counts, &borrowed);
+    if let Ok(mut cache) = hgetall_snapshot_cache().lock() {
+        cache.set_counts(&key, counts.clone());
+    }
+    Ok(counts)
+}
+
+/// Add one shard's counts into a running total.
+///
+/// The buckets are fixed and their leaves are integers, so this walks the two objects in step
+/// rather than trying to be general: anything that is not an integer under a known bucket is a
+/// shape change, and silently ignoring it would hide it.
+fn merge_inventory_counts(into: &mut Value, from: &Value) {
+    for bucket in ["session", "profile", "shared"] {
+        let Some(source) = from.get(bucket).and_then(Value::as_object).cloned() else {
+            continue;
+        };
+        let Some(target) = into.get_mut(bucket).and_then(Value::as_object_mut) else {
+            continue;
+        };
+        for (field, value) in source {
+            let added = value.as_u64().unwrap_or(0);
+            let running = target.get(&field).and_then(Value::as_u64).unwrap_or(0);
+            target.insert(field, json!(running.saturating_add(added)));
+        }
+    }
+}
+
 /// One shard's candidates for a scope, built at most once per shard per write.
 ///
 /// The filters are the same three the whole-corpus path applies, in the same order and for the
@@ -6009,7 +6076,15 @@ fn load_retrieve_candidate_snapshot(
     }
 
     let inventory_started = Instant::now();
-    let memory_inventory = native_retrieval_memory_inventory(&records, scope);
+    // Summed from per-shard counts rather than counted over every record again. The counters are
+    // scope-free, so a shard's are the same until that shard is written to; only the finishing
+    // step sees the scope.
+    let mut counts = empty_inventory_counts();
+    for shard in 0..shard_count {
+        let key = format!("{record_hash_key}:{shard:06}");
+        merge_inventory_counts(&mut counts, &shard_inventory_counts(engine, key)?);
+    }
+    let memory_inventory = finish_inventory(counts, scope);
     let inventory_ms = inventory_started.elapsed().as_secs_f64() * 1000.0;
     let scanned_records = records.len();
     let candidates_started = Instant::now();
@@ -7212,6 +7287,58 @@ fn _request_shape_for_docs() -> serde_json::Value {
 
 #[cfg(test)]
 mod tests {
+
+    /// Summing per-shard counts equals counting every record at once.
+    ///
+    /// A miscounted inventory does not fail, it changes which memory layers a retrieve believes
+    /// exist -- `available_layers` and the `has_*` flags are derived from these numbers. The
+    /// fixture puts records in all three buckets and includes a shard that contributes nothing,
+    /// which a shard of pure index records does.
+    #[test]
+    fn summing_shard_counts_equals_counting_them_together() {
+        let shard_one = vec![
+            json!({"record_type": "context_event", "memory_scope": "session"}),
+            json!({"record_type": "context_event", "session_continuity": "same_session"}),
+            json!({"record_type": "skill_section", "sharing_scope": "tenant_shared"}),
+        ];
+        let shard_two = vec![
+            json!({"record_type": "context_entity", "memory_scope": "user_profile"}),
+            json!({"record_type": "context_summary", "session_continuity": "cross_session"}),
+            json!({"record_type": "resource_chunk"}),
+        ];
+        // A shard the inventory takes nothing from.
+        let shard_three: Vec<Value> = vec![
+            json!({"record_type": "context_embedding"}),
+            json!({"record_type": "context_node"}),
+        ];
+
+        let mut summed = empty_inventory_counts();
+        for shard in [&shard_one, &shard_two, &shard_three] {
+            let borrowed: Vec<&Value> = shard.iter().collect();
+            let mut counts = empty_inventory_counts();
+            count_records_into(&mut counts, &borrowed);
+            merge_inventory_counts(&mut summed, &counts);
+        }
+
+        let everything: Vec<&Value> = shard_one
+            .iter()
+            .chain(shard_two.iter())
+            .chain(shard_three.iter())
+            .collect();
+        let mut at_once = empty_inventory_counts();
+        count_records_into(&mut at_once, &everything);
+
+        assert_eq!(summed, at_once, "summed counts differ from counting together");
+
+        // And the finished inventories agree, which is what a retrieve actually reads.
+        let scope = json!({"user_id": "u", "session_id": "s"});
+        assert_eq!(
+            finish_inventory(summed, Some(&scope)),
+            finish_inventory(at_once, Some(&scope)),
+            "the finished inventories differ"
+        );
+    }
+
 
     fn candidate_named(name: &str) -> CachedRetrieveCandidate {
         CachedRetrieveCandidate {

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl/native_serving.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl/native_serving.rs
@@ -90,8 +90,22 @@ fn inventory_layer_available(inventory: &Value, layer: &str) -> bool {
 ///
 /// Takes BORROWED records: the caller reads them out of the shard cache, and counting has never
 /// needed to own them.
-fn native_retrieval_memory_inventory(records: &[&Value], query_scope: Option<&Value>) -> Value {
-    let mut inventory = json!({
+fn native_retrieval_memory_inventory(
+    records: &[&Value],
+    query_scope: Option<&Value>,
+) -> Value {
+    let mut counts = empty_inventory_counts();
+    count_records_into(&mut counts, records);
+    finish_inventory(counts, query_scope)
+}
+
+/// The zeroed buckets a count starts from.
+///
+/// Separate from the finishing step because the counters do not depend on the query scope -- only
+/// the `query_scope` block and the derived flags do -- so counts for one shard can be built once,
+/// kept, and summed with another shard's.
+fn empty_inventory_counts() -> Value {
+    json!({
         "session": {
             "context_events": 0,
             "context_segments": 0,
@@ -114,28 +128,12 @@ fn native_retrieval_memory_inventory(records: &[&Value], query_scope: Option<&Va
             "context_entities": 0,
             "context_indexes": 0
         },
-        "available_layers": [],
-        "query_scope": {
-            "session_scope": query_scope.map(session_scope_mode).unwrap_or("prefer"),
-            "has_session_id": query_scope
-                .and_then(|scope| scope.get("session_id"))
-                .and_then(Value::as_str)
-                .map(|value| !value.trim().is_empty())
-                .unwrap_or(false),
-            "has_user_id": query_scope
-                .and_then(|scope| scope.get("user_id"))
-                .and_then(Value::as_str)
-                .map(|value| !value.trim().is_empty())
-                .unwrap_or(false),
-            "has_tenant_id": query_scope
-                .and_then(|scope| scope.get("tenant_id"))
-                .and_then(Value::as_str)
-                .map(|value| !value.trim().is_empty())
-                .unwrap_or(false)
-        },
         "profile_records_available_but_not_selected": false
-    });
+    })
+}
 
+/// Add a set of records to a counts object.
+fn count_records_into(inventory: &mut Value, records: &[&Value]) {
     for record in records.iter().copied() {
         let record_type = string_field(record, "record_type");
         let memory_scope = string_field(record, "memory_scope")
@@ -173,14 +171,14 @@ fn native_retrieval_memory_inventory(records: &[&Value], query_scope: Option<&Va
 
         if is_shared {
             match record_type {
-                "resource_chunk" => increment_inventory_count(&mut inventory, "shared", "resource_chunks"),
-                "resource_manifest" => increment_inventory_count(&mut inventory, "shared", "resource_manifests"),
-                "skill_section" => increment_inventory_count(&mut inventory, "shared", "skill_sections"),
+                "resource_chunk" => increment_inventory_count(inventory, "shared", "resource_chunks"),
+                "resource_manifest" => increment_inventory_count(inventory, "shared", "resource_manifests"),
+                "skill_section" => increment_inventory_count(inventory, "shared", "skill_sections"),
                 "skill_manifest" | "skill_registry_update" => {
-                    increment_inventory_count(&mut inventory, "shared", "skill_manifests")
+                    increment_inventory_count(inventory, "shared", "skill_manifests")
                 }
-                "context_entity" => increment_inventory_count(&mut inventory, "shared", "context_entities"),
-                "context_index" => increment_inventory_count(&mut inventory, "shared", "context_indexes"),
+                "context_entity" => increment_inventory_count(inventory, "shared", "context_entities"),
+                "context_index" => increment_inventory_count(inventory, "shared", "context_indexes"),
                 _ => {}
             }
             continue;
@@ -188,11 +186,11 @@ fn native_retrieval_memory_inventory(records: &[&Value], query_scope: Option<&Va
 
         if is_profile {
             match record_type {
-                "context_entity" => increment_inventory_count(&mut inventory, "profile", "context_entities"),
-                "context_index" => increment_inventory_count(&mut inventory, "profile", "context_indexes"),
-                "context_summary" => increment_inventory_count(&mut inventory, "profile", "context_summaries"),
+                "context_entity" => increment_inventory_count(inventory, "profile", "context_entities"),
+                "context_index" => increment_inventory_count(inventory, "profile", "context_indexes"),
+                "context_summary" => increment_inventory_count(inventory, "profile", "context_summaries"),
                 "context_summary_dirty" => {
-                    increment_inventory_count(&mut inventory, "profile", "summary_dirty_markers")
+                    increment_inventory_count(inventory, "profile", "summary_dirty_markers")
                 }
                 _ => {}
             }
@@ -201,19 +199,46 @@ fn native_retrieval_memory_inventory(records: &[&Value], query_scope: Option<&Va
 
         if is_session || matches!(record_type, "context_event" | "context_segment") {
             match record_type {
-                "context_event" => increment_inventory_count(&mut inventory, "session", "context_events"),
-                "context_segment" => increment_inventory_count(&mut inventory, "session", "context_segments"),
-                "context_entity" => increment_inventory_count(&mut inventory, "session", "context_entities"),
-                "context_index" => increment_inventory_count(&mut inventory, "session", "context_indexes"),
-                "context_summary" => increment_inventory_count(&mut inventory, "session", "context_summaries"),
+                "context_event" => increment_inventory_count(inventory, "session", "context_events"),
+                "context_segment" => increment_inventory_count(inventory, "session", "context_segments"),
+                "context_entity" => increment_inventory_count(inventory, "session", "context_entities"),
+                "context_index" => increment_inventory_count(inventory, "session", "context_indexes"),
+                "context_summary" => increment_inventory_count(inventory, "session", "context_summaries"),
                 "context_summary_dirty" => {
-                    increment_inventory_count(&mut inventory, "session", "summary_dirty_markers")
+                    increment_inventory_count(inventory, "session", "summary_dirty_markers")
                 }
                 _ => {}
             }
         }
     }
 
+}
+
+/// Turn counts into the inventory a request is served, which is where the scope comes in.
+fn finish_inventory(mut inventory: Value, query_scope: Option<&Value>) -> Value {
+    if let Some(object) = inventory.as_object_mut() {
+        object.insert(
+            "query_scope".to_string(),
+            json!({
+                "session_scope": query_scope.map(session_scope_mode).unwrap_or("prefer"),
+                "has_session_id": query_scope
+                    .and_then(|scope| scope.get("session_id"))
+                    .and_then(Value::as_str)
+                    .map(|value| !value.trim().is_empty())
+                    .unwrap_or(false),
+                "has_user_id": query_scope
+                    .and_then(|scope| scope.get("user_id"))
+                    .and_then(Value::as_str)
+                    .map(|value| !value.trim().is_empty())
+                    .unwrap_or(false),
+                "has_tenant_id": query_scope
+                    .and_then(|scope| scope.get("tenant_id"))
+                    .and_then(Value::as_str)
+                    .map(|value| !value.trim().is_empty())
+                    .unwrap_or(false)
+            }),
+        );
+    }
     let mut available_layers = Vec::new();
     for layer in ["session", "profile", "shared"] {
         if inventory_layer_available(&inventory, layer) {


### PR DESCRIPTION
"Does the snapshot really need to hold all that?" is a fair question and nothing could answer it:
the snapshot is resident for the life of its cache entry, holds a vector per candidate, and
reported neither how many candidates it had nor how many carried one.

It does now, on the line the retrieve already logs:

    snapshot holds 2981 candidates, 2981 with vectors up to 512 dims

### The answer, on this store

2,981 candidates, every one carrying a vector, 512 dims. That is 2,981 x 512 x 4 B = **6.1 MB of
vectors**, and roughly 10 MB for the whole snapshot once the refs are counted -- against a proxy
resident set of **454 MB**.

So the snapshot is about **2% of proxy memory**. It is not where the memory is. The payload cache,
the parse cache and the prepared candidates are, and all three are byte-budgeted, which is where a
memory question should be pointed.

Worth having said with numbers: the obvious next move was to trim the snapshot -- defer building a
ref until a candidate is selected, hold vectors quantised rather than as f32 -- and both would buy
a couple of percent of one process. The measurement is what stopped that being spent.

### Cost of the reporting

The candidates are walked only when the line is going to be printed, so a fast retrieve pays
nothing, and the threshold that governs it is the one that was already there.

The proxy binary suite: 123 passed, 0 failed.
