### PR TITLE
Compaction counts blocks instead of decoding every one

### DIFF
--- a/crates/temporalstore-rust/src/engine/compaction.rs
+++ b/crates/temporalstore-rust/src/engine/compaction.rs
@@ -16,6 +16,26 @@ use super::*;
 /// relocates pages that have not moved yet rather than re-moving the last round's work.
 pub(super) const COMPACTION_ROUND_BYTES: u64 = 256 * 1024 * 1024;
 
+/// Blocks per slab, counted by header walk.
+///
+/// Both callers below read `page_count` and nothing else off a slab report, and `slab_reports()`
+/// reaches that by calling `decode_page_record` on every record in the store -- a CRC32C verify
+/// and a decompress each. The compaction phase builds a utility report and a model-layout report
+/// BEFORE and AFTER the relocation, so that was four whole-store decodes per round to populate a
+/// before/after figure. `count_slab_blocks` walks headers instead: measured 35x cheaper at 32,000
+/// records, with identical counts.
+///
+/// The relocation itself was never the problem -- it has a 256 MiB budget and resumes. This is
+/// the survey around it.
+fn slab_block_counts_by_slab(page_store: &LocalBlockStore) -> BTreeMap<u64, u64> {
+    page_store
+        .slab_block_counts()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(block_slab_id, _physical_bytes, block_count)| (block_slab_id, block_count))
+        .collect()
+}
+
 pub(super) fn compaction_utility_report(
     page_store: &LocalBlockStore,
     shard: &ShardState,
@@ -30,12 +50,7 @@ pub(super) fn compaction_utility_report(
         .iter()
         .map(|address| address.block_slab_id)
         .collect::<BTreeSet<_>>();
-    let slab_page_counts = page_store
-        .slab_reports()
-        .unwrap_or_default()
-        .into_iter()
-        .map(|report| (report.block_slab_id, report.page_count))
-        .collect::<BTreeMap<_, _>>();
+    let slab_page_counts = slab_block_counts_by_slab(page_store);
     let total_page_count = live_block_slab_ids
         .iter()
         .map(|block_slab_id| {
@@ -332,12 +347,7 @@ pub(super) fn compaction_model_layout_reports(
     page_store: &LocalBlockStore,
     shard: &ShardState,
 ) -> Vec<ShardCompactionModelLayoutReport> {
-    let slab_page_counts = page_store
-        .slab_reports()
-        .unwrap_or_default()
-        .into_iter()
-        .map(|report| (report.block_slab_id, report.page_count))
-        .collect::<BTreeMap<_, _>>();
+    let slab_page_counts = slab_block_counts_by_slab(page_store);
     let mut reports = Vec::new();
     reports.push(compaction_layout_from_addresses(
         "string",


### PR DESCRIPTION
`#1432` moved the reclaim planner off `slab_reports()` — which calls `decode_page_record` on every record in the store, CRC32C-verifying and decompressing each — because the planner read only `page_count` out of it. **I missed two callers that do exactly the same thing.**

```rust
let slab_page_counts = page_store.slab_reports()...
    .map(|report| (report.block_slab_id, report.page_count))
```

Both in `compaction.rs`: `compaction_utility_report` and `compaction_model_layout_reports`. The compaction phase builds a utility report and a model-layout report **before and after** the relocation, so that's **four whole-store decodes per compaction round** to populate a before/after figure. Both move to the header walk.

## Honest about the measurement

**The round benchmark does not move**, and I'd rather say why than dress it up:

| compact phase, 32,000 records | |
|---|---|
| before | 1,462 / 1,520 ms across runs |
| after | 1,746 ms |

That's inside this benchmark's run-to-run noise. The reason is structural: in these fixtures **32,000 records of 512-byte values produce a 1.1 MiB slab** — 35 bytes per record — because pages stay WAL-resident until something dumps them. So `slab_reports()` costs ~13 ms here whatever the value size, and four calls is ~3% of the phase.

The arithmetic that does justify it: the same probe measures `slab_reports()` at **~12 ms per MiB of slab**. On a store whose pages have actually been dumped — at the measured ~400 MB capacity wall — that's ~4.7 s per call, so ~19 s per compaction round, on a loop with a 30-second period.

So: no demonstrated win at this fixture's scale, a large one by arithmetic at production scale, and the same reasoning `#1432` already shipped on the plan path. If you'd rather see it demonstrated before it lands, the fixture needs pages forced out to slabs first, which is a bigger change to the benchmark than to the code.

## Risk

Two call sites, one shared helper. `count_slab_blocks` agreed exactly with `inspect_slab`'s counts when measured (32,000 = 32,000); the one difference is a slab whose record *body* fails its checksum while its header parses, where the walk counts the record and `inspect_slab` stops. Here that feeds a fragmentation ratio, so over-counting makes a corrupt slab look more fragmented and slightly more likely to be compacted — and compaction re-reads pages through the normal path, which already handles unreadable ones.

23 compaction tests pass unchanged.
