### PR TITLE
The third wait hidden in an assert

### DIFF
--- a/tools/rebalance_add_drop_validation.py
+++ b/tools/rebalance_add_drop_validation.py
@@ -126,7 +126,12 @@ def main():
     start("dnb", "matrixark_rust_datanode", DNB,
           dn_env(2, f"{BASE}/dnb/pages", f"{BASE}/dnb/idx", f"{BASE}/dnb/cache",
                  {"TS_SERVER_BIND_ADDR": DNB, "TS_SERVER_ADVERTISE_ADDR": DNB}))
-    assert wait_port(DNA) and wait_port(DNB), "datanodes did not start"
+    # Both waits hoisted: `python -O` drops the assert and every call inside it. Note the
+    # `and` -- the first pass of this fix looked for an assert whose test IS a call and
+    # walked straight past this one.
+    dna_ready = wait_port(DNA)
+    dnb_ready = wait_port(DNB)
+    assert dna_ready and dnb_ready, "datanodes did not start"
     time.sleep(2)
 
     print("== write 3 keys per shard ==")


### PR DESCRIPTION
```python
assert wait_port(DNA) and wait_port(DNB), "datanodes did not start"
```

`python -O` drops an assert statement and every call inside it, so under optimisation neither
datanode is waited for and the run continues against processes that have not finished starting.

The commit that just merged (#1457) hoisted two waits out of asserts in this same file, for exactly
this reason, and left this one.

## Why it was missed

My check asked whether an assert's test **is** a call. This one's test is an `and` whose operands
are calls, so it did not match — and I reported the dimension as finished having fixed two of the
three instances in one file.

The check now asks whether the test **contains** a call anywhere, which is the question that was
meant. It ignores pure inspection — `isinstance`, `len`, `hasattr` — where dropping the call under
`-O` loses a check but performs no action.

Across every tracked non-test file there are 7 asserts. After this, none of them calls anything
impure.

Both waits are hoisted; the assertion stays an assertion, so the message and exception type are
unchanged.
