### PR TITLE
The running scheduler reaches every maintenance phase

### DIFF
--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -343,6 +343,101 @@ fn switching_reclaim_off_stops_the_reclaim_however_large_the_log() {
     );
 }
 
+/// The RUNNING scheduler reaches every maintenance phase, not just one round of it.
+///
+/// The guard beside this one proves a single round enables every phase. That is not the same
+/// claim: a loop that ran once, or only ever visited its first shard, or died on the first error,
+/// would satisfy it. This starts the scheduler the server starts, lets it tick, and requires that
+/// every per-phase counter moved.
+///
+/// Asserted as "at least once each" rather than "once per loop". Measured over four loops:
+/// prepare 4, reclaim_wal 1, reclaim_memory 3, expire 4, reclaim_page 4, compact 4, index_gc 4 --
+/// reclaim_wal ran once because after it reclaimed there was nothing left, and reclaim_memory is
+/// pressure-dependent. Pinning either to the loop count would pin this fixture's luck.
+#[test]
+fn the_running_scheduler_reaches_every_phase() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        256 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    let options = StorageManagerOptions::default();
+    // Pressure of several kinds, so a phase that declines for want of work is distinguishable
+    // from one the loop never reaches: volume for the dump threshold, overwrites for stale
+    // pages, deletes for tombstones, and a small cache so memory pressure is reachable.
+    let writes = options.min_undumped_wal_records as usize + 256;
+    for index in 0..writes {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("periodic-{index:05}"),
+                value: vec![b'v'; 64],
+            },
+        });
+    }
+    for index in 0..(writes / 2) {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("periodic-{index:05}"),
+                value: vec![b'w'; 96],
+            },
+        });
+    }
+    for index in 0..(writes / 4) {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::CommonDelete { key: format!("periodic-{index:05}") },
+        });
+    }
+
+    let runtime = DataNodeRuntime::new_without_workers_with_options(
+        engine,
+        DataNodeRuntimeOptions {
+            worker_threads: 0,
+            max_queue_depth: 4,
+            max_background_queue_depth: 2,
+        },
+    );
+    let scheduler = runtime.start_storage_manager_scheduler_for_all_shards(
+        std::time::Duration::from_millis(5),
+        options,
+    );
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    while std::time::Instant::now() < deadline {
+        if runtime.stats().storage_manager_loops >= 4 {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    let stats = runtime.stats();
+    drop(scheduler);
+
+    assert!(
+        stats.storage_manager_loops >= 4,
+        "the scheduler only completed {} rounds, so nothing below is about periodic behaviour",
+        stats.storage_manager_loops
+    );
+    for (phase, runs) in [
+        ("prepare", stats.storage_manager_prepare_runs),
+        ("reclaim_wal", stats.storage_manager_reclaim_wal_runs),
+        ("reclaim_memory", stats.storage_manager_reclaim_memory_runs),
+        ("expire", stats.storage_manager_expire_runs),
+        ("reclaim_page", stats.storage_manager_reclaim_page_runs),
+        ("compact", stats.storage_manager_compact_runs),
+        ("index_gc", stats.storage_manager_index_gc_runs),
+    ] {
+        assert!(
+            runs > 0,
+            "{phase} never ran across {} scheduler rounds",
+            stats.storage_manager_loops
+        );
+    }
+}
+
 #[test]
 fn runtime_enforces_authorized_lifecycle_token_when_installed() {
     let runtime = DataNodeRuntime::new_without_workers_with_options(


### PR DESCRIPTION
The running scheduler reaches every maintenance phase

The guard beside this one proves a single round enables every phase. That is
a different claim: a loop that ran once, or only ever visited its first shard,
or died on the first error would satisfy it while reclaiming nothing. This
starts the scheduler a server starts, lets it tick, and requires every
per-phase counter to have moved.

Measured over four rounds of the real scheduler:

  prepare 4   reclaim_wal 1   reclaim_memory 3   expire 4
  reclaim_page 4   compact 4   index_gc 4

Asserted as at least once each, not once per round. reclaim_wal ran once
because after it reclaimed there was nothing left to reclaim, and
reclaim_memory is pressure-dependent -- pinning either to the round count
would pin this fixture's luck rather than the behaviour. The fixture carries
pressure of several kinds on purpose (volume past the dump threshold,
overwrites for stale pages, deletes for tombstones, a small cache for memory
pressure), so a phase that declines for want of work is distinguishable from
one the loop never reaches.

Mutations: compaction never running and index-GC never running both fail it.
A loop that stops after one round fails the round-count assertion directly.

A fourth mutation -- visit only the first loaded shard -- SURVIVED here, and
that is a property of this fixture rather than a hole: it loads one shard, so
taking the first is taking them all. Rather than duplicate coverage, I ran
that mutation against the all-shards test, which kills it. That test loads a
second shard AFTER the scheduler has started, which is the case worth
defending.

Written as a probe first, printing the counters, and turned into assertions
only once the numbers were known. Asserting first would have meant guessing
which phases a fixture reaches, and the guess would have been wrong for
reclaim_wal.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
