### PR TITLE
The index-GC stage is not mostly index GC

### DIFF
--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -5896,6 +5896,86 @@ fn the_block_index_entry_count_falls_when_entries_go() {
     );
 }
 
+/// Where the reclaim_index stage's time actually goes.
+///
+///   cargo test --release -p temporalstore-rust --lib where_the_index_reclaim_time_goes -- --ignored --nocapture --test-threads=1
+///
+/// The stage is the most expensive one in a maintenance cycle -- 750 ms of a 1,336 ms cycle at
+/// 20k objects, and roughly linear in store size. It turns on three things at once
+/// (`purge_delayed_destroy`, `prune_bucket_dump_manifests`, `roll_forward_bucket_dump_installs`),
+/// and nothing said which of them costs. Same ablation as the stage-level probe, one level down:
+/// all three on, then each turned off in turn.
+#[test]
+#[ignore]
+fn where_the_index_reclaim_time_goes() {
+    fn request(
+        purge: bool,
+        prune: bool,
+        roll_forward: bool,
+    ) -> crate::engine::reports::StorageLifecycleRequest {
+        crate::engine::reports::StorageLifecycleRequest {
+            shard_id: 1,
+            selected_dump_buckets: Vec::new(),
+            max_dump_buckets_per_round: 0,
+            min_undumped_wal_records: 0,
+            min_undumped_wal_bytes: 0,
+            purge_delayed_destroy: purge,
+            prune_bucket_dump_manifests: prune,
+            roll_forward_bucket_dump_installs: roll_forward,
+            follower_replay_cursors: Vec::new(),
+            page_gc_shared_store_cursors: Vec::new(),
+            page_gc_raft_snapshot_refs: Vec::new(),
+            page_gc_checkpoint_floor_slab_id: None,
+            page_gc_raft_install_floor_slab_id: None,
+            page_gc_delayed_destroy_grace_ms: 0,
+            invalidate_cache: false,
+            warm_cache: false,
+        }
+    }
+
+    fn time_once(objects: usize, req: crate::engine::reports::StorageLifecycleRequest) -> f64 {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            16 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        for index in 0..objects {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("index-gc-{index:06}"),
+                    value: vec![b'v'; 96],
+                },
+            });
+        }
+        let started = std::time::Instant::now();
+        let response = engine.apply_storage_lifecycle(req);
+        let elapsed = started.elapsed().as_secs_f64() * 1000.0;
+        let _ = response;
+        elapsed
+    }
+
+    for objects in [5_000usize, 20_000] {
+        let all_on = time_once(objects, request(true, true, true));
+        eprintln!("  [index_gc] {objects:>6} objects, all three on -> {all_on:>9.1} ms");
+        for (name, req) in [
+            ("purge_delayed_destroy", request(false, true, true)),
+            ("prune_manifests", request(true, false, true)),
+            ("roll_forward_installs", request(true, true, false)),
+            ("ALL THREE OFF", request(false, false, false)),
+        ] {
+            let without = time_once(objects, req);
+            eprintln!(
+                "  [index_gc] {objects:>6}   without {name:<22} {without:>9.1} ms   (costs {:>8.1} ms)",
+                all_on - without,
+            );
+        }
+    }
+}
+
 #[test]
 fn the_resident_bucket_count_is_not_the_routing_range() {
     // `slot_index_entry_count` was published from `bucket_entries`, which is the routing RANGE --


### PR DESCRIPTION
`#1456` measured `reclaim_index` as the most expensive stage of a maintenance cycle — 750 ms of 1,336 ms at 20k objects, roughly linear in store size. It turns on three things at once, and nothing said which of them costs.

Same ablation, one level down: all three on, then each off in turn, then all three off.

**Probe only, `#[ignore]`d. No production code changes.**

## The stage is not mostly index GC

| 20,000 objects | ms |
|---|---|
| all three flags on | 694.3 |
| **all three OFF** | **634.9** |
| so the three features together | **59.4 (9%)** |

At 5,000: 169.2 on, 129.1 off → 40.1 (24%). The fixed part grows faster than the features do.

**Turning off everything the stage exists to do saves 9%.** The other 91% is `apply_storage_lifecycle`'s unconditional work — the lifecycle plan and the boundary/recovery report — which runs before any of these flags is read.

## The per-flag numbers are noise, and the run proves it

`purge_delayed_destroy` measured **−28.8 ms**: turning it off made the call *slower*. That is ~30 ms of run-to-run variance on this box, which swamps the individual attributions (19, 18, 71, 46 ms). Only the all-on vs all-off difference clears the noise floor.

A negative ablation result is the cheapest available proof that per-item attribution is not resolvable at this scale, so the per-flag figures should not be quoted — the probe prints them, and the doc says why they are not the answer.

## Why this matters beyond one stage

`apply_storage_lifecycle` is called by **three** stages of a cycle — `runtime_storage.rs:186` (reclaim_wal), `:289` (reclaim_memory), `:528` (reclaim_index) — and reclaim_wal and reclaim_index are the two most expensive stages measured.

One caveat stated so nobody does the arithmetic wrong: 3 × 635 ms would exceed the whole 1,336 ms cycle, so the in-cycle calls must be cheaper than this cold-engine standalone figure. The defensible claim is that the two costliest stages are the two that call this function and that its unconditional work dominates each — **not** that the cycle pays 635 ms three times.

So the lever is what that function does before it looks at a flag. `#1428` already cut one such cost (the plan read the whole store to keep one field, 978 → 83 ms) and left "the boundary report scans twice a round" open. That open item is now the prime suspect.

Full suite: **1757 passed, 1 failed** — `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the known baseline failure, unrelated and also failing on `main`.
