### PR TITLE
WAL reclaim stops comparing every bucket against every manifest entry

### DIFF
--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -674,6 +674,34 @@ impl TemporalEngine {
             })
             .collect::<Vec<_>>();
 
+        // Index each manifest's bucket summaries BY ROUTING BUCKET, once.
+        //
+        // The loop below asked `manifest.bucket_summaries.iter().any(..)` per bucket, so a shard
+        // with N buckets and a manifest carrying N of them ran N*N comparisons -- and
+        // `bucket_dump_summary_matches_current_generation` CLONES AND SORTS both slab vectors on
+        // every call. At 32,000 buckets that is about a billion of them: measured, reclaim_wal
+        // was 21,448 ms of a 23,310 ms round, on a loop whose period is 30 s.
+        //
+        // Equivalent by construction: the predicate's FIRST condition is
+        // `manifest_summary.routing_bucket == current_summary.routing_bucket`, so only summaries
+        // sharing a routing bucket could ever match. Duplicates under one bucket are kept in a
+        // vector and still tried with `any`, so a manifest carrying two summaries for one bucket
+        // behaves as it did.
+        let manifest_summaries_by_bucket = manifests
+            .iter()
+            .map(|manifest| {
+                let mut by_bucket =
+                    std::collections::HashMap::<u32, Vec<&BucketStorageSummary>>::new();
+                for manifest_summary in &manifest.bucket_summaries {
+                    by_bucket
+                        .entry(manifest_summary.routing_bucket)
+                        .or_default()
+                        .push(manifest_summary);
+                }
+                by_bucket
+            })
+            .collect::<Vec<_>>();
+
         for summary in &bucket_summaries {
             let matching_manifest = manifests
                 .iter()
@@ -687,14 +715,18 @@ impl TemporalEngine {
                     else {
                         return false;
                     };
-                    manifest.bucket_summaries.iter().any(|manifest_summary| {
-                        bucket_dump_summary_matches_current_generation(
-                            manifest_summary,
-                            summary,
-                            manifest_bucket_fingerprints,
-                            &current_bucket_fingerprints,
-                        )
-                    })
+                    manifest_summaries_by_bucket[*manifest_index]
+                        .get(&summary.routing_bucket)
+                        .is_some_and(|candidates| {
+                            candidates.iter().any(|manifest_summary| {
+                                bucket_dump_summary_matches_current_generation(
+                                    manifest_summary,
+                                    summary,
+                                    manifest_bucket_fingerprints,
+                                    &current_bucket_fingerprints,
+                                )
+                            })
+                        })
                 })
                 .map(|(_, manifest)| manifest);
             let Some(manifest) = matching_manifest else {

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -2639,6 +2639,74 @@ fn what_the_slab_survey_costs() {
         if survey_pages == walk_pages { "AGREE" } else { "DISAGREE" });
 }
 
