### PR TITLE
The server runs its own maintenance, and counting a log stops reading it

### DIFF
--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -44,6 +44,7 @@ use temporalstore_rust::{
     handle_authenticated_raft_http, production_raft_security_from_env, production_readiness_report,
     BlockStoreOptions, CheckedBatchExecuteRequest, CheckedExecuteRequest, Command, CommandResponse,
     CompactionRequest, DataNodeRuntime, DataNodeRuntimeOptions, DistributedRaftCommandResponse,
+
     DistributedRaftProposeRequest, DistributedRaftReadRequest, DumpShardRequest, GcRequest,
     LoadShardRequest, MembershipUpdateRequest, ProductionRaftEngineKind, ProductionRaftNode,
     ProductionRaftRuntime, ProductionRaftRuntimeOptions, RaftConfig, RaftControlLeadershipRequest,
@@ -240,6 +241,40 @@ fn main() {
             max_background_queue_depth: env_usize("TS_SERVER_MAX_BACKGROUND_QUEUE_DEPTH", 128),
         },
     );
+
+    // Background storage maintenance. Dump, WAL and index-log reclaim, expiry, eviction, page
+    // GC, compaction and index GC -- the same phases the cycle endpoint runs, run without anyone
+    // having to ask for them.
+    //
+    // Nothing asked. The runtime has shipped a scheduler for this the whole time and its only
+    // caller was a test, and no script, tool or doc in this repo ever posted
+    // /storage_manager/cycle either. A server started as shipped therefore never reclaimed
+    // anything: its write-ahead log and index log grew until the disk did. The embedded proxy
+    // avoided this by spawning a reclaim thread of its own, which is why it had not been felt
+    // here.
+    //
+    // Thirty seconds, where the design being followed loops every thirty MILLISECONDS. That is
+    // three orders of magnitude apart and deliberate: their prepare phase does almost nothing,
+    // while ours builds its plan by reading every live page in the shard. One such pass every
+    // thirty seconds is a few milliseconds of work; thirty-three per second would be the
+    // dominant cost of running the server. The interval is what makes the survey affordable, and
+    // it is the survey that would have to change before this could go faster.
+    //
+    // Zero disables it, for a deployment whose control plane drives maintenance itself.
+    let storage_manager_interval_ms = std::env::var("MATRIXARK_STORAGE_MANAGER_INTERVAL_MS")
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .unwrap_or(30_000);
+    let _storage_manager_scheduler = (storage_manager_interval_ms > 0).then(|| {
+        eprintln!(
+            "matrixark_storage_manager_scheduler interval_ms={storage_manager_interval_ms} \
+             phases=prepare,reclaim,evict,expire,page_gc,compaction,index_gc"
+        );
+        runtime.start_storage_manager_scheduler_for_all_shards(
+            std::time::Duration::from_millis(storage_manager_interval_ms),
+            temporalstore_rust::data_node::StorageManagerOptions::default(),
+        )
+    });
 
     // Async embedding drainer (gated by MATRIXARK_EMBED_DRAINER, default off).
     // Attaches vectors to nodes left embedding-dirty by raw-first bulk ingest or a

