### PR TITLE
The embedding pass can see a vector folded onto its owner

### DIFF
--- a/tools/matrixark_local_adapter_context_node.py
+++ b/tools/matrixark_local_adapter_context_node.py
@@ -348,6 +348,49 @@ class _LocalAdapterContextNodeMixin:
             if current is None or int(record.get("updated_at_ms") or 0) >= int(current.get("updated_at_ms") or 0):
                 existing_embeddings[key] = record
 
+        # A vector folded ONTO its owner is an existing embedding too, and this loop used to
+        # miss every one of them.
+        #
+        # `fold_embedding_records` sets `owner["vector"]` and drops the separate
+        # `context_embedding` row -- "the owners are the only place vectors live in new logs".
+        # This map was built from those separate rows alone, so on a folded store it sees almost
+        # nothing: measured on a 4 GB one-box, 2,530 separate rows against ~46,000 owners already
+        # carrying a vector, and for `context_node` SIX visible against 17,163 records. Everything
+        # it cannot see is re-targeted, re-embedded, folded onto the owner again and dropped
+        # again, so the next pass repeats it -- the store grew 67 MB in three minutes with zero
+        # requests served, and the pass was 14.6% of gateway CPU with the largest scan in the
+        # system (353 MB, ~5 GB of transient proxy RSS per run).
+        #
+        # The owner's key is the one its own target would use, so the two halves cannot drift.
+        # `embedding_meta` carries what the separate record held, MINUS the fields identical to
+        # the owner -- the fold deletes those -- so an absent `updated_at_ms` or `model_ref` there
+        # means "same as the owner", and falling back to the owner's value is exact rather than a
+        # guess.
+        for record in records:
+            if record.get("record_type") == "context_embedding":
+                continue
+            if not record_vector(record):
+                continue
+            folded = self._embedding_target_for_context_record(record)
+            if folded is None:
+                continue
+            meta = record.get("embedding_meta")
+            if not isinstance(meta, dict):
+                meta = {}
+            try:
+                key = (str(folded["embedding_type"]), str(folded["ref_type"]), int(folded["ref_hash"]))
+            except (TypeError, ValueError, KeyError):
+                continue
+            seen = {
+                "_folded_embedding_seen": True,
+                "vector": record.get("vector"),
+                "model_ref": meta.get("model_ref") or record.get("model_ref"),
+                "updated_at_ms": meta.get("updated_at_ms") or record.get("updated_at_ms"),
+            }
+            current = existing_embeddings.get(key)
+            if current is None or int(seen.get("updated_at_ms") or 0) >= int(current.get("updated_at_ms") or 0):
+                existing_embeddings[key] = seen
+
         targets: list[Json] = []
         skipped_current = 0
         skipped_scope = 0


### PR DESCRIPTION
`fold_embedding_records` sets `owner["vector"]` and drops the separate `context_embedding` row —
"the owners are the only place vectors live in new logs". The pass that decides what still needs
embedding builds its already-embedded map from those separate rows alone, so on a folded store it
sees almost nothing.

## What it misses

Counted on a 6 GB one-box store:

| record type | carrying an inline vector | separate rows the pass can see |
|---|---:|---:|
| `context_node` | **17,156 of 17,163** | **6** |
| `context_entity` | 15,494 of 15,494 | 1,249 |
| `context_event` | 12,766 of 12,766 | 673 |
| `context_summary` | 967 of 967 | 587 |

2,530 visible rows against ~46,000 owners that already hold vectors. Records the pass cannot see
are re-targeted and re-embedded; the write folds the vector onto the owner and drops the row again,
so the next pass repeats it. On that store the count of records it would target drops from roughly
43,900 to about 7.

## Scope — what this does and does not change

This is a correctness fix. It stops the pass re-doing work it has already done.

It does **not** reduce the pass's scan, which is a separate and larger cost: the scan reads 343 MB
to use 15.8 MB of it (4.6%), and is 14.6% of gateway CPU as the second-largest caller of
`_scan_records_of_types`. Field projection is not the fix for that either — the pass reads `vector`
on owner records to see folded embeddings, so projecting it away would break this change. A bounded
"what still needs embedding" query is the shape that would work.

Two things measured during this work turned out NOT to be attributable to this pass, and are called
out so nobody re-derives them: idle store growth (an A/B with and without this change moved it by
7%, and a record census showed the growth is page-store writes, not record appends), and the
proxy's transient memory excursions (plausible but untested — an attempt to A/B it could not run).

## Why the metadata fallback is exact

`embedding_meta` holds what the separate record carried minus the fields identical to the owner —
the fold deletes those — so an absent `updated_at_ms` or `model_ref` there means "same as the
owner", and falling back to the owner's value is exact rather than a guess.

## Testing

`python3 -m unittest discover -s tools`, run both ways on the same tree with the new block disabled
at its own function and then restored (sha256-verified identical): **4,455 tests each way, 116
distinct failing names each way, 0 new failures.** The 116 are pre-existing on main.

Behaviour is covered by a firing control: with the new block disabled, two nodes that already carry
a folded vector are both re-targeted; with it enabled only the un-embedded node is. The control arm
exhibits the bug, so the agreement is evidence rather than two no-ops.
