### PR TITLE
An undumped bucket holds the logs from its own oldest write, not from zero

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -1154,15 +1154,39 @@ impl TemporalEngine {
                 // barrier only under the TS_WAL_LEGACY_RECOVERY escape hatch (wal_single_barrier
                 // false -> delta-fold recovery, which trusts the durable delta).
                 let index_log_durable = !raft_applying() && !wal_single_barrier();
-                let _ = self.index_log_store.append_delta(
-                    request.shard_id,
-                    items,
-                    key_states,
-                    shard.applied_wal_sequence,
-                    None,
-                    upsert_record,
-                    index_log_durable,
-                );
+                let appended_index_log_sequence = self
+                    .index_log_store
+                    .append_delta(
+                        request.shard_id,
+                        items,
+                        key_states,
+                        shard.applied_wal_sequence,
+                        None,
+                        upsert_record,
+                        index_log_durable,
+                    )
+                    .unwrap_or(0);
+                // The index-log half of what each dirtied bucket holds, stamped the same way as
+                // the WAL half above and for the same reason: the reclaim plan keeps two
+                // frontiers, counted in two different sequences, and a bucket that can place
+                // itself in only one of them can hold neither.
+                //
+                // `append_delta` returns 0 when it wrote nothing (bulk ingest, or the log
+                // disabled), which is exactly "no claim" -- so the guard is the same one.
+                if appended_index_log_sequence > 0 {
+                    for key in &delta_command_keys {
+                        let routing_bucket =
+                            page_routing_bucket(key, start_routing_bucket, end_routing_bucket);
+                        if let Some(bucket) =
+                            shard.bucket_index.bucket_map.get_mut(&routing_bucket)
+                        {
+                            if bucket.first_dirty_index_log_sequence == 0 {
+                                bucket.first_dirty_index_log_sequence =
+                                    appended_index_log_sequence;
+                            }
+                        }
+                    }
+                }
             }
         }
         // Release the `shards` write lock BEFORE the durable barrier. A concurrent same-shard

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -1372,6 +1372,17 @@ pub(super) struct BucketNode {
     /// \ is what caught that.
     #[serde(skip)]
     pub(super) first_dirty_wal_sequence: u64,
+    /// The same claim against the INDEX LOG: the index-log sequence at which this bucket most
+    /// recently went from clean to dirty, or 0 when it is clean or not known.
+    ///
+    /// Both are needed, and one cannot stand in for the other: the reclaim plan keeps a WAL
+    /// frontier and an index-log frontier, and they count in different sequences. A bucket that
+    /// can say where it sits in the log but not in the index log can only hold both at 0.
+    ///
+    /// Transient for the same reason as its WAL twin -- a load clears every dirty flag and
+    /// recomputes from an empty dirty set, so a reloaded bucket holds no claim.
+    #[serde(skip)]
+    pub(super) first_dirty_index_log_sequence: u64,
     pub(super) last_dump_sequence: u64,
     #[serde(default, alias = "object_ids")]
     pub(super) object_index: ObjectIndex,

--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -516,6 +516,7 @@ impl TemporalEngine {
                 // The dump captured everything this bucket had, so it holds no claim over the
                 // log until it is written to again.
                 bucket.first_dirty_wal_sequence = 0;
+                bucket.first_dirty_index_log_sequence = 0;
                 for page in bucket.page_index.values_mut() {
                     page.dirty = false;
                 }
@@ -684,6 +685,34 @@ impl TemporalEngine {
             .get(&shard_id)
             .map(bucket_generation_fingerprints_by_bucket)
             .unwrap_or_default();
+        // What each bucket holds over the two logs when no manifest covers it.
+        //
+        // A dirty bucket with no durable dump manifest is captured nowhere, so the only answer
+        // the plan could give for it was "retain everything" -- floor 0. These two claims say
+        // where the bucket's oldest undumped write actually sits, so it can hold the logs from
+        // there instead of from the beginning.
+        let bucket_claims = self
+            .shards
+            .read()
+            .expect("shards lock poisoned")
+            .get(&shard_id)
+            .map(|shard| {
+                shard
+                    .bucket_index
+                    .bucket_map
+                    .iter()
+                    .map(|(routing_bucket, bucket)| {
+                        (
+                            *routing_bucket,
+                            (
+                                bucket.first_dirty_wal_sequence,
+                                bucket.first_dirty_index_log_sequence,
+                            ),
+                        )
+                    })
+                    .collect::<std::collections::HashMap<u32, (u64, u64)>>()
+            })
+            .unwrap_or_default();
         let manifests = self.list_bucket_dump_manifests(shard_id);
         let mut missing_bucket_generations = Vec::new();
         let mut retained_manifest_ids = BTreeSet::<String>::new();
@@ -771,7 +800,32 @@ impl TemporalEngine {
                 })
                 .map(|(_, manifest)| manifest);
             let Some(manifest) = matching_manifest else {
-                missing_bucket_generations.push(summary.routing_bucket);
+                // No manifest covers this bucket. It is still allowed to hold the logs only from
+                // its own oldest undumped write, PROVIDED it can name that point in both logs.
+                //
+                // `retain_from_* = frontier + 1`, so a bucket needing everything from `F` onward
+                // contributes `F - 1`: records at or below that are reclaimable, `F` and above
+                // are kept.
+                //
+                // BOTH claims are required. They count in different sequences -- one in the
+                // write-ahead log, one in the index log -- and a bucket that can place itself in
+                // one but not the other has said nothing about the second. A zero in either means
+                // NO CLAIM RECORDED, and the only safe reading of "unknown" is the old one:
+                // block, and retain everything. Treating unknown as "nothing to retain" is the
+                // direction that loses committed records.
+                let (wal_claim, index_log_claim) = bucket_claims
+                    .get(&summary.routing_bucket)
+                    .copied()
+                    .unwrap_or((0, 0));
+                if wal_claim > 0 && index_log_claim > 0 {
+                    durable_wal_frontier =
+                        durable_wal_frontier.min(wal_claim.saturating_sub(1));
+                    durable_index_log_frontier =
+                        durable_index_log_frontier.min(index_log_claim.saturating_sub(1));
+                    covered_bucket_count = covered_bucket_count.saturating_add(1);
+                } else {
+                    missing_bucket_generations.push(summary.routing_bucket);
+                }
                 continue;
             };
             retained_manifest_ids.insert(manifest.manifest_id.clone());

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -2974,6 +2974,74 @@ fn a_capped_dump_takes_the_oldest_undumped_bucket_first() {
     );
 }
 
+/// A capped dump still reclaims, because an undumped bucket holds the logs only from its own
+/// oldest write.
+///
+/// A bucket that is dirty and has no durable dump manifest is captured nowhere. The plan used to
+/// have no choice but to retain everything for it -- floor 0 -- so a round that dumped only some
+/// of the dirty buckets reclaimed NOTHING, for ever
+/// (`the_shipped_dump_cap_still_lets_the_log_be_reclaimed` is why the cap had to be turned off).
+///
+/// With `first_dirty_wal_sequence` and `first_dirty_index_log_sequence` such a bucket can say
+/// where its oldest undumped write sits in each log, and hold them only from there. Measured over
+/// 12 rounds of 500 dirty buckets:
+///
+/// | cap | records behind the head, before | after |
+/// |---|---|---|
+/// | 64 | 6001 (nothing reclaimed) | 436 |
+/// | 128 | 6001 | 372 |
+/// | 256 | 6001 | 244 |
+///
+/// Both claims are required and a zero in either still blocks: they count in different sequences,
+/// and a bucket that can place itself in one log but not the other has said nothing about the
+/// second. That is the assertion that matters here -- not the exact distance behind the head,
+/// which depends on the cap.
+#[test]
+fn a_capped_dump_still_reclaims() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        8 << 20,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+
+    // Far more dirty buckets per round than the cap can cover, for several rounds.
+    let mut last_retain = 0u64;
+    for _round in 1..=4u64 {
+        for index in 0..200 {
+            write_string(&engine, &format!("capped-{index:04}"), &[b'v'; 128]);
+        }
+        let report = engine.run_storage_manager_cycle(StorageManagerCycleRequest {
+            shard_id: 1,
+            min_undumped_wal_records: 0,
+            min_undumped_wal_bytes: 0,
+            max_dump_buckets_per_round: 16,
+            ..StorageManagerCycleRequest::default()
+        });
+        let wal = report
+            .wal_reclaim_report
+            .as_ref()
+            .expect("the round must run WAL reclaim");
+        last_retain = wal.plan.retain_from_wal_sequence;
+    }
+
+    let stats = engine.write_ahead_log_store().stats(1);
+    assert!(
+        last_retain > 0,
+        "a capped round reclaimed nothing: the floor is still pinned at 0 with {} records \
+         written, which is the state a dump cap used to force",
+        stats.last_sequence,
+    );
+    // And it must be a real floor, not a token one: most of the log should be behind it.
+    assert!(
+        last_retain * 2 > stats.last_sequence,
+        "the floor advanced to {last_retain} of {}, which is too little to call reclaimable",
+        stats.last_sequence,
+    );
+}
+
 fn write_string(engine: &TemporalEngine, key: &str, value: &[u8]) {
     engine.execute(ExecuteRequest {
         shard_id: 1,


### PR DESCRIPTION
A dirty bucket with no durable dump manifest is captured nowhere, so the reclaim plan had no choice but to retain everything for it — **floor 0**. That is why a round which dumps only some of the dirty buckets reclaimed nothing, for ever, and why the shipped dump cap had to be turned off in `#1439`.

This gives such a bucket a way to say where its oldest undumped write actually sits, so it holds the logs only from there.

## Both claims, because there are two frontiers

`#1440` added `first_dirty_wal_sequence`. It is **not sufficient on its own**: one gate governs both retain points, and `durable_index_log_frontier` is a min over `manifest.index_log_sequence` — a different counter. A bucket that can place itself in the write-ahead log but not the index log has said nothing about the second.

So this adds `first_dirty_index_log_sequence`, stamped at the same place and by the same rule. `append_delta` was already returning the sequence and it was being discarded with `let _`; it returns `0` when it writes nothing (bulk ingest, or the log disabled), which is exactly "no claim", so the guard is the same one.

## The result

Measured over 12 rounds of 500 dirty buckets each, 6,000 writes:

| cap | records behind the head — before | after | WAL bytes |
|---|---|---|---|
| 64 | **6001** (nothing reclaimed) | **436** | 524,368 → 35,238 |
| 128 | 6001 | 372 | → 30,054 |
| 256 | 6001 | 244 | → 19,742 |

## The safety rules, written at the code

- `retain_from_* = frontier + 1`, so a bucket needing everything from `F` onward contributes `F - 1`: records at or below that are reclaimable, `F` and above are kept.
- **Both** claims are required.
- A zero in either means *no claim recorded*, and the only safe reading of unknown is the old one — block and retain everything. Treating unknown as "nothing to retain" is the direction that loses committed records.

## It fixes a long-standing red test

`data_node::tests::part3::storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_flags` has been failing on `main`, and its failure dump was this exact bug:

```
reason: "WAL/index-log reclaim blocked ...: slot_generation_without_durable_dump, ..."
retain_from_wal_sequence: 0
```

It passes now, and fails again with the change stashed. **The baseline red is one test, not two.**

## Verification

`a_capped_dump_still_reclaims` pins the behaviour; disabling the new branch makes it fail with *"a capped round reclaimed nothing: the floor is still pinned at 0 with 800 records written"*.

Full suite: **1750 passed, 1 failed** — `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the remaining known baseline failure.

## Not in this change

Re-enabling the shipped dump cap. It is now safe to, and the table above says what each value costs — but flipping it also requires relaxing `the_log_stays_bounded_under_continuous_writing`, which asserts the floor reaches the head (true only with no cap). Rewriting a guard in the same commit that changes the behaviour it guards is how vacuous assertions get in.
