### PR TITLE
A capped dump takes the bucket that has held the log longest

### DIFF
--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -30,9 +30,47 @@ impl TemporalEngine {
             .iter()
             .filter(|summary| summary.dirty_object_count > 0)
             .collect::<Vec<_>>();
+        // Oldest undumped write first: the bucket that has held the log longest is dumped first.
+        //
+        // `last_dump_sequence` answers "when was this bucket last dumped", which is a proxy for
+        // "most overdue" and not the same question. What holds the log is the bucket's OLDEST
+        // UNDUMPED WRITE, and `first_dirty_wal_sequence` is that
+        // -- so ordering by it dumps the bucket pinning the log's floor first, and no bucket can
+        // be starved indefinitely while older ones keep being re-dirtied.
+        //
+        // Read from the bucket node rather than added to `BucketStorageSummary`: a summary is
+        // stored in the dump manifest and compared field-by-field when a manifest is validated,
+        // so a new field there is a durability contract, not a report field.
+        //
+        // 0 means no claim recorded, which sorts LAST: a bucket we cannot place in the log is not
+        // evidence of being old, and the ones we can place are the ones whose dump moves the
+        // floor.
+        let first_dirty_by_bucket = self
+            .shards
+            .read()
+            .expect("engine lock poisoned")
+            .get(&request.shard_id)
+            .map(|shard| {
+                shard
+                    .bucket_index
+                    .bucket_map
+                    .iter()
+                    .map(|(routing_bucket, bucket)| {
+                        (*routing_bucket, bucket.first_dirty_wal_sequence)
+                    })
+                    .collect::<std::collections::HashMap<u32, u64>>()
+            })
+            .unwrap_or_default();
+        let first_dirty_rank = |routing_bucket: u32| -> u64 {
+            match first_dirty_by_bucket.get(&routing_bucket).copied() {
+                Some(0) | None => u64::MAX,
+                Some(sequence) => sequence,
+            }
+        };
         dirty_bucket_summaries.sort_by(|left, right| {
-            left.last_dump_sequence
-                .cmp(&right.last_dump_sequence)
+            first_dirty_rank(left.routing_bucket)
+                .cmp(&first_dirty_rank(right.routing_bucket))
+                .then_with(|| left.last_dump_sequence.cmp(&right.last_dump_sequence))
                 .then_with(|| left.routing_bucket.cmp(&right.routing_bucket))
         });
         let dirty_buckets = dirty_bucket_summaries

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -2910,6 +2910,70 @@ fn a_bucket_remembers_its_oldest_undumped_write() {
     );
 }
 
