### PR TITLE
Measure what one bucket costs in memory, and how to read the number

### DIFF
--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -7547,6 +7547,75 @@ fn where_a_record_is_kept_everywhere() {
 /// A meta-server-managed shard gets 0..1023 instead. This loads the same corpus both ways and
 /// counts, so the saving is measured rather than argued.
 ///
+/// What does one bucket cost in memory? Prints.
+///
+///   cargo test --features alloc-probe -p temporalstore-rust --lib what_a_bucket_costs -- --ignored --nocapture --test-threads=1
+///
+/// At the default routing range every key gets its own bucket, so this is also "what does one
+/// stored object cost in index memory".
+///
+/// Read the MARGINAL bytes between two rows, not a single row's "B per bucket". Engine startup
+/// retains several megabytes that have nothing to do with record count -- caches and store
+/// buffers -- so a small fixture divides that fixed cost over too few buckets and reports a
+/// per-bucket figure several times the truth. Measured 2026-09-11 the rows fit
+/// `fixed + 760 B x buckets` closely, while the smallest row alone reads 2,486 B.
+///
+/// The single-page and single-object cases are already held inline by `BlockIndexMap::One` and
+/// `ObjectIndex::One`, so what remains is the node itself rather than container allocation.
+#[test]
+#[ignore]
+#[cfg(feature = "alloc-probe")]
+fn what_a_bucket_costs() {
+    use crate::engine::state;
+    for (name, bytes) in [
+        ("BucketNode", std::mem::size_of::<state::BucketNode>()),
+        ("  ObjectIndex", std::mem::size_of::<state::ObjectIndex>()),
+        ("  BlockIndexMap", std::mem::size_of::<state::BlockIndexMap>()),
+        ("    BlockIndex", std::mem::size_of::<state::BlockIndex>()),
+        (
+            "      BlockAddress",
+            std::mem::size_of::<crate::block_store::BlockAddress>(),
+        ),
+    ] {
+        eprintln!("  size_of::<{name}>() = {bytes}");
+    }
+    for records in [5_000usize, 20_000, 40_000, 80_000] {
+        let dir = tempfile::tempdir().unwrap();
+        let probe = crate::alloc_probe::Probe::start();
+        let engine = TemporalEngine::with_local_dirs(
+            16 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        for index in 0..records {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("cost-{index:07}"),
+                    value: vec![b'v'; 64],
+                },
+            });
+        }
+        let counts = probe.stop();
+        let live = counts.alloc_bytes.saturating_sub(counts.free_bytes);
+        let buckets = {
+            let shards = engine.shards.read().expect("engine lock poisoned");
+            shards
+                .get(&1)
+                .map(|shard| shard.bucket_index.bucket_map.len())
+                .unwrap_or(0)
+        };
+        eprintln!(
+            "  {records:>6} records -> {buckets:>6} buckets: {live:>12} live bytes, \
+             {:>8.0} B per record, {:>8.0} B per bucket",
+            live as f64 / records as f64,
+            live as f64 / buckets.max(1) as f64,
+        );
+    }
+}
+
 ///   cargo test --features alloc-probe -p temporalstore-rust --lib what_a_bounded_slot_range_saves -- --ignored --nocapture --test-threads=1
 #[test]
 #[ignore]


### PR DESCRIPTION
At the default routing range every key gets its own bucket, so "bytes per bucket" is also "bytes of index per stored object". We had no measurement of it — only the whole-engine retention figure — so this adds one.

`what_a_bucket_costs` prints the live heap at four store sizes and the size of each layer of the node. Feature-gated and `#[ignore]`d, like the probes beside it. **No production code changes.**

## What a bucket is made of

| `size_of` | bytes | share of node |
|---|---|---|
| `BucketNode` | **216** | |
| `BlockIndexMap` (`page_index`) | 120 | 55% |
| → `BlockIndex` | 112 | |
| → → `BlockAddress` | 56 | 26% |
| `ObjectIndex` × 2 | 32 | 15% |

## How much it grows by, and how to read that

| records | live bytes | naive "B per bucket" |
|---|---|---|
| 5,000 | 12,428,154 | 2,486 |
| 20,000 | 24,051,118 | 1,203 |
| 40,000 | 38,888,846 | 972 |
| 80,000 | 69,299,658 | 866 |

**Read the marginal bytes between two rows, not the last column.** Engine startup retains several megabytes that have nothing to do with record count, so a small fixture divides that fixed cost over too few buckets. The marginal cost between consecutive rows is 775, 742 and 760 B, and `8.6 MB fixed + 760 B × buckets` predicts the 80,000-record row to within 0.2%.

Quoting the smallest row would have overstated the per-bucket cost by 3.3×. The doc comment on the probe says so, so the next reader does not make that mistake.

## Two things this settles that were previously assumed

- **The single-page and single-object cases are already held inline**, by `BlockIndexMap::One` and `ObjectIndex::One`. So what a bucket costs is the node itself, not container allocation — I had believed otherwise before measuring.
- **`BlockAddress` is 56 B of the 216.** Narrowing `offset`/`length` to `u32` saves 8 B (~4%) and puts a width decision into the serialized form. The node is effectively irreducible without changing what a bucket stores, which means the lever on index memory is eviction rather than packing.

Full suite: **1750 passed, 1 failed** — `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the known baseline failure, unrelated and also failing on `main`.
