### PR TITLE
Publish a floor on what the bucket index costs in memory

### DIFF
--- a/crates/temporalstore-rust/src/control.rs
+++ b/crates/temporalstore-rust/src/control.rs
@@ -230,8 +230,29 @@ pub struct ShardCanonicalStorageStats {
     pub page_index_entries: u64,
     pub block_index_entries: u64,
     pub object_index_entries: u64,
+    /// The routing RANGE this shard covers -- the hash modulus, `end - start` -- and NOT a count
+    /// of buckets that exist. A default shard covers the whole space, so this reads 4,294,967,295
+    /// on an empty one. Read `bucket_index_resident_bytes_floor` below if you want a number that
+    /// tracks what is actually resident.
     #[serde(rename = "slot_entries")]
     pub bucket_entries: u64,
+    /// A FLOOR on what the bucket index costs in memory: one `BucketNode` per RESIDENT bucket,
+    /// and nothing else.
+    ///
+    /// Published because every other memory number this engine emits reads the CACHE only -- the
+    /// maintenance cycle's pressure gate and the `ShardLoad.memory_bytes` the metaserver balances
+    /// on are both `cache.memory_bytes`. The bucket index is in neither, and it grows one entry
+    /// per stored object and is never evicted, so "zero" is the one answer that is certainly
+    /// wrong.
+    ///
+    /// A FLOOR, not the total: it counts the node structs and not the heap they point at (the
+    /// shared object key, the map nodes). Measured over 96-byte values the true resident cost was
+    /// roughly 3.5x this; `what_a_bucket_costs` prints both. Do not gate on it as though it were
+    /// the whole figure -- it is published to make a growing index visible, not to size it.
+    ///
+    /// O(1): a count the stats path already holds, times a compile-time size.
+    #[serde(default)]
+    pub bucket_index_resident_bytes_floor: u64,
     #[serde(rename = "storage_zone_count")]
     pub storage_band_count: u64,
     #[serde(rename = "active_storage_zones")]

--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -800,6 +800,11 @@ impl TemporalEngine {
                 block_index_entries: page_store.writes,
                 object_index_entries: object_manager.object_count as u64,
                 bucket_entries: object_manager.routing_bucket_count as u64,
+                // `bucket_entries` above is the routing RANGE (the hash modulus), which is
+                // u32::MAX on a default shard and says nothing about how many buckets exist.
+                // The resident count is the map's length.
+                bucket_index_resident_bytes_floor: (state.bucket_index.bucket_map.len() as u64)
+                    .saturating_mul(std::mem::size_of::<super::state::BucketNode>() as u64),
                 storage_band_count: page_store_bands
                     .active_bands
                     .saturating_add(page_store_bands.sealed_bands)

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -5845,6 +5845,66 @@ fn does_writing_scale_with_the_store() {
 /// safe while loading actually rebuilds it. `a_reload_rebuilds_the_lookup_the_index_no_longer_writes`
 /// holds that half; this one holds that the format stays as small as that change made it.
 #[test]
+fn the_stats_report_a_floor_on_what_the_bucket_index_costs() {
+    // Every other memory number this engine emits is the CACHE's. The bucket index grows one
+    // entry per stored object and is never evicted, so a shard can hold gigabytes of it while
+    // every published signal reads near zero. This is not a gate -- it is the number being
+    // visible at all.
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        4 * 1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+
+    // CONTROL: an empty shard has no buckets, so the floor is genuinely zero here -- which is
+    // what makes a non-zero reading below mean something.
+    let empty = engine.get_stats(1).stats.expect("stats for a loaded shard");
+    assert_eq!(empty.storage.bucket_index_resident_bytes_floor, 0);
+    // And NOT from , which is the routing RANGE: it reads u32::MAX here, so a
+    // floor derived from it would report ~927 GB for an empty shard. That is how this was first
+    // written, and this control is what caught it.
+    assert_eq!(empty.storage.bucket_entries, u32::MAX as u64);
+
+    for index in 0..500usize {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("index-cost-{index:05}"),
+                value: vec![b'v'; 32],
+            },
+        });
+    }
+
+    let filled = engine.get_stats(1).stats.expect("stats for a loaded shard");
+    assert!(
+        filled.storage.bucket_entries > 0,
+        "the fixture should have produced buckets"
+    );
+    assert!(
+        filled.storage.bucket_index_resident_bytes_floor > 0,
+        "500 stored objects must show a non-zero index cost"
+    );
+    assert_eq!(
+        filled.storage.bucket_index_resident_bytes_floor
+            % std::mem::size_of::<crate::engine::state::BucketNode>() as u64,
+        0,
+        "the floor is a whole number of nodes"
+    );
+    // And it tracks the index rather than the cache: the cache can be dropped without the index
+    // going anywhere, which is the whole reason this number exists.
+    let before = filled.storage.bucket_index_resident_bytes_floor;
+    let _ = engine.cache().invalidate_shard(1);
+    let after = engine.get_stats(1).stats.expect("stats for a loaded shard");
+    assert_eq!(
+        after.storage.bucket_index_resident_bytes_floor, before,
+        "dropping the cache must not change what the INDEX costs"
+    );
+}
+
+#[test]
 fn the_index_wire_keys_are_what_they_were() {
     let dir = tempfile::tempdir().unwrap();
     let engine = TemporalEngine::with_local_dirs(


### PR DESCRIPTION
Every memory number this engine publishes is the **cache's**. The maintenance cycle's pressure gate and the `ShardLoad.memory_bytes` the metaserver balances placement on are both `cache.memory_bytes`:

```rust
memory_bytes: stats.cache.memory_bytes as u64,
```

The bucket index is in neither. It grows one entry per stored object, is never evicted, and measures ~760 B of live heap per key — so a shard holding millions of keys can carry gigabytes of index while every published signal reads near zero. "Zero" is the one answer that is certainly wrong.

## What this adds

`ShardCanonicalStorageStats.bucket_index_resident_bytes_floor` — `bucket_map.len() × size_of::<BucketNode>()`. O(1): a length and a compile-time size.

**Visibility only.** It is not wired into any gate, and `ShardLoad.memory_bytes` is unchanged — the metaserver balances on that, so redefining what it counts would change placement decisions across the cluster. Making the number visible and acting on it are separate changes, and this is the first.

It is honestly a **floor**, and the doc says so: it counts the node structs, not the heap they point at (the shared object key, the map nodes). Measured over 96-byte values the true resident cost is roughly 3.5× this. A floor from `size_of` is stable and defensible; a multiplier taken from one fixture's shape would not be.

## The control caught a real error

The first version derived the floor from `bucket_entries`, which is already published and looked like a bucket count. On an empty shard it returned **4,294,967,295** — because `routing_bucket_count(start, end)` is the routing **range** (the hash modulus, `end - start`), not a count of anything resident. A default shard covers the whole space, so the floor would have reported **~927 GB for an empty shard**.

The only reason that did not ship is the assertion that an empty shard reads zero. That control stays in the test, with a comment naming what it caught.

`bucket_entries` now documents the trap, since the next reader would have made the same assumption:

```rust
/// The routing RANGE this shard covers — the hash modulus, `end - start` — and NOT a count
/// of buckets that exist. A default shard covers the whole space, so this reads 4,294,967,295
/// on an empty one.
```

## The test

`the_stats_report_a_floor_on_what_the_bucket_index_costs` pins three things:

- an empty shard reads **0** (the control), while `bucket_entries` reads `u32::MAX` beside it
- 500 stored objects read non-zero, and a whole number of nodes
- **invalidating the cache does not change it** — which is the whole point: this number tracks the index, not the cache

Mutation-verified: forcing the computation to 0 fails it with *"500 stored objects must show a non-zero index cost."*

Full suite: **1754 passed, 1 failed** — `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the known baseline failure, unrelated and also failing on `main`.
