### PR TITLE
A server started as shipped can reclaim its log again

### DIFF
--- a/crates/temporalstore-rust/src/data_node.rs
+++ b/crates/temporalstore-rust/src/data_node.rs
@@ -904,8 +904,30 @@ impl Default for StorageManagerOptions {
     }
 }
 
+/// How many dirty buckets one round may dump. 0 means all of them.
+///
+/// This was 64, and a cap here does not slow reclaim down -- it stops it completely.
+///
+/// Reclaim frees the log below a floor, and that floor is the oldest sequence any bucket still
+/// needs. A bucket that is dirty and has no durable dump manifest is captured nowhere, so it
+/// holds the floor at 0. A capped round dumps `cap` buckets and leaves every other dirty bucket
+/// in exactly that state, so the floor stays at 0 and the log grows for ever -- while every round
+/// reports success. Measured at 500 dirty buckets per round over 12 rounds:
+///
+///   cap   0: retain_from reaches the head, the log stays at one segment
+///   cap  64: retain_from = 0 on every round, the log rolls a second segment
+///   cap 128, 256: the same
+///   cap 512 (above the dirty count): reaches the head again
+///
+/// At the default routing range every key gets its own bucket, so "more dirty buckets than the
+/// cap" is every real workload.
+///
+/// A cap becomes safe once a bucket records the log sequence at which it FIRST went dirty: an
+/// undumped bucket then holds the floor at its own oldest write instead of at 0, and the floor
+/// advances as far as the dumped buckets allow. That is a data-structure change to the bucket
+/// node and is not done; until it is, this stays off.
 fn default_storage_manager_max_dump_buckets_per_round() -> usize {
-    64
+    0
 }
 
 fn default_storage_manager_stage_enabled() -> bool {

--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -112,7 +112,19 @@ fn a_dump_fires_under_the_shipped_default_once_the_threshold_is_crossed() {
         dir.path().join("indexes"),
     );
     engine.load_shard(1);
-    let options = StorageManagerOptions::default();
+    // Every default except the dump cap, which this fixture pins on purpose.
+    //
+    // A data-node round calls `apply_storage_lifecycle` more than once, and only the first one
+    // that finds undumped records dumps -- the rest correctly see a threshold the dump reset.
+    // So WHICH apply carries `dump_manifest` depends on how many buckets the first one covered,
+    // and with the cap off the first one covers them all and the reported apply has nothing
+    // left to do. Pinning the cap keeps this a test of the RECORD THRESHOLD, which is what its
+    // name is about; `the_shipped_dump_cap_still_lets_the_log_be_reclaimed` is where the cap's
+    // own behaviour is pinned.
+    let options = StorageManagerOptions {
+        max_dump_buckets_per_round: 64,
+        ..StorageManagerOptions::default()
+    };
     // Past the coalescing delay, and not by one: the threshold counts UNDUMPED records, so a
     // round that dumps resets it, and a fixture sitting exactly on the line would be deciding
     // the test on an off-by-one in the counter rather than on whether a dump happens.

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -2707,6 +2707,134 @@ fn what_a_round_still_reads() {
     }
 }
 
