### PR TITLE
One write batch keeps one copy of a record

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -5697,8 +5697,88 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             kept.append(record)
         return kept
 
+    #: Fields that identify a record cheaply. Used only to decide which records are WORTH
+    #: comparing in full -- never as the equality itself, so a record type missing from this
+    #: list is compared by its whole content like any other, just after a coarser first pass.
+    _RECORD_IDENTITY_HINTS = (
+        "event_id_hash",
+        "entity_hash",
+        "segment_hash",
+        "ref_hash",
+        "summary_hash",
+        "commit_id_hash",
+        "child_ref_hash",
+        "task_hash",
+        "node_hash",
+    )
+
+    def _coarse_record_key(self, record: Json) -> tuple:
+        return (
+            str(record.get("record_type") or ""),
+            tuple(record.get(field) for field in self._RECORD_IDENTITY_HINTS
+                  if isinstance(record.get(field), (int, str))),
+        )
+
+    def _collapse_identical_records(self, records: list[Json]) -> list[Json]:
+        """Keep ONE copy of each byte-identical record in a single write batch.
+
+        A batch was observed carrying the same `context_event` three times, byte for byte --
+        same identity hash, same `updated_at_ms`, no field differing at all -- and nothing
+        downstream collapsed it: `_filter_duplicate_model_registry` and `_coalesce_summary_dirty`
+        each cover one record type, and `materialize_serving_record_batch` returns as many events
+        as it is given. On one soak store this reached 6,700 copies of a single event, about a
+        ninth of every log row, and 45.7 MB of the 59.4 MB that each `session_commit` scan reads
+        back and parses.
+
+        Dropping the extra copies loses nothing. Serving already collapses them --
+        `compact_latest_value_records` keeps the newest record per identity -- so the second and
+        third copies cannot be read back as anything the first is not; they only cost log bytes,
+        scan bytes and parse time. Equality here is the WHOLE record, so two rows that differ in
+        any field, including a timestamp or a status, are both kept.
+
+        The cheap pass exists because the fix must not cost more than it saves: serialising every
+        record of every batch to look for duplicates would add work to the write path that has
+        none today. Records are grouped by type and identity first, and only a group holding more
+        than one member is serialised.
+        """
+        if len(records) < 2:
+            return records
+        counts: dict[tuple, int] = {}
+        for record in records:
+            if isinstance(record, dict):
+                key = self._coarse_record_key(record)
+                counts[key] = counts.get(key, 0) + 1
+        if not any(count > 1 for count in counts.values()):
+            return records
+        seen: set[str] = set()
+        kept: list[Json] = []
+        dropped = 0
+        for record in records:
+            if not isinstance(record, dict) or counts.get(self._coarse_record_key(record), 0) < 2:
+                kept.append(record)
+                continue
+            try:
+                identity = json.dumps(record, sort_keys=True, separators=(",", ":"), default=str)
+            except (TypeError, ValueError):
+                # Unserialisable: duplication cannot be PROVEN, so the record is kept. A dedup
+                # that guesses is worse than one that misses.
+                kept.append(record)
+                continue
+            if identity in seen:
+                dropped += 1
+                continue
+            seen.add(identity)
+            kept.append(record)
+        if dropped:
+            self._identical_records_dropped_total = (
+                getattr(self, "_identical_records_dropped_total", 0) + dropped
+            )
+        return kept
+
     def _apply_serving_dedup(self, records: list[Json]) -> list[Json]:
-        return self._coalesce_summary_dirty(self._filter_duplicate_model_registry(records))
+        return self._collapse_identical_records(
+            self._coalesce_summary_dirty(self._filter_duplicate_model_registry(records))
+        )
 
     @property
     def _append_coalesce_tls(self) -> threading.local:

--- a/tools/matrixark_temporal_direct_write.py
+++ b/tools/matrixark_temporal_direct_write.py
@@ -300,6 +300,23 @@ class _TemporalDirectWriteMixin:
         )
         if not records:
             return
+        # One batch keeps one copy of a record. Measured on a soak store: 18.5% of every
+        # record written here is byte-identical to another record in the SAME batch --
+        # 1,618 of 8,747 rows over 788 batches, context_node worst, then context_event.
+        # Serving collapses them on read (compact_latest_value_records keeps the newest per
+        # identity), so the extra copies are log bytes, scan bytes and parse time and nothing
+        # else; one event reached 6,700 copies, 45.7 MB of the 59.4 MB that each
+        # session_commit scan reads back.
+        #
+        # This runs HERE, and not only in `_apply_serving_dedup`, because the native backend
+        # deliberately skips that one -- its summary-dirty coalescing calls read_all(), an
+        # O(store) read per batch -- so a collapse placed there alone would never execute on
+        # this path. Same trap the fold comment above describes. This collapse reads nothing:
+        # it compares records already in hand, after the fold, so what it compares is exactly
+        # what would be written.
+        collapse = getattr(self, "_collapse_identical_records", None)
+        if callable(collapse):
+            records = collapse(records)
         self._ensure_backend_metric_fields()
         records = compact_latest_context_state_records(records)
         self._append_disk_fallback_records(records)


### PR DESCRIPTION
One write batch was carrying the same record three and four times, byte for byte: same
identity hash, same `updated_at_ms`, no field differing at all. Nothing collapsed it —
`_filter_duplicate_model_registry` and `_coalesce_summary_dirty` each cover one record type, and
`materialize_serving_record_batch` returns as many records as it is given.

## What it costs

Measured over 788 real bundles read straight out of the live record log:

| | rows | bytes |
|---|---:|---:|
| written | 8,747 | 32.97 MB |
| after the collapse | 7,129 | 22.82 MB |
| **removed** | **1,618 (18.5%)** | **10.14 MB (30.8%)** |

`context_node` is the worst offender, not `context_event` — 1,002 rows and 5.44 MB, because
`ensure_context_node_path` writes a node embedding that folds into the node record.

Serving already collapses these on read (`compact_latest_value_records` keeps the newest per
identity), so the extra copies are log bytes, scan bytes and parse time and nothing else.

## Why it is safe

Equality is the WHOLE record, so two rows differing in any field — a status, a timestamp — are both
kept. A record that cannot be serialised is kept rather than guessed at. Count-sensitive types were
checked on eight stripes of real log and are untouched: `session_buffer_event` (whose row count
drives the commit threshold) and `matrixark_async_pipeline_task` both show 0 removed.

The cheap pass matters: serialising every record of every batch to find duplicates would add work
to a write path that has none today. Records are grouped by type and identity hint first, and only
a group with more than one member is serialised. A batch with no collision returns the original
list untouched.

## Where it runs

The first commit put the collapse in `_apply_serving_dedup`, which the native backend deliberately
does not call — its summary-dirty coalescing does an O(store) `read_all()` per batch. That made it
inert on a one-box. The second commit moves it to `_append_many_materialized`, the canonical native
writer that `append_many`, the fast direct-ingest path, the hook and the queue drain all route
through, immediately after `fold_embedding_records` so it compares the shapes that actually get
written. It is safe there for the exact reason `_apply_serving_dedup` was not: it reads nothing.

## Testing

`python3 -m unittest discover -s tools`, run both ways on the same tree with the change disabled at
its own function and then restored (sha256-verified identical):

| | tests | distinct failing names |
|---|---:|---:|
| change on | 4,455 | 116 |
| change off | 4,455 | 116 |

**0 new failures, 0 removed.** The 116 are pre-existing on main — identical name sets.
