### PR TITLE
The engine sends the serving shape, instead of sending more for the caller to discard

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -6130,7 +6130,13 @@ fn retrieve_context_pack_output(
         );
     }
     let correctness = selected_count > 0;
-    let serving_selected_refs = native_serving_refs(&selected_refs);
+    // The caller asks for the serving shape; it knows whether this retrieve wants debug refs and
+    // the engine does not. Absent, the answer is no, so an older caller keeps the shape it expects.
+    let compact_serving = request_record
+        .get("serving_refs_compact")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let serving_selected_refs = native_serving_refs(&selected_refs, compact_serving);
     let serving_dropped_refs = native_serving_dropped_refs(json!({
         "refs": dropped_ref_details,
         "native_summary": true,
@@ -6143,6 +6149,9 @@ fn retrieve_context_pack_output(
         // Says the refs have already had the redundancy sweep applied, so a caller that carries
         // its own copy of that filter can skip it rather than scan the pack again to find nothing.
         "redundant_items_dropped": swept_redundant_items,
+        // Says the refs are already in the serving shape, so a caller that carries its own
+        // compaction can skip it rather than rebuild every ref to the same thing.
+        "serving_refs_compact": compact_serving && engine_compact_serving_refs_allowed(),
         "dropped_refs": serving_dropped_refs,
         "memory_inventory": memory_inventory.clone(),
         "recall_policy": {

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl/native_serving.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl/native_serving.rs
@@ -66,7 +66,94 @@ fn native_serving_ref(mut item: Value) -> Value {
     item
 }
 
-fn native_serving_refs(refs: &[Value]) -> Vec<Value> {
+/// What a served ref carries when the engine shapes it, rather than the caller.
+///
+/// The caller's allow-list, intersected with what a selected ref actually holds. `citation`,
+/// `source_ref`, `resource_type` and their kin are in that allow-list and are never set on an
+/// engine-built ref, so they cannot be lost by keeping this list -- and `memory_layer` is added
+/// alongside, which the caller also does.
+const COMPACT_SERVING_REF_FIELDS: &[&str] = &[
+    "ref_type",
+    "text",
+    "text_preview",
+    "citation",
+    "resource_type",
+    "sharing_scope",
+    "event_type",
+    "source_role",
+    "entity_type",
+    "entity_name",
+    "summary_type",
+    "operator",
+    "memory_scope",
+    "session_continuity",
+    "profile_memory_kind",
+    "profile_memory_class",
+    "profile_entity_current",
+    "profile_summary_current",
+    "profile_current_state_representative",
+    "memory_layer",
+];
+
+/// Whether a deployment permits the engine to emit the serving shape.
+///
+/// A kill switch, not the decision: the decision is the caller's, because only the caller knows
+/// whether this retrieve wants debug refs, which carry lineage the serving shape drops.
+/// `MATRIXARK_ENGINE_COMPACT_SERVING_REFS=0` returns every deployment to the old behaviour without
+/// touching its callers.
+fn engine_compact_serving_refs_allowed() -> bool {
+    !matches!(
+        std::env::var("MATRIXARK_ENGINE_COMPACT_SERVING_REFS")
+            .unwrap_or_default()
+            .trim(),
+        "0" | "false" | "off" | "no"
+    )
+}
+
+/// Keep only the fields a served ref is allowed to carry.
+///
+/// An empty value is dropped rather than sent, matching the caller: it tests
+/// `value not in (None, "", [], {})`, so a zero or a `false` is KEPT and an empty string, list or
+/// map is not.
+fn compact_serving_ref(item: &Value) -> Value {
+    let mut compact = serde_json::Map::new();
+    let Some(object) = item.as_object() else {
+        return item.clone();
+    };
+    for field in COMPACT_SERVING_REF_FIELDS {
+        let Some(value) = object.get(*field) else {
+            continue;
+        };
+        let empty = match value {
+            Value::Null => true,
+            Value::String(text) => text.is_empty(),
+            Value::Array(items) => items.is_empty(),
+            Value::Object(map) => map.is_empty(),
+            _ => false,
+        };
+        if empty {
+            continue;
+        }
+        // The caller lowercases and trims this one on its way out; matching it here keeps the two
+        // shapes byte-identical.
+        if *field == "memory_layer" {
+            if let Some(text) = value.as_str() {
+                compact.insert(
+                    (*field).to_string(),
+                    Value::String(text.trim().to_lowercase()),
+                );
+                continue;
+            }
+        }
+        compact.insert((*field).to_string(), value.clone());
+    }
+    Value::Object(compact)
+}
+
+fn native_serving_refs(refs: &[Value], compact: bool) -> Vec<Value> {
+    if compact && engine_compact_serving_refs_allowed() {
+        return refs.iter().map(compact_serving_ref).collect();
+    }
     refs.iter().cloned().map(native_serving_ref).collect()
 }
 

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl/retrieve_pack.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl/retrieve_pack.rs
@@ -645,7 +645,9 @@ fn retrieve_context_pack_native(
         "extraction_phase_budget_dropped": extraction_phase_budget_dropped_class_counts
     });
     let memory_layer_budget = selected_ref_layer_budget(&selected);
-    let serving_selected_refs = native_serving_refs(&selected);
+    // This packer keeps the shape it always sent: the serving-shape ask is carried on the
+    // other path's request and does not reach here.
+    let serving_selected_refs = native_serving_refs(&selected, false);
     let selected_profile_ref_count = selected
         .iter()
         .filter(|item| {

--- a/tools/matrixark_local_adapter_retrieve.py
+++ b/tools/matrixark_local_adapter_retrieve.py
@@ -988,6 +988,10 @@ class _LocalAdapterRetrieveMixin:
             "query_plan": query_plan,
             "secondary_index_groups": [sorted(group) for group in secondary_index_filter_groups],
             "secondary_index_filter_mode": secondary_index_filter_mode,
+            # Ask the engine for the serving shape rather than rebuilding every ref here. Not for a
+            # debug retrieve: those carry lineage fields the serving shape drops, and the engine
+            # cannot know which kind this is.
+            "serving_refs_compact": not debug_refs,
             "max_context_tokens": max_context_tokens,
             "local_budget": {
                 "token_estimate": int(local_budget.get("token_estimate", 0)),
@@ -1088,7 +1092,14 @@ class _LocalAdapterRetrieveMixin:
             if apply_remote_only_local_fallback(local_budget, native_used_remote):
                 native_pack["local_context_refs"] = compact_local_context_refs(local_budget)
                 native_pack["context_source_mode"] = "remote_only_local_fallback"
-            serving_selected_refs = compact_context_pack_refs(selected_refs, include_debug=debug_refs)
+            # Already in the serving shape when the engine says so, which is what was asked for
+            # above. Rebuilding them here produced the same refs -- verified by diffing two full
+            # packs over one store, 441 items byte for byte -- at the cost of the largest single
+            # item in this process's profile.
+            if native_pack.get("serving_refs_compact"):
+                serving_selected_refs = selected_refs
+            else:
+                serving_selected_refs = compact_context_pack_refs(selected_refs, include_debug=debug_refs)
             native_pack["selected_refs"] = serving_selected_refs
             native_pack["remote_context_refs"] = serving_selected_refs
             native_pack["dropped_refs"] = compact_dropped_refs_for_context_pack(native_pack.get("dropped_refs", {}), include_debug=debug_refs)


### PR DESCRIPTION
The engine shipped every selected ref with about twenty fields. The caller then rebuilt each one
keeping an allow-list — and of the engine's fields only seven survive it: `ref_type`, `text`,
`entity_type`, `entity_name`, `memory_scope`, `session_continuity` and `memory_layer`. **The other
thirteen were serialised, carried across the wire, decoded, and dropped.**

Sampling the gateway put that rebuild at 37% of its on-CPU time — the largest single item there
once the redundancy sweep moved — and the decode of what it discards at another 8%.

So the engine emits the serving shape, and the caller skips its own pass.

### The caller asks; the engine does not assume

The caller knows one thing the engine does not: whether this retrieve wants **debug** refs, which
carry lineage fields the serving shape drops. An engine compacting unconditionally would quietly
strip them.

So the request carries `serving_refs_compact`, set to `not debug_refs`, and the engine compacts
only when asked. Absent, the answer is no — an older caller keeps the shape it expects, and a
newer caller against an older engine gets the full shape and compacts it itself, as it does today.
`MATRIXARK_ENGINE_COMPACT_SERVING_REFS=0` is a deployment-level veto that needs no caller change.

### Verified by diffing two full packs, not by reasoning

One store, one query, the same proxy binary restarted with the flag off and then on, and the two
gateway responses compared field by field: **441 items each, identical** apart from the pack id,
which is a hash of the wall clock.

Two things that check took to be worth anything, both of which caught real faults first:

- **It refuses to compare empty packs.** The first attempt compared two 485-byte responses and
  reported them identical. Two empty packs are identical for reasons that have nothing to do with
  the change; a check that passes on nothing reads as proof.
- **The restarted proxy carries its full profile.** With only the proxy address set it came up
  without the `TS_*` profile, opened its own empty store, and served those empty packs. That is the
  wrong-backend failure, and the non-empty gate is what surfaced it.

### Measured

| | |
|---|---:|
| warm retrieve, end to end | 42.5 ms → **37.2 ms** |
| served response | 247 KB → **167 KB** (−33%) |
| proxy retrieve | 12 ms |

The payload figure is the more interesting one: it is 13 fewer fields on every ref, so it is
serialisation the proxy no longer does, bytes the socket no longer carries, and JSON the gateway no
longer decodes.

133 proxy-bin tests and 10 Python pack tests pass.
