### PR TITLE
The route now carries the fencing token its primary reports

### DIFF
--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -3006,6 +3006,7 @@ mod tests {
                                         temporalstore_rust::meta::TableServingOptions::default(),
                                 }),
                                 shards: vec![temporalstore_rust::meta::TableShard {
+                                    load_version: 0,
                                     shard_id: 9,
                                     start_bucket: 90,
                                     end_bucket: 99,

--- a/crates/temporalstore-rust/src/client.rs
+++ b/crates/temporalstore-rust/src/client.rs
@@ -738,6 +738,12 @@ struct CachedRoute {
     next_replica_index: std::sync::atomic::AtomicUsize,
     fetched_at: Instant,
     topology_version: u64,
+    /// The fencing token the metaserver gave for this route's primary, or 0 when it gave none.
+    ///
+    /// Held here so a routed write can be sent to the checked execute path, which refuses it if
+    /// the node no longer holds that version. 0 keeps the unchecked path, so a route fetched from
+    /// a metaserver that does not send one behaves exactly as before.
+    load_version: u64,
     refresh_reason: String,
 }
 
@@ -758,6 +764,7 @@ impl Clone for CachedRoute {
             ),
             fetched_at: self.fetched_at,
             topology_version: self.topology_version,
+            load_version: self.load_version,
             refresh_reason: self.refresh_reason.clone(),
         }
     }
@@ -777,6 +784,8 @@ impl CachedRoute {
             next_replica_index: std::sync::atomic::AtomicUsize::new(0),
             fetched_at: Instant::now(),
             topology_version: 0,
+            // A route built without topology carries no token, so writes through it stay unfenced.
+            load_version: 0,
             refresh_reason: refresh_reason.to_string(),
         }
     }

--- a/crates/temporalstore-rust/src/client/client_meta_sync.rs
+++ b/crates/temporalstore-rust/src/client/client_meta_sync.rs
@@ -178,6 +178,7 @@ impl TemporalStoreClient {
                             next_replica_index: std::sync::atomic::AtomicUsize::new(0),
                             fetched_at: Instant::now(),
                             topology_version: route_topology_version,
+                            load_version: partition.load_version,
                             refresh_reason: "table_topology_sync".to_string(),
                         },
                     )

