### PR TITLE
The engine embeds its own query, from one encoder configuration

### DIFF
--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -10,7 +10,8 @@ use serde::{Deserialize, Serialize};
 use temporalstore_rust::env_flag::env_bool;
 use temporalstore_rust::context_workflow::{
     context_pipeline_manage_report, context_workflow_state_report, default_context_model_providers,
-    embed_drainer_config_from_env, embed_drainer_enabled, extract_context, ingest_extract_context,
+    context_provider_from_env, embed_drainer_config_from_env, embed_drainer_enabled,
+    extract_context, ingest_extract_context,
     inject_context, retrieve_context, run_embed_drainer_loop, ContextExtractRequest,
     ContextIngestExtractRequest, ContextInjectRequest, ContextModelProviderConfig,
     ContextRetrieveRequest,
@@ -247,22 +248,13 @@ fn main() {
     // (O(pending)); the interval is a short idle fallback (MATRIXARK_EMBED_DRAINER_INTERVAL_MS).
     if embed_drainer_enabled() {
         let drainer_engine = engine.clone();
-        // Provider: a configured OpenAI-compatible embed server (MATRIXARK_EMBED_BASE_URL)
-        // else the default deterministic provider (safe offline; real vectors need a
-        // real server + MATRIXARK_REQUIRE_MODEL_EMBEDDINGS).
-        let provider = match std::env::var("MATRIXARK_EMBED_BASE_URL").ok() {
-            Some(base_url) if !base_url.trim().is_empty() => ContextModelProviderConfig {
-                provider_name: "embed-drainer".to_string(),
-                provider_kind: ContextProviderKind::OpenAiCompatible,
-                base_url,
-                api_key_env: std::env::var("MATRIXARK_EMBED_API_KEY_ENV").unwrap_or_default(),
-                embedding_model: std::env::var("MATRIXARK_EMBEDDING_MODEL")
-                    .unwrap_or_else(|_| "all-MiniLM-L6-v2".to_string()),
-                mock_mode: false,
-                ..ContextModelProviderConfig::default()
-            },
-            _ => ContextModelProviderConfig::default(),
-        };
+        // One constructor, shared with the serving path, rather than a second inline provider.
+        // It reads the endpoint from `MATRIXARK_EMBEDDING_API_BASE` and still accepts the older
+        // `MATRIXARK_EMBED_BASE_URL` this used to read on its own, so a deployment setting either
+        // gets real vectors on BOTH paths instead of one. With neither set it stays deterministic,
+        // which is what it did before.
+        let mut provider = context_provider_from_env();
+        provider.provider_name = "embed-drainer".to_string();
         let drainer_config = embed_drainer_config_from_env(shard_id, 0, provider);
         println!(
             "embed drainer enabled: shard {shard_id}, batch {}, interval {}ms",

--- a/crates/temporalstore-rust/src/context_workflow.rs
+++ b/crates/temporalstore-rust/src/context_workflow.rs
@@ -60,7 +60,7 @@ pub use ingest::{
     validate_resource_skill_secondary_indexes,
 };
 pub(crate) use model_provider::*;
-pub use model_provider::context_backfill_embeddings;
+pub use model_provider::{context_backfill_embeddings, context_provider_from_env};
 pub use query::context_embedding_ref_hash;
 pub use embed_drainer::{
     drain_embedding_dirty_once, embed_drainer_config_from_env, embed_drainer_enabled,

--- a/crates/temporalstore-rust/src/context_workflow/model_provider.rs
+++ b/crates/temporalstore-rust/src/context_workflow/model_provider.rs
@@ -86,6 +86,70 @@ pub(crate) fn context_summaries_for_extract(
     }
 }
 
+/// The embedding provider a deployment has configured, read from the environment.
+///
+/// The engine could already call a real embedding endpoint, but only a caller holding a
+/// `ContextModelProviderConfig` could reach it -- and the proxy had none, which is why a query
+/// vector had to be computed elsewhere and sent in.
+///
+/// It reads the variables the rest of the deployment already sets rather than a second set of its
+/// own: `MATRIXARK_EMBEDDING_API_BASE`, `MATRIXARK_EMBEDDING_MODEL`, and
+/// `MATRIXARK_EMBEDDING_API_KEY_ENV` for the NAME of the variable holding a key, so a key is never
+/// read from a value that might be logged.
+///
+/// With no base URL the provider stays deterministic, exactly as it was: a deployment that has not
+/// configured an encoder does not silently acquire one, and one that requires a real model still
+/// gets the error `MATRIXARK_REQUIRE_MODEL_EMBEDDINGS` exists to raise.
+pub fn context_provider_from_env() -> ContextModelProviderConfig {
+    // Two names for one endpoint, because two paths grew their own: the serving side and the
+    // Python side read `MATRIXARK_EMBEDDING_API_BASE`, the embed drainer read
+    // `MATRIXARK_EMBED_BASE_URL`. Both are honoured here so there is one constructor rather than
+    // two spellings of the same deployment, and the newer name wins when both are set.
+    let base_url = std::env::var("MATRIXARK_EMBEDDING_API_BASE")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            std::env::var("MATRIXARK_EMBED_BASE_URL")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .unwrap_or_default()
+        .trim()
+        .trim_end_matches('/')
+        .to_string();
+    let embedding_model = std::env::var("MATRIXARK_EMBEDDING_MODEL")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    let api_key_env = std::env::var("MATRIXARK_EMBEDDING_API_KEY_ENV")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            std::env::var("MATRIXARK_EMBED_API_KEY_ENV")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+
+    let mut provider = ContextModelProviderConfig {
+        base_url: base_url.clone(),
+        api_key_env,
+        // An endpoint that answers without a key is the local, self-hosted case, and it is the
+        // configuration this is most often pointed at.
+        mock_mode: base_url.is_empty(),
+        ..ContextModelProviderConfig::default()
+    };
+    if !base_url.is_empty() {
+        provider.provider_kind = ContextProviderKind::OpenAiCompatible;
+    }
+    if let Some(model) = embedding_model {
+        provider.embedding_model = model;
+    }
+    provider
+}
+
 /// Backfill helper: compute REAL model embeddings for a batch of already-stored
 /// context node/event texts, reusing the exact provider path the live extract
 /// path uses -- request batching, `MATRIXARK_REQUIRE_MODEL_EMBEDDINGS`

--- a/crates/temporalstore-rust/src/lib.rs
+++ b/crates/temporalstore-rust/src/lib.rs
@@ -72,6 +72,7 @@ pub use client::{
 };
 pub use context_workflow::{
     context_backfill_embeddings, context_embedding_ref_hash, context_pipeline_manage_report,
+    context_provider_from_env,
     context_pipeline_parity_evidence,
     context_skill_registry_from_parsed,
     context_workflow_state_report, default_context_model_providers, extract_context,

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -6262,12 +6262,21 @@ fn retrieve_context_pack_output(
     let has_event_candidate = snapshot
         .candidates()
         .any(|candidate| candidate.ref_type == "event");
+    let mut query_embed_ms = 0.0_f64;
     let query_vector = ranking_field_from(
         request.query_vector.clone(),
         &request_record,
         "query_vector",
     )
-    .filter(|v: &Vec<f32>| !v.is_empty());
+    .filter(|v: &Vec<f32>| !v.is_empty())
+    .or_else(|| {
+        // Only when the caller sent none: a caller that embedded the query itself keeps its own
+        // vector, and which model ranked the store stays its decision.
+        let started = Instant::now();
+        let embedded = embed_query_text(&query);
+        query_embed_ms = started.elapsed().as_secs_f64() * 1000.0;
+        embedded
+    });
     let ranking_uses_vectors = query_vector.is_some();
     let weights = ranking_field_from(
         request.ranking_weights,
@@ -6535,14 +6544,15 @@ fn retrieve_context_pack_output(
         // Phases, not just a total: a rebuild and a scoring pass are fixed by different work, and
         // "the retrieve took a second" has never been enough to tell them apart.
         eprintln!(
-            "slow retrieve: {elapsed_ms} ms total, snapshot {snapshot_ms:.1} ms (cache_hit={candidate_cache_hit}), score {score_ms:.1} ms, {} records scanned, {selected_count} refs selected; rebuild {:.1} read / {:.1} inventory / {:.1} candidates; snapshot holds {} candidates, {} with vectors up to {} dims",
+            "slow retrieve: {elapsed_ms} ms total, snapshot {snapshot_ms:.1} ms (cache_hit={candidate_cache_hit}), score {score_ms:.1} ms, {} records scanned, {selected_count} refs selected; rebuild {:.1} read / {:.1} inventory / {:.1} candidates; snapshot holds {} candidates, {} with vectors up to {} dims; query embed {:.1} ms",
             snapshot.scanned_records,
             snapshot.build.read_ms,
             snapshot.build.inventory_ms,
             snapshot.build.candidates_ms,
             snapshot.candidate_count(),
             vectors_held,
-            widest_vector
+            widest_vector,
+            query_embed_ms
         );
     }
     let correctness = selected_count > 0;
@@ -6997,6 +7007,48 @@ const DEFAULT_MAX_SELECTED_REFS: usize = 1000;
 /// silences the line entirely for a deployment that does not want it.
 const SLOW_RETRIEVE_LOG_MS: u128 = 250;
 
+/// Whether the retrieve embeds its own query when the caller sent no vector.
+///
+/// On by default: ranking is dense, and a retrieve that cannot embed its query ranks lexically.
+/// `MATRIXARK_PROXY_EMBED_QUERY=0` turns it off for a deployment that would rather its caller own
+/// the embedding entirely.
+fn embed_query_here() -> bool {
+    !matches!(
+        std::env::var("MATRIXARK_PROXY_EMBED_QUERY")
+            .unwrap_or_default()
+            .trim(),
+        "0" | "false" | "off" | "no"
+    )
+}
+
+/// Embed one query, or return `None` and let the retrieve rank lexically.
+///
+/// Never an error: an encoder that is down, misconfigured or slow must not take retrieval with it.
+/// The caller reports how long this took, so a model call on the retrieve path is visible rather
+/// than hidden inside a total.
+fn embed_query_text(query: &str) -> Option<Vec<f32>> {
+    if query.trim().is_empty() || !embed_query_here() {
+        return None;
+    }
+    let provider = temporalstore_rust::context_provider_from_env();
+    // A provider with no endpoint is deterministic, and a deterministic vector is not a ranking
+    // signal -- it would score every candidate against noise, which is worse than ranking
+    // lexically.
+    if provider.mock_mode {
+        return None;
+    }
+    match temporalstore_rust::context_backfill_embeddings(&provider, &[query]) {
+        Ok(vectors) => vectors.into_iter().next().filter(|vector| !vector.is_empty()),
+        Err(status) => {
+            eprintln!(
+                "query embedding unavailable ({}): ranking lexically for this retrieve",
+                status.message
+            );
+            None
+        }
+    }
+}
+
 fn slow_retrieve_log_ms() -> u128 {
     std::env::var("MATRIXARK_SLOW_RETRIEVE_LOG_MS")
         .ok()
@@ -7314,6 +7366,56 @@ fn _request_shape_for_docs() -> serde_json::Value {
 
 #[cfg(test)]
 mod tests {
+
+    /// An unconfigured encoder yields NO vector, not a deterministic one.
+    ///
+    /// With no endpoint the provider is deterministic, and a deterministic vector is not a ranking
+    /// signal: it scores every candidate against noise. Returning one would rank worse than
+    /// lexical scoring while looking like dense ranking was working.
+    #[test]
+    fn an_unconfigured_encoder_yields_no_query_vector() {
+        let _guard = env_guard();
+        let previous = std::env::var("MATRIXARK_EMBEDDING_API_BASE").ok();
+        std::env::remove_var("MATRIXARK_EMBEDDING_API_BASE");
+
+        assert!(
+            embed_query_text("the storage manager reclaims the log").is_none(),
+            "an unconfigured encoder produced a vector"
+        );
+
+        if let Some(value) = previous {
+            std::env::set_var("MATRIXARK_EMBEDDING_API_BASE", value);
+        }
+    }
+
+    /// An unreachable encoder yields no vector, and does not fail the retrieve.
+    ///
+    /// An encoder outage must cost dense ranking for the duration, not retrieval itself.
+    #[test]
+    fn an_unreachable_encoder_yields_no_query_vector() {
+        let _guard = env_guard();
+        let previous = std::env::var("MATRIXARK_EMBEDDING_API_BASE").ok();
+        // A port nothing is listening on, so the call fails rather than hanging on a real service.
+        std::env::set_var("MATRIXARK_EMBEDDING_API_BASE", "http://127.0.0.1:1/v1");
+
+        assert!(
+            embed_query_text("the storage manager reclaims the log").is_none(),
+            "an unreachable encoder produced a vector"
+        );
+
+        match previous {
+            Some(value) => std::env::set_var("MATRIXARK_EMBEDDING_API_BASE", value),
+            None => std::env::remove_var("MATRIXARK_EMBEDDING_API_BASE"),
+        }
+    }
+
+    /// An empty query is never sent to the encoder.
+    #[test]
+    fn an_empty_query_is_not_embedded() {
+        let _guard = env_guard();
+        assert!(embed_query_text("").is_none());
+        assert!(embed_query_text("   ").is_none());
+    }
 
     /// Summing per-shard counts equals counting every record at once.
     ///


### PR DESCRIPTION
The engine has been able to call a real OpenAI-compatible embedding endpoint all along — it is what
the embed drainer and the backfill binary do. But only a caller holding a
`ContextModelProviderConfig` could reach it, and the proxy had none, so the query vector had to be
computed on the Python side and shipped over.

This gives the engine one, and points both paths at one configuration.

### The retrieve embeds its own query

When the caller sends no vector and the query is not empty, the retrieve embeds it through the same
provider path extraction uses. Three things it deliberately does not do:

- **It does not override a vector the caller sent.** A caller that embedded the query itself — with
  its own model, or from its own cache — keeps its vector. Which model ranked the store stays the
  caller's decision.
- **It does not fail a retrieve when the encoder is unreachable.** No vector means lexical ranking,
  which is what a retrieve without one already did. An encoder outage costs dense ranking for the
  duration, not retrieval.
- **It does not use a deterministic vector.** With no endpoint the provider is deterministic, and a
  deterministic vector is not a ranking signal — it scores every candidate against noise, which is
  worse than ranking lexically *and* looks like dense ranking is working.

`MATRIXARK_PROXY_EMBED_QUERY=0` turns it off.

### One encoder, one configuration

The same endpoint was configured by two different variables: the Python side and the proxy read
`MATRIXARK_EMBEDDING_API_BASE`, while the embed drainer inside the data node read
`MATRIXARK_EMBED_BASE_URL` and built its provider inline. **A deployment that set one and not the
other got real vectors on one path and deterministic ones on the other, with nothing saying so.**

`context_provider_from_env` is now the single constructor, honours both names (preferring the one
the rest of the deployment uses), and the data node stops building its own. The old name is kept
rather than dropped: a running deployment sets it, and removing it would silently move that
deployment onto deterministic vectors — the exact failure this consolidates to prevent.

### What this does NOT fix, stated plainly

I tried to exercise the new path end to end by pointing the gateway at a dead encoder so it would
send no vector. It still sent one, and the retrieve logged:

```
snapshot holds 194 candidates, 194 with vectors up to 32 dims; query embed 0.0 ms
```

**32 dims.** With its encoder unreachable the Python side does not fail — it falls back to a 32-dim
hash vector, for the stored vectors *and* the query. So the engine never sees a missing vector, the
new path does not trigger, and ranking runs on hash noise while looking healthy.

That is a pre-existing defect and this change does not fix it. What it does is make the engine able
to embed on its own, which is what fixing it will need.

### Tests

`an_unconfigured_encoder_yields_no_query_vector` pins the deterministic-vector refusal — the one
that would silently degrade ranking while appearing to work.
`an_unreachable_encoder_yields_no_query_vector` pins that an outage costs a vector, not a retrieve.
`an_empty_query_is_not_embedded` covers the trivial case. All three take the file's existing
`env_guard`, which recovers from poisoning rather than turning one failure into a cascade.

The proxy binary suite: 126 passed, 0 failed.
