### PR TITLE
Measure where the compaction round budget starts to bind

### DIFF
--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -260,9 +260,13 @@ fn what_a_dump_costs_as_the_shard_grows() {
 
 /// What one compaction costs, and for how long it holds the shard.
 ///
-/// `compact_shard_pages` takes the shard write lock and relocates EVERY live page of every model
-/// onto a freshly rolled slab, with no bound on how much that is. A write cannot proceed while
-/// that runs, so its duration IS the stall every reader and writer of the shard sees.
+/// `compact_shard_pages` takes the shard write lock for the whole relocation, so its duration IS
+/// the stall every reader and writer of the shard sees.
+///
+/// It is no longer unbounded: the round relocates at most `COMPACTION_ROUND_BYTES` and resumes
+/// onto the slab it was filling rather than rolling a fresh one. But that budget is 256 MiB and
+/// a store this size has a live set of about two, so the bound does not bind and the cost below
+/// is still the whole shard. `what_the_compaction_budget_buys` above measures where it starts to.
 ///
 /// Measured here, debug build, so a floor rather than a ceiling:
 ///
@@ -273,11 +277,58 @@ fn what_a_dump_costs_as_the_shard_grows() {
 /// Twenty seconds at twenty thousand objects, and the per-ref cost RISES with the shard -- 2.6x
 /// between five and twenty thousand -- so it is worse than linear in the thing it is unbounded in.
 ///
-/// Bounding it is not a one-line change, which is why this records the cost instead of pretending
-/// otherwise: `compact_shard_pages` rolls a fresh slab at the top of every call, so simply
-/// stopping early would leave each round with its own half-filled slab and trade a stall for slab
-/// proliferation. A bounded compaction needs to roll once and keep filling that slab across
-/// rounds, which is campaign state this does not have yet.
+/// This records the cost rather than choosing a smaller budget, because the value is a production
+/// decision and these are debug numbers. The mechanism for a smaller one is already in place --
+/// a round resumes onto the slab it was filling, so stopping early no longer trades a stall for
+/// slab proliferation.
+/// What the compaction ROUND BUDGET actually buys, at one shard size.
+///
+///   cargo test -p temporalstore-rust --lib what_the_compaction_budget_buys -- --ignored --nocapture --test-threads=1
+///
+/// `COMPACTION_ROUND_BYTES` is 256 MiB, chosen so every store the suite builds still compacts in
+/// ONE round. This asks what the first round costs at smaller budgets, because the stall it was
+/// built to bound is only bounded once the budget is smaller than the live set.
+#[test]
+#[ignore]
+fn what_the_compaction_budget_buys() {
+    for budget in [
+        256u64 * 1024 * 1024,
+        16 * 1024 * 1024,
+        4 * 1024 * 1024,
+        1024 * 1024,
+        256 * 1024,
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        for index in 0..20_000usize {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("compact-budget-{index:07}"),
+                    value: vec![b'v'; 96],
+                },
+            });
+        }
+        let started = std::time::Instant::now();
+        let report = engine
+            .compact_shard_pages_with_budget(1, budget)
+            .expect("compaction should run");
+        let elapsed = started.elapsed();
+        eprintln!(
+            "  [budget] {:>9} KiB -> first round {:>9.1} ms, {:>6} page refs moved",
+            budget / 1024,
+            elapsed.as_secs_f64() * 1000.0,
+            report.rewritten_page_refs,
+        );
+    }
+}
+
 #[test]
 #[ignore]
 fn what_a_whole_shard_compaction_costs() {


### PR DESCRIPTION
Compaction holds the **shard write lock** for the whole relocation, so its duration is the stall every reader and writer of that shard sees. It is bounded — `COMPACTION_ROUND_BYTES` — but nothing measured where that bound starts to bind. This measures it.

**Probe only, `#[ignore]`d. No production code changes.**

## The bound does not bind

20,000 records of 96-byte values, debug build so a floor:

| round budget | first round | page refs moved |
|---|---|---|
| **256 MiB (shipped)** | **19,142.7 ms** | 20,000 (all) |
| 16 MiB | 19,050.5 ms | 20,000 (all) |
| 4 MiB | 19,076.5 ms | 20,000 (all) |
| 1 MiB | 8,075.4 ms | 9,709 |
| 256 KiB | 2,016.7 ms | 2,427 |

The live set here is about **2 MiB** (~108 B per page ref), so the shipped budget is roughly 128× larger than the thing it bounds, and the first round still relocates the entire shard. `engine/compaction.rs` is explicit about why the value is what it is: *"Large enough that a store whose live pages fit inside it still compacts in a single round — which is every store the suite builds, so the existing assertions about what one compaction leaves behind are unchanged."* It was sized to preserve test behaviour.

## A byte budget bounds this only indirectly

The stall tracks **ref count**, not bytes — ~830–950 µs per page ref across every row above. A byte budget reaches that only through average page size, so the same constant produces very different stalls for different value sizes. A page-count budget would bound the stall directly.

## Why this does not change the constant

Debug numbers are the wrong basis for a production constant, and `engine/compaction.rs` says plainly that lowering it breaks the suite's single-round assumptions — the same trap `#1439` hit when the dump cap moved. Choosing a value needs a release-build measurement and a decision about stall versus round count. This ships the measurement so that decision has something to stand on.

## Also corrects a stale comment next door

`what_a_whole_shard_compaction_costs` still said compaction relocates every live page *"with no bound on how much that is"*, and that bounding it *"needs campaign state this does not have yet."*

Both are out of date. The budget exists, and so does the campaign state: a round resumes onto the slab it was filling rather than rolling a fresh one, which is exactly what stopping early used to trade for slab proliferation. The comment now says what is actually true — the bound exists and is simply too large to bind at this size.

Full suite: **1753 passed, 1 failed** — `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the known baseline failure, unrelated and also failing on `main`.
