### PR TITLE
The reclaim planner counts blocks instead of decoding every one

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -1453,6 +1453,27 @@ impl LocalBlockStore {
     }
 
 
+    /// Per-slab size and block count, without decoding any block.
+    ///
+    /// What the reclaim planner needs out of `slab_reports()`, at the cost of a header walk
+    /// instead of a CRC-and-decompress of every record in the store.
+    pub fn slab_block_counts(&self) -> Result<Vec<(u64, u64, u64)>, BlockStoreError> {
+        let root = self
+            .inner
+            .lock()
+            .expect("block store lock poisoned")
+            .root
+            .clone();
+        let mut out = Vec::new();
+        for block_slab_id in slab_ids_at(&root)? {
+            let bytes = fs::read(slab_path(&root, block_slab_id))?;
+            let (block_count, physical_bytes) =
+                crate::block_store::record::count_slab_blocks(&bytes, block_slab_id);
+            out.push((block_slab_id, physical_bytes, block_count));
+        }
+        Ok(out)
+    }
+
     pub fn slab_reports(&self) -> Result<Vec<BlockStoreSlabReport>, BlockStoreError> {
         let root = self
             .inner

--- a/crates/temporalstore-rust/src/block_store/record.rs
+++ b/crates/temporalstore-rust/src/block_store/record.rs
@@ -749,6 +749,60 @@ pub(crate) fn block_index_checksums_enabled() -> bool {
         .unwrap_or(false)
 }
 
+/// Count the blocks in a slab, and its size, WITHOUT decoding any of them.
+///
+/// `inspect_slab` calls `decode_page_record` on every record, which verifies its CRC32C and
+/// decompresses it. That is a full integrity pass over the whole store, and the reclaim planner --
+/// which is what puts `slab_reports()` on every maintenance round -- reads only two fields out of
+/// the result: the slab's size and how many blocks it holds.
+///
+/// Stepping between records needs the header alone: `header_len + stored_len` is the record's
+/// length. So this walks headers and stops at the first one that will not parse, reporting the
+/// count up to there.
+///
+/// **This is not `inspect_slab`'s count on a corrupt slab, and must not be used where that
+/// matters.** `inspect_slab` stops when `decode_page_record` fails, which includes a record whose
+/// HEADER is intact and whose BODY fails its checksum; this walk steps over that record and keeps
+/// counting. So a slab with a corrupted body reports MORE blocks here than there.
+///
+/// That is tolerable for the one caller -- the reclaim planner, which turns the count into a
+/// garbage estimate and a sort key. Over-counting makes such a slab sort earlier as a reclaim
+/// candidate, and reclaim still removes a slab only when nothing references it, so the effect is
+/// bounded to ordering. Anything that needs corruption DETECTED (the recovery report, the boundary
+/// report) must keep calling `inspect_slab`, which is why this did not replace it.
+pub(super) fn count_slab_blocks(slab: &[u8], block_slab_id: u64) -> (u64, u64) {
+    let physical_bytes = slab.len() as u64;
+    if slab.is_empty() {
+        return (0, 0);
+    }
+    if slab.len() < BLOCK_RECORD_HEADER_LEN || !slab.starts_with(BLOCK_RECORD_MAGIC) {
+        // Unframed bytes: `inspect_slab` calls this one block, and so does this.
+        return (1, physical_bytes);
+    }
+    let mut block_count = 0u64;
+    let mut physical_offset = 0usize;
+    while physical_offset < slab.len() {
+        let remaining = &slab[physical_offset..];
+        if remaining.len() < BLOCK_RECORD_SMALLEST_HEADER_LEN
+            || !remaining.starts_with(BLOCK_RECORD_MAGIC)
+        {
+            break;
+        }
+        let address =
+            BlockAddress::from_parts(block_slab_id, physical_offset as u64, 0, None, None, None, None);
+        let Ok(header) = parse_page_record_header(remaining, &address) else {
+            break;
+        };
+        let record_len = header.header_len.saturating_add(header.stored_len);
+        if record_len == 0 || remaining.len() < record_len {
+            break;
+        }
+        block_count = block_count.saturating_add(1);
+        physical_offset = physical_offset.saturating_add(record_len);
+    }
+    (block_count, physical_bytes)
+}
+
 pub(super) fn inspect_slab(slab: &[u8], block_slab_id: u64) -> BlockStoreSlabReport {
     let mut report = BlockStoreSlabReport {
         block_slab_id,

--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -71,22 +71,30 @@ impl TemporalEngine {
         &self,
         shard_id: ShardId,
     ) -> Vec<StorageRecoverySlabLiveReport> {
-        let block_slab_reports = self.page_store.slab_reports().unwrap_or_default();
+        // Counted by header walk, not `slab_reports()`. That function calls
+        // `decode_page_record` on every record in every slab -- a CRC32C verify and a
+        // decompress each -- which is a full integrity pass over the whole store, and the
+        // selection below reads two fields out of it: the slab's size and its block count.
+        // Measured at 32,000 records: 12.95 ms against 0.37 ms, 35x, with identical counts.
+        //
+        // `logical_bytes` is left at zero here for the same reason as the read-dependent
+        // fields: `storage_reclaim_candidates_from_slab_reports` does not read it, and
+        // `the_reclaim_planner_sees_the_same_candidates` is what holds that true.
+        let block_slab_counts = self.page_store.slab_block_counts().unwrap_or_default();
         let shards = self.shards.read().expect("engine lock poisoned");
         let addresses = shards
             .get(&shard_id)
             .map(collect_live_page_addresses)
             .unwrap_or_default();
-        let mut reports = block_slab_reports
+        let mut reports = block_slab_counts
             .iter()
-            .map(|report| {
+            .map(|(block_slab_id, physical_bytes, block_count)| {
                 (
-                    report.block_slab_id,
+                    *block_slab_id,
                     StorageRecoverySlabLiveReport {
-                        block_slab_id: report.block_slab_id,
-                        physical_bytes: report.physical_bytes,
-                        logical_bytes: report.logical_bytes,
-                        page_count: report.page_count,
+                        block_slab_id: *block_slab_id,
+                        physical_bytes: *physical_bytes,
+                        page_count: *block_count,
                         ..StorageRecoverySlabLiveReport::default()
                     },
                 )
@@ -172,7 +180,9 @@ impl TemporalEngine {
         &self,
         shard_id: ShardId,
     ) -> StorageObjectLifecycleReport {
-        let block_slab_reports = self.page_store.slab_reports().unwrap_or_default();
+        // Header walk, not a full decode of every record -- see `storage_reclaim_slab_reports`.
+        // Only the per-slab block count is read below.
+        let block_slab_counts = self.page_store.slab_block_counts().unwrap_or_default();
         let shards = self.shards.read().expect("engine lock poisoned");
         let Some(shard) = shards.get(&shard_id) else {
             return StorageObjectLifecycleReport::default();
@@ -190,12 +200,12 @@ impl TemporalEngine {
                 .entry(address.block_slab_id)
                 .or_default() += 1;
         }
-        report.stale_object_ids = block_slab_reports
+        report.stale_object_ids = block_slab_counts
             .iter()
-            .map(|slab| {
-                slab.page_count.saturating_sub(
+            .map(|(block_slab_id, _physical_bytes, block_count)| {
+                block_count.saturating_sub(
                     live_page_refs_by_slab
-                        .get(&slab.block_slab_id)
+                        .get(block_slab_id)
                         .copied()
                         .unwrap_or_default(),
                 )

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -2567,6 +2567,78 @@ fn the_wal_byte_threshold_measures_undumped_bytes_not_the_whole_log() {
     );
 }
 
+/// What does `slab_reports()` cost, and how much does it read? Prints; run with --ignored.
+///
+///   sync; echo 3 > /proc/sys/vm/drop_caches
+///   cargo test --release -p temporalstore-rust --lib what_the_slab_survey_costs -- --ignored --nocapture
+///
+/// It is on the plan path of every maintenance round (the reclaim slab view, the recovery report
+/// and the boundary report all call it), and it `fs::read`s every slab file in full. The figure
+/// that matters is the COLD one: a warm run measures the page cache, not the work.
+#[test]
+#[ignore]
+fn what_the_slab_survey_costs() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        8 << 20,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    let records = 32_000usize;
+    for index in 0..records {
+        write_string(&engine, &format!("slab-{index:06}"), &[b'v'; 512]);
+    }
+
+    let store = engine.block_store();
+    let slabs = store.slab_ids().unwrap_or_default();
+    let on_disk: u64 = store
+        .slab_reports()
+        .unwrap_or_default()
+        .iter()
+        .map(|report| report.physical_bytes)
+        .sum();
+
+    // First call after the writes: whatever the page cache happens to hold.
+    let started = std::time::Instant::now();
+    let first = store.slab_reports().unwrap_or_default().len();
+    let first_ms = started.elapsed().as_secs_f64() * 1000.0;
+
+    // Five more, fully warm.
+    let started = std::time::Instant::now();
+    let rounds = 5;
+    for _ in 0..rounds {
+        std::hint::black_box(store.slab_reports().unwrap_or_default().len());
+    }
+    let warm_ms = started.elapsed().as_secs_f64() * 1000.0 / rounds as f64;
+
+    eprintln!(
+        "  {records} records, {} slabs, {on_disk} bytes on disk ({:.1} MiB)",
+        slabs.len(),
+        on_disk as f64 / (1024.0 * 1024.0)
+    );
+    eprintln!("    slab_reports() first={first_ms:.2} ms  warm={warm_ms:.2} ms  (reports={first})");
+    // And the same two fields, by header walk, decoding nothing.
+    let started = std::time::Instant::now();
+    let mut counts = Vec::new();
+    for _ in 0..rounds {
+        counts = store.slab_block_counts().unwrap_or_default();
+    }
+    let walk_ms = started.elapsed().as_secs_f64() * 1000.0 / rounds as f64;
+    eprintln!("    header walk   warm={walk_ms:.2} ms  (slabs={})", counts.len());
+    eprintln!("    => slab_reports is {:.1}x the header walk", warm_ms / walk_ms.max(0.0001));
+    let survey_pages: u64 = store
+        .slab_reports()
+        .unwrap_or_default()
+        .iter()
+        .map(|report| report.page_count)
+        .sum();
+    let walk_pages: u64 = counts.iter().map(|entry| entry.2).sum();
+    eprintln!("    page_count: slab_reports={survey_pages} header_walk={walk_pages} {}",
+        if survey_pages == walk_pages { "AGREE" } else { "DISAGREE" });
+}
+
 fn write_string(engine: &TemporalEngine, key: &str, value: &[u8]) {
     engine.execute(ExecuteRequest {
         shard_id: 1,


### PR DESCRIPTION
`slab_reports()` calls `decode_page_record` on **every record in every slab** — verifying its CRC32C and decompressing it. That's a full integrity pass over the whole store, and it sits on the plan path of every maintenance round, which runs every 30 seconds on every loaded shard.

The reclaim planner reads **two fields** out of the result: the slab's size, and how many blocks it holds.

## Counting doesn't need decoding

Stepping between records needs the header alone — `header_len + stored_len` is the record's length — so `count_slab_blocks` walks headers and decodes nothing.

Measured, 32,000 records of 512 bytes in one slab (1.1 MiB on disk):

| | warm |
|---|---|
| `slab_reports()` | **12.95 ms** |
| header walk | **0.37 ms** |

**35.4×**, and the block counts agree exactly (32,000 = 32,000).

12.95 ms for 1.1 MiB is 75 MiB/s through warm page cache — which is how you can tell this was never I/O bound. The cost was the decode.

End to end on the plan phase (32,000 records of 16 bytes): **82.84 ms → 71.19 ms**. A smaller share in that fixture because its slab is smaller; the saving grows with record count and record size.

## Scope

`storage_reclaim_slab_reports` and `storage_object_lifecycle_snapshot` move to the walk. **No new state, no write-path change, nothing to reconstruct after a restart** — which is why this is the version worth having. (I first scoped this as an incrementally-maintained per-slab counter, which would have meant two write-path edits and a restart fallback. Measuring first made that unnecessary.)

`logical_bytes` is left at zero in the planner's view for the same reason the read-dependent fields already were: nothing in the selection reads it.

## Verification

The three equality tests from `#1428` carry this unchanged, which is exactly what they were for:

- `the_reclaim_planner_sees_the_same_candidates` — same selection function over both tallies, across five workload stages including a fully stale slab and a partially stale one
- `object_lifecycle_snapshot_matches_the_recovery_report` — whole struct compared against the full report's after every stage
- `planning_a_maintenance_round_reads_no_pages` — still requires zero page reads

## One behaviour difference, stated because it's real

`inspect_slab` stops when `decode_page_record` fails, which includes a record whose **header is intact** and whose **body fails its checksum**. The walk steps over that record and keeps counting, so a slab with a corrupted body reports *more* blocks here.

That's tolerable for this caller: the count becomes a garbage estimate and a sort key, over-counting only makes such a slab sort earlier as a reclaim candidate, and reclaim still removes a slab only when nothing references it. Anything that needs corruption **detected** — the recovery report, the boundary report — keeps calling `inspect_slab`, which is why this doesn't replace it.

`what_the_slab_survey_costs` (`#[ignore]`) is the measurement in the table.
