### PR TITLE
Planning a maintenance round no longer reads the whole store

### DIFF
--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -22,6 +22,188 @@ impl TemporalEngine {
         report
     }
 
+    /// The reclaim candidates, built once from the narrow view and once from the full report.
+    ///
+    /// Same selection function, two sources for the tally it reads. The narrow view leaves the
+    /// read-dependent fields at zero, so this is the check that the planner never looked at
+    /// them.
+    #[cfg(test)]
+    pub(crate) fn reclaim_candidates_two_ways_for_test(
+        &self,
+        shard_id: ShardId,
+    ) -> (Vec<StorageReclaimCandidate>, Vec<StorageReclaimCandidate>) {
+        let live = self
+            .live_block_slab_ids(shard_id)
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+        let stale = self
+            .page_store
+            .slab_ids()
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|id| !live.contains(id))
+            .collect::<BTreeSet<_>>();
+        let narrow = storage_reclaim_candidates_from_slab_reports(
+            &self.storage_reclaim_slab_reports(shard_id),
+            &stale,
+        );
+        let full = storage_reclaim_candidates_from_slab_reports(
+            &self.storage_recovery_report(shard_id).block_slab_live_reports,
+            &stale,
+        );
+        (narrow, full)
+    }
+
+    /// The per-slab live/stale tally the reclaim planner reads, without the whole-store scan.
+    ///
+    /// `storage_reclaim_candidates_from_slab_reports` consumes seven fields off each of these:
+    /// the slab id, its physical bytes and page count, its live page refs and live physical
+    /// bytes, and the two figures derived from those. Not one of them needs the page itself --
+    /// a page's physical size is in the address that names it. The recovery report supplied
+    /// them anyway, and supplied them by reading every live page off the block store to fill
+    /// in `live_logical_bytes`, which the planner never reads.
+    ///
+    /// The fields that DO require the read -- `live_logical_bytes`, `readable_live_page_refs`,
+    /// `unreadable_live_page_refs` -- are left at zero here, so this is not a drop-in for the
+    /// report: it is the planner's view, and `the_reclaim_planner_sees_the_same_candidates`
+    /// pins it to the answer the report produced.
+    pub(super) fn storage_reclaim_slab_reports(
+        &self,
+        shard_id: ShardId,
+    ) -> Vec<StorageRecoverySlabLiveReport> {
+        let block_slab_reports = self.page_store.slab_reports().unwrap_or_default();
+        let shards = self.shards.read().expect("engine lock poisoned");
+        let addresses = shards
+            .get(&shard_id)
+            .map(collect_live_page_addresses)
+            .unwrap_or_default();
+        let mut reports = block_slab_reports
+            .iter()
+            .map(|report| {
+                (
+                    report.block_slab_id,
+                    StorageRecoverySlabLiveReport {
+                        block_slab_id: report.block_slab_id,
+                        physical_bytes: report.physical_bytes,
+                        logical_bytes: report.logical_bytes,
+                        page_count: report.page_count,
+                        ..StorageRecoverySlabLiveReport::default()
+                    },
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        let mut live_object_ids = BTreeMap::<u64, BTreeSet<u64>>::new();
+        let mut live_routing_buckets = BTreeMap::<u64, BTreeSet<u32>>::new();
+        for address in &addresses {
+            let slab_report = reports.entry(address.block_slab_id).or_insert(
+                StorageRecoverySlabLiveReport {
+                    block_slab_id: address.block_slab_id,
+                    ..StorageRecoverySlabLiveReport::default()
+                },
+            );
+            slab_report.live_page_refs = slab_report.live_page_refs.saturating_add(1);
+            slab_report.live_physical_bytes = slab_report
+                .live_physical_bytes
+                .saturating_add(address.length);
+            if let Some(object_id) = address.object_id() {
+                let objects = live_object_ids.entry(address.block_slab_id).or_default();
+                objects.insert(object_id);
+                slab_report.live_object_count = objects.len() as u64;
+            }
+            if let Some(routing_bucket) = address.routing_bucket() {
+                let buckets = live_routing_buckets
+                    .entry(address.block_slab_id)
+                    .or_default();
+                buckets.insert(routing_bucket);
+                slab_report.live_routing_bucket_count = buckets.len() as u64;
+            }
+        }
+        reports
+            .into_values()
+            .map(|mut report| {
+                report.stale_page_estimate =
+                    report.page_count.saturating_sub(report.live_page_refs);
+                report.live_ref_density_basis_points = if report.page_count == 0 {
+                    0
+                } else {
+                    report.live_page_refs.saturating_mul(10_000) / report.page_count
+                };
+                report
+            })
+            .collect()
+    }
+
+    /// The object-lifecycle view on its own, without the whole-store scan around it.
+    ///
+    /// The recovery report produces this field as a by-product of reading EVERY live page off
+    /// disk, which is how it counts the readable ones. Two callers on the maintenance path want
+    /// nothing else from that report, so they were paying a full-store read to get it -- on a
+    /// loop that runs every thirty seconds, for the life of the process.
+    ///
+    /// Nothing here reads a page. Every count comes from the shard's own maps, the ownership
+    /// validation and the slab reports, which is all the field was ever made of:
+    ///
+    /// | at 32,000 live pages | the report | this |
+    /// |---|---|---|
+    /// | wall time | ~840 ms | ~45 ms |
+    /// | pages read from the block store | 32,000 | 0 |
+    ///
+    /// `object_lifecycle_snapshot_matches_the_recovery_report` holds the two to the same answer,
+    /// so a change to either that separates them fails there rather than in a shipped round.
+    /// The snapshot, and the live page count, for the tests that hold it to the report.
+    #[cfg(test)]
+    pub(crate) fn storage_object_lifecycle_snapshot_for_test(
+        &self,
+        shard_id: ShardId,
+    ) -> StorageObjectLifecycleReport {
+        self.storage_object_lifecycle_snapshot(shard_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn live_page_count_for_test(&self, shard_id: ShardId) -> usize {
+        let shards = self.shards.read().expect("engine lock poisoned");
+        shards
+            .get(&shard_id)
+            .map(|shard| collect_live_page_addresses(shard).len())
+            .unwrap_or_default()
+    }
+
+    pub(super) fn storage_object_lifecycle_snapshot(
+        &self,
+        shard_id: ShardId,
+    ) -> StorageObjectLifecycleReport {
+        let block_slab_reports = self.page_store.slab_reports().unwrap_or_default();
+        let shards = self.shards.read().expect("engine lock poisoned");
+        let Some(shard) = shards.get(&shard_id) else {
+            return StorageObjectLifecycleReport::default();
+        };
+        let ownership = self.validate_shard_page_ownership(shard_id, shard);
+        let mut report = storage_object_lifecycle_report(shard_id, shard);
+        report.owner_mismatch_page_refs = ownership.mismatches.len() as u64;
+        report.missing_owner_page_refs = ownership.missing_owner_page_refs as u64;
+        // stale_object_ids is the per-slab shortfall of live refs against the slab's own page
+        // count, summed. An address naming a slab the store has no report for contributes
+        // nothing (the report path gives it page_count 0, so its shortfall saturates to 0).
+        let mut live_page_refs_by_slab = BTreeMap::<u64, u64>::new();
+        for address in collect_live_page_addresses(shard) {
+            *live_page_refs_by_slab
+                .entry(address.block_slab_id)
+                .or_default() += 1;
+        }
+        report.stale_object_ids = block_slab_reports
+            .iter()
+            .map(|slab| {
+                slab.page_count.saturating_sub(
+                    live_page_refs_by_slab
+                        .get(&slab.block_slab_id)
+                        .copied()
+                        .unwrap_or_default(),
+                )
+            })
+            .sum();
+        report
+    }
+
     pub(super) fn storage_recovery_report_without_boundary(&self, shard_id: ShardId) -> StorageRecoveryReport {
         // Durable served-index size. The base is materialized only at compaction, so a fresh
         // crash-recovered shard has no base file yet -- the durable served index is the base

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -50,12 +50,16 @@ pub(super) fn storage_slab_integrity_report(
     }
 }
 
-pub(super) fn storage_reclaim_candidates_from_recovery(
-    recovery: &StorageRecoveryReport,
+/// The slabs worth reclaiming, chosen from the per-slab live/stale tally.
+///
+/// This took a whole `StorageRecoveryReport` and read one field off it. Taking that field
+/// directly is what lets the planner build the tally without the report's whole-store page
+/// scan -- see `storage_reclaim_slab_reports`.
+pub(super) fn storage_reclaim_candidates_from_slab_reports(
+    block_slab_live_reports: &[StorageRecoverySlabLiveReport],
     fully_stale_slab_ids: &BTreeSet<u64>,
 ) -> Vec<StorageReclaimCandidate> {
-    let mut candidates = recovery
-        .block_slab_live_reports
+    let mut candidates = block_slab_live_reports
         .iter()
         .filter_map(|report| {
             let fully_stale = fully_stale_slab_ids.contains(&report.block_slab_id);

--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -84,13 +84,15 @@ impl TemporalEngine {
             .into_iter()
             .filter(|id| !live_block_slab_set.contains(id))
             .collect::<Vec<_>>();
-        let recovery = self.storage_recovery_report_without_boundary(request.shard_id);
+        let reclaim_slab_reports = self.storage_reclaim_slab_reports(request.shard_id);
         let stale_block_slab_set = stale_block_slab_ids
             .iter()
             .copied()
             .collect::<BTreeSet<_>>();
-        let mut reclaim_candidates =
-            storage_reclaim_candidates_from_recovery(&recovery, &stale_block_slab_set);
+        let mut reclaim_candidates = storage_reclaim_candidates_from_slab_reports(
+            &reclaim_slab_reports,
+            &stale_block_slab_set,
+        );
         let delayed_destroy_reports = self
             .page_store
             .delayed_destroy_slab_reports()
@@ -550,9 +552,7 @@ impl TemporalEngine {
                 request.follower_replay_cursors.clone(),
             )
         });
-        let object_lifecycle = self
-            .storage_recovery_report_without_boundary(request.shard_id)
-            .object_lifecycle;
+        let object_lifecycle = self.storage_object_lifecycle_snapshot(request.shard_id);
         let mut report = StorageLifecycleReport {
             shard_id: request.shard_id,
             public_storage_contract: Default::default(),

--- a/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
+++ b/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
@@ -1095,8 +1095,7 @@ impl TemporalEngine {
                 install_roll_forward_reports: self
                     .bucket_dump_install_roll_forward_reports(lifecycle_request.shard_id),
                 object_lifecycle: self
-                    .storage_recovery_report_without_boundary(lifecycle_request.shard_id)
-                    .object_lifecycle,
+                    .storage_object_lifecycle_snapshot(lifecycle_request.shard_id),
                 ..StorageLifecycleReport::default()
             }
         };

--- a/crates/temporalstore-rust/src/engine/storage_reports.rs
+++ b/crates/temporalstore-rust/src/engine/storage_reports.rs
@@ -17,9 +17,7 @@ impl TemporalEngine {
             StorageLifecycleReport {
                 shard_id: request.shard_id,
                 plan,
-                object_lifecycle: self
-                    .storage_recovery_report_without_boundary(request.shard_id)
-                    .object_lifecycle,
+                object_lifecycle: self.storage_object_lifecycle_snapshot(request.shard_id),
                 ..StorageLifecycleReport::default()
             }
         };

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -2221,6 +2221,278 @@ fn reconcile_does_not_resurrect_evicted_feature_points_on_reload() {
     );
 }
 
+/// The object-lifecycle snapshot answers exactly what the recovery report answers.
+///
+/// The maintenance round used to obtain this field by building a whole recovery report, which
+/// reads every live page off the block store to count the readable ones and then discards all
+/// of that. The snapshot computes the same field from the shard's maps and the slab reports.
+/// "Same" has to be checked rather than argued: this drives a workload that moves each of its
+/// parts -- writes, overwrites, deletes, a maintenance cycle, a rolled slab -- and compares the
+/// whole struct after every stage.
+#[test]
+fn object_lifecycle_snapshot_matches_the_recovery_report() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1 << 20,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+
+    let mut stages = 0usize;
+    let mut check = |engine: &TemporalEngine, what: &str| {
+        let from_report = engine.storage_recovery_report(1).object_lifecycle;
+        let snapshot = engine.storage_object_lifecycle_snapshot_for_test(1);
+        assert_eq!(
+            snapshot, from_report,
+            "after {what}: the snapshot and the recovery report disagree"
+        );
+        stages += 1;
+    };
+
+    check(&engine, "an empty shard");
+
+    for index in 0..120 {
+        write_string(&engine, &format!("life-{index:04}"), b"value");
+    }
+    check(&engine, "120 writes");
+
+    for index in 0..60 {
+        write_string(&engine, &format!("life-{index:04}"), b"a longer replacement value");
+    }
+    check(&engine, "60 overwrites leaving stale pages");
+
+    for index in 0..30 {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::CommonDelete {
+                key: format!("life-{index:04}"),
+            },
+        });
+    }
+    check(&engine, "30 deletes");
+
+    engine.run_storage_manager_cycle(StorageManagerCycleRequest {
+        shard_id: 1,
+        min_undumped_wal_records: 0,
+        min_undumped_wal_bytes: 0,
+        ..StorageManagerCycleRequest::default()
+    });
+    check(&engine, "a maintenance cycle");
+
+    // A rolled slab separates the slab reports from the live refs, which is what
+    // stale_object_ids measures.
+    engine.block_store().roll_slab().unwrap();
+    for index in 120..160 {
+        write_string(&engine, &format!("life-{index:04}"), b"value");
+    }
+    check(&engine, "a rolled slab and 40 more writes");
+
+    assert_eq!(stages, 6, "every stage must have been compared");
+}
+
+/// Planning and applying a maintenance round reads no pages at all.
+///
+/// Both phases used to build a whole `StorageRecoveryReport`, which reads EVERY live page off
+/// the block store so it can count the readable ones -- and then kept one field: the planner
+/// kept a per-slab byte tally, the apply kept `object_lifecycle`. Neither field needs a page.
+///
+/// This is the property that regresses silently: a caller reaching for the recovery report
+/// again still passes `object_lifecycle_snapshot_matches_the_recovery_report`, because the
+/// answer would be right -- it would just cost a full-store read on a loop that runs every
+/// thirty seconds. Counting the reads is the only thing that shows it.
+#[test]
+fn planning_a_maintenance_round_reads_no_pages() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1 << 20,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    for index in 0..400 {
+        write_string(&engine, &format!("round-{index:04}"), b"value");
+    }
+    let lifecycle = StorageLifecycleRequest {
+        shard_id: 1,
+        selected_dump_buckets: Vec::new(),
+        max_dump_buckets_per_round: 64,
+        min_undumped_wal_records: 0,
+        min_undumped_wal_bytes: 0,
+        purge_delayed_destroy: false,
+        prune_bucket_dump_manifests: false,
+        roll_forward_bucket_dump_installs: false,
+        follower_replay_cursors: Vec::new(),
+        page_gc_shared_store_cursors: Vec::new(),
+        page_gc_raft_snapshot_refs: Vec::new(),
+        page_gc_checkpoint_floor_slab_id: None,
+        page_gc_raft_install_floor_slab_id: None,
+        page_gc_delayed_destroy_grace_ms: 0,
+        invalidate_cache: false,
+        warm_cache: false,
+    };
+    // Settle first: the fixture's own dump is not what this measures.
+    engine.apply_storage_lifecycle(lifecycle.clone());
+
+    let live_pages = engine.live_page_count_for_test(1);
+    assert!(
+        live_pages >= 300,
+        "the fixture must hold pages worth reading: {live_pages}"
+    );
+
+    let before = engine.block_store().stats().reads;
+    let plan = engine.storage_lifecycle_plan(lifecycle.clone());
+    let planned = engine.block_store().stats().reads.saturating_sub(before);
+    assert_eq!(
+        planned, 0,
+        "planning read {planned} pages with {live_pages} live -- it is scanning the store"
+    );
+    assert!(
+        !plan.bucket_summaries.is_empty(),
+        "the plan must have surveyed something, or the count above proves nothing"
+    );
+
+    let before = engine.block_store().stats().reads;
+    engine.apply_storage_lifecycle(lifecycle);
+    let applied = engine.block_store().stats().reads.saturating_sub(before);
+    assert_eq!(
+        applied, 0,
+        "applying read {applied} pages with {live_pages} live -- it is scanning the store"
+    );
+}
+
+/// What one plan phase costs, at several store sizes. Prints; run it with --ignored.
+///
+///   cargo test --release -p temporalstore-rust --lib what_the_plan_phase_costs -- --ignored --nocapture
+///
+/// This is the measurement the narrow reclaim view was made for. Before it, the plan built a
+/// whole StorageRecoveryReport -- 50.04 / 219.92 / 978.02 ms at 2k / 8k / 32k live pages, and
+/// one read of every live page. After: 2.31 / 17.40 / 82.84 ms, and no reads at all.
+#[test]
+#[ignore]
+fn what_the_plan_phase_costs() {
+    for records in [2_000usize, 8_000, 32_000] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            8 << 20,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        for index in 0..records {
+            write_string(&engine, &format!("survey-{index:06}"), b"0123456789abcdef");
+        }
+        let started = std::time::Instant::now();
+        let rounds = 5;
+        for _ in 0..rounds {
+            let _ = engine.storage_lifecycle_plan(StorageLifecycleRequest {
+                shard_id: 1,
+                selected_dump_buckets: Vec::new(),
+                max_dump_buckets_per_round: 64,
+                min_undumped_wal_records: 1_000,
+                min_undumped_wal_bytes: 96 * 1024 * 1024,
+                purge_delayed_destroy: false,
+                prune_bucket_dump_manifests: false,
+                roll_forward_bucket_dump_installs: false,
+                follower_replay_cursors: Vec::new(),
+                page_gc_shared_store_cursors: Vec::new(),
+                page_gc_raft_snapshot_refs: Vec::new(),
+                page_gc_checkpoint_floor_slab_id: None,
+                page_gc_raft_install_floor_slab_id: None,
+                page_gc_delayed_destroy_grace_ms: 0,
+                invalidate_cache: false,
+                warm_cache: false,
+            });
+        }
+        let each = started.elapsed().as_secs_f64() * 1000.0 / rounds as f64;
+        eprintln!(
+            "  {records:>6} records: {each:>8.2} ms per plan phase ({:.3}% of a 30 s round)",
+            each / 30_000.0 * 100.0
+        );
+    }
+}
+
+/// The reclaim planner picks the same slabs from the narrow view as from the full report.
+///
+/// This is the other half of the change that removed the whole-store scan from the plan phase.
+/// `storage_reclaim_slab_reports` leaves the three read-dependent fields at zero, so if the
+/// selection had ever consulted one of them the two lists would separate here -- which is
+/// exactly the claim being made, and not one to take on inspection.
+///
+/// The fixture rolls slabs so the stale/live split is real: a slab whose pages have all been
+/// overwritten is the case the planner exists to find.
+#[test]
+fn the_reclaim_planner_sees_the_same_candidates() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1 << 20,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+
+    let mut stages = 0usize;
+    let mut check = |engine: &TemporalEngine, what: &str| {
+        let (narrow, full) = engine.reclaim_candidates_two_ways_for_test(1);
+        assert_eq!(
+            narrow, full,
+            "after {what}: the planner's view and the report disagree on what to reclaim"
+        );
+        stages += 1;
+    };
+
+    check(&engine, "an empty shard");
+
+    for index in 0..200 {
+        write_string(&engine, &format!("reclaim-{index:04}"), b"first value");
+    }
+    check(&engine, "200 writes");
+
+    // Roll, then overwrite every key: slab 0 is now entirely stale, which is the candidate the
+    // planner must find and score.
+    engine.block_store().roll_slab().unwrap();
+    for index in 0..200 {
+        write_string(&engine, &format!("reclaim-{index:04}"), b"second value, longer");
+    }
+    check(&engine, "a rolled slab and 200 overwrites");
+    let (narrow, _) = engine.reclaim_candidates_two_ways_for_test(1);
+    assert!(
+        !narrow.is_empty(),
+        "the fixture must produce a candidate, or the comparisons prove nothing"
+    );
+
+    // Partially stale: roll again, overwrite half.
+    engine.block_store().roll_slab().unwrap();
+    for index in 0..100 {
+        write_string(&engine, &format!("reclaim-{index:04}"), b"third value");
+    }
+    check(&engine, "a partially stale slab");
+
+    for index in 0..50 {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::CommonDelete {
+                key: format!("reclaim-{index:04}"),
+            },
+        });
+    }
+    check(&engine, "50 deletes");
+
+    engine.run_storage_manager_cycle(StorageManagerCycleRequest {
+        shard_id: 1,
+        min_undumped_wal_records: 0,
+        min_undumped_wal_bytes: 0,
+        ..StorageManagerCycleRequest::default()
+    });
+    check(&engine, "a maintenance cycle");
+
+    assert_eq!(stages, 6, "every stage must have been compared");
+}
+
 fn write_string(engine: &TemporalEngine, key: &str, value: &[u8]) {
     engine.execute(ExecuteRequest {
         shard_id: 1,


### PR DESCRIPTION
The storage manager plans a maintenance round every 30 seconds on every loaded shard. Both halves of that round — `storage_lifecycle_plan` and `apply_storage_lifecycle` — built a whole `StorageRecoveryReport`, which reads **every live page** off the block store so it can count how many are readable. Each then kept one field and discarded the rest.

## What each caller actually used

| caller | kept | needs the page? |
|---|---|---|
| the planner | the per-slab live/stale byte tally, to pick reclaim candidates | **no** — all seven fields it reads come from `slab_reports()` and `address.length` |
| the apply | `object_lifecycle` | **no** — the shard's own maps, the ownership validation, and the slab page counts |
| the merged-dump policy report | `object_lifecycle` | no |

`live_logical_bytes` is the only field in that report that requires reading the page, and nothing on the maintenance path reads it. A page's physical size is already in the address that names it.

## Measured

Release build, same fixture, five plan phases averaged:

| live pages | before | after | page reads per plan |
|---|---|---|---|
| 2,000 | 50.04 ms | **2.31 ms** | 2,000 → 0 |
| 8,000 | 219.92 ms | **17.40 ms** | 8,000 → 0 |
| 32,000 | 978.02 ms | **82.84 ms** | 32,000 → 0 |

Extrapolated to a store at the measured ~400 MB capacity wall, the plan was around ten seconds of every thirty-second round — on a shard that may be completely idle — and it read the whole store off disk to get there.

## What keeps this honest

Two tests, because "same answer" and "no reads" fail independently:

- **`object_lifecycle_snapshot_matches_the_recovery_report`** drives writes, overwrites, deletes, a maintenance cycle and a rolled slab, and compares the whole struct against the report's after every stage. The narrow path is only worth having if it agrees.
- **`planning_a_maintenance_round_reads_no_pages`** counts block-store reads across a plan and an apply and requires zero. This is the property that regresses silently: a caller reaching for the recovery report again would still return the right answer and still pass the equality test, while putting a full-store read back on a thirty-second loop.

`what_the_plan_phase_costs` (`#[ignore]`) is the measurement in the table, kept so the next person can re-run it rather than trust me.

## Scope

The recovery report itself is unchanged and still serves the diagnostic endpoints and harnesses that want the readability check.

**Still open, and deliberately not in this PR:** counting reads across a whole cycle on a 400-page shard gives 2,000 before this change and 800 after. The remaining two passes are `storage_recovery_boundary_report`, which genuinely has to read every page — it reports which ones are unreadable. Whether a background loop should run a full-store integrity scan every thirty seconds is a behaviour question, not an optimisation, so it needs its own decision rather than being folded in here.

## How this was found, including the part I got wrong

I spent a long time treating `bucket_storage_summaries` as the dominant cost, because it is O(live pages) while every phase after it is bounded, and I had a measurement of "978 ms" to back it. That measurement timed the whole plan phase and I named the result after the part I suspected. Timing the parts separately: the recovery report is 95% of it, and the survey is 4%.