+/// A capped dump takes the bucket that has held the log longest first.
+///
+/// What pins the log's reclaim floor is a bucket's OLDEST UNDUMPED WRITE. When a round can only
+/// dump some of the dirty buckets, dumping them in that order is what stops one bucket being
+/// starved for ever while newer ones are re-dirtied and dumped ahead of it -- the ordering the
+/// bucket node's `first_dirty_wal_sequence` exists to make possible.
+///
+/// The fixture writes three keys in a known order, dirtying three buckets at three known
+/// sequences, then asks for a plan that may dump only one. It must pick the oldest.
+#[test]
+fn a_capped_dump_takes_the_oldest_undumped_bucket_first() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1 << 20,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+
+    // Three buckets, dirtied oldest-first.
+    write_string(&engine, "aaa-oldest", b"one");
+    write_string(&engine, "bbb-middle", b"two");
+    write_string(&engine, "ccc-newest", b"three");
+
+    let claims = engine.first_dirty_sequences_for_test(1);
+    let oldest = claims
+        .iter()
+        .filter(|(_, sequence)| *sequence > 0)
+        .min_by_key(|(_, sequence)| *sequence)
+        .map(|(routing_bucket, _)| *routing_bucket)
+        .expect("a bucket must hold a claim after three writes");
+
+    let plan = engine.storage_lifecycle_plan(StorageLifecycleRequest {
+        shard_id: 1,
+        selected_dump_buckets: Vec::new(),
+        max_dump_buckets_per_round: 1,
+        min_undumped_wal_records: 0,
+        min_undumped_wal_bytes: 0,
+        purge_delayed_destroy: false,
+        prune_bucket_dump_manifests: false,
+        roll_forward_bucket_dump_installs: false,
+        follower_replay_cursors: Vec::new(),
+        page_gc_shared_store_cursors: Vec::new(),
+        page_gc_raft_snapshot_refs: Vec::new(),
+        page_gc_checkpoint_floor_slab_id: None,
+        page_gc_raft_install_floor_slab_id: None,
+        page_gc_delayed_destroy_grace_ms: 0,
+        invalidate_cache: false,
+        warm_cache: false,
+    });
+    assert_eq!(
+        plan.selected_dump_buckets.len(),
+        1,
+        "the cap of one must select exactly one bucket: {:?}",
+        plan.selected_dump_buckets
+    );
+    assert_eq!(
+        plan.selected_dump_buckets[0], oldest,
+        "a round that can dump one bucket must dump the one holding the log's floor; claims were \
+         {claims:?}"
+    );
+}
+
 fn write_string(engine: &TemporalEngine, key: &str, value: &[u8]) {
     engine.execute(ExecuteRequest {
         shard_id: 1,


### PR DESCRIPTION
A capped dump round now selects the bucket that has held the log longest, ordered by its **oldest undumped write** (`first_dirty_wal_sequence`, added in `#1440`) rather than by `last_dump_sequence`.

`last_dump_sequence` answers *"when was this bucket last dumped"*. What actually pins the log's reclaim floor is the bucket's oldest undumped write — a different question, and the proxy picks the wrong bucket.

## The control

Three keys written in order, dirtying three buckets at sequences 1, 2, 3, then a plan allowed to dump one. With the old ordering:

```
claims were [(1959506620, 2), (3109661579, 1), (3635647327, 3)]
  left: 1959506620   right: 3109661579
```

It picks the bucket whose oldest write is at sequence **2** over the one at **1**. That is the starvation mechanism in miniature: under a cap, a bucket can be passed over indefinitely while newer ones are re-dirtied and dumped ahead of it. This is also the ordering the comparison design asserts on when it pops its dirty queue.

## Why the field is read from the bucket node, not the summary

`BucketStorageSummary` is **stored in the dump manifest and compared field-by-field when a manifest is validated**. A new field there is a durability contract, not a report field — adding one would make every existing manifest fail to validate. (That trap cost me a reverted change earlier: `tombstoned_object_ids` is in the same position.)

So the plan reads `first_dirty_wal_sequence` off the bucket nodes directly. `0` means no claim recorded and sorts **last**: a bucket we cannot place in the log is not evidence of being old, and the ones we can place are the ones whose dump moves the floor.

## What this does not do

**It does not re-enable the dump cap, and it does not change the reclaim floor.** I attempted the floor and stopped, because the field is not sufficient on its own:

```rust
let generations_durable = missing_bucket_generations.is_empty()
    && covered_bucket_count == bucket_summaries.len()
    && durable_wal_frontier > 0
    && durable_index_log_frontier > 0;
```

One gate governs **both** retain points, and `durable_index_log_frontier` is a min over `manifest.index_log_sequence` — a different counter from the WAL sequence. An undumped bucket can contribute `first_dirty_wal_sequence - 1` to the WAL frontier and **nothing** to the index-log one; counting it as covered would permit index-log reclaim with no basis. Closing it needs a first-dirty *index-log* sequence as well, or the gate split so the two frontiers advance independently.

That is the one place where being wrong reclaims records that are still needed, so it belongs in its own change with its own evidence.

Full suite: 1748 passed, with the two known baseline failures.
