### PR TITLE
Three targets that stopped compiling get their new field

### DIFF
--- a/crates/temporalstore-rust/src/bin/storage_production_harness.rs
+++ b/crates/temporalstore-rust/src/bin/storage_production_harness.rs
@@ -182,7 +182,11 @@ async fn run_case(root: &Path, case: &StorageMigrationCase) -> StorageProduction
         shard_id: case.shard_id,
         selected_dump_buckets: dirty_buckets,
         max_dump_buckets_per_round: 64,
+        // Both thresholds at zero: this harness drives the dump itself and must not be told to
+        // wait for pressure to build. A delay here would leave the buckets it just dirtied
+        // undumped and every assertion after this line would be about the wrong state.
         min_undumped_wal_records: 0,
+        min_undumped_wal_bytes: 0,
         purge_delayed_destroy: true,
         prune_bucket_dump_manifests: true,
         roll_forward_bucket_dump_installs: true,

--- a/crates/temporalstore-rust/tests/storage_migration_corpus.rs
+++ b/crates/temporalstore-rust/tests/storage_migration_corpus.rs
@@ -113,7 +113,11 @@ fn verify_engine_dump_load_recovery(case: &StorageMigrationCase) {
         shard_id: case.shard_id,
         selected_dump_buckets: dirty_buckets,
         max_dump_buckets_per_round: 64,
+        // Both thresholds at zero: this corpus drives the dump itself and must not be told to
+        // wait for pressure to build, or the buckets it just dirtied stay undumped and every
+        // assertion below is about the wrong state.
         min_undumped_wal_records: 0,
+        min_undumped_wal_bytes: 0,
         purge_delayed_destroy: true,
         prune_bucket_dump_manifests: true,
         roll_forward_bucket_dump_installs: true,

--- a/crates/temporalstore-rust/tests/unified_temporalstore_corpus.rs
+++ b/crates/temporalstore-rust/tests/unified_temporalstore_corpus.rs
@@ -3623,7 +3623,11 @@ fn verify_storage_follower_safe_gc(case: &StorageMigrationCase) {
         shard_id: case.shard_id,
         selected_dump_buckets: dirty_buckets,
         max_dump_buckets_per_round: 64,
+        // Both thresholds at zero: this corpus drives the dump itself and must not be told to
+        // wait for pressure to build, or the buckets it just dirtied stay undumped and every
+        // assertion below is about the wrong state.
         min_undumped_wal_records: 0,
+        min_undumped_wal_bytes: 0,
         purge_delayed_destroy: true,
         prune_bucket_dump_manifests: true,
         roll_forward_bucket_dump_installs: true,


### PR DESCRIPTION
`#1422` added `min_undumped_wal_bytes` to `StorageLifecycleRequest` and updated the callers under `src/`. Three literals outside it were missed:

- `src/bin/storage_production_harness.rs`
- `tests/storage_migration_corpus.rs`
- `tests/unified_temporalstore_corpus.rs`

`cargo check -p temporalstore-rust --all-targets` has failed since that commit — and that command is the **first step of Rust CI**.

## Rust CI has been red on main for six merges

| commit | Rust CI |
|---|---|
| #1421 | ✅ |
| #1422 | ❌ |
| #1423, #1424, #1426, #1427, #1428 | ❌ |

I missed it because I gate locally on `cargo test -p temporalstore-rust --lib`, which builds neither the binaries nor the integration tests. The lib is the part that changed, so the lib is the part I checked — but the field is on a public struct and its callers are everywhere. That's my error and it's the reason five subsequent PRs (including three of mine) merged over a red main.

## The value

All three sites drive their own dump and then assert on the result, so they want it to fire immediately — which is what they already meant by `min_undumped_wal_records: 0`. Both thresholds are therefore zero. A non-zero byte threshold at any of them would leave the buckets that site just dirtied undumped, and every assertion after that line would be about the wrong state. Each site now carries a comment saying that, because `0` on its own doesn't.

## What this does not fix

`cargo check --all-targets` passes again. The suite is not fully green: `storage_migration_corpus` then fails an assertion of its own —

```
slot_dump_object_lifecycle_mismatch: the model-map derivation disagrees.
manifest=... live_object_ids: 12 ...  derived=... live_object_ids: 10 ...
```

That reproduces **identically at #1421 and at #1402**, so it is neither from this change nor from #1422; the compile break was hiding an already-failing test. It's being investigated separately rather than folded in here, because main should stop being red first.
