### PR TITLE
A round stops running a full install preflight for an install it is not doing

### DIFF
--- a/crates/temporalstore-rust/src/engine/bucket_dump_manifest_methods.rs
+++ b/crates/temporalstore-rust/src/engine/bucket_dump_manifest_methods.rs
@@ -755,9 +755,27 @@ impl TemporalEngine {
         Ok(())
     }
 
+    /// The install preflight, checking EVERY page the manifest names.
+    ///
+    /// This is what an actual install must use: a dump whose pages cannot be read must not be
+    /// installed, and a sample cannot establish that.
     pub fn bucket_dump_install_preflight_report(
         &self,
         manifest: &BucketDumpManifest,
+    ) -> BucketDumpInstallPreflightReport {
+        self.bucket_dump_install_preflight_report_sampled(manifest, 0)
+    }
+
+    /// The same preflight, reading at most `readable_probe_limit` of the manifest's pages.
+    ///
+    /// 0 means no bound. The maintenance cycle computes a preflight every round for an install it
+    /// is not performing (`install_dump_manifest: false`) -- the result feeds a reported readiness
+    /// flag and nothing destructive -- and the unbounded version read every live page to do it:
+    /// measured 8,000 reads for 8,000 live pages, the last whole-store pass left in a round.
+    pub fn bucket_dump_install_preflight_report_sampled(
+        &self,
+        manifest: &BucketDumpManifest,
+        readable_probe_limit: usize,
     ) -> BucketDumpInstallPreflightReport {
         let current_wal_sequence = self.wal_store.stats(manifest.shard_id).last_sequence;
         let current_index_log_sequence =
@@ -802,11 +820,16 @@ impl TemporalEngine {
         if !manifest.index_bytes.is_empty() && missing_block_slab_ids.is_empty() {
             if let Ok(restored) = crate::engine::decode_index_bytes(&manifest.index_bytes) {
                 let manifest_buckets = manifest.bucket_ids.iter().copied().collect::<BTreeSet<_>>();
+                let mut probed_page_refs = 0usize;
                 for entry in collect_live_page_entries(&restored) {
                     let routing_bucket = entry.address.routing_bucket().unwrap_or_else(|| {
                         self.routing_bucket_for_key(manifest.shard_id, &entry.object_key)
                     });
                     if manifest_buckets.is_empty() || manifest_buckets.contains(&routing_bucket) {
+                        if readable_probe_limit > 0 && probed_page_refs >= readable_probe_limit {
+                            continue;
+                        }
+                        probed_page_refs += 1;
                         if self.page_store.read(&entry.address).is_err() {
                             unreadable_page_ref_count = unreadable_page_ref_count.saturating_add(1);
                             unreadable_page_bytes =

--- a/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
+++ b/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
@@ -1152,9 +1152,21 @@ impl TemporalEngine {
         // would return empty, because apply_storage_lifecycle already rolled the
         // interrupted installs forward (and cleared their markers).
         let install_roll_forward_reports = lifecycle.install_roll_forward_reports.clone();
-        let load_preflight = manifest
-            .as_ref()
-            .map(|manifest| self.bucket_dump_install_preflight_report(manifest));
+        // Sampled, because this round is not installing anything: `install_dump_manifest` is
+        // false here, the result feeds a reported readiness flag and gates nothing destructive,
+        // and the unbounded form read every page the manifest names -- the last whole-store pass
+        // left in a round. A real install still uses the unbounded one, where a sample could let
+        // a dump with unreadable pages through.
+        let load_preflight = manifest.as_ref().map(|manifest| {
+            if request.install_dump_manifest {
+                self.bucket_dump_install_preflight_report(manifest)
+            } else {
+                self.bucket_dump_install_preflight_report_sampled(
+                    manifest,
+                    RECOVERY_READABLE_PROBE_PER_ROUND,
+                )
+            }
+        });
         let install_status = if request.install_dump_manifest {
             manifest
                 .as_ref()


### PR DESCRIPTION
The maintenance cycle computes an install preflight **every round for an install it is not doing** — it passes `install_dump_manifest: false` — and the preflight reads every page the manifest names. That was the last whole-store pass left in a round.

| a whole cycle, 8,000 live pages | reads |
|---|---|
| before `#1436` | 16,000 — **2.0×** live pages |
| after `#1436` (boundary report bounded) | 8,512 — **1.0×** |
| **this change** | **1,024 — constant** |

| round, 32,000 records | |
|---|---|
| before | 2,382 ms |
| after | **2,166 ms** |

At 8,000 records the round halves: 1,006 → 509 ms. The milliseconds are not really the point — **a round's page reads no longer scale with the store**, which is what made a 30-second loop untenable at the measured ~400 MB capacity wall.

## The line that matters

**A real install still uses the unbounded preflight.** A sample cannot establish that a dump's pages are all readable, and installing a dump with unreadable pages is precisely the failure that check exists to prevent. So the cycle branches on `install_dump_manifest`, and only the informational path samples. Every other caller — the install paths, the load paths, the tests — keeps calling the unbounded form, and `0` still means no bound.

Checked before touching it: `load_preflight_safe` feeds `blockers`, which feeds `policy_ready`, which is read into a report flag and carried. It gates nothing destructive — nothing installs or reclaims on it.

## Where the reads actually were

Worth recording because I had it wrong: I assumed `create_bucket_dump_manifest` validated its pages on the create path and was the second full pass. Measured, it reads **zero**. The preflight was the whole of it.

## Verification

9 preflight, 34 install and 39 manifest tests pass unchanged. Full suite 1744 passed, with the two known baseline failures.
