### PR TITLE
The page-handle comment outlived the sequencing it described

### DIFF
--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -264,15 +264,23 @@ pub struct IndexItem {
     pub kind: IndexItemKind,
     #[serde(rename = "rb", alias = "routing_bucket", alias = "routing_slot", default)]
     pub routing_bucket: u32,
-    /// The page handle, carried as text.
+    /// The page handle. A `String` in this struct, a NUMBER on the wire whenever it holds one.
     ///
     /// It is a `u64` everywhere else -- `BlockLookupRef::page_ref_key` is one, and the write path
-    /// stringifies it on the way in. As decimal text it is 20 bytes of a 161-byte item, 12.4%;
-    /// as a number it would be about nine.
+    /// stringifies it on the way in. As decimal text it was 20 bytes of a 161-byte item, 12.4%;
+    /// as a number it is about nine.
     ///
-    /// The reader takes either shape as of this change, which is the half that has to land first:
-    /// a writer that emitted a number today would hand it to a reader expecting a string, and
-    /// msgpack would refuse the type outright rather than degrade. Nothing writes a number yet.
+    /// Both halves have landed. `page_ref_key_as_number_when_it_is_one` parses the string and
+    /// serializes a `u64` when it parses, falling back to a string when it does not; the reader
+    /// takes either shape, because records written before the writer half exist on disk and are
+    /// not going to rewrite themselves.
+    ///
+    /// (This said "Nothing writes a number yet" while sitting directly above the serializer that
+    /// writes one. That order was right when the reader half landed alone -- a writer emitting a
+    /// number to a reader expecting a string would have been refused outright by msgpack rather
+    /// than degrading -- and the sentence outlived the sequencing it described. On a durable
+    /// format a stale claim about what is on the wire is the kind that gets acted on: the same
+    /// file's encoder comment claimed struct-as-map while calling the array form.)
     #[serde(
         rename = "pk",
         alias = "page_ref_key",


### PR DESCRIPTION
The page-handle comment outlived the sequencing it described

`IndexItem::page_ref_key` is documented as text, ending "Nothing writes a
number yet" -- directly above the attribute
`serialize_with = "page_ref_key_as_number_when_it_is_one"`, which parses the
string and serializes a u64 whenever it parses.

Both halves have landed. The sentence was true when the reader half landed
alone, and it explained a real ordering constraint: a writer emitting a number
to a reader that expected a string would have been refused outright by
msgpack rather than degrading, so the reader had to go first. Then the writer
followed and the sentence stayed.

On a durable format that is the kind of stale claim that gets acted on. What
a reader believes is on the wire decides whether they think a type can change,
whether an old record can still be decoded, and what an alias is protecting.
The same file had an encoder comment claiming struct-as-MAP while calling the
array form, fixed a few hours ago for the same reason.

So the comment now says what the code does: a String in the struct, a NUMBER
on the wire whenever it holds one, with the reader taking either shape because
records written before the writer half exist on disk and will not rewrite
themselves. The byte figures move from the conditional to the actual -- 20
bytes of a 161-byte item as text, about nine as a number.

Comments only. Verified mechanically: every changed line in the diff begins
with `///`. The index-log suite is green at 40 passed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