+/// What does the boundary report cost, and how many pages does a whole round read? Prints.
+///
+///   cargo test --release -p temporalstore-rust --lib what_a_round_still_reads -- --ignored --nocapture
+#[test]
+#[ignore]
+fn what_a_round_still_reads() {
+    for records in [2_000usize, 8_000, 32_000] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            8 << 20,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        for index in 0..records {
+            write_string(&engine, &format!("round-{index:06}"), &[b'v'; 256]);
+        }
+        let cycle = |engine: &TemporalEngine| {
+            engine.run_storage_manager_cycle(StorageManagerCycleRequest {
+                shard_id: 1,
+                min_undumped_wal_records: 0,
+                min_undumped_wal_bytes: 0,
+                ..StorageManagerCycleRequest::default()
+            });
+        };
+        cycle(&engine);
+
+        let live = engine.live_page_count_for_test(1) as u64;
+
+        let before = engine.block_store().stats().reads;
+        let started = std::time::Instant::now();
+        let _ = engine.storage_recovery_boundary_report(1);
+        let boundary_ms = started.elapsed().as_secs_f64() * 1000.0;
+        let boundary_reads = engine.block_store().stats().reads.saturating_sub(before);
+
+        let before = engine.block_store().stats().reads;
+        let started = std::time::Instant::now();
+        cycle(&engine);
+        let round_ms = started.elapsed().as_secs_f64() * 1000.0;
+        let round_reads = engine.block_store().stats().reads.saturating_sub(before);
+
+        eprintln!(
+            "  {records:>6} records ({live} live pages):  boundary={boundary_ms:>8.2} ms \
+             / {boundary_reads} reads   whole round={round_ms:>8.2} ms / {round_reads} reads \
+             ({:.1}x the live pages)",
+            round_reads as f64 / live.max(1) as f64
+        );
+
+        // Which stage is it? The cycle reports a duration per stage.
+        let report = engine.run_storage_manager_cycle(StorageManagerCycleRequest {
+            shard_id: 1,
+            min_undumped_wal_records: 0,
+            min_undumped_wal_bytes: 0,
+            ..StorageManagerCycleRequest::default()
+        });
+        let mut stages = report
+            .stages
+            .iter()
+            .map(|stage| (stage.duration_ms, stage.stage.clone()))
+            .collect::<Vec<_>>();
+        stages.sort_by(|left, right| right.0.cmp(&left.0));
+        for (duration_ms, stage) in stages.iter().take(5) {
+            eprintln!("        {stage:<18} {duration_ms:>8} ms");
+        }
+    }
+}
+
 fn write_string(engine: &TemporalEngine, key: &str, value: &[u8]) {
     engine.execute(ExecuteRequest {
         shard_id: 1,


### PR DESCRIPTION
**A maintenance round could not finish inside its own period.** The loop fires every 30 seconds; measured on a release build with thresholds open so the round does real work:

| records | whole round | reclaim_wal | compact | prepare | boundary |
|---|---|---|---|---|---|
| 2,000 | 258 ms | 178 ms | 142 ms | 19 ms | 67 ms |
| 8,000 | 1,720 ms | 1,184 ms | 439 ms | 66 ms | 195 ms |
| 32,000 | **23,310 ms** | **21,448 ms** | 1,462 ms | 539 ms | 592 ms |

At 32,000 records `reclaim_wal` was **92% of a 23.3-second round**, and growing **18×** for the last 4× of records.

## The quadratic

For every bucket summary, the coverage loop asked whether *any* of a manifest's bucket summaries matched it:

```rust
manifest.bucket_summaries.iter().any(|manifest_summary| {
    bucket_dump_summary_matches_current_generation(..)
})
```

With N buckets and a manifest carrying N of them that's N², and `bucket_dump_summary_matches_current_generation` **clones and sorts both summaries' slab vectors on every call**. At 32,000 buckets that's roughly a billion clone-and-sorts.

## The change

Index each manifest's bucket summaries by routing bucket once — beside the fingerprint decode that is already hoisted there for exactly this reason — and look up instead of scanning.

| records | reclaim_wal before | after | |
|---|---|---|---|
| 2,000 | 178 ms | 40 ms | |
| 8,000 | 1,184 ms | 243 ms | |
| 32,000 | **21,448 ms** | **865 ms** | **24.8×** |

Whole round at 32,000 records: **23,310 ms → 3,145 ms**, and `reclaim_wal` is linear again. What remains is compaction (1,520 ms) and the boundary report (670 ms) — the next two to look at, rather than this one.

## Why this is a lookup and not a heuristic

Equivalent by construction. The predicate's **first condition** is `manifest_summary.routing_bucket == current_summary.routing_bucket`, so only summaries sharing a routing bucket could ever match — the scan was visiting all the others purely to reject them. Duplicates under one routing bucket are kept in a vector and still tried with `any`, so a manifest carrying two summaries for one bucket behaves exactly as before.

This is the same shape as the quadratic already removed from this function once — the per-bucket re-decode of every manifest's whole index — **one level deeper in the same loop**. That fix hoisted the decode; the scan underneath it stayed.

## Verification

38 reclaim tests and 39 manifest tests pass unchanged, as do the three equality tests from `#1428` (`the_reclaim_planner_sees_the_same_candidates`, `object_lifecycle_snapshot_matches_the_recovery_report`, `planning_a_maintenance_round_reads_no_pages`).

`what_a_round_still_reads` (`#[ignore]`) is the measurement in both tables, including the per-stage breakdown.
