### PR TITLE
Planning gets its own stage, so prepare stops reporting 328 ms for doing nothing

### DIFF
--- a/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
+++ b/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
@@ -251,6 +251,26 @@ impl TemporalEngine {
         };
         let mut stages = Vec::new();
         let mut errors = Vec::new();
+        // Everything above gets its own stage, for the reason mx#1435 gave for the dump-load
+        // policy report: `stage_clock` runs from the previous stage's push, and this is the FIRST
+        // stage boundary in the round. So `storage_lifecycle_plan` (which surveys the shard),
+        // `storage_page_gc_dependency_plan` and the pressure-snapshot arithmetic were all being
+        // charged to `prepare` -- which pre-allocates the next slab and surveys nothing, yet
+        // reported 328 ms at 32,000 records.
+        stages.push(StorageManagerStageReport {
+            duration_ms: {
+                let elapsed = stage_clock.elapsed().as_millis() as u64;
+                stage_clock = std::time::Instant::now();
+                elapsed
+            },
+            stage: "plan".to_string(),
+            enabled: true,
+            applied: true,
+            skipped: false,
+            reason: "lifecycle plan, page-GC dependency plan and the pressure snapshot"
+                .to_string(),
+            ..StorageManagerStageReport::default()
+        });
         stages.push(StorageManagerStageReport {
             duration_ms: {
                 let elapsed = stage_clock.elapsed().as_millis() as u64;


### PR DESCRIPTION
Same defect as `#1435`, at the head of the round instead of the middle.

`stage_clock` runs from the previous stage's push, and `prepare` is the **first** stage boundary in the round — so `storage_lifecycle_plan` (which surveys the shard), `storage_page_gc_dependency_plan` and the whole pressure snapshot were all charged to it.

Prepare pre-allocates the next slab. It surveys nothing.

| stage, 32,000 records | before | after |
|---|---|---|
| `prepare` | 328 ms | **0 ms** |
| `plan` | *hidden* | **278 ms** |
| `reclaim_wal` | 858 ms | 694 ms |
| `merged_dump_load_policy` | 925 ms | 733 ms |
| **whole round** | 2,166 ms | **1,683 ms** |

`prepare` genuinely does nothing measurable — the 328 ms was entirely the plan. That's the third instance of this bug in the round's telemetry and the second fixed; it's worth knowing the pattern, because a stage report that names the wrong stage sends whoever reads it at the wrong function.

## Risk

One stage entry. The declared stage-order check requires every name in `native_stage_order` to be **present** among the stages and every stage to be enabled — an addition satisfies both, and the new entry is always enabled.

Full suite: 1744 passed with the two known baseline failures.
