### PR TITLE
Serving carries a score floor and no secondary index

### DIFF
--- a/tools/matrixark_local_adapter_retrieve.py
+++ b/tools/matrixark_local_adapter_retrieve.py
@@ -78,6 +78,8 @@ try:  # package path
     from tools.matrixark_mcp_runtime_config import (
         apply_remote_only_local_fallback,
         resolve_context_source_mode,
+        retrieval_min_score,
+        serving_secondary_index_enabled,
         QUERY_REWRITE_ENABLED,
         QUERY_REWRITE_WINDOW,
         PACK_PRECISION_EXPAND_ENABLED,
@@ -89,6 +91,8 @@ except ImportError:
     from matrixark_mcp_runtime_config import (  # noqa: F401
         apply_remote_only_local_fallback,
         resolve_context_source_mode,
+        retrieval_min_score,
+        serving_secondary_index_enabled,
         QUERY_REWRITE_ENABLED,
         QUERY_REWRITE_WINDOW,
         PACK_PRECISION_EXPAND_ENABLED,
@@ -474,10 +478,12 @@ class _LocalAdapterRetrieveMixin:
             retrieval_session_scope = "only"
         retrieval_scope = {**scope, "_session_scope": retrieval_session_scope}
         secondary_index_filter_groups = infer_secondary_index_filter_groups(query, question_type)
-        # Resolved here because the scan is about to start and both are read per request. The
-        # secondary-index groups are deliberately LEFT ALONE: on this path they are not an
-        # admission filter, they add 0.08 to a node's score, so clearing them changed nothing on
-        # two fixtures -- including one built from a query that does produce groups.
+        # Resolved here because the scan is about to start and both are read per request.
+        #
+        # On THIS path the groups are not an admission filter: they add 0.08 to a node's score, so
+        # clearing them changed nothing on two fixtures -- including one built from a query that
+        # does produce groups. The ENGINE reads the same groups differently, and that is why they
+        # are no longer sent to it: see `serving_secondary_index_enabled`.
         retrieval_return_all = _return_all_candidates(scope)
         retrieval_return_all_threshold = _return_all_candidate_threshold(scope)
         secondary_index_filter_mode = "any_group" if len(secondary_index_filter_groups) > 1 else "all_groups"
@@ -986,8 +992,29 @@ class _LocalAdapterRetrieveMixin:
             "scope": retrieval_scope,
             "question_type": question_type,
             "query_plan": query_plan,
-            "secondary_index_groups": [sorted(group) for group in secondary_index_filter_groups],
+            # A one-box serving retrieve sends NO secondary index groups. The engine treats them
+            # as an admission filter over terms gathered across every shard, so a request carrying
+            # them cannot be prepared per shard: measured on one store, 930.9 ms against 87.0 ms,
+            # shards reused 0/6 against 4/7, and 448 items served against 757 -- the same items,
+            # 309 fewer. The caller's own use of them, three lines above, is a 0.08 score nudge.
+            #
+            # It is also inferring them wrongly: "storage manager durable dump" produces
+            # entity_type:family_profile and entity_type:relationship, and then pays whole-corpus
+            # for that. Redesigning the inference is a separate piece of work; serving does not
+            # wait for it.
+            "secondary_index_groups": (
+                [sorted(group) for group in secondary_index_filter_groups]
+                if serving_secondary_index_enabled()
+                else []
+            ),
             "secondary_index_filter_mode": secondary_index_filter_mode,
+            # The engine has always had a score floor and this path never sent one, so it fell to
+            # its own default of 0.0 -- which its comment describes accurately as excluding only
+            # what scores EXACTLY zero. Sweeping the knob through the gateway changed nothing at
+            # any value, because nothing was carrying it: 123 refs at 0.01 and 123 at 0.4.
+            #
+            # Sent from the caller's ranking policy, like every other ranking decision here.
+            "min_score": retrieval_min_score(args, ranking),
             # Ask the engine for the serving shape rather than rebuilding every ref here. Not for a
             # debug retrieve: those carry lineage fields the serving shape drops, and the engine
             # cannot know which kind this is.

--- a/tools/matrixark_mcp_runtime_config.py
+++ b/tools/matrixark_mcp_runtime_config.py
@@ -92,6 +92,43 @@ def native_candidate_prefilter_required(*, backend_label: str = "") -> bool:
 
 DEFAULT_MAX_CONTEXT_TOKENS = int(os.environ.get("MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS", "500000"))
 
+
+def retrieval_min_score(args: Any = None, ranking: Any = None) -> float:
+    """The score floor for this retrieve: the request's, else the deployment's.
+
+    Read in the same order as every other ranking decision -- per-request first, then the
+    deployment default -- so a caller can lower it for a broad question without the deployment
+    losing its floor for everything else.
+    """
+    for source in (args, ranking):
+        if isinstance(source, dict):
+            value = source.get("min_score")
+            if value not in (None, ""):
+                try:
+                    return max(0.0, float(value))
+                except (TypeError, ValueError):
+                    continue
+    return max(0.0, DEFAULT_RETRIEVAL_MIN_SCORE)
+
+
+def serving_secondary_index_enabled() -> bool:
+    """Whether a serving retrieve sends secondary index groups to the engine.
+
+    OFF, and the default is the decision rather than caution. The engine reads the groups as an
+    admission filter over index terms gathered across EVERY shard, so a request carrying them
+    cannot be prepared per shard and gives up the candidate cache entirely: measured on one store,
+    930.9 ms against 87.0 ms with shards reused 0/6 against 4/7, serving 448 items where the same
+    query without them served 757 -- every one of the 448 among the 757, so the groups only
+    removed. The caller that computes them documents its own use as a 0.08 score nudge.
+
+    `MATRIXARK_SERVING_SECONDARY_INDEX=1` sends them again, for a deployment that wants the old
+    behaviour back without a code change. Nothing about the INDEX ITSELF is decided here -- this is
+    only whether serving filters on it.
+    """
+    return os.environ.get("MATRIXARK_SERVING_SECONDARY_INDEX", "").strip().lower() in {
+        "1", "true", "yes", "on",
+    }
+
 # Context-source policy: which context the agent's prompt is assembled from.
 #   auto (default)   -> synthetic/debug requests (retrieve arg synthetic=true) use the
 #                       remote TemporalStore pack ONLY; real Codex/Claude sessions keep

--- a/tools/test_codex_pipeline_part1.py
+++ b/tools/test_codex_pipeline_part1.py
@@ -2207,3 +2207,50 @@ class _CodexPipelinePart1:
         )
         self.assertEqual("beta", served["defaults"]["session_continuity"])
         self.assertEqual({"alpha": 1, "beta": 1}, served["counts"]["session_continuity"])
+
+    def test_the_serving_request_carries_a_score_floor(self) -> None:
+        """The deployment's declared floor has to reach the engine to be a floor at all.
+
+        `DEFAULT_RETRIEVAL_MIN_SCORE` has existed with a portal setting behind it, and the serving
+        request never carried it -- so the engine fell to its own 0.0, which excludes only what
+        scores exactly zero. Sweeping the value through the gateway changed nothing at any setting:
+        123 refs at 0.01 and 123 at 0.4.
+        """
+        from matrixark_mcp_runtime_config import retrieval_min_score
+
+        self.assertEqual(0.25, retrieval_min_score({"min_score": 0.25}, {}))
+        self.assertEqual(0.4, retrieval_min_score({}, {"min_score": 0.4}))
+        self.assertEqual(
+            0.25,
+            retrieval_min_score({"min_score": 0.25}, {"min_score": 0.4}),
+            "the request wins over the deployment, as every other ranking decision does",
+        )
+        # Junk is ignored rather than raising: a bad value must not be the reason a retrieve fails.
+        self.assertGreaterEqual(retrieval_min_score({"min_score": "x"}, {}), 0.0)
+        # And it is never negative, which would admit what the engine excludes at zero.
+        self.assertGreaterEqual(retrieval_min_score({"min_score": -5}, {}), 0.0)
+
+    def test_serving_does_not_send_secondary_index_groups(self) -> None:
+        """One-box serving carries no secondary index, and can be given one back.
+
+        The engine reads the groups as an admission filter over terms gathered across every shard,
+        so a request carrying them cannot be prepared per shard: 930.9 ms against 87.0 ms on one
+        store, shards reused 0/6 against 4/7, 448 items served where the same query without them
+        served 757 -- all 448 among the 757, so the groups only removed.
+        """
+        import os
+
+        from matrixark_mcp_runtime_config import serving_secondary_index_enabled
+
+        previous = os.environ.get("MATRIXARK_SERVING_SECONDARY_INDEX")
+        try:
+            os.environ.pop("MATRIXARK_SERVING_SECONDARY_INDEX", None)
+            self.assertFalse(serving_secondary_index_enabled(), "off unless asked for")
+            os.environ["MATRIXARK_SERVING_SECONDARY_INDEX"] = "1"
+            self.assertTrue(serving_secondary_index_enabled(), "and a deployment can have it back")
+            os.environ["MATRIXARK_SERVING_SECONDARY_INDEX"] = "0"
+            self.assertFalse(serving_secondary_index_enabled())
+        finally:
+            os.environ.pop("MATRIXARK_SERVING_SECONDARY_INDEX", None)
+            if previous is not None:
+                os.environ["MATRIXARK_SERVING_SECONDARY_INDEX"] = previous


### PR DESCRIPTION
Two things the serving request should have been carrying, and one it should not.

### The secondary index leaves the serving path

The engine reads `secondary_index_groups` as an **admission filter** over index terms gathered
across *every* shard — so a request carrying them cannot be prepared per shard, and gives up the
candidate cache entirely. Measured earlier on one store: **930.9 ms against 87.0 ms**, `shards
reused 0/6` against `4/7`, and **448 items served where the same query without them served 757** —
every one of the 448 among the 757, so the groups only removed.

The caller's own note beside where it computes them says that on *its* path they are not an
admission filter at all: they add 0.08 to a node's score. Both can be true of their own paths. The
result is that a retrieve was paying whole-corpus and dropping 41% of its candidates through a
mechanism one side documents as a nudge.

It is also inferring them wrongly. `"storage manager durable dump"` produces
`entity_type:family_profile` and `entity_type:relationship`, and then pays whole-corpus for that.
Redesigning the inference is separate work; serving does not wait for it.

`MATRIXARK_SERVING_SECONDARY_INDEX=1` sends them again, for a deployment that wants the old
behaviour without a code change. Nothing here decides anything about the index itself — only
whether serving filters on it.

### The score floor was declared and unreachable

`DEFAULT_RETRIEVAL_MIN_SCORE` has existed at **0.05**, with a portal setting and an env var behind
it. The serving request never carried it, so the engine fell to its own `unwrap_or(0.0)` — which
its comment describes accurately as excluding only what scores *exactly* zero. Sweeping the value
through the gateway confirmed it: **123 refs at 0.01 and 123 at 0.4**, identical bytes, because
nothing was carrying it.

It is now sent, read per request first and per deployment second, like every other ranking decision
on this path.

**And a measurement worth recording, because it says the declared value is inert.** With the floor
actually arriving, sweeping it shows where the score mass sits:

```
  narrow  0.0:103  0.4:102  0.6:90  0.8:80  0.99:80
  broad   0.0:22   0.4:22   0.6:6   0.8:6   0.99:6
  junk    0.0:17   0.4:16   0.6:0   0.8:0   0.99:0
```

The cliff is between 0.4 and 0.6 — nowhere near 0.05, so honouring the declared value changes
nothing on this corpus, which is why this change is safe to land on its own. The junk row is the
useful one: a query matching nothing is served **17 refs today** and **zero at 0.6**. That also
gives a way to choose the number per deployment rather than by taste — *the floor is the value at
which a query that matches nothing returns nothing*. The scale belongs to the encoder, so the
default is left where the deployment declared it rather than moved here.

### While plumbing it

`DEFAULT_RETRIEVAL_MIN_SCORE` was defined **twice** in the same module. The second definition wins
in Python, so the first read as live while the later line decided the value. The duplicate is gone.

Pipeline suite: 52 failing names with the change and 52 without, none moved. Backend policy green.
Two tests cover the floor's resolution order and the index switch in both directions.
