### PR TITLE
The serving pack counted each field twice

### DIFF
--- a/tools/matrixark_mcp_context_pack.py
+++ b/tools/matrixark_mcp_context_pack.py
@@ -1117,11 +1117,20 @@ def _memory_layer_counts(refs: list[Json]) -> Json:
     return counts
 
 
-def _default_memory_layer_for_pack(refs: list[Json]) -> str:
-    counts = _memory_layer_counts(refs)
+def _most_common_counted_name(counts: Json) -> str:
+    """The name a pack leaves off its items: most common, ties broken by the larger name.
+
+    One copy of the tie rule. It used to be written out twice, once per default, and it is not a
+    detail either copy could drift on quietly: a different winner does not rename a default, it
+    moves the field onto or off every item in the pack.
+    """
     if not counts:
         return ""
     return max(counts.items(), key=lambda item: (item[1], item[0]))[0]
+
+
+def _default_memory_layer_for_pack(refs: list[Json]) -> str:
+    return _most_common_counted_name(_memory_layer_counts(refs))
 
 
 def serving_ref_for_pack(ref: Json, *, default_session_continuity: str = "", default_memory_layer: str = "", include_debug: bool = False) -> Json:
@@ -1158,8 +1167,15 @@ def serving_ref_for_pack(ref: Json, *, default_session_continuity: str = "", def
         ("resource_version", "version"),
         ("version_state", "version_state"),
     ]
+    # `ref.get(field, metadata.get(field))` reads the metadata FIRST, every time, to build a
+    # default the ref usually overrides -- sixteen lookups into a dict that on the serving path is
+    # empty on every ref. The fallback is kept exactly: metadata answers only when the ref does not
+    # carry the field at all, so a ref holding an explicit None still resolves to None.
+    metadata_field = metadata.get if metadata else None
     for field, alias in optional_field_aliases:
-        value = ref.get(field, metadata.get(field))
+        value = ref.get(field)
+        if value is None and metadata_field is not None and field not in ref:
+            value = metadata_field(field)
         if value not in (None, "", [], {}):
             item[alias] = value
     session_continuity = str(ref.get("session_continuity") or metadata.get("session_continuity") or "")
@@ -1247,10 +1263,7 @@ def session_continuity_counts(refs: list[Json]) -> Json:
 
 
 def default_session_continuity_for_pack(refs: list[Json]) -> str:
-    counts = session_continuity_counts(refs)
-    if not counts:
-        return ""
-    return max(counts.items(), key=lambda item: (item[1], item[0]))[0]
+    return _most_common_counted_name(session_continuity_counts(refs))
 
 
 def serving_refs_for_pack(refs: list[Json], *, default_session_continuity: str = "", default_memory_layer: str = "", include_debug: bool = False) -> list[Json]:
@@ -1648,8 +1661,13 @@ def compact_context_pack_for_serving(pack: Json, *, include_debug: bool = False)
     compact: Json = {"context_pack_id": pack.get("context_pack_id") or pack.get("pack_id") or ""}
     selected_refs = pack.get("selected_refs", [])
     if isinstance(selected_refs, list) and (selected_refs or not isinstance(pack.get("groups"), list)):
-        default_session_continuity = default_session_continuity_for_pack(selected_refs)
-        default_memory_layer = _default_memory_layer_for_pack(selected_refs)
+        # Counted once. The defaults ARE these counts read one way, and asking for them through
+        # the two `*_for_pack` helpers counted the whole pack a second time for each -- four walks
+        # where two do, and three calls to `_memory_layer_for_ref` per ref rather than two.
+        continuity_counts = session_continuity_counts(selected_refs)
+        layer_counts = _memory_layer_counts(selected_refs)
+        default_session_continuity = _most_common_counted_name(continuity_counts)
+        default_memory_layer = _most_common_counted_name(layer_counts)
         compact["groups"] = serving_ref_groups_for_pack(
             selected_refs,
             default_session_continuity=default_session_continuity,
@@ -1659,11 +1677,9 @@ def compact_context_pack_for_serving(pack: Json, *, include_debug: bool = False)
         )
         if pack.get("selected_ref_counts"):
             compact.setdefault("counts", {})["refs"] = pack.get("selected_ref_counts", {})
-        continuity_counts = session_continuity_counts(selected_refs)
         if continuity_counts:
             compact.setdefault("defaults", {})["session_continuity"] = default_session_continuity
             compact.setdefault("counts", {})["session_continuity"] = continuity_counts
-        layer_counts = _memory_layer_counts(selected_refs)
         if layer_counts:
             compact.setdefault("defaults", {})["memory_layer"] = default_memory_layer
             compact.setdefault("counts", {})["memory_layer"] = layer_counts

--- a/tools/test_codex_pipeline_part1.py
+++ b/tools/test_codex_pipeline_part1.py
@@ -2141,3 +2141,69 @@ class _CodexPipelinePart1:
         with mock.patch.object(core_context_pack, "compact_context_pack_refs", refuse):
             proven = compact_context_pack_for_serving_flat(dict(pack), refs_already_compact=True)
         self.assertEqual(rebuilt, proven)