+/// The dump cap a server ships with still lets the log be reclaimed.
+///
+/// Reclaim frees the log below a floor, and that floor is the oldest sequence any bucket still
+/// needs. A bucket that is dirty and has no durable dump manifest is captured nowhere, so it
+/// holds the floor at 0 -- and a round that dumps at most `max_dump_buckets_per_round` buckets
+/// leaves every other dirty bucket in exactly that state.
+///
+/// So a shard that dirties more buckets per round than the cap allows never advances the floor at
+/// all -- not slowly, at all -- and the log grows for ever while every round reports success.
+/// Measured, 500 dirty buckets per round over 12 rounds and 6,000 writes:
+///
+/// | cap | floor after 12 rounds | log |
+/// |---|---|---|
+/// | 0 (no cap) | reaches the head | one segment |
+/// | 64 | **0, every round** | rolled a second segment |
+/// | 128, 256 | **0, every round** | rolled a second segment |
+/// | 512 (above the dirty count) | reaches the head | one segment |
+///
+/// At the default routing range every key gets its own bucket, so "more than the cap in a round"
+/// is every real workload. This is the other half of the symptom
+/// `the_data_node_server_never_runs_a_maintenance_cycle` named: the cycle runs now, and still
+/// could not reclaim.
+///
+/// A capped dump only becomes safe once a bucket records the log sequence at which it FIRST went
+/// dirty -- then an undumped bucket holds the floor at its own oldest write rather than at 0,
+/// and the floor advances as far as the dumped buckets allow. Until that exists the cap has to
+/// be off, which is what this pins.
+#[test]
+fn the_shipped_dump_cap_still_lets_the_log_be_reclaimed() {
+    let shipped_cap = crate::data_node::StorageManagerOptions::default().max_dump_buckets_per_round;
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        8 << 20,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    // Many more dirty buckets in one round than a small cap would cover.
+    for index in 0..500 {
+        write_string(&engine, &format!("floor-{index:04}"), &[b'v'; 256]);
+    }
+    let report = engine.run_storage_manager_cycle(StorageManagerCycleRequest {
+        shard_id: 1,
+        min_undumped_wal_records: 0,
+        min_undumped_wal_bytes: 0,
+        max_dump_buckets_per_round: shipped_cap,
+        ..StorageManagerCycleRequest::default()
+    });
+    let last_sequence = engine.write_ahead_log_store().stats(1).last_sequence;
+    let wal = report
+        .wal_reclaim_report
+        .as_ref()
+        .expect("the round must run WAL reclaim");
+    assert!(
+        wal.plan.retain_from_wal_sequence > 0,
+        "the shipped dump cap ({shipped_cap}) left the reclaim floor at 0 with {last_sequence} \
+         records written, so this log can never be reclaimed: blockers={:?}",
+        wal.plan.blocker_reasons,
+    );
+}
+
+/// The write-ahead log stays bounded under continuous writing, round after round.
+///
+/// This is the production symptom the maintenance work started from: a data node whose logs grew
+/// until the disk did. Making the cycle run was the fix; this is the guard that it KEEPS working.
+///
+/// Reclaim can only free the log below its floor, and the floor is held by the oldest bucket that
+/// has not been dumped. The dump selects buckets ordered by `last_dump_sequence` -- a proxy for
+/// "most overdue". If that proxy ever starves a bucket, the floor stops advancing and the log
+/// grows for ever while every round still reports success. Nothing else here would notice: the
+/// cycle completes, the stages report applied, and only the disk fills.
+///
+/// So this writes the same working set every round and requires the floor to reach the head each
+/// time. Twelve rounds and 6,000 writes: every round removes exactly what that round wrote, the
+/// floor advances to `last_sequence + 1`, and the log's on-disk size never moves off the
+/// preallocated segment.
+#[test]
+fn the_log_stays_bounded_under_continuous_writing() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        8 << 20,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+
+    let mut bytes_seen: Vec<u64> = Vec::new();
+    for round in 1..=12u64 {
+        // The same 500 keys every round, so everything written is superseded and the whole log
+        // below the floor is reclaimable. A shard that cannot free THIS cannot free anything.
+        for index in 0..500 {
+            write_string(&engine, &format!("bound-{index:04}"), &[b'v'; 256]);
+        }
+        let report = engine.run_storage_manager_cycle(StorageManagerCycleRequest {
+            shard_id: 1,
+            min_undumped_wal_records: 0,
+            min_undumped_wal_bytes: 0,
+            ..StorageManagerCycleRequest::default()
+        });
+        let stats = engine.write_ahead_log_store().stats(1);
+        let wal = report
+            .wal_reclaim_report
+            .as_ref()
+            .expect("the round must run WAL reclaim");
+        assert_eq!(
+            wal.plan.retain_from_wal_sequence,
+            stats.last_sequence.saturating_add(1),
+            "round {round}: the reclaim floor did not reach the head, so a bucket is starving \
+             the log: last_sequence={} retain_from={}",
+            stats.last_sequence,
+            wal.plan.retain_from_wal_sequence,
+        );
+        assert!(
+            wal.wal_records_removed > 0,
+            "round {round}: nothing was reclaimed, though 500 records were written into it"
+        );
+        bytes_seen.push(stats.persistent_bytes);
+    }
+
+    let first = bytes_seen[0];
+    assert!(
+        bytes_seen.iter().all(|bytes| *bytes == first),
+        "the log grew across rounds while the same keys were rewritten: {bytes_seen:?}"
+    );
+}
+
 fn write_string(engine: &TemporalEngine, key: &str, value: &[u8]) {
     engine.execute(ExecuteRequest {
         shard_id: 1,


### PR DESCRIPTION
**A server started as shipped cannot reclaim its write-ahead log.** Not slowly — at all.

```
the shipped dump cap (64) left the reclaim floor at 0 with 500 records written,
so this log can never be reclaimed: blockers=["slot_generation_without_durable_dump"]
```

Reclaim frees the log below a floor, and that floor is the oldest sequence any bucket still needs. A bucket that is dirty and has **no durable dump manifest** is captured nowhere, so it holds the floor at 0. A round that dumps at most `max_dump_buckets_per_round` buckets leaves every other dirty bucket in exactly that state.

Measured, 500 dirty buckets per round over 12 rounds and 6,000 writes:

| dump cap | floor after 12 rounds | log |
|---|---|---|
| 0 (no cap) | reaches the head | one segment |
| **64 — the shipped default** | **0, every round** | rolled a second segment |
| 128, 256 | 0, every round | rolled a second segment |
| 512 (above the dirty count) | reaches the head | one segment |

At the default routing range every key gets its own bucket, so "more dirty buckets than the cap" is every real workload. Every round still reports success while the log grows.

## This is the other half of a symptom already reported

`the_data_node_server_never_runs_a_maintenance_cycle` was the first half — the cycle never ran. Making it run exposed this: the cycle runs now, and still could not reclaim. The 64 is long-standing and predates that fix; it was simply inert while nothing called it.

## The change

The cap goes to 0 (dump every dirty bucket). That is what every round measurement in `#1428`–`#1438` already used — 1,683 ms at 32,000 records.

**Why a cap cannot simply be re-enabled**, written at the default so the next person sees it: a cap becomes safe once a bucket records the log sequence at which it **first went dirty**. An undumped bucket then holds the floor at its own oldest write instead of at 0, and the floor advances as far as the dumped buckets allow. That's a data-structure change to the bucket node and is not done.

## Two guards, both with controls that fail

- `the_shipped_dump_cap_still_lets_the_log_be_reclaimed` — reads the shipped cap out of `StorageManagerOptions::default()` and requires the floor above 0. It fails today on `main`.
- `the_log_stays_bounded_under_continuous_writing` — twelve rounds rewriting the same 500 keys; every round must remove what it wrote, the floor must reach the head, and the log's size must not move. Its control (`cap = 1`) starves the floor and it fails naming exactly that.

## One existing test changed, and why it is not weakened

`a_dump_fires_under_the_shipped_default_once_the_threshold_is_crossed` asserts a round's `lifecycle_report` carries a dump manifest. A data-node round calls `apply_storage_lifecycle` more than once and only the first one with undumped records dumps — so *which* apply carries the manifest depends on how many buckets the first covered, i.e. on the cap. With the cap off the first apply covers everything and the reported one correctly has nothing to do.

I tried two replacements and **discarded both after their controls passed**: "a manifest exists on disk" and "the undumped count fell" are each satisfied with `enable_wal_reclaim` *and* `enable_memory_reclaim` both off, because manifests are written through paths those flags don't gate. Rather than trade a real assertion for one that proves nothing, the original assertion is kept and the fixture pins `max_dump_buckets_per_round: 64` itself — making it a test of the record threshold, which is what its name is about.

Full suite: 1746 passed, with the two known baseline failures.
