### PR TITLE
The proxy can say what its memory is made of

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -1420,6 +1420,7 @@ fn render_prometheus_metrics(
     ));
     // The engine's own series, which include the page-cache counters. Appended rather than
     // re-rendered: see engine_prometheus_metrics.
+    output.push_str(&serving_cache_prometheus_metrics());
     output.push_str(&engine_prometheus_metrics());
     output
 }
@@ -4844,6 +4845,41 @@ fn engine_cache() -> &'static Mutex<BTreeMap<PathBuf, RecordStore>> {
 /// series with identical labels -- which is a malformed scrape rather than more information. One
 /// engine is the onebox case this exists for; a proxy fanned out over several record-log prefixes
 /// keeps the request counters it always had.
+
+/// What this process is holding, beside the engine's own counters.
+///
+/// Without these the proxy's RSS is one number and four possible explanations. They are gauges
+/// rather than counters: each is a current size, and the budgets are rendered beside the sizes so
+/// a reading says how close to its bound each cache is without needing the configuration.
+fn serving_cache_prometheus_metrics() -> String {
+    let (entries, payload_bytes, derived_bytes, payload_budget, derived_budget) =
+        serving_cache_gauges();
+    let (candidate_entries, scan_entries) = serving_derived_cache_entries();
+    format!(
+        "# HELP matrixark_proxy_snapshot_cache_entries Shards held in the serving snapshot cache.\n\
+         # TYPE matrixark_proxy_snapshot_cache_entries gauge\n\
+         matrixark_proxy_snapshot_cache_entries {entries}\n\
+         # HELP matrixark_proxy_snapshot_cache_payload_bytes Shard payload bytes held.\n\
+         # TYPE matrixark_proxy_snapshot_cache_payload_bytes gauge\n\
+         matrixark_proxy_snapshot_cache_payload_bytes {payload_bytes}\n\
+         # HELP matrixark_proxy_snapshot_cache_derived_bytes Parsed records and prepared candidates held.\n\
+         # TYPE matrixark_proxy_snapshot_cache_derived_bytes gauge\n\
+         matrixark_proxy_snapshot_cache_derived_bytes {derived_bytes}\n\
+         # HELP matrixark_proxy_snapshot_cache_payload_budget_bytes Budget for shard payloads.\n\
+         # TYPE matrixark_proxy_snapshot_cache_payload_budget_bytes gauge\n\
+         matrixark_proxy_snapshot_cache_payload_budget_bytes {payload_budget}\n\
+         # HELP matrixark_proxy_snapshot_cache_derived_budget_bytes Budget for derived data.\n\
+         # TYPE matrixark_proxy_snapshot_cache_derived_budget_bytes gauge\n\
+         matrixark_proxy_snapshot_cache_derived_budget_bytes {derived_budget}\n\
+         # HELP matrixark_proxy_candidate_snapshot_entries Candidate snapshots held, cleared per store on write.\n\
+         # TYPE matrixark_proxy_candidate_snapshot_entries gauge\n\
+         matrixark_proxy_candidate_snapshot_entries {candidate_entries}\n\
+         # HELP matrixark_proxy_scan_cache_entries Scan results held.\n\
+         # TYPE matrixark_proxy_scan_cache_entries gauge\n\
+         matrixark_proxy_scan_cache_entries {scan_entries}\n"
+    )
+}
+
 fn engine_prometheus_metrics() -> String {
     let cache = match engine_cache().lock() {
         Ok(cache) => cache,

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl/serving_caches.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl/serving_caches.rs
@@ -365,6 +365,46 @@ fn total_memory_bytes() -> usize {
     0
 }
 
+
+/// What the serving caches are holding, for the process to report about itself.
+///
+/// The proxy's resident set has been optimised twice this week against readings that could not say
+/// which part of it was which: the payload cache, the derived cache, the candidate snapshots and
+/// the engine this process holds open are all in the same RSS, and only the last of them reported
+/// anything. Returned as a tuple rather than a struct because it has exactly one caller, the
+/// metrics render, and a struct here would be a type nothing else names.
+///
+/// `(entries, payload bytes, derived bytes, payload budget, derived budget)`.
+fn serving_cache_gauges() -> (usize, usize, usize, usize, usize) {
+    match hgetall_snapshot_cache().lock() {
+        Ok(cache) => (
+            cache.entries.len(),
+            cache.bytes,
+            cache.decoded_bytes,
+            cache.budget,
+            cache.decoded_budget,
+        ),
+        // A poisoned lock must not cost the rest of the response.
+        Err(_) => (0, 0, 0, 0, 0),
+    }
+}
+
+/// How many candidate snapshots are held, and how many scan results.
+///
+/// Both are cleared per store when it is written, so a number that keeps climbing here means
+/// writes are not reaching the invalidation, not that the cache is unbounded.
+fn serving_derived_cache_entries() -> (usize, usize) {
+    let candidates = retrieve_candidate_cache()
+        .lock()
+        .map(|cache| cache.len())
+        .unwrap_or(0);
+    let scans = matrixark_scan_cache()
+        .lock()
+        .map(|cache| cache.len())
+        .unwrap_or(0);
+    (candidates, scans)
+}
+
 fn hgetall_snapshot_cache() -> &'static Mutex<SnapshotCache> {
     static HGETALL_SNAPSHOT_CACHE: OnceLock<Mutex<SnapshotCache>> = OnceLock::new();
     HGETALL_SNAPSHOT_CACHE.get_or_init(|| Mutex::new(SnapshotCache::new()))


### PR DESCRIPTION
The proxy's resident set was one number with four possible explanations.

Its memory is the serving snapshot cache (shard payloads), the derived cache (parsed records and
prepared candidates), the candidate snapshots, the scan results, and the storage engine this
process holds open — and only the last of those reported anything. So every attempt to reduce it
has been an argument rather than a measurement.

Seven gauges, rendered beside the engine's own block:

```
matrixark_proxy_snapshot_cache_entries              shards held
matrixark_proxy_snapshot_cache_payload_bytes        payload bytes
matrixark_proxy_snapshot_cache_derived_bytes        parses + prepared candidates
matrixark_proxy_snapshot_cache_payload_budget_bytes the bound, beside the size
matrixark_proxy_snapshot_cache_derived_budget_bytes the other bound
matrixark_proxy_candidate_snapshot_entries          candidate snapshots held
matrixark_proxy_scan_cache_entries                  scan results held
```

The budgets are rendered next to the sizes deliberately: a reading then says how close to its
bound each cache is without anyone having to go and find the configuration. Both budgets resolve to
`total_memory / 16`, clamped to 512 MB — so on a 24 GB machine the snapshot cache alone may hold
about a gigabyte, which is policy rather than a defect, and worth being able to see.

Read over the same JSON-RPC lane everything else uses:

```
curl -s -X POST http://127.0.0.1:17099/ -H 'Content-Type: application/json' \
  -d '{"op":"metrics_prometheus"}' | jq -r .prometheus | grep matrixark_proxy_
```

On a freshly loaded store that reports 15 shards, 1,503,547 payload bytes, 0 derived, and both
budgets at 536,870,912 — the derived cache being empty until something asks for a parse, which is
what it is supposed to do.

**Why this rather than another reduction.** Two changes were tried against this process's memory
this week and neither could be measured: its RSS swings 80–100 MB on a 20-second timescale with no
load at all, so an effect worth a few megabytes is invisible in the total and only visible in the
component. An 8-hour soak now records the split per sample rather than the sum.

`matrixark_proxy_candidate_snapshot_entries` also answers a question directly: those entries are
cleared per store when it is written, so a number that keeps climbing means writes are not reaching
the invalidation — not that the cache is unbounded. I checked that invalidation exists before
assuming it did not, having assumed wrong first.

133 proxy-bin tests pass.
