### PR TITLE
A bucket remembers the log sequence of its oldest undumped write

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -747,6 +747,10 @@ impl TemporalEngine {
         // write's durable barrier out of the `shards` lock (TS_ENGINE_CONCURRENT_COMMIT).
         // The barrier is awaited AFTER the lock is released, just before the ack.
         let mut pending_barrier_seq: Option<u64> = None;
+        // The sequence this write took, whichever append path assigned it. Separate from
+        // `pending_barrier_seq`, which means "the barrier for this sequence is deferred" and is
+        // set on only one of the two paths.
+        let mut appended_sequence: Option<u64> = None;
         if outcome.mutated {
             let object_keys = command_object_keys(&command);
             // Capture this write's touched keys for the O(delta) index-log append below
@@ -942,7 +946,10 @@ impl TemporalEngine {
                                 std::mem::take(&mut carried_pages)
                             },
                         )
-                        .map(|record| Some(record.sequence))
+                        .map(|record| {
+                            appended_sequence = Some(record.sequence);
+                            Some(record.sequence)
+                        })
                 } else {
                     self.wal_store
                         .append_with_outcomes(
@@ -967,6 +974,7 @@ impl TemporalEngine {
                             std::mem::take(&mut staged_outcomes),
                         )
                         .map(|(record, log_id)| {
+                            appended_sequence = Some(record.sequence);
                             // Point every page this record carries at the record, keyed on the
                             // object id the write derived -- which is what the stored address
                             // carries, so a read finds it by identity rather than by timing.
@@ -1002,6 +1010,32 @@ impl TemporalEngine {
                         // full replay re-derives the page.
                         for (object_id, placement) in wal_resident_updates.drain(..) {
                             shard.wal_resident_pages.insert(object_id, placement);
+                        }
+                        // Record where this write sits in the log, for every bucket it dirtied
+                        // that did not already have a claim.
+                        //
+                        // Done HERE rather than where the bucket is marked dirty, because the
+                        // mark happens before the append and the sequence does not exist yet at
+                        // that point. Both the sync and the async mark paths run above this, so
+                        // one pass covers them.
+                        //
+                        // Only when unset: the field is the OLDEST undumped write, so a second
+                        // write to an already-dirty bucket must not move it forward.
+                        if let Some(sequence) = appended_sequence {
+                            for key in &delta_command_keys {
+                                let routing_bucket = page_routing_bucket(
+                                    key,
+                                    start_routing_bucket,
+                                    end_routing_bucket,
+                                );
+                                if let Some(bucket) =
+                                    shard.bucket_index.bucket_map.get_mut(&routing_bucket)
+                                {
+                                    if bucket.first_dirty_wal_sequence == 0 {
+                                        bucket.first_dirty_wal_sequence = sequence;
+                                    }
+                                }
+                            }
                         }
                         // In concurrent-commit mode remember the reserved sequence; its durable
                         // barrier is awaited after the `shards` lock is dropped (below). The ack

--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -54,6 +54,23 @@ impl TemporalEngine {
         (narrow, full)
     }
 
+    /// Each dirty bucket's first undumped write sequence, for the test that pins it.
+    #[cfg(test)]
+    pub(crate) fn first_dirty_sequences_for_test(&self, shard_id: ShardId) -> Vec<(u32, u64)> {
+        let shards = self.shards.read().expect("engine lock poisoned");
+        let Some(shard) = shards.get(&shard_id) else {
+            return Vec::new();
+        };
+        let mut out = shard
+            .bucket_index
+            .bucket_map
+            .iter()
+            .map(|(routing_bucket, bucket)| (*routing_bucket, bucket.first_dirty_wal_sequence))
+            .collect::<Vec<_>>();
+        out.sort();
+        out
+    }
+
     /// The per-slab live/stale tally the reclaim planner reads, without the whole-store scan.
     ///
     /// `storage_reclaim_candidates_from_slab_reports` consumes seven fields off each of these:

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -1353,6 +1353,25 @@ pub(super) struct BucketNode {
     pub(super) in_memory: bool,
     pub(super) ttl_ms: Option<u64>,
     pub(super) dirty_generation: u64,
+    /// The write-ahead log sequence at which this bucket most recently went from clean to dirty,
+    /// or 0 when it is clean or the answer is not known.
+    ///
+    /// This is the floor the bucket holds over the log. Reclaim may free the log below the
+    /// oldest sequence any bucket still needs; a dirty bucket with no durable dump manifest is
+    /// captured nowhere, so without this the only safe answer for it is 0 -- and one such bucket
+    /// pins the whole log for ever. With it, that bucket pins the log only from its own oldest
+    /// undumped write.
+    ///
+    /// 0 means "no claim", which is the safe direction: an unknown value reads as the old
+    /// behaviour rather than as permission to reclaim more.
+    ///
+    /// NOT serialized. A load clears every dirty flag -- reloaded data is durable, hence clean --
+    /// and recomputes dirtiness from the live \ set, which is empty on load. So a
+    /// reloaded bucket holds no claim by definition, and persisting this would both add a key to
+    /// the index wire format and carry a number that is meaningless the moment it is read back.
+    /// \ is what caught that.
+    #[serde(skip)]
+    pub(super) first_dirty_wal_sequence: u64,
     pub(super) last_dump_sequence: u64,
     #[serde(default, alias = "object_ids")]
     pub(super) object_index: ObjectIndex,

--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -475,6 +475,9 @@ impl TemporalEngine {
                 // Record the dumped-log sequence (informational; not part of the fingerprint).
                 bucket.last_dump_sequence = bucket.last_dump_sequence.max(manifest.wal_sequence);
                 bucket.dirty = false;
+                // The dump captured everything this bucket had, so it holds no claim over the
+                // log until it is written to again.
+                bucket.first_dirty_wal_sequence = 0;
                 for page in bucket.page_index.values_mut() {
                     page.dirty = false;
                 }

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -2835,6 +2835,81 @@ fn the_log_stays_bounded_under_continuous_writing() {
     );
 }
 
+/// A bucket remembers the log sequence of its OLDEST undumped write.
+///
+/// That is the floor the bucket holds over the write-ahead log. Reclaim frees the log below the
+/// oldest sequence any bucket still needs, and a dirty bucket with no durable dump manifest is
+/// captured nowhere -- so without this the only safe answer for it is 0, and one such bucket pins
+/// the entire log for ever. That is what made a capped dump stop reclaim completely
+/// (`the_shipped_dump_cap_still_lets_the_log_be_reclaimed`).
+///
+/// Three properties, and the middle one is the one that is easy to get wrong:
+///
+///  * a write to a clean bucket records THIS write's sequence;
+///  * a second write to an already-dirty bucket does NOT move it forward -- it is the oldest
+///    undumped write, not the newest;
+///  * a dump clears it, because the dump captured everything the bucket held.
+#[test]
+fn a_bucket_remembers_its_oldest_undumped_write() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1 << 20,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+
+    write_string(&engine, "first", b"one");
+    let after_first = engine.first_dirty_sequences_for_test(1);
+    let claimed = after_first
+        .iter()
+        .filter(|(_, sequence)| *sequence > 0)
+        .count();
+    assert!(
+        claimed > 0,
+        "a write left no bucket holding a claim over the log: {after_first:?}"
+    );
+    let first_claim = after_first
+        .iter()
+        .map(|(_, sequence)| *sequence)
+        .filter(|sequence| *sequence > 0)
+        .min()
+        .expect("a claim");
+
+    // More writes to OTHER keys, then the same key again. The first key's bucket must still
+    // point at its original write, not at the later one.
+    for index in 0..20 {
+        write_string(&engine, &format!("other-{index:02}"), b"value");
+    }
+    write_string(&engine, "first", b"two");
+    let after_more = engine.first_dirty_sequences_for_test(1);
+    let still = after_more
+        .iter()
+        .map(|(_, sequence)| *sequence)
+        .filter(|sequence| *sequence > 0)
+        .min()
+        .expect("a claim");
+    assert_eq!(
+        still, first_claim,
+        "the oldest claim moved forward when a dirty bucket was written again; it must stay at \
+         the OLDEST undumped write, or reclaim would free records still needed"
+    );
+
+    // A dump captures everything, so nothing holds a claim afterwards.
+    engine.run_storage_manager_cycle(StorageManagerCycleRequest {
+        shard_id: 1,
+        min_undumped_wal_records: 0,
+        min_undumped_wal_bytes: 0,
+        ..StorageManagerCycleRequest::default()
+    });
+    let after_dump = engine.first_dirty_sequences_for_test(1);
+    assert!(
+        after_dump.iter().all(|(_, sequence)| *sequence == 0),
+        "a dump captured every bucket, so none may still hold a claim: {after_dump:?}"
+    );
+}
+
 fn write_string(engine: &TemporalEngine, key: &str, value: &[u8]) {
     engine.execute(ExecuteRequest {
         shard_id: 1,


### PR DESCRIPTION
`BucketNode` gains `first_dirty_wal_sequence`: the log sequence at which a bucket last went clean → dirty. That is the floor the bucket holds over the write-ahead log, and it is the field a dump cap needs in order to be safe.

Reclaim frees the log below the oldest sequence any bucket still needs. A dirty bucket with **no durable dump manifest** is captured nowhere, so without this the only safe answer for it is 0 — and one such bucket pins the whole log for ever. That is why the shipped dump cap had to be turned off in `#1439`: a capped round leaves dirty buckets undumped, and each of them forced the floor to 0. With this field, such a bucket pins the log only from **its own** oldest undumped write.

## Where it is set, and the mistake I had made about it

**After the append**, not at the dirty-mark. The mark happens *before* the append, so the sequence does not exist yet at that site — which is why I previously said this could not be done accurately without restructuring the write path. That was wrong, and only because I was looking at the mark site: both the sync and async mark paths run above the append, so a single pass there covers both.

Three properties, and the middle one is the one that is easy to lose:

- a write to a clean bucket records that write's sequence;
- a second write to an **already-dirty** bucket does not move it forward — it is the *oldest* undumped write, not the newest;
- a dump clears it.

`a_bucket_remembers_its_oldest_undumped_write` pins all three. Dropping the "only when unset" check makes it fail on the middle assertion (`left: 2, right: 1`), so it is not passing by accident.

## Not serialized, and a guard is why

A load clears every dirty flag — *"reloaded data is durable, hence clean"* — and recomputes dirtiness from the live `dirty_objects` set, which is empty on load. So a reloaded bucket holds no claim by definition.

The first version carried `#[serde(default)]` and added a key to the index wire format, to persist a number that is meaningless the moment it is read back. **`the_index_wire_keys_are_what_they_were` caught it**, which is exactly what that tripwire is for; the fix was `#[serde(skip)]`, not an updated key list.

## Cost

Write throughput unchanged: **827 µs/write at 20,000 records and 801 at 40,000**, against 862 and 893 on `main`. (A first sample read 1,445 µs at 40,000 and looked like a 62% regression — re-running showed it was this box's load, not the change.)

## Scope

This deliberately **does not** change the reclaim floor or re-enable the dump cap. The floor is safety-critical and the cap is currently off with reclaim working, so using the field belongs in its own reviewable change.

Full suite: 1747 passed, with the two known baseline failures.