--- a/crates/temporalstore-rust/src/data_node.rs
+++ b/crates/temporalstore-rust/src/data_node.rs
@@ -168,6 +168,15 @@ pub struct DataNodeRuntimeStats {
     pub storage_manager_runs: u64,
     #[serde(default)]
     pub storage_manager_loops: u64,
+    /// The shard the last maintenance round ran for.
+    ///
+    /// `storage_manager_loops` counts rounds and cannot say WHICH shard a round chose, so a
+    /// server whose loop only ever reached one of its shards looked identical to one reaching
+    /// them all. That is a thing an operator needs to be able to tell, and it is also the only
+    /// way to test the all-shards loop -- a counter that climbs with the interval proves nothing
+    /// about coverage.
+    #[serde(default)]
+    pub storage_manager_last_shard_id: Option<ShardId>,
     #[serde(default)]
     pub storage_manager_prepare_runs: u64,
     #[serde(rename = "storage_manager_reclaim_wal_runs", default)]
@@ -1351,6 +1360,7 @@ struct MutableRuntimeStats {
     storage_lifecycle_runs: u64,
     storage_manager_runs: u64,
     storage_manager_loops: u64,
+    storage_manager_last_shard_id: Option<ShardId>,
     storage_manager_prepare_runs: u64,
     storage_manager_reclaim_wal_runs: u64,
     storage_manager_reclaim_memory_runs: u64,

--- a/crates/temporalstore-rust/src/data_node/runtime_reports.rs
+++ b/crates/temporalstore-rust/src/data_node/runtime_reports.rs
@@ -55,6 +55,7 @@ impl DataNodeRuntime {
             storage_lifecycle_runs: stats.storage_lifecycle_runs,
             storage_manager_runs: stats.storage_manager_runs,
             storage_manager_loops: stats.storage_manager_loops,
+            storage_manager_last_shard_id: stats.storage_manager_last_shard_id,
             storage_manager_prepare_runs: stats.storage_manager_prepare_runs,
             storage_manager_reclaim_wal_runs: stats.storage_manager_reclaim_wal_runs,
             storage_manager_reclaim_memory_runs: stats.storage_manager_reclaim_memory_runs,

--- a/crates/temporalstore-rust/src/data_node/runtime_storage.rs
+++ b/crates/temporalstore-rust/src/data_node/runtime_storage.rs
@@ -632,11 +632,13 @@ impl DataNodeRuntime {
             (!options.enable_metrics_reap).then(|| "reap_metrics_disabled".to_string()),
         ));
 
-        self.inner
-            .stats
-            .lock()
-            .expect("runtime stats lock poisoned")
-            .storage_manager_loops += 1;
+        {
+            // Recorded beside the round counter, so every caller gets it: the per-shard
+            // scheduler, the all-shards scheduler, and the cycle endpoint.
+            let mut stats = self.inner.stats.lock().expect("runtime stats lock poisoned");
+            stats.storage_manager_loops += 1;
+            stats.storage_manager_last_shard_id = Some(shard_id);
+        }
 
         StorageManagerLoopReport {
             shard_id,
@@ -651,6 +653,46 @@ impl DataNodeRuntime {
             compaction_report,
             gc_report,
             status,
+        }
+    }
+
+    /// Run a maintenance cycle for EVERY loaded shard, forever, on an interval.
+    ///
+    /// The per-shard scheduler below needs to be told which shard it serves, so a server that
+    /// does not know its shards up front could not start one -- which is why nothing started
+    /// one. This asks the engine each tick instead, so a shard loaded later is picked up without
+    /// restarting anything and a shard unloaded in between is simply not visited.
+    ///
+    /// A cycle that fails is not fatal to the loop. The failure is already recorded in the
+    /// report the cycle returns and in the runtime's stats; stopping the loop over one bad round
+    /// would turn a transient error into a store that never reclaims again, which is the state
+    /// this exists to end.
+    pub fn start_storage_manager_scheduler_for_all_shards(
+        &self,
+        interval: Duration,
+        options: StorageManagerOptions,
+    ) -> StorageLifecycleScheduler {
+        let runtime = self.clone();
+        let stop = Arc::new(AtomicBool::new(false));
+        let scheduler_stop = Arc::clone(&stop);
+        let sleep_interval = interval.max(Duration::from_millis(1));
+        let handle = thread::spawn(move || {
+            while !scheduler_stop.load(Ordering::Relaxed) {
+                thread::sleep(sleep_interval);
+                if scheduler_stop.load(Ordering::Relaxed) {
+                    break;
+                }
+                for shard_id in runtime.inner.engine.loaded_shard_ids() {
+                    if scheduler_stop.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    runtime.run_storage_manager_once(shard_id, options.clone());
+                }
+            }
+        });
+        StorageLifecycleScheduler {
+            stop,
+            handle: Some(handle),
         }
     }
 

--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -1340,6 +1340,80 @@ fn runtime_storage_manager_scale_repeats_style_pressure_stages() {
     assert_eq!(stats.storage_manager_index_gc_runs, reports.len() as u64);
 }
 
+/// The all-shards loop visits EVERY loaded shard, and picks up one loaded after it started.
+///
+/// The per-shard scheduler beside this one has to be told which shard it serves, which is why
+/// nothing in the server ever started one -- a server does not know its shards up front. This
+/// asks the engine each tick, so the thing worth asserting is not that it ran, but that it
+/// reached a shard nobody named when it was started.
+///
+/// Asserted through the SHARD ID the last round recorded, not through a loop counter. The first
+/// version of this counted `storage_manager_loops` and waited for it to climb, which at a 5 ms
+/// interval it does whatever the loop visits -- so it measured the clock, and BOTH mutations
+/// (visit only the first shard; snapshot the shard list at startup) passed it. A count per tick
+/// cannot see which shard a tick chose. The report's shard id can.
+#[test]
+fn the_all_shards_scheduler_reaches_a_shard_loaded_after_it_started() {
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+    let runtime = DataNodeRuntime::new(
+        engine.clone(),
+        DataNodeRuntimeOptions {
+            worker_threads: 1,
+            max_queue_depth: 8,
+            max_background_queue_depth: 8,
+        },
+    );
+    let response = runtime.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringSet {
+            key: "all-shards-1".to_string(),
+            value: b"v".to_vec(),
+        },
+    });
+    assert!(response.status.ok, "{response:?}");
+
+    let scheduler = runtime.start_storage_manager_scheduler_for_all_shards(
+        Duration::from_millis(5),
+        StorageManagerOptions::default(),
+    );
+    wait_until(Duration::from_secs(2), || {
+        runtime.stats().storage_manager_last_shard_id == Some(1)
+    });
+    assert_eq!(
+        runtime.stats().storage_manager_last_shard_id,
+        Some(1),
+        "the loop never ran for the shard it started with"
+    );
+
+    // A shard the scheduler was never told about, loaded while it is already running.
+    engine.load_shard(2);
+    let response = runtime.execute(ExecuteRequest {
+        shard_id: 2,
+        command: Command::StringSet {
+            key: "all-shards-2".to_string(),
+            value: b"v".to_vec(),
+        },
+    });
+    assert!(response.status.ok, "{response:?}");
+    assert!(
+        engine.loaded_shard_ids().contains(&2),
+        "the engine must be holding the second shard for this to prove anything"
+    );
+
+    // The report has to name shard 2 at some point, which only happens if a tick chose it.
+    wait_until(Duration::from_secs(5), || {
+        runtime.stats().storage_manager_last_shard_id == Some(2)
+    });
+    let reached = runtime.stats().storage_manager_last_shard_id;
+    scheduler.stop();
+    assert_eq!(
+        reached,
+        Some(2),
+        "the loop never reached the shard loaded after it started; last report was for {reached:?}"
+    );
+}
+
 #[test]
 // rust-internal: validates periodic runtime scheduling for the storage-manager loop
 fn runtime_storage_manager_scheduler_runs_continuous_loop() {

--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -39,16 +39,10 @@ impl TemporalEngine {
         } else {
             base_index_bytes
         };
-        let wal_records = self
-            .wal_store
-            .scan(shard_id, 0, u64::MAX, u64::MAX)
-            .map(|records| records.len())
-            .unwrap_or_default();
-        let index_log_records = self
-            .index_log_store
-            .scan(shard_id, 0, u64::MAX, u64::MAX)
-            .map(|records| records.len())
-            .unwrap_or_default();
+        // Counted, not collected. Both of these used to read their whole log into a vector
+        // and take its length -- on the plan path of every maintenance round.
+        let wal_records = self.wal_store.record_count(shard_id).unwrap_or_default();
+        let index_log_records = self.index_log_store.record_count(shard_id).unwrap_or_default();
         let active_block_slab_ids = self.page_store.slab_ids().unwrap_or_default();
         let band_descriptors = self.page_store.band_descriptors();
         let band_summary = self.page_store.band_summary();

--- a/crates/temporalstore-rust/src/engine/storage_reports.rs
+++ b/crates/temporalstore-rust/src/engine/storage_reports.rs
@@ -355,16 +355,12 @@ impl TemporalEngine {
     ) -> StorageLogCompatibilityReport {
         let wal_stats = self.wal_store.stats(shard_id);
         let index_log_stats = self.index_log_store.stats(shard_id);
-        let wal_records = self
-            .wal_store
-            .scan(shard_id, 0, u64::MAX, u64::MAX)
-            .map(|records| records.len())
-            .unwrap_or_default();
-        let index_log_records = self
-            .index_log_store
-            .scan(shard_id, 0, u64::MAX, u64::MAX)
-            .map(|records| records.len())
-            .unwrap_or_default();
+        // Counted, not collected -- the twin of the pair in the recovery report. This one is
+        // reached through `storage_manager_pressure_snapshot`, so it is on the SAME maintenance
+        // round as that pair: fixing only the other would have left every round still reading
+        // both logs in full, from a second site.
+        let wal_records = self.wal_store.record_count(shard_id).unwrap_or_default();
+        let index_log_records = self.index_log_store.record_count(shard_id).unwrap_or_default();
         StorageLogCompatibilityReport {
             shard_id,
             wal_format: "rust-jsonl-command-v1".to_string(),

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -2344,6 +2344,63 @@ fn a_catalog_dump_waits_out_the_interval_before_the_next_one() {
     );
 }
 
+/// Counting a log's records agrees with scanning it, exactly, on both logs.
+///
+/// The recovery report used to learn these two numbers by scanning each log in full and taking
+/// the length of the result -- reading every record of both logs into memory, on the plan path
+/// of every maintenance round. The counts now walk without collecting.
+///
+/// The property that matters is not "the count is plausible", it is "the count is what the scan
+/// would have said". So this asserts them equal on a log with real content, rather than pinning
+/// a number that would drift with anything that changes how much a write logs.
+#[test]
+fn counting_a_logs_records_agrees_with_scanning_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let page_dir = dir.path().join("pages");
+    let index_dir = dir.path().join("indexes");
+    let engine =
+        TemporalEngine::with_local_dirs(1 << 20, dir.path().join("cache"), &page_dir, &index_dir);
+    engine.load_shard(1);
+
+    // Empty first: a log with no file at all must count zero rather than fail.
+    assert_eq!(engine.write_ahead_log_store().record_count(1).unwrap(), 0);
+    assert_eq!(engine.index_log_store().record_count(1).unwrap(), 0);
+
+    for index in 0..64 {
+        write_string(&engine, &format!("counted-{index:03}"), b"value");
+    }
+    engine.flush_shard_index(1);
+
+    let wal_scanned = engine
+        .write_ahead_log_store()
+        .scan(1, 0, u64::MAX, u64::MAX)
+        .unwrap()
+        .len();
+    let wal_counted = engine.write_ahead_log_store().record_count(1).unwrap();
+    assert_eq!(
+        wal_counted, wal_scanned,
+        "the write-ahead log counted {wal_counted} records where a scan found {wal_scanned}"
+    );
+    assert!(wal_scanned > 0, "the log must have records for this to prove anything");
+
+    let index_scanned = engine
+        .index_log_store()
+        .scan(1, 0, u64::MAX, u64::MAX)
+        .unwrap()
+        .len();
+    let index_counted = engine.index_log_store().record_count(1).unwrap();
+    assert_eq!(
+        index_counted, index_scanned,
+        "the index log counted {index_counted} records where a scan found {index_scanned}"
+    );
+    assert!(index_scanned > 0, "the index log must have records too");
+
+    // And the report that drove this reads the same numbers.
+    let report = engine.storage_recovery_report(1);
+    assert_eq!(report.wal_records, wal_scanned);
+    assert_eq!(report.index_log_records, index_scanned);
+}
+
 #[test]
 fn catalog_dump_reclaim_shrinks_both_logs_and_reload_stays_exact() {
     // Embedded-path log reclaim: once a threshold dump durably captures the shard, the

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -1612,6 +1612,36 @@ impl LocalIndexLogStore {
         end_offset: u64,
         max_bytes: u64,
     ) -> Result<(Vec<(u64, Vec<u8>)>, bool), IndexLogError> {
+        self.scan_collect(shard_id, start_offset, end_offset, max_bytes, |offset, raw| {
+            (offset, raw)
+        })
+    }
+
+    /// How many records the log holds, without building them.
+    ///
+    /// The caller that wanted this asked `scan(.., u64::MAX, u64::MAX)` and took `.len()` of the
+    /// result, so it read the whole log into a vector to learn how many records were in it --
+    /// on the plan path of every maintenance round.
+    ///
+    /// The same walk, projecting to `()`. A zero-sized element costs nothing per record, so peak
+    /// memory is one record rather than all of them, and the count cannot drift from what a scan
+    /// would have returned because it IS the scan. The write-ahead log store has the twin of
+    /// this, for the same caller.
+    pub fn record_count(&self, shard_id: ShardId) -> Result<usize, IndexLogError> {
+        self.scan_collect(shard_id, 0, u64::MAX, u64::MAX, |_offset, _raw| ())
+            .map(|(records, _truncated)| records.len())
+    }
+
+    /// The one walk every scan of this log shares, so they cannot drift about what a window
+    /// contains. Mirrors `scan_collect` on the write-ahead log store.
+    fn scan_collect<T>(
+        &self,
+        shard_id: ShardId,
+        start_offset: u64,
+        end_offset: u64,
+        max_bytes: u64,
+        mut take: impl FnMut(u64, Vec<u8>) -> T,
+    ) -> Result<(Vec<T>, bool), IndexLogError> {
         let mut inner = self.inner.lock().expect("index log lock poisoned");
         let path = index_log_path(&inner.root, shard_id);
         if !path.exists() {
@@ -1644,7 +1674,7 @@ impl LocalIndexLogStore {
                 truncated = true;
                 break;
             }
-            records.push((offset, raw));
+            records.push(take(offset, raw));
             offset = next_offset;
             total += read;
         }

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -1643,6 +1643,26 @@ impl LocalWriteAheadLogStore {
         )
     }
 
+    /// How many records the log holds, without building them.
+    ///
+    /// The caller that wanted this asked `scan(.., u64::MAX, u64::MAX)` and took `.len()` of the
+    /// result -- so it read every record of the whole log into a vector, to learn how many there
+    /// were. On a shard whose log has not been reclaimed that is the entire write-ahead log in
+    /// memory, for a number.
+    ///
+    /// This is the same walk, through the same `scan_collect`, projecting to `()` instead of to
+    /// the bytes. A zero-sized element costs nothing per record, so peak memory is one record
+    /// rather than all of them, and the count cannot drift from what a scan would have returned
+    /// because it IS the scan.
+    ///
+    /// The tail is not verified. A count is a diagnostic, and a torn tail is the recovery path's
+    /// business; refusing to count because the last record is half-written would make a
+    /// diagnostic fail exactly when it is most wanted.
+    pub fn record_count(&self, shard_id: ShardId) -> Result<usize, WriteAheadLogError> {
+        self.scan_collect(shard_id, 0, u64::MAX, u64::MAX, false, |_, _, _| Some(()))
+            .map(|(records, _truncated, _resume_at)| records.len())
+    }
+
     /// The one walk both scans share, so they cannot drift about what a window contains.
     fn scan_collect<T>(
         &self,


### PR DESCRIPTION
The server runs its own maintenance, and counting a log stops reading it

A data-node server, started as shipped, never reclaimed anything. It never
dumped, never truncated its write-ahead log or index log, never expired,
evicted, compacted or collected a band. Its logs grew until the disk did.

The machinery was all there. DataNodeRuntime has shipped a scheduler for this
the whole time and its only caller was a test, and no script, tool or doc in
this repo ever posted /storage_manager/cycle either -- so a cycle happened
only if an operator wired one up, and nothing showed them how. The embedded
proxy has always spawned a reclaim thread of its own, which is why this had
not been felt here; its comment says it does so because "the proxy engine runs
no storage-manager cycle (only the server/data-node do)", which is exactly
backwards about which one has a cycle running.

The scheduler could not simply be started: it is per shard, and a server does
not know its shards up front. So there is now one that asks the engine each
tick. A shard loaded later is picked up without restarting anything, a shard
unloaded in between is skipped, and a round that fails does not stop the loop
-- turning a transient error into a store that never reclaims again is the
state this exists to end.

Thirty seconds, where the design being followed loops every thirty
MILLISECONDS. Three orders of magnitude, and deliberate: their prepare phase
does almost nothing, while ours builds its plan by reading every live page in
the shard. One such pass every thirty seconds is a few milliseconds of work;
thirty-three per second would be the dominant cost of running the server. The
interval is what makes that survey affordable, and the survey is what would
have to change before this could go faster.

Which brings the second half, because the first is unsafe without it.

storage_recovery_report_without_boundary and storage_log_compatibility_report
each learned two numbers -- how many records are in the write-ahead log, how
many in the index log -- by scanning each log in full and taking the length of
the result. Both are on the plan path of every round. Both read every record
of both logs into memory, for a count. Enabling a thirty-second loop over that
would have read both whole logs every thirty seconds, on exactly the servers
whose logs had never been reclaimed.

Both now count without collecting, and the count cannot drift from what a scan
would have said because it IS the scan. The write-ahead log already had
scan_collect -- "the one walk both scans share, so they cannot drift about
what a window contains" -- so counting is that walk projecting to (), a
zero-sized element: peak memory is one record instead of all of them. The
index log had no such shared walk, so it has one now, and its own scan_bounded
goes through it.

Fixing one of the two would have left every round still reading both logs from
the other site. That is the same shape as the three log-framing readers, where
fixing one left the abort happening from the other two.

One unbounded scan is deliberately left: publish_shard_checkpoint mirrors
every record to shared storage, so it needs the records rather than a count,
and it is an operator-triggered checkpoint rather than a periodic round.

The loop's test asserts WHICH shard a round chose, through a shard id now
recorded beside the round counter. The first version waited for
storage_manager_loops to climb, which at a five millisecond interval it does
whatever the loop visits -- so it measured the clock, and both mutations
(visit only the first shard; snapshot the shard list at startup) passed it. A
per-tick counter cannot see coverage. Both mutations fail against the shard id.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
