### PR TITLE
Measure what each maintenance stage costs, by ablation

### DIFF
--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -3253,3 +3253,77 @@ fn the_slot_index_metric_counts_resident_buckets_not_the_routing_range() {
     // cannot pass by the numbers happening to agree.
     assert_eq!(shard.storage.bucket_entries, u32::MAX as u64);
 }
+
+/// What each maintenance stage costs on a realistic shard, by ablation.
+///
+///   cargo test --release -p temporalstore-rust --lib what_each_maintenance_stage_costs -- --ignored --nocapture --test-threads=1
+///
+/// The cycle is timed with everything on, then once per stage with that stage off. The difference
+/// is that stage's cost. Ablation rather than instrumentation, so no stage has to be edited to be
+/// measured, and a stage that declines for want of pressure shows up as ~0 rather than as absent.
+///
+/// Compaction was already measured directly at seconds per round
+/// (`what_a_whole_shard_compaction_costs`); this is the rest of them, which had no number at all.
+#[test]
+#[ignore]
+fn what_each_maintenance_stage_costs() {
+    fn build(objects: usize) -> (tempfile::TempDir, DataNodeRuntime) {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            16 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        for index in 0..objects {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("stage-cost-{index:06}"),
+                    value: vec![b'v'; 96],
+                },
+            });
+        }
+        let runtime = DataNodeRuntime::new_without_workers_with_options(
+            engine,
+            DataNodeRuntimeOptions {
+                worker_threads: 0,
+                max_queue_depth: 4,
+                max_background_queue_depth: 2,
+            },
+        );
+        (dir, runtime)
+    }
+
+    fn time_once(objects: usize, options: StorageManagerOptions) -> f64 {
+        let (_dir, runtime) = build(objects);
+        let started = std::time::Instant::now();
+        let report = runtime.run_storage_manager_once(1, options);
+        let elapsed = started.elapsed().as_secs_f64() * 1000.0;
+        let _ = report;
+        elapsed
+    }
+
+    for objects in [5_000usize, 20_000] {
+        let all_on = time_once(objects, StorageManagerOptions::default());
+        eprintln!("  [stages] {objects:>6} objects, everything on -> {all_on:>9.1} ms");
+
+        for (name, off) in [
+            ("prepare", StorageManagerOptions { enable_prepare: false, ..Default::default() }),
+            ("reclaim_wal", StorageManagerOptions { enable_wal_reclaim: false, ..Default::default() }),
+            ("reclaim_memory", StorageManagerOptions { enable_memory_reclaim: false, ..Default::default() }),
+            ("expire", StorageManagerOptions { enable_expire: false, ..Default::default() }),
+            ("reclaim_page", StorageManagerOptions { enable_page_gc: false, ..Default::default() }),
+            ("compact_pages", StorageManagerOptions { enable_page_compaction: false, ..Default::default() }),
+            ("reclaim_index", StorageManagerOptions { enable_index_gc: false, ..Default::default() }),
+            ("reap_metrics", StorageManagerOptions { enable_metrics_reap: false, ..Default::default() }),
+        ] {
+            let without = time_once(objects, off);
+            eprintln!(
+                "  [stages] {objects:>6}   without {name:<15} {without:>9.1} ms   (stage costs {:>9.1} ms)",
+                all_on - without,
+            );
+        }
+    }
+}


### PR DESCRIPTION
Compaction had a number (`what_a_whole_shard_compaction_costs`). The other seven maintenance stages had none, so there was no way to say which part of a cycle is expensive.

This measures each one by **ablation**: run `run_storage_manager_once` with everything on, then once per stage with that stage off, and take the difference. No stage has to be instrumented to be measured, and a stage that declines for want of pressure shows up as ~0 rather than as absent — which turns out to matter.

**Probe only, `#[ignore]`d. No production code changes.**

## Release build, 96-byte values

| stage | 20,000 objects | 5,000 |
|---|---|---|
| **reclaim_index** | **750.2 ms** | 178.8 ms |
| **reclaim_wal** | **682.7 ms** | 145.1 ms |
| expire | 201.5 ms | 45.8 ms |
| reclaim_page | 94.0 ms | 58.3 ms |
| reclaim_memory | 75.3 ms | 34.5 ms |
| compact_pages | 62.1 ms | 58.4 ms |
| prepare | 5.2 ms | 40.0 ms |
| reap_metrics | 8.4 ms | 58.3 ms |
| **whole cycle** | **1,336.5 ms** | 296.8 ms |

The two stages nobody had measured are the two that dominate. `reclaim_index` is 56% of the cycle at 20k and grows ~4.2× between 5k and 20k against 4× the objects, so it is roughly linear in store size.

That also sharpens what was already known: the index-GC **gate** was measured at 39 ms over 32k records. The gate is cheap and the stage is not — the cost is in the work, not in deciding whether to do it.

## Two caveats, both load-bearing

**Ablation is not additive.** The parts sum to more than the whole, because removing one stage changes what the others find left to do. Read these as shares, not a partition.

**`compact_pages` is not 62 ms in general.** This fixture writes and never deletes, so there are no reclaimable bytes and `stale_page_pressure` never fires — the stage declines. Measured directly, a compaction round is **3.1 s in release** at this size. The gate fires once any garbage exists, so the cycle total above is a **floor**: it is what a store that has never deleted anything pays.

That second point is the argument for ablation over instrumentation. An instrumented stage that never ran would have reported nothing at all; here it reported ~0, which is what exposed the gate not firing on this fixture.

`prepare` and `reap_metrics` costing more at 5k than at 20k is noise at that scale, not an inversion — nothing should be read into it.

Full suite: **1757 passed, 1 failed** — `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the known baseline failure, unrelated and also failing on `main`.
