### PR TITLE
The slot index metric reported the routing range, not a count

### DIFF
--- a/crates/temporalstore-rust/src/control.rs
+++ b/crates/temporalstore-rust/src/control.rs
@@ -253,6 +253,13 @@ pub struct ShardCanonicalStorageStats {
     /// O(1): a count the stats path already holds, times a compile-time size.
     #[serde(default)]
     pub bucket_index_resident_bytes_floor: u64,
+    /// How many buckets are actually resident -- `bucket_map.len()`.
+    ///
+    /// Distinct from `bucket_entries` above, which is the routing RANGE. The metric
+    /// `slot_index_entry_count` was published from that range and therefore read
+    /// 4,294,967,295 per shard no matter how large the index really was.
+    #[serde(default)]
+    pub bucket_index_resident_entries: u64,
     #[serde(rename = "storage_zone_count")]
     pub storage_band_count: u64,
     #[serde(rename = "active_storage_zones")]

--- a/crates/temporalstore-rust/src/data_node.rs
+++ b/crates/temporalstore-rust/src/data_node.rs
@@ -444,7 +444,11 @@ fn apply_shard_storage_metrics(
         let page_entries = storage.page_index_entries.max(shard.total_records as u64);
         let block_entries = storage.block_index_entries.max(page_entries);
         let object_entries = storage.object_index_entries.max(shard.total_records as u64);
-        let bucket_entries = storage.bucket_entries.max(shard.dirty_bucket_count);
+        // NOT `storage.bucket_entries`: that is the routing RANGE, so this metric reported
+        // u32::MAX per shard -- summed across shards -- regardless of the real index size.
+        let bucket_entries = storage
+            .bucket_index_resident_entries
+            .max(shard.dirty_bucket_count);
         add(metrics, "object_index_entry_count", object_entries);
         add(metrics, "slot_index_entry_count", bucket_entries);
         add(metrics, "slot_object_ref_count", object_entries);

--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -3223,4 +3223,33 @@ fn wait_until(timeout: Duration, mut predicate: impl FnMut() -> bool) {
     );
 }
 
+#[test]
+fn the_slot_index_metric_counts_resident_buckets_not_the_routing_range() {
+    // `slot_index_entry_count` was built from `storage.bucket_entries`, which is the routing
+    // RANGE. On a default shard that is u32::MAX, and `max(u32::MAX, anything)` is u32::MAX, so
+    // the metric exported 4,294,967,295 per shard whatever the index held -- and these are SUMMED
+    // across shards. Nothing asserted it, which is why it stayed that way.
+    let shard = crate::meta::ServerShardServingState {
+        shard_id: 1,
+        dirty_bucket_count: 3,
+        storage: crate::control::ShardCanonicalStorageStats {
+            // the routing range a default shard reports
+            bucket_entries: u32::MAX as u64,
+            bucket_index_resident_entries: 42,
+            ..crate::control::ShardCanonicalStorageStats::default()
+        },
+        ..crate::meta::ServerShardServingState::default()
+    };
 
+    let mut metrics = std::collections::BTreeMap::new();
+    super::super::apply_shard_storage_metrics(&mut metrics, std::slice::from_ref(&shard));
+
+    assert_eq!(
+        metrics.get("slot_index_entry_count").copied(),
+        Some(42),
+        "the metric must report resident buckets"
+    );
+    // The control: the field it used to read is still u32::MAX right here, so a regression to it
+    // cannot pass by the numbers happening to agree.
+    assert_eq!(shard.storage.bucket_entries, u32::MAX as u64);
+}

--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -805,6 +805,7 @@ impl TemporalEngine {
                 // The resident count is the map's length.
                 bucket_index_resident_bytes_floor: (state.bucket_index.bucket_map.len() as u64)
                     .saturating_mul(std::mem::size_of::<super::state::BucketNode>() as u64),
+                bucket_index_resident_entries: state.bucket_index.bucket_map.len() as u64,
                 storage_band_count: page_store_bands
                     .active_bands
                     .saturating_add(page_store_bands.sealed_bands)

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -5845,6 +5845,51 @@ fn does_writing_scale_with_the_store() {
 /// safe while loading actually rebuilds it. `a_reload_rebuilds_the_lookup_the_index_no_longer_writes`
 /// holds that half; this one holds that the format stays as small as that change made it.
 #[test]
+fn the_resident_bucket_count_is_not_the_routing_range() {
+    // `slot_index_entry_count` was published from `bucket_entries`, which is the routing RANGE --
+    // u32::MAX on a default shard -- so the metric read 4,294,967,295 per shard whatever the
+    // index actually held, and the per-shard values are SUMMED. A count that cannot move is not
+    // a measurement.
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        4 * 1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+
+    let empty = engine.get_stats(1).stats.expect("stats for a loaded shard");
+    assert_eq!(empty.storage.bucket_index_resident_entries, 0);
+    // The control: the old source reads u32::MAX on this very same empty shard.
+    assert_eq!(empty.storage.bucket_entries, u32::MAX as u64);
+
+    for index in 0..300usize {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("resident-{index:05}"),
+                value: vec![b'v'; 16],
+            },
+        });
+    }
+
+    let filled = engine.get_stats(1).stats.expect("stats for a loaded shard");
+    assert!(
+        filled.storage.bucket_index_resident_entries > 0
+            && filled.storage.bucket_index_resident_entries <= 300,
+        "300 objects must give a resident count in range, got {}",
+        filled.storage.bucket_index_resident_entries
+    );
+    // And the floor stays consistent with it -- one node per resident bucket.
+    assert_eq!(
+        filled.storage.bucket_index_resident_bytes_floor,
+        filled.storage.bucket_index_resident_entries
+            * std::mem::size_of::<crate::engine::state::BucketNode>() as u64
+    );
+}
+
+#[test]
 fn the_stats_report_a_floor_on_what_the_bucket_index_costs() {
     // Every other memory number this engine emits is the CACHE's. The bucket index grows one
     // entry per stored object and is never evicted, so a shard can hold gigabytes of it while


### PR DESCRIPTION
`slot_index_entry_count` is exported for every shard and has never reported anything real:

```rust
let bucket_entries = storage.bucket_entries.max(shard.dirty_bucket_count);
add(metrics, "slot_index_entry_count", bucket_entries);
```

`storage.bucket_entries` is the routing **range** — `routing_bucket_count(start, end)`, the hash modulus — not a count of buckets. A shard covering the default range reports `u32::MAX`, and `max(u32::MAX, anything)` is `u32::MAX`. So the metric emitted **4,294,967,295 per shard** whatever the index actually held, and `add` sums across shards, so a node with 8 shards exported ~34 billion.

The `.max(shard.dirty_bucket_count)` is the tell: a dirty-bucket floor only makes sense if the first term were a count.

## The fix

`ShardCanonicalStorageStats` gains `bucket_index_resident_entries` — `bucket_map.len()`, what is actually resident — and the metric reads that. The byte floor added in `#1453` is now derived from the same count, so the two cannot drift.

`bucket_entries` is left alone: it is a real number that some caller may depend on, and it is documented as the routing range rather than silently repurposed.

## Nothing was guarding it

`slot_index_entry_count` had **no test at all** — grepping the suite for it returns nothing, which is how a constant-valued metric survived.

Two guards now:

- `the_slot_index_metric_counts_resident_buckets_not_the_routing_range` calls the metric builder with a shard whose routing range is `u32::MAX` and whose resident count is 42, and asserts the metric reads **42**. It then re-asserts that `bucket_entries` is still `u32::MAX` in that same fixture, so a regression cannot pass by the two numbers happening to agree.
- `the_resident_bucket_count_is_not_the_routing_range` pins the field itself: 0 on an empty shard, where `bucket_entries` reads `u32::MAX` beside it.

Verified by mutation — pointing the metric back at `bucket_entries` fails with:

```
assertion `left == right` failed: the metric must report resident buckets
  left: Some(4294967295)
 right: Some(42)
```

which is exactly the number production has been exporting.

## How it was found

`#1453` had to learn what `bucket_entries` actually was, after an earlier version of that change derived an index-memory floor from it and would have published ~927 GB for an empty shard. The same misreading was already live here, in an exported metric, with nothing asserting it.

Full suite: **1756 passed, 1 failed** — `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the known baseline failure, unrelated and also failing on `main`.
