### PR TITLE
A routed write now sends its fencing token

### DIFF
--- a/crates/temporalstore-rust/src/client/client_routing.rs
+++ b/crates/temporalstore-rust/src/client/client_routing.rs
@@ -131,6 +131,51 @@ impl TemporalStoreClient {
         !commands.iter().any(super::commands::is_write) || err.request_never_reached_the_server()
     }
 
+    /// The fencing token to send with a write bound for `server_addr`, or 0 for none.
+    ///
+    /// The token describes the PRIMARY's placement, so it only means anything when the write is
+    /// actually going to the primary. Sending it to a replica would fence on a version that
+    /// replica never claimed to hold, turning every replica-directed write into a mismatch.
+    ///
+    /// 0 whenever there is nothing to say -- no cached route, a route from a metaserver that
+    /// sends no token, or an address that is not the primary -- and 0 keeps the unchecked path,
+    /// so this can only ever ADD a check, never remove one.
+    fn fencing_token_for(&self, shard_id: ShardId, server_addr: &str) -> u64 {
+        self.inner
+            .routes
+            .read()
+            .expect("client route cache lock poisoned")
+            .get(&shard_id)
+            .filter(|route| route.primary_addr == server_addr)
+            .map(|route| route.load_version)
+            .unwrap_or(0)
+    }
+
+    /// Send one write, fenced when a token is known.
+    ///
+    /// The checked path answers with a `CheckedExecuteResponse` whose inner response carries the
+    /// same status, so unwrapping it here keeps the caller's type and keeps a rejection visible:
+    /// `load_version_mismatch` is already classified retryable, and a retry re-resolves the route
+    /// rather than repeating the write to a node that has been fenced out.
+    fn post_execute(
+        server_addr: &str,
+        request: &ExecuteRequest,
+        load_version: u64,
+        http_options: HttpRequestOptions,
+    ) -> Result<ExecuteResponse, HttpError> {
+        if load_version == 0 {
+            return post_json_with_options(server_addr, "/execute", request, http_options);
+        }
+        let checked = crate::control::CheckedExecuteRequest {
+            shard_id: request.shard_id,
+            load_version,
+            command: request.command.clone(),
+        };
+        let response: crate::control::CheckedExecuteResponse =
+            post_json_with_options(server_addr, "/execute_checked", &checked, http_options)?;
+        Ok(response.response)
+    }
+
     pub(super) fn execute_routed_with_http_and_policy(
         &self,
         request: ExecuteRequest,
@@ -153,7 +198,8 @@ impl TemporalStoreClient {
                 policy,
                 preferred_location,
             )?;
-            return post_json_with_options(&server_addr, "/execute", &request, http_options)
+            let load_version = self.fencing_token_for(request.shard_id, &server_addr);
+            return Self::post_execute(&server_addr, &request, load_version, http_options)
                 .or_else(|err| {
                     let became_continuous = self.record_backend_failure(
                         &server_addr,
@@ -193,8 +239,14 @@ impl TemporalStoreClient {
                         policy,
                         preferred_location,
                     )?;
-                    let response =
-                        post_json_with_options(&refreshed, "/execute", &request, http_options)?;
+                    let refreshed_load_version =
+                        self.fencing_token_for(request.shard_id, &refreshed);
+                    let response = Self::post_execute(
+                        &refreshed,
+                        &request,
+                        refreshed_load_version,
+                        http_options,
+                    )?;
                     self.record_backend_success(&refreshed);
                     self.inner
                         .stats

--- a/crates/temporalstore-rust/src/client/tests/part3.rs
+++ b/crates/temporalstore-rust/src/client/tests/part3.rs
@@ -605,3 +605,159 @@ fn pipeline_batches_partial_failures_and_timeout_budget_contract() {
     assert!(stale_route_retry.would_retry);
 }
 
+#[test]
+fn a_routed_write_sends_the_fencing_token_when_the_topology_gives_one() {
+    // The token only closes the stale-route window if the routed write actually carries it, so
+    // this asserts the PATH the write took, not just that it succeeded.
+    //
+    // Both halves matter. With a token the write must take the checked path -- the one a node
+    // that no longer holds that version refuses. With no token it must keep the unchecked path,
+    // or every client whose metaserver does not send one would start failing.
+    fn write_once(topology_load_version: u64) -> (String, u64) {
+        let node_addr = free_local_addr();
+        let meta_addr = free_local_addr();
+        let seen: std::sync::Arc<std::sync::Mutex<Option<(String, u64)>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(None));
+
+        let node_server = node_addr.clone();
+        let node_seen = std::sync::Arc::clone(&seen);
+        std::thread::spawn(move || {
+            serve(&node_server, move |request| {
+                match (request.method.as_str(), request.path.as_str()) {
+                    ("POST", "/execute") => {
+                        let _ = parse_json::<ExecuteRequest>(&request.body).unwrap();
+                        *node_seen.lock().expect("seen lock poisoned") =
+                            Some(("/execute".to_string(), 0));
+                        json_response(
+                            200,
+                            &ExecuteResponse {
+                                status: Status::ok(),
+                                response: CommandResponse::Empty,
+                            },
+                        )
+                    }
+                    ("POST", "/execute_checked") => {
+                        let checked =
+                            parse_json::<crate::control::CheckedExecuteRequest>(&request.body)
+                                .unwrap();
+                        *node_seen.lock().expect("seen lock poisoned") =
+                            Some(("/execute_checked".to_string(), checked.load_version));
+                        json_response(
+                            200,
+                            &crate::control::CheckedExecuteResponse {
+                                status: Status::ok(),
+                                response: ExecuteResponse {
+                                    status: Status::ok(),
+                                    response: CommandResponse::Empty,
+                                },
+                            },
+                        )
+                    }
+                    _ => json_response(404, &Status::error("not_found", "not found")),
+                }
+            })
+            .unwrap();
+        });
+        wait_for_http(&node_addr);
+
+        let meta_server = meta_addr.clone();
+        let primary = node_addr.clone();
+        std::thread::spawn(move || {
+            serve(&meta_server, move |request| {
+                match (request.method.as_str(), request.path.as_str()) {
+                    ("POST", "/tables/topology") => json_response(
+                        200,
+                        &TableTopologyResponse {
+                            status: Status::ok(),
+                            table: Some(TableMetaInfo {
+                                table_id: 5,
+                                namespace: "ns".to_string(),
+                                table_name: "fenced".to_string(),
+                                state: crate::meta::MetaEntityState::Normal,
+                                topology_version: 3,
+                                first_shard_id: 1,
+                                shard_count: 1,
+                                replica_count: 1,
+                                partition_version: 0,
+                                serving_options: crate::meta::TableServingOptions::default(),
+                            }),
+                            shards: vec![TableShard {
+                                load_version: topology_load_version,
+                                shard_id: 1,
+                                start_bucket: 0,
+                                end_bucket: u32::MAX as u64,
+                                primary: Some(primary.clone()),
+                                replicas: vec![primary.clone()],
+                                primary_endpoint: None,
+                                replica_endpoints: Vec::new(),
+                            }],
+                            unchanged: false,
+                        },
+                    ),
+                    _ => json_response(404, &Status::error("not_found", "not found")),
+                }
+            })
+            .unwrap();
+        });
+        wait_for_http(&meta_addr);
+
+        let client = TemporalStoreClient::with_options(ClientOptions {
+            meta_addr: Some(meta_addr),
+            meta_sync_interval_ms: 1,
+            ..ClientOptions::default()
+        });
+        let table = client.open_table(
+            "ns",
+            "fenced",
+            TableOptions {
+                first_shard_id: 1,
+                shard_count: 1,
+                ..TableOptions::default()
+            },
+        );
+
+        // Force the topology sync: without a synced table route the client falls back to
+        // resolving the shard on its own, which never carries a token.
+        std::thread::sleep(Duration::from_millis(20));
+        assert_eq!(
+            client.run_due_meta_sync_once(ClientMetaSyncLoopOptions {
+                tick_ms: 1,
+                max_tables_per_tick: 1,
+            }),
+            1,
+            "the table topology should have synced"
+        );
+
+        // Through the TABLE handle, so routing goes via the table topology -- which is where the
+        // token lives. A raw shard-id route resolves through /shards/{id} and never sees one.
+        let response = table
+            .execute(Command::StringSet {
+                key: "k".to_string(),
+                value: b"v".to_vec(),
+            })
+            .expect("the routed write should reach the node");
+        assert!(
+            response.status.ok,
+            "unexpected write failure: {:?}",
+            response.status
+        );
+        let observed = seen
+            .lock()
+            .expect("seen lock poisoned")
+            .clone()
+            .expect("the node saw no write at all");
+        observed
+    }
+
+    assert_eq!(
+        write_once(9),
+        ("/execute_checked".to_string(), 9),
+        "a write with a known token must take the checked path, carrying that exact version"
+    );
+    // CONTROL: no token, so nothing changes for a client whose metaserver does not send one.
+    assert_eq!(
+        write_once(0),
+        ("/execute".to_string(), 0),
+        "a write with no token must keep the unchecked path"
+    );
+}


### PR DESCRIPTION
`#1450` carried the fencing token down to the client's cached route but did not use it. This uses it: a routed write whose route carries a non-zero token goes to `/execute_checked`, which a node that no longer holds that version refuses.

That closes the window `#1450` described — after a shard moves, a client on a stale route writes to the **old** owner, and the old owner accepts it because `/execute` does not check.

## Two conditions, both required

```rust
.get(&shard_id)
.filter(|route| route.primary_addr == server_addr)   // it must be the PRIMARY
.map(|route| route.load_version)                     // and there must be a token
.unwrap_or(0)
```

The token describes the **primary's** placement, so sending it to a replica would fence on a version that replica never claimed to hold — turning every replica-directed write into a mismatch. It is only sent when the write is actually bound for the primary.

A `0` keeps the unchecked path, so this can only ever **add** a check, never remove one. No cached route, a metaserver that sends no token, or a non-primary address all read as 0 and behave exactly as before.

## The retry re-reads the token

The refresh path re-resolves the route and posts again. That second post reads the token again rather than reusing the first, because a refreshed route may name a different primary on a different version — reusing the old token there would fence against the wrong node.

## A rejection is already handled

`retry.rs` classifies `load_version_mismatch` as retryable, and a retry re-resolves the route rather than repeating the write to a node that has been fenced out. The checked path answers with a `CheckedExecuteResponse` whose inner response carries the same status, so unwrapping it keeps the caller's type *and* keeps the rejection visible.

## The test asserts the path, not just success

`a_routed_write_sends_the_fencing_token_when_the_topology_gives_one` stands up a fake node that records which path it was called on, and runs the same write twice:

| topology token | path the node saw | carried |
|---|---|---|
| 9 | `/execute_checked` | 9 |
| 0 (**control**) | `/execute` | — |

The control is the half that protects everyone else: a client whose metaserver sends no token must keep working unchanged.

Verified by mutation — forcing the token lookup to 0 fails it with `left: ("/execute", 0)`, `right: ("/execute_checked", 9)`.

One thing the test itself established: routing through the **table handle** is what carries a token. A raw shard-id route resolves through `/shards/{id}` and never sees one, so the first version of this test was silently exercising the wrong path.

Full suite: **1753 passed, 1 failed** — `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the known baseline failure, unrelated and also failing on `main`.
