### PR TITLE
The log byte threshold reads the log, not the segment preallocated size

### DIFF
--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -183,9 +183,15 @@ fn a_large_log_dumps_on_bytes_while_the_record_count_still_says_wait() {
 
     // A byte threshold small enough to reach in a test, and a record threshold far out of reach,
     // so only the byte one can release the dump.
+    //
+    // 2 KiB, not the 64 KiB this asked for originally. The threshold now counts the bytes the
+    // log has TAKEN since its last dump; it used to read `persistent_bytes`, which on a
+    // preallocated segment is 262,144 from the very first record and never moves. So the old
+    // 64 KiB was cleared by the preallocation, not by anything written -- the fixture below
+    // holds about 3.7 KiB of records, and would have passed with no writes at all.
     let options = StorageManagerOptions {
         min_undumped_wal_records: 1_000_000,
-        min_undumped_wal_bytes: 64 * 1024,
+        min_undumped_wal_bytes: 2 * 1024,
         ..StorageManagerOptions::default()
     };
 
@@ -235,6 +241,21 @@ fn a_large_log_dumps_on_bytes_while_the_record_count_still_says_wait() {
     assert!(
         control.lifecycle_plan.dump_delayed,
         "with no byte threshold the record count alone must still be delaying this dump"
+    );
+
+    // And the half that was missing: the threshold must track HOW MUCH, not merely that a log
+    // exists. Set it above what this fixture wrote and the dump has to go back to being delayed.
+    // Without this the test passes on any reading that is large for an unrelated reason -- which
+    // is exactly how the preallocated segment size passed it before.
+    let above_what_was_written = StorageManagerOptions {
+        min_undumped_wal_bytes: 64 * 1024,
+        ..options
+    };
+    let still_delayed = runtime.run_storage_manager_once(1, above_what_was_written);
+    assert!(
+        still_delayed.lifecycle_plan.dump_delayed,
+        "a threshold above what the log has taken must delay the dump; releasing here means the \
+         byte reading is not measuring this shard's log growth"
     );
 }
 
@@ -302,9 +323,12 @@ fn switching_reclaim_off_stops_the_reclaim_however_large_the_log() {
 
     // Past the byte threshold and far short of the record one, so only the byte threshold can
     // release the dump that reclaim follows.
+    // 2 KiB for the same reason as the test above: the byte threshold counts what the log has
+    // taken since its last dump, and this fixture writes about 3.7 KiB of records. The 64 KiB
+    // this asked for originally was cleared by the segment's preallocated size, not by writes.
     let reclaiming = StorageManagerOptions {
         min_undumped_wal_records: 1_000_000,
-        min_undumped_wal_bytes: 64 * 1024,
+        min_undumped_wal_bytes: 2 * 1024,
         ..StorageManagerOptions::default()
     };
     let not_reclaiming = StorageManagerOptions {

--- a/crates/temporalstore-rust/src/engine/bucket_dump_manifest_methods.rs
+++ b/crates/temporalstore-rust/src/engine/bucket_dump_manifest_methods.rs
@@ -131,6 +131,13 @@ impl TemporalEngine {
         manifest.checksum = bucket_dump_manifest_checksum(&manifest)?;
         self.persist_bucket_dump_manifest(&manifest)
             .map_err(|err| Status::error("slot_dump_failed", err.to_string()))?;
+        // The manifest is durable from here, so this shard's log is dumped up to its current
+        // durable length. Marked AFTER the write and behind its `?`, never before: a watermark
+        // that ran ahead of the manifest would let a restart mid-dump skip records the failed
+        // dump never captured. Only this path marks it -- a MERGED manifest consolidates
+        // existing dumps and its coverage is bounded by its sources, so it makes nothing newer
+        // dumped and must not reset the growth counter.
+        self.wal_store.mark_dumped(shard_id);
         // The index-log is bounded by the storage-manager's consumer-aware index GC (see
         // `storage_wal_reclaim_plan` / `run_storage_manager_cycle`), which retains from the
         // durable dump frontier -- the min anchor across durable manifests, held back by any

--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -48,9 +48,11 @@ impl TemporalEngine {
         let undumped_wal_records =
             current_wal_sequence.saturating_sub(latest_dump_wal_sequence);
         let explicit_buckets = !request.selected_dump_buckets.is_empty();
-        // Durable bytes: what is actually on disk to be reclaimed, rather than what has been
-        // written and may not have reached it.
-        let undumped_wal_bytes = wal_stats.persistent_bytes;
+        // Durable bytes that are UNDUMPED, not the log's size. `persistent_bytes` is the whole
+        // log across every segment, so a log that is large but fully dumped cleared this
+        // threshold on every round: a shard that had written one record since its last dump
+        // earned another whole-index serialize, which is the cost this cadence exists to avoid.
+        let undumped_wal_bytes = self.wal_store.undumped_len_since_dump(request.shard_id);
         // Each threshold can only RELEASE the dump, never hold it: a delay needs both to agree
         // there is not enough yet. Requiring both to be CROSSED instead would let the byte
         // threshold suppress a dump the record count had already earned, which is the opposite

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -2493,6 +2493,80 @@ fn the_reclaim_planner_sees_the_same_candidates() {
     assert_eq!(stages, 6, "every stage must have been compared");
 }
 
+/// The write-ahead log's byte threshold measures what is UNDUMPED, not the whole file.
+///
+/// The threshold exists to let a shard that is writing hard dump before its record count says
+/// so. Measuring it against the log's total size on disk breaks that in both directions: a log
+/// that is large but fully dumped clears the threshold on every round, so a shard that has
+/// written one record since its last dump dumps again -- and a whole-index serialize per round
+/// is the cost this cadence exists to avoid.
+///
+/// The index log already draws the distinction, in `undumped_len_since_dump`: current length
+/// minus the length at the last dump. This holds the write-ahead log to the same meaning.
+#[test]
+fn the_wal_byte_threshold_measures_undumped_bytes_not_the_whole_log() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1 << 20,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+
+    let lifecycle = |min_records: u64, min_bytes: u64| StorageLifecycleRequest {
+        shard_id: 1,
+        selected_dump_buckets: Vec::new(),
+        max_dump_buckets_per_round: 0,
+        min_undumped_wal_records: min_records,
+        min_undumped_wal_bytes: min_bytes,
+        purge_delayed_destroy: false,
+        prune_bucket_dump_manifests: false,
+        roll_forward_bucket_dump_installs: false,
+        follower_replay_cursors: Vec::new(),
+        page_gc_shared_store_cursors: Vec::new(),
+        page_gc_raft_snapshot_refs: Vec::new(),
+        page_gc_checkpoint_floor_slab_id: None,
+        page_gc_raft_install_floor_slab_id: None,
+        page_gc_delayed_destroy_grace_ms: 0,
+        invalidate_cache: false,
+        warm_cache: false,
+    };
+
+    // Enough writes that the log is comfortably past any threshold this test uses.
+    for index in 0..400 {
+        write_string(&engine, &format!("wal-{index:04}"), &[b'v'; 256]);
+    }
+    // Dump everything, so nothing after this point is undumped except what we write next.
+    engine.apply_storage_lifecycle(lifecycle(0, 0));
+
+    let log_bytes = engine.write_ahead_log_store().stats(1).persistent_bytes;
+    assert!(
+        log_bytes > 4_096,
+        "the fixture needs a log bigger than the threshold below: {log_bytes}"
+    );
+
+    // One small write. Against the UNDUMPED bytes that is far under 4 KiB, so with a record
+    // threshold that also says wait, the round must delay the dump.
+    write_string(&engine, "wal-after-the-dump", b"one small record");
+    let plan = engine.storage_lifecycle_plan(lifecycle(1_000, 4_096));
+    assert!(
+        plan.dump_delayed,
+        "one record and a few bytes after a dump must not earn another dump; \
+         the threshold is reading the whole {log_bytes}-byte log instead of what is undumped"
+    );
+
+    // And the threshold must still RELEASE a dump once real work has piled up: write past it.
+    for index in 0..400 {
+        write_string(&engine, &format!("wal-more-{index:04}"), &[b'v'; 256]);
+    }
+    let plan = engine.storage_lifecycle_plan(lifecycle(1_000, 4_096));
+    assert!(
+        !plan.dump_delayed,
+        "past the byte threshold the dump must fire even though the record count says wait"
+    );
+}
+
 fn write_string(engine: &TemporalEngine, key: &str, value: &[u8]) {
     engine.execute(ExecuteRequest {
         shard_id: 1,

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -912,6 +912,14 @@ struct WriteAheadLogInner {
     scratch: Option<std::sync::Arc<crate::scratch::ScratchDirGuard>>,
     stats: WriteAheadLogStats,
     last_sequence_by_shard: HashMap<ShardId, u64>,
+    /// Bytes appended for each shard since its last durable dump.
+    ///
+    /// A COUNTER, not a mark against the file's length. The obvious version -- remember the
+    /// length at the dump, subtract it later -- is wrong here because reclaim TRUNCATES the log
+    /// right after a dump: the file then sits below its own watermark and the subtraction
+    /// saturates to zero, so the threshold never fires again. Counting growth is immune to that,
+    /// and growth is what the threshold is about.
+    undumped_bytes_by_shard: HashMap<ShardId, u64>,
     /// Per shard: how far the ACTIVE segment has actually been made durable, and the highest
     /// sequence covered by that barrier.
     ///
@@ -974,6 +982,7 @@ impl LocalWriteAheadLogStore {
                 scratch: None,
                 stats: WriteAheadLogStats::default(),
                 last_sequence_by_shard: HashMap::new(),
+                undumped_bytes_by_shard: HashMap::new(),
                 durable_active_bytes_by_shard: HashMap::new(),
                 block_last_record_by_shard: HashMap::new(),
                 block_mode_by_shard: HashMap::new(),
@@ -2224,6 +2233,39 @@ impl LocalWriteAheadLogStore {
         })
     }
 
+    /// How many bytes this shard's log has taken since its last dump.
+    ///
+    /// This is the figure the dump cadence wants, and it is not the log's size. A log that is
+    /// large but fully dumped has nothing undumped in it: measuring the whole file instead made
+    /// a shard that had written one record since its last dump clear the byte threshold on every
+    /// round, and a whole-index serialize per round is exactly what the cadence exists to avoid.
+    ///
+    /// Counted rather than derived from the file, because reclaim truncates the log immediately
+    /// after a dump -- any watermark held against the file's length is stranded above it.
+    ///
+    /// A shard that has not dumped in this process reports what it has appended since start-up,
+    /// which is 0 for one that has not written. That under-reports where the file-length version
+    /// over-reported, and it is the safer direction to be wrong in only because the RECORD
+    /// threshold is anchored on the durable manifest sequence and so survives a restart intact;
+    /// the two are read together and either can release the dump.
+    pub fn undumped_len_since_dump(&self, shard_id: ShardId) -> u64 {
+        let inner = self.inner.lock().expect("write-ahead log lock poisoned");
+        inner
+            .undumped_bytes_by_shard
+            .get(&shard_id)
+            .copied()
+            .unwrap_or(0)
+    }
+
+    /// Record that a dump captured this shard's log, resetting its undumped growth to 0.
+    ///
+    /// Called only once the dump manifest is durably written, so the counter never clears past
+    /// state a crash could lose -- a restart mid-dump re-dumps rather than skipping.
+    pub fn mark_dumped(&self, shard_id: ShardId) {
+        let mut inner = self.inner.lock().expect("write-ahead log lock poisoned");
+        inner.undumped_bytes_by_shard.insert(shard_id, 0);
+    }
+
     pub fn stats(&self, shard_id: ShardId) -> WriteAheadLogStats {
         let mut inner = self.inner.lock().expect("write-ahead log lock poisoned");
         inner.stats.stats_full_scans = inner.stats.stats_full_scans.saturating_add(1);
@@ -3469,6 +3511,12 @@ fn append_record_locked_on(
         *durable_sequence = (*durable_sequence).max(record.sequence);
     }
     let size = bytes.len() as u64;
+    // Every append path funnels through here, so this is the one place the undumped growth has
+    // to be counted for all of them.
+    *inner
+        .undumped_bytes_by_shard
+        .entry(record.shard_id)
+        .or_default() += size;
     // Give the buffer back with its capacity, which is the whole reason it was borrowed. An early
     // return above simply drops it and the next append allocates once -- correct either way, just
     // not free that once.


### PR DESCRIPTION
`#1422` gave the dump cadence a byte threshold so a shard writing hard could dump before its record count said so. It read `wal_stats.persistent_bytes`. That number does not measure the log.

## What `persistent_bytes` actually reports

Measured, one shard, 4 KiB values:

| after | `persistent_bytes` | bytes the log actually took |
|---|---|---|
| nothing | 0 | 0 |
| **one** 4 KiB write | **262,144** | 69 |
| 48 more 4 KiB writes | **262,144** | 3,762 |

A piece is preallocated to `DEFAULT_WAL_SEGMENT_BYTES` (256 KiB), so `persistent_bytes` is the segment's size from the first record and does not move as records accumulate. The threshold was reading a constant.

Two consequences, both bad in opposite directions:

- with the shipped 96 MiB default, a one-segment log reports 256 KiB and the threshold can never release a dump, however much is written into it;
- once enough segments exist to pass 96 MiB, it reports over the threshold permanently — so every round dumps, whatever arrived since the last one.

And `#1422`'s own tests set `min_undumped_wal_bytes: 64 * 1024` against fixtures holding ~3.7 KiB of records. **They passed on the preallocation.** They would have passed with no writes at all.

## The change

Count the bytes the log has taken since its last dump.

- Every append funnels through `append_record_locked_on`, so the counter increments in **one** place and no path can miss it. (I checked this rather than assuming it: all five append entry points reach that function.)
- It resets in `mark_dumped`, called after the manifest is durably persisted and **behind its `?`** — a counter cleared before the write would let a restart mid-dump skip records the failed dump never captured.
- A **merged** manifest deliberately does not reset it: merging consolidates existing dumps, its coverage is bounded by its sources, and it makes nothing newer dumped.

A watermark against the file's length would be the obvious alternative, and it is wrong here — I wrote it that way first. Reclaim truncates the log right after a dump, so the file sits below its own watermark, the subtraction saturates to zero, and the threshold never fires again. The second half of the test caught that.

## Why the threshold matters at all

Delaying a dump until enough log has accumulated is what gives **several updates to the same bucket a chance to merge into one dump**. A threshold that is always satisfied re-serializes the index for whatever single record arrived — the worst possible ratio of dump cost to data dumped.

## The default is unchanged, and now means something

96 MiB of undumped log. That was always a sensible number — it was the measurement under it that was wrong.

## Tests

- `the_wal_byte_threshold_measures_undumped_bytes_not_the_whole_log` (new) asserts both directions: one record after a dump must not earn another, and the threshold must still release one once real bytes pile up. Turned off at the call site it fails naming the whole-log figure it read.
- The two `#1422` tests are retargeted to the real unit, and one gains the assertion it was missing: with the threshold set **above** what the fixture wrote, the dump must go back to being delayed. That is what makes them test the amount rather than the existence of a log, and it is the assertion that would have caught the preallocation.
