### PR TITLE
Four comments that begin mid-sentence and say nothing

### DIFF
--- a/crates/temporalstore-rust/src/block_store/gc.rs
+++ b/crates/temporalstore-rust/src/block_store/gc.rs
@@ -266,8 +266,7 @@ impl LocalBlockStore {
         candidates.sort_by(|left, right| {
             // Reclaim the highest-garbage band first: a lower band live-fraction
             // (utility_basis_points) means more garbage, so ascending live-fraction ==
-            // descending garbage ratio. This is the GC victim order (zone_manager.
-            // native gc_list_ sorted by GetGarbageRate() descending), which the previous
+            // descending garbage ratio. That is the GC victim order, which the previous
             // key (a categorical utility_score, uniformly 0 for all candidates) never
             // actually applied.
             left.utility_basis_points

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -1046,15 +1046,12 @@ impl TemporalEngine {
                     if sync {
                         // A synchronous write whose durable WAL commit failed is NOT durable: the
                         // WAL is the recovery source of truth (replayed on load), so returning ok
-                        // would tell the client a write that is gone after a crash succeeded.
-                        // surfaces the wal Commit failure to the client
-                        // The failed commit status is copied into the response.
-                        // rather than acking a non-durable write. Match that instead of swallowing
-                        // the error. (async/bulk mode is a fire-and-forget commit, so
-                        // its append errors stay
-                        // best-effort and do not fail the command.) We also skip the index anchor
-                        // + persist below, so durable state never advances past a write the WAL
-                        // did not accept.
+                        // would tell the client a write that is gone after a crash succeeded. The
+                        // failed commit status is surfaced to the client instead of acking a write
+                        // that is not durable, so the error is never swallowed. (Async/bulk mode is
+                        // a fire-and-forget commit, so its append errors stay best-effort and do
+                        // not fail the command.) We also skip the index anchor + persist below, so
+                        // durable state never advances past a write the WAL did not accept.
                         return ExecuteResponse {
                             status: Status::error(
                                 "wal_commit_failed",
@@ -2150,16 +2147,20 @@ fn encode_index_msgpack(shard: &ShardState) -> Option<Vec<u8>> {
 /// page bytes do not move at all -- the data is unchanged, only the way the index is written.
 ///
 /// A format default is a durability decision, not a size one, so the flip is gated on recovery
-/// rather than on the table above. Three cases, 120 memories each, comparing full retrieval
+/// rather than on the table above. Measured over 120 memories per case, comparing full retrieval
 /// snapshots across a restart:
 ///
 ///   * written by the container, reopened by it -- identical.
 ///   * written as JSON, reopened with the container on -- identical, and the index on disk becomes
 ///     a container, so an existing store upgrades in place with no migration step.
-///     make it the default rather than an opt-in.
+///
+/// A third case -- a container-written index reopened with raw-JSON writing selected -- measured
+/// identical too, and being reversible in both directions is what made the container safe to adopt
+/// as a default rather than an opt-in. That switch has since been removed, so only the two cases
+/// above are reachable now.
 ///
 /// A reader never has to be told which it is holding: JSON starts with `{`, a container with its
-/// magic, so both formats stay loadable whichever way this flag points.
+/// magic, so both formats stay loadable.
 ///
 /// Writing raw JSON was a switch until nothing selected it: reading is sniffed either way, so the
 /// only thing the off position produced was an index an older build could read, and producing one

--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -839,8 +839,8 @@ fn expiry_scan_budget(limit: usize) -> usize {
             // behavior) let the independent next-cycle reclaim trust this volatile index, see a
             // fully-vacated old slab as stale, quarantine+purge it, and a later reload of the STALE
             // on-disk index would then dangle at the deleted slab -> silent durable data loss.
-            // avoids the desync structurally (the compactor leaves the index unchanged on
-            // failure and commits the rewrite atomically). We instead
+            // A compactor that leaves the index untouched on failure and commits the rewrite
+            // atomically avoids the desync structurally. We instead
             // durably commit the consistent partial: rebuild the secondary views so the serialized
             // index is internally consistent, fsync the relocated bytes so the index never names a
             // non-durable page, then persist -- leaving volatile == durable so reclaim is safe --


### PR DESCRIPTION
Four comments in the crate begin mid-sentence, right after a line that ends one. Each is a fragment with no subject, so it says nothing:

```
// long-running node permanently rejected all writes once it tripped.
// compares live resident size and evicts; this at least lets
```

**Comment-only. No behaviour change**, and no code moved.

## How they were found, not who noticed them

A detector for comment lines that start with a lowercase verb when the previous comment line ended with a full stop. That shape is what a botched edit leaves behind. It reported 16 candidates across the crate; 12 are false positives — CLI usage blocks and code snippets quoted inside comments — and 4 were real. After this change the detector reports 12, all of them the known false positives.

## The four

| file | what it said | what was wrong |
|---|---|---|
| `engine.rs` (sync WAL commit) | `surfaces the wal Commit failure to the client` … `rather than acking a non-durable write` | three fragments, one of them a replacement sentence inserted **into the middle** of another clause |
| `engine.rs` (`encode_index_bytes`) | `make it the default rather than an opt-in.` | announced "Three cases" and listed two |
| `recovery_sweep_compact.rs` | `avoids the desync structurally (…). We instead` | the thing that avoids it was never named |
| `block_store/gc.rs` | the victim-order note carried a parenthetical naming three identifiers | none of them exist in this codebase; the sentence works without it |

## The index-format one needed history, not invention

`encode_index_bytes` said "Three cases, 120 memories each" and then listed two, with a dangling `make it the default rather than an opt-in.`

The missing third case was a real measurement, so I recovered it from history (`git log -S`) rather than writing one. It was *"written by the container, reopened with the hatch pulled — identical, and the index goes back to JSON"* — reversible in both directions, which is what justified making the container the default.

But that switch was **removed in #929**, so restoring the bullet verbatim would document a toggle that no longer exists — and the surrounding prose still said "whichever way this flag points". The comment now states the two cases that are still reachable, records the third as history with the reason it mattered, and says the switch is gone. Nothing measured is erased and nothing unmeasured is claimed.

Full suite: **1751 passed, 1 failed** — `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the known baseline failure, unrelated and also failing on `main`.
