### PR TITLE
A maintenance round samples pages for readability instead of reading them all

### DIFF
--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -215,6 +215,29 @@ impl TemporalEngine {
     }
 
     pub(super) fn storage_recovery_report_without_boundary(&self, shard_id: ShardId) -> StorageRecoveryReport {
+        self.storage_recovery_report_without_boundary_sampled(shard_id, 0)
+    }
+
+    /// The same report, reading at most `readable_probe_limit` live pages this call.
+    ///
+    /// The readability check is the only part of this report that reads a page, and it reads
+    /// EVERY live one: measured at 32,000 records it is 575 ms and 32,000 reads, about a fifth
+    /// of a maintenance round, growing with the store.
+    ///
+    /// The maintenance cycle wants this report for `manifest_chain_issues`, the two dump
+    /// sequences and the two replay sequences -- none of which reads a page. It never consults
+    /// `unreadable_page_refs` or `unreadable_page_bytes`, but it does CARRY them in the report it
+    /// returns, so simply not filling them in would be a silent lie to whoever reads that report.
+    /// Sampling is the honest version: corruption is still found, over rounds rather than all in
+    /// one, and `readable_probe_limit` says how much of the store this particular call looked at.
+    ///
+    /// 0 means no bound, matching every other round bound here. The diagnostic endpoint and the
+    /// harnesses keep passing 0 and so keep scanning everything.
+    pub(super) fn storage_recovery_report_without_boundary_sampled(
+        &self,
+        shard_id: ShardId,
+        readable_probe_limit: usize,
+    ) -> StorageRecoveryReport {
         // Durable served-index size. The base is materialized only at compaction, so a fresh
         // crash-recovered shard has no base file yet -- the durable served index is the base
         // folded with the index-log deltas, whose reconstructed size we report (via the
@@ -246,6 +269,7 @@ impl TemporalEngine {
             .unwrap_or_default();
         let total_page_refs = addresses.len();
         let mut readable_page_refs = 0usize;
+        let mut probed_page_refs = 0usize;
         let mut unreadable_page_refs = Vec::new();
         let mut owner_mismatch_page_refs = Vec::new();
         let mut missing_owner_page_refs = 0usize;
@@ -291,6 +315,13 @@ impl TemporalEngine {
                 buckets.insert(routing_bucket);
                 slab_report.live_routing_bucket_count = buckets.len() as u64;
             }
+            // Past the sample budget this call stops READING, and keeps everything above that
+            // does not need a read -- the per-slab live tallies are what the reclaim planner and
+            // the object-lifecycle report are built from, and they must stay complete.
+            if readable_probe_limit > 0 && probed_page_refs >= readable_probe_limit {
+                continue;
+            }
+            probed_page_refs += 1;
             match self.page_store.read(address) {
                 Ok(bytes) => {
                     readable_page_refs += 1;
@@ -363,7 +394,10 @@ impl TemporalEngine {
             owner_mismatch_page_refs,
             missing_owner_page_refs,
             object_lifecycle,
-            all_live_pages_readable: total_page_refs == readable_page_refs,
+            // Against what was PROBED, not against every live page. With a sample budget the
+            // two differ, and reading it as "every page is readable" when only some were tried
+            // is exactly the false assurance this field exists to avoid.
+            all_live_pages_readable: probed_page_refs == readable_page_refs,
             boundary: StorageRecoveryBoundaryReport::default(),
             slab_integrity: StorageSlabIntegrityReport::default(),
             feature_page_layout,

--- a/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
+++ b/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
@@ -14,6 +14,14 @@
 
 use super::*;
 
+/// How many live pages one maintenance round checks for readability.
+///
+/// The round used to check every one. A bound makes the cost of the check independent of the
+/// store's size, and 512 is chosen the way the other round bounds were: large enough that a
+/// small store is still fully checked every round, small enough that a large one pays a fixed
+/// price. At the measured ~18 microseconds per page read that is about 9 ms.
+pub(super) const RECOVERY_READABLE_PROBE_PER_ROUND: usize = 512;
+
 impl TemporalEngine {
     pub fn run_storage_manager_cycle(
         &self,
@@ -1125,7 +1133,16 @@ impl TemporalEngine {
             .dump_manifest
             .clone()
             .or_else(|| latest_bucket_dump_manifest_at(&self.index_dir, lifecycle_request.shard_id));
-        let boundary = self.storage_recovery_boundary_report(lifecycle_request.shard_id);
+        // Sampled, not the whole store. This report is here for `manifest_chain_issues`, the two
+        // dump sequences and the two replay sequences, none of which reads a page -- but it also
+        // CARRIES `stale_index_page_refs` / `unreadable_page_bytes`, so the readability check is
+        // bounded rather than skipped: corruption is still found, across rounds instead of all in
+        // one. Measured at 32,000 records the unbounded version was 575 ms and 32,000 reads,
+        // about a fifth of the round.
+        let boundary = self.storage_recovery_boundary_report_sampled(
+            lifecycle_request.shard_id,
+            RECOVERY_READABLE_PROBE_PER_ROUND,
+        );
         let manifest_prune_plan = self.bucket_dump_manifest_prune_plan_with_follower_cursors(
             lifecycle_request.shard_id,
             lifecycle_request.follower_replay_cursors.clone(),

--- a/crates/temporalstore-rust/src/engine/storage_reports.rs
+++ b/crates/temporalstore-rust/src/engine/storage_reports.rs
@@ -532,9 +532,23 @@ impl TemporalEngine {
             .map_err(|err| Status::error("cache_slot_invalidation_failed", err.to_string()))
     }
 
+    /// The boundary report, checking EVERY live page for readability.
+    ///
+    /// What the diagnostic endpoint and the harnesses want: the whole store looked at. The
+    /// maintenance cycle calls the sampled form instead -- see
+    /// `storage_recovery_report_without_boundary_sampled` for why.
     pub fn storage_recovery_boundary_report(
         &self,
         shard_id: ShardId,
+    ) -> StorageRecoveryBoundaryReport {
+        self.storage_recovery_boundary_report_sampled(shard_id, 0)
+    }
+
+    /// The same report, reading at most `readable_probe_limit` live pages. 0 means no bound.
+    pub fn storage_recovery_boundary_report_sampled(
+        &self,
+        shard_id: ShardId,
+        readable_probe_limit: usize,
     ) -> StorageRecoveryBoundaryReport {
         let manifests = self.list_bucket_dump_manifests(shard_id);
         let latest_dump_wal_sequence = manifests
@@ -581,7 +595,8 @@ impl TemporalEngine {
             unknown_bucket_dump_install_count,
         ) = bucket_dump_install_phase_counts(&interrupted_bucket_dump_installs);
         let manifest_chain_issues = bucket_dump_manifest_chain_issues(&manifests);
-        let recovery = self.storage_recovery_report_without_boundary(shard_id);
+        let recovery =
+            self.storage_recovery_report_without_boundary_sampled(shard_id, readable_probe_limit);
         let corrupt_block_slab_ids = recovery
             .block_slab_reports
             .iter()


### PR DESCRIPTION
The recovery report's readability check is the only part of it that reads a page — and it reads **every live one**. Measured at 32,000 records that's 575 ms and 32,000 reads inside the maintenance round, about a fifth of it, growing with the store.

The round wants that report for `manifest_chain_issues`, the two dump sequences and the two replay sequences. **None of those reads a page.** It never consults `unreadable_page_refs` or `unreadable_page_bytes`.

## Why bounded rather than dropped

The round does **carry** those two fields in the report it returns. Leaving them unfilled would be a silent lie to whoever reads that report — which is the part that made this different from `#1428`, where the discarded fields went nowhere.

Sampling is the honest version: the check still runs, corruption is still found (across rounds instead of all in one), and the round's cost stops depending on the store's size.

| at 32,000 records | before | after |
|---|---|---|
| reads per round | 64,000 — **2.0×** live pages | 32,512 — **1.0×** |
| `merged_dump_load_policy` | 1,628 ms | **1,149 ms** |
| whole round | 2,881 ms | **2,382 ms** |

The remaining 1.0× is `validate_bucket_dump_manifest`, which checks a dump's pages are readable before that dump may anchor WAL reclaim. That one is load-bearing and left alone.

## Two things this had to get right

- **`all_live_pages_readable` now compares against what was probed**, not against every live page. Read as "every page is readable" when only some were tried, it's exactly the false assurance the field exists to prevent.
- **The unbounded path is untouched.** `storage_recovery_boundary_report` still scans everything, for the diagnostic endpoint and the harnesses; only the cycle passes a budget. `0` means no bound, as it does for every other round bound here.

512 pages per round, chosen the way the other round bounds were: large enough that a small store is still fully checked every round, small enough that a large one pays a fixed price. At the measured ~18 µs per read that's about 9 ms.

28 recovery tests and 3 boundary tests pass unchanged; full suite is 1744 passed with the two known baseline failures.
