### PR TITLE
A qps of 0 means unlimited on every scope, not just the shard one

### DIFF
--- a/crates/temporalstore-rust/src/engine/command_validation.rs
+++ b/crates/temporalstore-rust/src/engine/command_validation.rs
@@ -385,9 +385,13 @@ pub(super) fn admission_limits(
     info: &Option<ShardInfo>,
 ) -> Vec<AdmissionLimit> {
     let mut limits = Vec::new();
-    // A configured qps of 0 means UNLIMITED (QuotaManager: a 0 qps installs no limiter
-    // and ConsumeQuota always succeeds), NOT deny-all. Filtering out 0 here keeps the
-    // downstream `limit == 0` reject from ever firing on an intended "no limit" setting.
+    // A configured qps of 0 means UNLIMITED on EVERY scope below, not deny-all. Zero is what
+    // an unset knob reads as, so treating it as "refuse everything" turns an intended "no limit
+    // here" into a total outage; denying traffic outright has its own controls.
+    //
+    // The filter has to stay uniform across the three scopes. It once guarded the shard knob
+    // alone, so `write_qps: 0` meant no limit while `table_write_qps: 0` a few lines below denied
+    // every write to that table -- two knobs of identical shape with opposite meanings.
     if let Some(limit) = (if write_command {
         config.write_qps
     } else {
@@ -410,11 +414,13 @@ pub(super) fn admission_limits(
         .map(|info| info.table_name.trim())
         .filter(|table_name| !table_name.is_empty())
     {
-        if let Some(limit) = if write_command {
+        if let Some(limit) = (if write_command {
             config.table_write_qps
         } else {
             config.table_read_qps
-        } {
+        })
+        .filter(|&limit| limit > 0)
+        {
             limits.push(AdmissionLimit {
                 scope: AdmissionScope::Table(table_name.to_string()),
                 limit,
@@ -432,11 +438,13 @@ pub(super) fn admission_limits(
         .map(str::trim)
         .filter(|tenant_name| !tenant_name.is_empty())
     {
-        if let Some(limit) = if write_command {
+        if let Some(limit) = (if write_command {
             config.tenant_write_qps
         } else {
             config.tenant_read_qps
-        } {
+        })
+        .filter(|&limit| limit > 0)
+        {
             limits.push(AdmissionLimit {
                 scope: AdmissionScope::Tenant(tenant_name.to_string()),
                 limit,

--- a/crates/temporalstore-rust/src/engine/tests/part3.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part3.rs
@@ -1465,10 +1465,9 @@ fn write_qps_config_rejects_writes_after_admission_limit() {
 
 #[test]
 fn write_qps_zero_means_unlimited_not_deny_all_like_native() {
-    // QuotaManager treats a configured qps of 0 as UNLIMITED (it installs no limiter
-    // and ConsumeQuota always succeeds), NOT deny-all. The live admission path must not
-    // push a limit==0 (which the downstream gate rejects as "is zero"). Regression for the
-    // case where the >0 filter existed only in an orphaned, never-compiled module.
+    // A configured qps of 0 is UNLIMITED, not deny-all. The live admission path must not push
+    // a limit==0, which the downstream gate rejects as "is zero". Regression for the case where
+    // the >0 filter existed only in an orphaned, never-compiled module.
     let engine = TemporalEngine::default();
     engine.load_shard(1);
     engine.set_config(SetConfigRequest {
@@ -1504,6 +1503,69 @@ fn write_qps_zero_means_unlimited_not_deny_all_like_native() {
             },
         });
         assert!(resp.status.ok, "read_qps=0 must be unlimited (got {:?})", resp.status);
+    }
+}
+
+#[test]
+fn table_and_tenant_qps_zero_mean_unlimited_like_the_shard_knob() {
+    // The shard knob above pins 0 = unlimited. The table and tenant knobs have identical shape
+    // and must mean the same thing. A 0 that denied every request here, while `write_qps: 0`
+    // eight lines away meant no limit, is a trap an operator falls into by reading one knob and
+    // assuming the next: setting `table_write_qps: 0` to mean "no table limit" took the table
+    // completely offline instead.
+    let engine = TemporalEngine::default();
+    assert!(
+        engine
+            .load_shard_with(LoadShardRequest {
+                shard_id: 1,
+                load_version: 1,
+                local_node_id: Some(1),
+                shard_uri: "local://feature_table/1".to_string(),
+                start_routing_bucket: 0,
+                end_routing_bucket: u32::MAX,
+                readonly: false,
+                table_name: "feature_table".to_string(),
+            })
+            .status
+            .ok
+    );
+    engine.set_config(SetConfigRequest {
+        shard_id: 1,
+        config: Config {
+            version: 2,
+            table_write_qps: Some(0),
+            table_read_qps: Some(0),
+            tenant_write_qps: Some(0),
+            tenant_read_qps: Some(0),
+            tenant_name: Some("a_tenant".to_string()),
+            ..Config::default()
+        },
+    });
+    wait_for_fresh_admission_second();
+    for i in 0..5 {
+        let wrote = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("k{i}"),
+                value: b"v".to_vec(),
+            },
+        });
+        assert!(
+            wrote.status.ok,
+            "a table/tenant write qps of 0 must be unlimited (got {:?})",
+            wrote.status
+        );
+        let read = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringGet {
+                key: format!("k{i}"),
+            },
+        });
+        assert!(
+            read.status.ok,
+            "a table/tenant read qps of 0 must be unlimited (got {:?})",
+            read.status
+        );
     }
 }
 


### PR DESCRIPTION
`admission_limits` builds limits for three scopes, and a configured `0` meant opposite things depending on which one you set:

| scope | config knob | `Some(0)` meant |
|---|---|---|
| shard | `write_qps` / `read_qps` | **unlimited** |
| table | `table_write_qps` / `table_read_qps` | **deny all** |
| tenant | `tenant_write_qps` / `tenant_read_qps` | **deny all** |

The `.filter(|&limit| limit > 0)` that established "0 is unlimited" was added to the shard branch only. The table and tenant branches a few lines below kept the older meaning, where a `0` reaches the downstream gate and is rejected as `"<label> is zero"`.

So an operator who set `table_write_qps: 0` to mean "no table limit" — by analogy with the `write_qps` knob directly above it, which means exactly that — took the entire table offline instead. Two knobs of identical shape, in one function, with opposite meanings.

## The control came first

Neither the table nor the tenant zero case was asserted anywhere, which is how the drift survived. `table_and_tenant_qps_zero_mean_unlimited_like_the_shard_knob` now pins both, and I ran it against unfixed code before changing anything. It fails on the very first write:

```
admission_rejected: "table_write_qps is zero"
```

A test that passed before the fix would have proved nothing.

## Enforcement is unchanged for real limits

The shared-scope tests set a limit of `1` and expect the second request to be rejected. Both pass untouched, so the filter did not weaken enforcement — it only stopped `0` from being read as a limit:

- `table_write_qps_config_is_shared_across_loaded_table_shards`
- `tenant_read_qps_config_is_shared_across_tables`
- plus `write_qps_config_rejects_writes_after_admission_limit`, `read_qps_config_rejects_reads_after_admission_limit`, `write_qps_zero_means_unlimited_not_deny_all_like_native`

## One thing deliberately left in place

The `limit == 0` reject inside `check_admission` is now unreachable, since all three constructors filter zero out. I kept it, because it is **not** what makes `0` deny-all: with `limit == 0` the `*count >= limit.limit` comparison is already always true, so removing the guard would leave deny-all behind a worse message. It stays as the better diagnostic if the invariant is ever broken again.

Also drops two comments that described another implementation's class and method by name instead of stating the rule this code follows.

Full suite: **1750 passed, 1 failed** — `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the known baseline failure, unrelated and also failing on `main`.
