### PR TITLE
The serving pack was compacted twice

### DIFF
--- a/tools/matrixark_local_adapter_retrieve.py
+++ b/tools/matrixark_local_adapter_retrieve.py
@@ -1109,7 +1109,14 @@ class _LocalAdapterRetrieveMixin:
                 "dropped_ref_details": "audit_only" if not debug_refs else "included",
                 "enable_debug_refs_with": "include_debug_refs=true or MATRIXARK_CONTEXT_PACK_DEBUG_REFS=1",
             }
-            return compact_context_pack_for_serving(native_pack, include_debug=debug_refs)
+            # The refs above are already the serving shape -- either the engine emitted it, or
+            # this function just built it. Compacting them a second time here was two passes over
+            # every ref (selected and remote) for a result that cannot differ.
+            return compact_context_pack_for_serving(
+                native_pack,
+                include_debug=debug_refs,
+                refs_already_compact=True,
+            )
         if self.native_context_pack_required():
             raise MatrixArkError(
                 "backend-native ContextPack assembly is required for TemporalStore serving, "

--- a/tools/matrixark_mcp_core_context_pack.py
+++ b/tools/matrixark_mcp_core_context_pack.py
@@ -294,8 +294,15 @@ def compact_context_pack_refs(refs: list[Json], *, include_debug: bool = False) 
     return [compact_context_pack_ref(ref, include_debug=include_debug) for ref in refs]
 
 
-def compact_context_pack_for_serving_flat(pack: Json, *, include_debug: bool = False) -> Json:
-    """Strip non-answer-bearing routing details from normal ContextPack output."""
+def compact_context_pack_for_serving_flat(
+    pack: Json, *, include_debug: bool = False, refs_already_compact: bool = False
+) -> Json:
+    """Strip non-answer-bearing routing details from normal ContextPack output.
+
+    ``refs_already_compact`` says the caller handed over refs that are already in this
+    shape, so the per-ref pass is skipped. It is the caller's assertion and not a guess:
+    the engine states it per response, and the caller checks that statement.
+    """
     compact = dict(pack)
     serving_aliases = {
         "context_pack_id": "pack_id",
@@ -304,8 +311,14 @@ def compact_context_pack_for_serving_flat(pack: Json, *, include_debug: bool = F
         if compact.get(source) not in (None, "", [], {}):
             compact[target] = compact.get(source)
         compact.pop(source, None)
-    compact["selected_refs"] = compact_context_pack_refs(list(compact.get("selected_refs", [])), include_debug=include_debug)
-    remote_refs = compact_context_pack_refs(list(compact.get("remote_context_refs", compact.get("selected_refs", []))), include_debug=include_debug)
+    selected_refs = list(compact.get("selected_refs", []))
+    remote_source_refs = list(compact.get("remote_context_refs", compact.get("selected_refs", [])))
+    if refs_already_compact:
+        compact["selected_refs"] = selected_refs
+        remote_refs = remote_source_refs
+    else:
+        compact["selected_refs"] = compact_context_pack_refs(selected_refs, include_debug=include_debug)
+        remote_refs = compact_context_pack_refs(remote_source_refs, include_debug=include_debug)
     if remote_refs and remote_refs != compact["selected_refs"]:
         compact["remote_context_refs"] = remote_refs
     else:

--- a/tools/test_codex_pipeline_part1.py
+++ b/tools/test_codex_pipeline_part1.py
@@ -2095,3 +2095,49 @@ class _CodexPipelinePart1:
         self.assertEqual(1, compact_dropped["source_role_budget"])
         self.assertEqual({"assistant": 0}, compact_dropped["source_role_budget_policy"]["selected_tokens_by_role"])
 
+    def test_serving_compaction_skipped_for_refs_that_are_already_compact(self) -> None:
+        """The skip must return what the second pass would have returned.
+
+        The engine emits the serving shape and says so per response, so the caller stops
+        rebuilding every ref. That is only sound while a ref already in the shape survives the
+        pass unchanged, which is what this pins: if the two ever diverge, the skip starts
+        serving something the compaction would have removed.
+        """
+        already_compact = [
+            compact_context_pack_ref(ref)
+            for ref in [
+                {
+                    "ref_type": "segment",
+                    "text": "the storage manager dumped the durable index",
+                    "source_locator": "notes.md#L4",
+                    "token_estimate": 12,
+                    "score": 0.83,
+                    "memory_scope": "session",
+                    "session_continuity": "same_session",
+                    "metadata": {"heading": "Durability", "relative_path": "notes.md"},
+                    # Dropped by the compaction, so a ref carrying it is not yet in the shape.
+                    "matched_index_terms": ["durable", "dump"],
+                },
+            ]
+        ]
+        pack = {
+            "context_pack_id": "pack-1",
+            "selected_refs": already_compact,
+            "remote_context_refs": already_compact,
+        }
+
+        rebuilt = compact_context_pack_for_serving_flat(dict(pack))
+        skipped = compact_context_pack_for_serving_flat(dict(pack), refs_already_compact=True)
+        self.assertEqual(rebuilt, skipped)
+
+        # And the skip really skipped. Equality alone cannot show that: a pass that rebuilt
+        # every ref and returned the same values would satisfy it. So the per-ref pass is made
+        # to fail loudly, and the skip is the reason nothing raises.
+        import matrixark_mcp_core_context_pack as core_context_pack
+
+        def refuse(*args, **kwargs):
+            raise AssertionError("the per-ref compaction ran on refs already in the shape")
+
+        with mock.patch.object(core_context_pack, "compact_context_pack_refs", refuse):
+            proven = compact_context_pack_for_serving_flat(dict(pack), refs_already_compact=True)
+        self.assertEqual(rebuilt, proven)


### PR DESCRIPTION
The serving pack was compacted twice per retrieve, and the second pass could not change anything.

The engine emits the serving ref shape and says so per response; the caller checks that statement
and, when it holds, stops rebuilding every ref. It then handed the pack to
`compact_context_pack_for_serving_flat`, which rebuilt every ref anyway — once for `selected_refs`
and once for `remote_context_refs`. Profiling put `compact_context_pack_ref` at **20.0% of gateway
on-CPU time**, and the two heaviest stacks under it were exactly those two lines.

`refs_already_compact` lets the caller say what it already knows. It defaults to false, so every
other caller of this function is untouched.

### The served pack does not move

One store, settled, one query, the gateway restarted each way with nothing but that constant
changed:

```
  arm refs_already_compact=False   441 items
  arm refs_already_compact=True    441 items
  IDENTICAL -- the second compaction was producing what it was given
```

Both packs were compared whole, not sampled, and the comparison refuses packs under five items —
two empty packs are identical for reasons that have nothing to do with the question.

**And the engine branch really ran.** The claim rests on the engine emitting the shape, so that was
recorded rather than assumed: for the retrieve under test the caller saw
`serving_refs_compact=True` over 530 refs. Without that, both arms would have been comparing refs
this function had just built itself, and the measurement would have proved nothing about the case
that matters.

### Gateway CPU per message

Ticks per message, 200 messages per arm, ABAB — wall clock on this box has a spread wider than the
effect, and the first arm after a restart pays a cold candidate cache, so an earlier best-of-5
reading of 954.9 ms against 60.1 ms says nothing at all:

| arm | round 1 | round 2 | mean |
|---|---:|---:|---:|
| compacting twice | 2.27 | 2.22 | 2.245 |
| **skipping the second pass** | **1.83** | **1.82** | **1.825** |

**-18.7% of gateway CPU per message.** A 40-message run put the arms at 2.20/3.60 against
3.17/2.60 — no signal at all — so the run length is doing real work here, not decoration.

Timed on its own, one pass over a real 441-ref pack is 2.57 ms, so the path was spending 5.14 ms
per retrieve to produce what it was handed.

### What holds it

A test builds refs already in the shape, asserts the skipped result equals the rebuilt one, and
then makes the per-ref pass raise — so the skip is the reason nothing throws. Equality alone would
be satisfied by a pass that rebuilt every ref and returned the same values.

Suite: 52 failing names with the change, 53 without, and the one name that moved is the new test
turning green. The backend policy suite is green both ways.
