### PR TITLE
The block index entry count could only ever go up

### DIFF
--- a/crates/temporalstore-rust/src/control.rs
+++ b/crates/temporalstore-rust/src/control.rs
@@ -228,6 +228,9 @@ pub struct ShardStatInfo {
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ShardCanonicalStorageStats {
     pub page_index_entries: u64,
+    /// The same live count as `page_index_entries` -- block and page are one concept under two
+    /// names, and both are published while the rename is in flight. It is NOT a write counter;
+    /// `block_writes` and `page_writes` are.
     pub block_index_entries: u64,
     pub object_index_entries: u64,
     /// The routing RANGE this shard covers -- the hash modulus, `end - start` -- and NOT a count

--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -797,7 +797,11 @@ impl TemporalEngine {
             };
             let storage = crate::control::ShardCanonicalStorageStats {
                 page_index_entries: object_manager.page_ref_count as u64,
-                block_index_entries: page_store.writes,
+                // Live refs, NOT `page_store.writes`: that counter only ever increases, so
+                // publishing it as an entry count meant the number could never fall after a GC
+                // or a compaction reclaimed anything. `block_*` mirrors `page_*` here the same
+                // way `block_reads` mirrors `page_reads`.
+                block_index_entries: object_manager.page_ref_count as u64,
                 object_index_entries: object_manager.object_count as u64,
                 bucket_entries: object_manager.routing_bucket_count as u64,
                 // `bucket_entries` above is the routing RANGE (the hash modulus), which is

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -5845,6 +5845,58 @@ fn does_writing_scale_with_the_store() {
 /// safe while loading actually rebuilds it. `a_reload_rebuilds_the_lookup_the_index_no_longer_writes`
 /// holds that half; this one holds that the format stays as small as that change made it.
 #[test]
+fn the_block_index_entry_count_falls_when_entries_go() {
+    // `block_index_entries` was fed `page_store.writes`, a counter that only ever increases, so
+    // the published entry count could never fall -- after a delete it still reported every write
+    // the shard had ever taken. An "entry count" that cannot go down is not a count.
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        4 * 1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+
+    for index in 0..40usize {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("block-entry-{index:04}"),
+                value: vec![b'v'; 16],
+            },
+        });
+    }
+    let filled = engine.get_stats(1).stats.expect("stats for a loaded shard");
+    let entries_before = filled.storage.block_index_entries;
+    let writes_before = filled.storage.block_writes;
+    assert!(entries_before > 0, "40 writes should produce entries");
+
+    for index in 0..40usize {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringDelete {
+                key: format!("block-entry-{index:04}"),
+            },
+        });
+    }
+    let emptied = engine.get_stats(1).stats.expect("stats for a loaded shard");
+
+    assert!(
+        emptied.storage.block_index_entries < entries_before,
+        "deleting every object must lower the entry count: {} -> {}",
+        entries_before,
+        emptied.storage.block_index_entries
+    );
+    // The control: writes DID keep climbing over the same span, which is what the entry count
+    // used to be reporting. If the two moved together this test would prove nothing.
+    assert!(
+        emptied.storage.block_writes >= writes_before,
+        "the write counter is monotonic and is a separate number"
+    );
+}
+
+#[test]
 fn the_resident_bucket_count_is_not_the_routing_range() {
     // `slot_index_entry_count` was published from `bucket_entries`, which is the routing RANGE --
     // u32::MAX on a default shard -- so the metric read 4,294,967,295 per shard whatever the


### PR DESCRIPTION
`block_index_entries` was fed `page_store.writes`:

```rust
page_index_entries: object_manager.page_ref_count as u64,
block_index_entries: page_store.writes,
```

That counter is incremented on append (`inner.stats.writes += 1`) and never decremented. Published as an entry count it **could not fall** — after a GC or a compaction reclaimed pages, the exported `block_index_entry_count` still reported every write the shard had ever taken.

## The fix

`object_manager.page_ref_count` — live refs — mirroring `page_index_entries`, the same way `block_reads` already mirrors `page_reads`. Block and page are one concept under two names while the rename is in flight, and both are published.

Nothing needed the old value: **`block_writes` and `page_writes` already carry the write counters.** That is what makes this a misfeed rather than a judgment call — the write count was never lost, it was just also being reported under a name that promised something else.

## The guard, and its control

`the_block_index_entry_count_falls_when_entries_go` writes 40 objects, deletes all 40, and asserts the count drops. It also asserts `block_writes` kept climbing over the same span — so the two numbers moving together cannot make it pass vacuously.

Watched fail against the old source:

```
deleting every object must lower the entry count: 40 -> 40
```

## Third of a kind

This is the third number in `ShardCanonicalStorageStats` whose name promised a population while its source was something else:

| field | was fed | reported |
|---|---|---|
| `bucket_entries` → `slot_index_entry_count` (`#1454`) | the routing range | 4,294,967,295 per shard, constant |
| `block_index_entries` (this) | a monotonic write counter | a count that could never fall |

Both survived because nothing asserted them. Checking what each field in a stats struct is actually *fed from* turns out to be a cheap and high-yield sweep.

Full suite: **1757 passed, 1 failed** — `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the known baseline failure, unrelated and also failing on `main`.
