### PR TITLE
A rebuild says how many shards it reused, and for which scope

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -308,6 +308,9 @@ struct RetrieveBuildCost {
     /// should leave every shard but the newest reusable -- this says whether it does.
     prepared_hits: usize,
     prepared_shards: usize,
+    /// Which scope this snapshot's candidates were prepared for. If it moves between rebuilds, the
+    /// per-shard candidate cache cannot hit however well it works.
+    scope_digest: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -5562,6 +5565,14 @@ fn candidate_from_record(record: &Value) -> Option<CachedRetrieveCandidate> {
     })
 }
 
+/// A short digest of a scope signature, for a log line.
+///
+/// Hashed rather than printed: whether the signature MOVED is the whole question, and a scope
+/// carries tenant and user identity that has no business in a log.
+fn scope_signature_digest(signature: &str) -> u64 {
+    stable_hash64(signature) % 1_000_000
+}
+
 /// The scope a shard's candidates were filtered for, as a cache key.
 fn shard_scope_signature(scope: Option<&Value>) -> String {
     scope
@@ -5654,10 +5665,12 @@ fn load_retrieve_candidate_snapshot(
     let scanned_records = records.len();
     let candidates_started = Instant::now();
     let mut prepared_hits = 0usize;
+    let mut scope_digest = 0u64;
     let segments: Vec<Arc<Vec<CachedRetrieveCandidate>>> = if secondary_groups.is_empty() {
         // Per shard, and cached there: records are appended, so every shard but the newest
         // produces exactly the candidates it produced before, filter for filter and ref for ref.
         let signature = shard_scope_signature(scope);
+        scope_digest = scope_signature_digest(&signature);
         let mut segments = Vec::with_capacity(shard_count);
         for shard in 0..shard_count {
             let key = format!("{record_hash_key}:{shard:06}");
@@ -5703,6 +5716,7 @@ fn load_retrieve_candidate_snapshot(
             candidates_ms,
             prepared_hits,
             prepared_shards: shard_count,
+            scope_digest,
         },
     ));
     if let Ok(mut cache) = retrieve_candidate_cache().lock() {
@@ -6114,7 +6128,7 @@ fn retrieve_context_pack_output(
         // Phases, not just a total: a rebuild and a scoring pass are fixed by different work, and
         // "the retrieve took a second" has never been enough to tell them apart.
         eprintln!(
-            "slow retrieve: {elapsed_ms} ms total, snapshot {snapshot_ms:.1} ms (cache_hit={candidate_cache_hit}), score {score_ms:.1} ms, {} records scanned, {selected_count} refs selected; rebuild {:.1} read / {:.1} inventory / {:.1} candidates; snapshot holds {} candidates, {} with vectors up to {} dims; query embed {:.1} ms; sweep {:.1} ms dropped {}; shards reused {}/{}",
+            "slow retrieve: {elapsed_ms} ms total, snapshot {snapshot_ms:.1} ms (cache_hit={candidate_cache_hit}), score {score_ms:.1} ms, {} records scanned, {selected_count} refs selected; rebuild {:.1} read / {:.1} inventory / {:.1} candidates; snapshot holds {} candidates, {} with vectors up to {} dims; query embed {:.1} ms; sweep {:.1} ms dropped {}; shards reused {}/{} for scope {}",
             snapshot.scanned_records,
             snapshot.build.read_ms,
             snapshot.build.inventory_ms,
@@ -6126,7 +6140,8 @@ fn retrieve_context_pack_output(
             sweep_ms,
             swept_away,
             snapshot.build.prepared_hits,
-            snapshot.build.prepared_shards
+            snapshot.build.prepared_shards,
+            snapshot.build.scope_digest
         );
     }
     let correctness = selected_count > 0;


### PR DESCRIPTION
A rebuild reports how many shards it reused, and which scope it prepared for. Those two numbers
answer a question the log could not: whether the per-shard candidate cache is working, or silently
never hitting.

They are already earning their keep. **They found that a retrieve carrying secondary index groups
costs 930.9 ms against 87.0 ms without them**, and showed why — `shards reused 0/6` against `4/7`.

### What the numbers say

```
shards reused 10/11 for scope 276600     <- the cache working: only the newest shard rebuilt
shards reused  0/12 for scope 0          <- the whole-corpus path, no reuse possible
```

The scope is a short digest rather than the scope itself, because whether it MOVED is the whole
question and a scope carries tenant and user identity that has no business in a log. A stable
digest with rising reuse is a healthy cache; a digest that changes per request is a cache that
cannot hit however well it works, and the fix for that is upstream in what the scope carries.

`scope 0` marks the path that does not prepare per shard at all: secondary index groups are matched
against index terms gathered across **every** shard, so a shard cannot be filtered on its own.

### A divergence these numbers exposed, which this change does not resolve

Measured on one store, one query, with and without the groups:

| | with groups | without |
|---|---:|---:|
| retrieve | 930.9 ms | **87.0 ms** |
| items in the pack | 448 | 757 |
| shards reused | 0/6 | 4/7 |

**All 448 items appear in the 757.** The groups purely remove items — 309 of them, 41% of the pack.
So the engine uses them as an **admission filter**.

The caller's own note beside where it computes them says the opposite:

> *"The secondary-index groups are deliberately LEFT ALONE: on this path they are not an admission
> filter, they add 0.08 to a node's score, so clearing them changed nothing on two fixtures."*

Both can be true — that comment is about the caller's own scan path, not the engine's — but the
result is that a retrieve drops 41% of its candidates through a mechanism one side documents as a
score nudge, and pays 10x latency for it. Whether that filtering is wanted is a retrieval-quality
decision, so this change reports it rather than altering it.

### Cost

The digest is computed once per rebuild and the counter is an increment per shard. Both are read
only when the line is printed.

133 proxy-bin tests pass.
