### PR TITLE
The dump-load policy report gets its own stage, so compact stops paying for it

### DIFF
--- a/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
+++ b/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
@@ -906,6 +906,28 @@ impl TemporalEngine {
                 create_dump_manifest: request.enable_wal_reclaim,
                 install_dump_manifest: false,
             });
+        // Its own stage, because it is its own work: this report runs a lifecycle plan, an apply
+        // and a recovery-boundary report (which reads every live page).
+        //
+        // `stage_clock` measures from the PREVIOUS stage's push, so before this entry existed
+        // every millisecond of that landed on `compact`. Compaction then read as the most
+        // expensive stage of the round at 32,000 records -- about 1.7 s -- while reporting
+        // `skipped=true` and moving zero pages, because it was being charged for work it does
+        // not do. A stage report that names the wrong stage is worse than no stage report: it
+        // sends whoever reads it to optimise the wrong function, which is exactly what it did.
+        stages.push(StorageManagerStageReport {
+            duration_ms: {
+                let elapsed = stage_clock.elapsed().as_millis() as u64;
+                stage_clock = std::time::Instant::now();
+                elapsed
+            },
+            stage: "merged_dump_load_policy".to_string(),
+            enabled: true,
+            applied: true,
+            skipped: false,
+            reason: "dump-load policy: plan, apply and recovery boundary".to_string(),
+            ..StorageManagerStageReport::default()
+        });
 
         let should_compact = request.enable_page_compaction
             && !request.dry_run


### PR DESCRIPTION
`stage_clock` measures from the **previous** stage's push. Between that push and the compact stage's sits `storage_merged_dump_load_policy_report`, which runs a lifecycle plan, an apply, and a recovery-boundary report that reads every live page. All of it was charged to compaction.

So at 32,000 records the round reported compaction as its most expensive stage — about **1.7 s** — while the same stage report said:

```
applied=false  pages_moved=0
reason: "compaction skipped because page density does not show stale-segment pressure"
```

1.7 seconds attributed to a stage that correctly declined to run and moved nothing.

## What it cost me, which is the argument for fixing it

I followed that number for several steps before the `reason` line and the zero made the contradiction impossible to miss:

- scoped an incrementally-maintained per-slab counter for it (two write-path edits, a restart fallback),
- shipped a substitution worth ~3% of it,
- timed its helpers — `validate_shard_page_ownership`, both compaction reports, `collect_live_page_addresses` — at **36 ms of 1,746**,

before looking at what the clock actually spanned.

## After

| stage, 32,000 records | ms |
|---|---|
| `merged_dump_load_policy` | **1,628** |
| `reclaim_wal` | 962 |
| `prepare` | 359 |
| `compact` | falls out of the top five entirely |

A stage report that names the wrong stage is worse than no stage report: it sends whoever reads it to optimise the wrong function, which is exactly what it did. The round's own telemetry now points at the dump-load policy report, and inside it at the boundary report's 575 ms of whole-store page reads — which is where the next look belongs.

## Risk

One stage entry. The declared stage-order check requires every name in `native_stage_order` to be **present** among the stages and every stage to be enabled; an addition satisfies both, and the new entry is always enabled, so that flag is unchanged.

Full suite: 1743 passed, with the two known baseline failures and one appearance of the HTTP raft transport flake, which passes in isolation in 1.9 s and has now been seen across five runs on unrelated trees.