+
+    def test_metadata_answers_only_when_the_ref_does_not_carry_the_field(self) -> None:
+        """The metadata fallback is a fallback, and an explicit None is an answer.
+
+        The alias loop stopped reading metadata eagerly, and the difference between the two forms
+        shows up in exactly one case: a ref that CARRIES the field with a null value. Reading the
+        metadata as a `dict.get` default returns null there, so pinning it keeps the rewrite from
+        quietly promoting metadata over the ref's own word.
+        """
+        from matrixark_mcp_context_pack import serving_ref_for_pack
+
+        absent = serving_ref_for_pack(
+            {"ref_type": "segment", "text": "t", "metadata": {"heading": "From metadata"}}
+        )
+        self.assertEqual("From metadata", absent.get("heading"))
+
+        explicit_null = serving_ref_for_pack(
+            {
+                "ref_type": "segment",
+                "text": "t",
+                "heading": None,
+                "metadata": {"heading": "From metadata"},
+            }
+        )
+        self.assertIsNone(
+            explicit_null.get("heading"),
+            "a ref carrying the field with no value is not overridden by metadata",
+        )
+
+        own = serving_ref_for_pack(
+            {
+                "ref_type": "segment",
+                "text": "t",
+                "heading": "From the ref",
+                "metadata": {"heading": "From metadata"},
+            }
+        )
+        self.assertEqual("From the ref", own.get("heading"))
+
+    def test_the_pack_defaults_and_counts_come_from_one_count(self) -> None:
+        """One tie rule, and the default is the counts read one way.
+
+        The two defaults used to ask for their own count of the whole pack, and each carried its
+        own copy of `max(..., key=(count, name))`. The tie case is what a drifted copy would get
+        wrong, and it is not cosmetic: the winner decides which value is left off every item.
+        """
+        from matrixark_mcp_context_pack import (
+            _most_common_counted_name,
+            default_session_continuity_for_pack,
+        )
+
+        self.assertEqual("", _most_common_counted_name({}))
+        self.assertEqual("beta", _most_common_counted_name({"alpha": 2, "beta": 2}))
+        self.assertEqual("alpha", _most_common_counted_name({"alpha": 3, "beta": 2}))
+
+        refs = [
+            {"ref_type": "event", "text": "a", "session_continuity": "alpha"},
+            {"ref_type": "event", "text": "b", "session_continuity": "beta"},
+        ]
+        self.assertEqual("beta", default_session_continuity_for_pack(refs))
+
+        served = compact_context_pack_for_serving(
+            {"context_pack_id": "p", "selected_refs": refs, "redundant_items_dropped": True}
+        )
+        self.assertEqual("beta", served["defaults"]["session_continuity"])
+        self.assertEqual({"alpha": 1, "beta": 1}, served["counts"]["session_continuity"])


### PR DESCRIPTION
Two passes over the serving pack that could not change its answer.

**Each field was counted twice.** `compact_context_pack_for_serving` asked
`default_session_continuity_for_pack` and `_default_memory_layer_for_pack` for the two defaults,
and each of those counts the whole pack — then the function counted the whole pack again for the
`counts` map it serves. Four walks where two do, and `_memory_layer_for_ref`, the one with the
fallback chain, ran three times per ref rather than twice. The defaults *are* those counts read one
way, so they are now taken from them.

That also leaves **one** copy of the tie rule. It was written out twice, once per default, and it
is not a detail a copy can drift on quietly: the winner of a tie decides which value is left off
every item in the pack.

**The alias loop read an empty dict sixteen times per ref.** `ref.get(field, metadata.get(field))`
evaluates the default first, always — and on the serving path no ref carries metadata at all
(0 of 536 on the measured pack), so that is 8,576 lookups per retrieve building defaults nothing
uses. The fallback is kept exactly as it was: metadata answers only when the ref does not carry the
field, so a ref holding an explicit null still resolves to null rather than being overridden.

### What it is worth

The one-box cannot resolve a sub-millisecond effect end to end — every retrieve writes, so the
store is larger for each arm than the one before it — so the function is timed directly, on the
536 refs a real retrieve produced, with the file swapped between arms and nothing else changed:

| | round 1 | round 2 | mean |
|---|---:|---:|---:|
| before | 3.25 ms | 3.29 ms | 3.27 |
| **after** | **2.80 ms** | **2.83 ms** | **2.815** |

**-13.9%, 0.46 ms per retrieve**, and the two served packs are byte-identical over all 536 items.

Of that, the duplicate counting alone is 0.38 ms of work removed — both counts over 536 refs
measure 0.38 ms, and one of the two rounds was pure repetition.

### What holds it

Two tests. One pins the metadata fallback in the case that separates the two forms — a ref that
carries the field with a null value — because the obvious "simplification" to
`ref.get(field) or metadata.get(field)` would silently let metadata win there. The other pins the
tie rule and that the served defaults and counts agree.

Pipeline suite: 52 failing names with the change and 52 without, no name moved either way. Backend
policy suite green.