--- a/crates/temporalstore-rust/src/client/tests/part1.rs
+++ b/crates/temporalstore-rust/src/client/tests/part1.rs
@@ -651,6 +651,7 @@ fn table_write_refreshes_topology_after_meta_changed_without_write_retry_budget(
                             serving_options: crate::meta::TableServingOptions::default(),
                         }),
                         shards: vec![TableShard {
+                            load_version: 0,
                             shard_id: 1,
                             start_bucket: 0,
                             end_bucket: u64::MAX,

--- a/crates/temporalstore-rust/src/client/tests/part2.rs
+++ b/crates/temporalstore-rust/src/client/tests/part2.rs
@@ -163,6 +163,7 @@ fn client_metasync_backoff_deadline_and_topology_refresh_survive_outage_churn() 
                                 serving_options: crate::meta::TableServingOptions::default(),
                             }),
                             shards: vec![TableShard {
+                                load_version: 0,
                                 shard_id: 40,
                                 start_bucket: 0,
                                 end_bucket: 1_073_741_823,
@@ -368,6 +369,7 @@ fn a_second_sync_asks_only_for_what_changed_and_keeps_its_routes() {
                             status: Status::ok(),
                             table: Some(table),
                             shards: vec![TableShard {
+                                load_version: 0,
                                 shard_id: 1,
                                 start_bucket: 0,
                                 end_bucket: u64::MAX,
@@ -476,6 +478,7 @@ fn a_topology_missing_a_primary_keeps_the_route_it_cannot_replace() {
                                 serving_options: crate::meta::TableServingOptions::default(),
                             }),
                             shards: vec![TableShard {
+                                load_version: 0,
                                 shard_id: 1,
                                 start_bucket: 0,
                                 end_bucket: u64::MAX,
@@ -662,6 +665,7 @@ fn a_batch_is_split_across_shards_the_table_gained_after_it_was_opened() {
                     let count = count_for_server.load(Ordering::Relaxed);
                     let shards = (0..count)
                         .map(|offset| crate::meta::TableShard {
+                            load_version: 0,
                             shard_id: 10 + offset,
                             start_bucket: offset * 4096,
                             end_bucket: (offset + 1) * 4096 - 1,
@@ -1023,6 +1027,7 @@ fn table_read_policy_can_select_secondary_from_metaserver_topology() {
                             serving_options: crate::meta::TableServingOptions::default(),
                         }),
                         shards: vec![TableShard {
+                            load_version: 0,
                             shard_id: 1,
                             start_bucket: 0,
                             end_bucket: u64::MAX,
@@ -1133,6 +1138,7 @@ fn a_read_only_batch_reaches_the_replica_and_a_write_batch_the_primary() {
                             serving_options: crate::meta::TableServingOptions::default(),
                         }),
                         shards: vec![TableShard {
+                            load_version: 0,
                             shard_id: 1,
                             start_bucket: 0,
                             end_bucket: u64::MAX,
@@ -1312,6 +1318,7 @@ fn client_router_matches_crc64_bucket_formula() {
 #[test]
 fn client_router_round_robins_secondary_reads_like_router() {
     let mut route = CachedRoute {
+        load_version: 0,
         table_key: String::new(),
         partition_id: 1,
         start_bucket: 0,
@@ -1347,6 +1354,7 @@ fn client_router_round_robins_secondary_reads_like_router() {
 #[test]
 fn client_router_prefers_same_location_replica_when_available() {
     let mut route = CachedRoute {
+        load_version: 0,
         table_key: String::new(),
         partition_id: 1,
         start_bucket: 0,
@@ -1526,6 +1534,7 @@ fn client_deployment_placement_routes_reads_to_local_secondary_and_writes_to_pri
                                 },
                             }),
                             shards: vec![TableShard {
+                                load_version: 0,
                                 shard_id: 81,
                                 start_bucket: 0,
                                 end_bucket: u64::MAX,

--- a/crates/temporalstore-rust/src/client/tests/part3.rs
+++ b/crates/temporalstore-rust/src/client/tests/part3.rs
@@ -63,6 +63,7 @@ fn table_write_refreshes_due_topology_before_network() {
                                     serving_options: crate::meta::TableServingOptions::default(),
                                 }),
                                 shards: vec![crate::meta::TableShard {
+                                    load_version: 0,
                                     shard_id: first_shard_id,
                                     start_bucket: 0,
                                     end_bucket: u64::MAX,

--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -1341,6 +1341,7 @@ fn runtime_builds_style_server_load_report() {
             serving_options: crate::meta::TableServingOptions::default(),
         }),
         shards: vec![crate::meta::TableShard {
+            load_version: 0,
             shard_id: 7,
             start_bucket: 10,
             end_bucket: 19,
@@ -1360,6 +1361,7 @@ fn runtime_builds_style_server_load_report() {
         status: Status::ok(),
         table: None,
         shards: vec![crate::meta::TableShard {
+            load_version: 0,
             shard_id: 7,
             start_bucket: 0,
             end_bucket: 9,

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -1004,6 +1004,15 @@ pub struct TableShard {
     pub primary_endpoint: Option<ServerEndpoint>,
     #[serde(default)]
     pub replica_endpoints: Vec<ServerEndpoint>,
+    /// The fencing token for this shard's placement: the `load_version` its PRIMARY reports for
+    /// it. A write carrying this is refused by a node that no longer holds that version, which is
+    /// the window a stale route otherwise writes into.
+    ///
+    /// 0 means NOT KNOWN, and is the safe direction: a client without a version keeps the
+    /// unfenced behaviour rather than being locked out. A topology written before this field
+    /// existed reads as 0 for the same reason.
+    #[serde(default)]
+    pub load_version: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -3553,6 +3562,89 @@ mod tests {
             replicas.len(),
             2,
             "spreading turned a fill into a shortfall: {replicas:?}"
+        );
+    }
+
+    #[test]
+    fn the_topology_carries_the_load_version_the_primary_reports() {
+        // The fencing token only reaches a client if the topology carries it. Without it a client
+        // has no version to send, so the checked execute path cannot be used at all and a write
+        // routed on a stale topology is accepted by a node that no longer owns the shard.
+        let meta = SingleNodeMeta::default();
+        assert!(meta
+            .register_server(RegisterServerRequest {
+                registered_at_ms: 0,
+                numa_nodes: Vec::new(),
+                server_addr: "node-a".to_string(),
+                node_id: 1,
+                location: "us-east/dc1/az1/rack1".to_string(),
+                binary_version: "v1".to_string(),
+            })
+            .status
+            .ok);
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "ns".to_string(),
+        });
+        assert!(meta
+            .add_table(AddTableRequest {
+                namespace: "ns".to_string(),
+                table_name: "orders".to_string(),
+                first_shard_id: 1,
+                shard_count: 1,
+                replica_count: 1,
+                partition_version: 0,
+                serving_options: TableServingOptions::default(),
+            })
+            .status
+            .ok);
+
+        let topology = || {
+            meta.get_table_topology(GetTableTopologyRequest {
+                client_location: String::new(),
+                namespace: "ns".to_string(),
+                table_name: "orders".to_string(),
+                old_topology_version: 0,
+            })
+        };
+
+        // CONTROL: nothing reported yet. An unknown must read as 0 -- a token invented here would
+        // fence out every client the moment this field started being sent.
+        let before = topology();
+        assert!(before.status.ok);
+        assert_eq!(before.shards.len(), 1);
+        assert_eq!(
+            before.shards[0].load_version, 0,
+            "an unreported shard must carry 0, not a token that would fence a client out"
+        );
+        let primary = before.shards[0]
+            .primary
+            .clone()
+            .expect("the shard should have a primary");
+
+        assert!(meta
+            .server_heartbeat(ServerHeartbeatRequest {
+                server_addr: primary,
+                boot_time_ms: 1,
+                binary_version: "v1".to_string(),
+                shard_loads: Vec::new(),
+                shard_stat_loads: Vec::new(),
+                runtime_load: ServerRuntimeLoad::default(),
+                shard_states: vec![ServerShardServingState {
+                    shard_id: 1,
+                    loaded: true,
+                    load_version: 7,
+                    ..ServerShardServingState::default()
+                }],
+            })
+            .status
+            .ok);
+
+        let after = topology();
+        assert!(after.status.ok);
+        assert_eq!(after.shards.len(), 1);
+        assert_eq!(
+            after.shards[0].load_version, 7,
+            "the topology must carry the load_version its primary reports"
         );
     }
 

--- a/crates/temporalstore-rust/src/meta/partitioning.rs
+++ b/crates/temporalstore-rust/src/meta/partitioning.rs
@@ -6,6 +6,30 @@
 use super::*;
 use std::collections::BTreeSet;
 
+/// The `load_version` the PRIMARY reports for this shard, or 0 when nothing is known.
+///
+/// This is the same value `validate_load_version` compares against on the data node, because it
+/// is the server's own report of what it has loaded. Taking the max is deliberate: a server
+/// mid-handoff can briefly report two entries for one shard, and the newer one is the one a write
+/// should be fenced against.
+///
+/// 0 on every unknown -- no such server, no entry, not loaded -- so an unknown never produces a
+/// token that would fence a client out.
+fn reported_load_version(state: &MetaState, server_addr: &str, shard_id: ShardId) -> u64 {
+    state
+        .servers
+        .get(server_addr)
+        .and_then(|server| {
+            server
+                .shard_states
+                .iter()
+                .filter(|shard_state| shard_state.shard_id == shard_id && shard_state.loaded)
+                .map(|shard_state| shard_state.load_version)
+                .max()
+        })
+        .unwrap_or(0)
+}
+
 /// Whether the server a shard is registered to is in service.
 ///
 /// An unknown address counts as serving: a route can outlive the server record
@@ -135,6 +159,8 @@ pub(super) fn build_shards(
                 replicas: Vec::new(),
                 primary_endpoint: None,
                 replica_endpoints: Vec::new(),
+                // Not serving, so there is no primary to be fenced against.
+                load_version: 0,
             });
             continue;
         }
@@ -292,6 +318,10 @@ pub(super) fn build_shards(
             .iter()
             .map(|server_addr| server_endpoint(state, server_addr))
             .collect();
+        let load_version = primary
+            .as_deref()
+            .map(|server_addr| reported_load_version(state, server_addr, shard_id))
+            .unwrap_or(0);
         shards.push(TableShard {
             shard_id,
             start_bucket,
@@ -300,6 +330,7 @@ pub(super) fn build_shards(
             replicas,
             primary_endpoint,
             replica_endpoints,
+            load_version,
         });
     }
     shards

--- a/crates/temporalstore-rust/src/raft/tests/helpers.rs
+++ b/crates/temporalstore-rust/src/raft/tests/helpers.rs
@@ -292,6 +292,7 @@ pub(super) fn topology_for_shard(
             serving_options: crate::meta::TableServingOptions::default(),
         }),
         shards: vec![TableShard {
+            load_version: 0,
             shard_id,
             start_bucket: 0,
             end_bucket: u64::MAX,

--- a/crates/temporalstore-rust/tests/unified_temporalstore_corpus.rs
+++ b/crates/temporalstore-rust/tests/unified_temporalstore_corpus.rs
@@ -2234,6 +2234,7 @@ fn verify_client_partition_set_route_cache() {
                         }),
                         shards: vec![
                             TableShard {
+                                load_version: 0,
                                 shard_id: PartitionId::new(42, 0, 0, 17).unwrap().id(),
                                 start_bucket: 0,
                                 end_bucket: 536_870_911,
@@ -2249,6 +2250,7 @@ fn verify_client_partition_set_route_cache() {
                                 }],
                             },
                             TableShard {
+                                load_version: 0,
                                 shard_id: PartitionId::new(42, 1, 0, 17).unwrap().id(),
                                 start_bucket: 536_870_912,
                                 end_bucket: 1_073_741_823,
@@ -2494,6 +2496,7 @@ fn verify_client_metasync_outage_churn() {
                                 serving_options: Default::default(),
                             }),
                             shards: vec![TableShard {
+                                load_version: 0,
                                 shard_id: 40,
                                 start_bucket: 0,
                                 end_bucket: 1_073_741_823,
@@ -2722,6 +2725,7 @@ fn verify_client_deployment_placement_routing() {
                             },
                         }),
                         shards: vec![TableShard {
+                            load_version: 0,
                             shard_id: 81,
                             start_bucket: 0,
                             end_bucket: u64::MAX,


### PR DESCRIPTION
`validate_load_version` refuses a write whose `load_version` does not match the one the node has loaded, and it is reachable — `/execute_checked`, `/async_execute_checked`, `/batch_execute_checked` and the data node's own worker all use it.

The client's routed write does not, and **could not**: the topology it syncs carries no `load_version` at all, so there has never been a token to send.

## The window this leaves open

After a shard moves, a client holding a stale route writes to the **old** owner, and the old owner accepts it, because `/execute` does not check. The window closes when that owner's own topology sync unloads the shard — so it is bounded by a sync interval rather than unbounded, but it is exactly the window a fencing token exists to remove, and writes taken inside it are taken by a node that no longer owns the data.

## This change carries the token; it does not yet use it

| | |
|---|---|
| `TableShard` | gains `load_version` (`#[serde(default)]`) |
| metaserver | fills it from what the shard's **primary** reports |
| `CachedRoute` | holds it |
| request routing | **unchanged** — nothing changes path |

There is no behaviour change in this PR. The value the metaserver publishes is the server's own report of what it has loaded, which is the same value `validate_load_version` compares against.

## Why this is safe to ship on its own

**0 means NOT KNOWN everywhere**, and that is the safe direction. A client without a token, a topology written before the field existed, a shard nobody has reported, and a shard with no primary all read as 0 and keep exactly today's behaviour. Nothing can be fenced out by a token that was invented here rather than reported.

Taking the **max** of a server's reported states is deliberate: a server mid-handoff can briefly report two entries for one shard, and a write should be fenced against the newer one.

## The test asserts the plumbing, not a constant

`the_topology_carries_the_load_version_the_primary_reports` pins both halves:

- **control** — a shard nobody has reported carries `0`. A token invented here would fence out every client the moment this field started being sent, so the zero case is the one that matters most.
- after the primary heartbeats version `7`, the topology carries `7`.

Verified by mutation: forcing the lookup to return 0 fails the test with `left: 0, right: 7`.

## What comes next, separately

Post to the checked path when the token is non-zero. That is the behaviour change, and it belongs in its own commit — the client write path also decides `WriteOutcomeUnknown`, and that is not somewhere to change two things at once.

Full suite: **1751 passed, 1 failed** — `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the known baseline failure, unrelated and also failing on `main`.
