### PR TITLE
A warm engine pays a fifth of what a cold one does

### DIFF
--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -5896,6 +5896,154 @@ fn the_block_index_entry_count_falls_when_entries_go() {
     );
 }
 
+/// Is the lifecycle PLAN the fixed cost, or is it the rest of the apply?
+///
+///   cargo test --release -p temporalstore-rust --lib what_the_lifecycle_plan_costs_alone -- --ignored --nocapture --test-threads=1
+///
+/// `apply_storage_lifecycle` costs ~635 ms at 20k objects with every optional flag off, and the
+/// first thing it does unconditionally is `storage_lifecycle_plan`. The plan was already the
+/// subject of one large cut. This times the plan on its own against the whole call, so the
+/// remaining fixed cost is attributed to one side or the other rather than guessed at.
+#[test]
+#[ignore]
+fn what_the_lifecycle_plan_costs_alone() {
+    fn bare_request(shard_id: ShardId) -> crate::engine::reports::StorageLifecycleRequest {
+        crate::engine::reports::StorageLifecycleRequest {
+            shard_id,
+            selected_dump_buckets: Vec::new(),
+            max_dump_buckets_per_round: 0,
+            min_undumped_wal_records: 0,
+            min_undumped_wal_bytes: 0,
+            purge_delayed_destroy: false,
+            prune_bucket_dump_manifests: false,
+            roll_forward_bucket_dump_installs: false,
+            follower_replay_cursors: Vec::new(),
+            page_gc_shared_store_cursors: Vec::new(),
+            page_gc_raft_snapshot_refs: Vec::new(),
+            page_gc_checkpoint_floor_slab_id: None,
+            page_gc_raft_install_floor_slab_id: None,
+            page_gc_delayed_destroy_grace_ms: 0,
+            invalidate_cache: false,
+            warm_cache: false,
+        }
+    }
+
+    fn build(objects: usize) -> (tempfile::TempDir, TemporalEngine) {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            16 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        for index in 0..objects {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("plan-cost-{index:06}"),
+                    value: vec![b'v'; 96],
+                },
+            });
+        }
+        (dir, engine)
+    }
+
+    for objects in [5_000usize, 20_000] {
+        let (_d1, engine) = build(objects);
+        let started = std::time::Instant::now();
+        let plan = engine.storage_lifecycle_plan(bare_request(1));
+        let plan_ms = started.elapsed().as_secs_f64() * 1000.0;
+        let _ = plan;
+
+        let (_d2, engine2) = build(objects);
+        let started = std::time::Instant::now();
+        let response = engine2.apply_storage_lifecycle(bare_request(1));
+        let apply_ms = started.elapsed().as_secs_f64() * 1000.0;
+        let _ = response;
+
+        // The SAME engine again. A cycle calls this three times, so if the second call is cheap
+        // the cost is first-call initialisation and not per-call work -- which is also the only
+        // way three calls fit inside a cycle shorter than three times this number.
+        let started = std::time::Instant::now();
+        let second = engine2.apply_storage_lifecycle(bare_request(1));
+        let second_ms = started.elapsed().as_secs_f64() * 1000.0;
+        let _ = second;
+        let started = std::time::Instant::now();
+        let third = engine2.apply_storage_lifecycle(bare_request(1));
+        let third_ms = started.elapsed().as_secs_f64() * 1000.0;
+        let _ = third;
+        eprintln!(
+            "  [plan] {objects:>6}   apply again on the SAME engine: 2nd {second_ms:>8.1} ms | 3rd {third_ms:>8.1} ms",
+        );
+
+        eprintln!(
+            "  [plan] {objects:>6} objects: plan alone {plan_ms:>8.1} ms | whole apply {apply_ms:>8.1} ms | plan is {:>5.1}% of it",
+            if apply_ms > 0.0 { plan_ms / apply_ms * 100.0 } else { 0.0 },
+        );
+
+        // The three calls the apply makes UNCONDITIONALLY after the plan. Note the manifest
+        // prune PLAN is computed even when pruning is switched off -- only the apply of it is
+        // gated -- so it is paid on every round regardless.
+        let (_d3, engine3) = build(objects);
+        let started = std::time::Instant::now();
+        let lifecycle = engine3.storage_object_lifecycle_snapshot_for_test(1);
+        let lifecycle_ms = started.elapsed().as_secs_f64() * 1000.0;
+        let _ = lifecycle;
+
+        let started = std::time::Instant::now();
+        let roll_forward = engine3.bucket_dump_install_roll_forward_reports(1);
+        let roll_forward_ms = started.elapsed().as_secs_f64() * 1000.0;
+        let _ = roll_forward;
+
+        let started = std::time::Instant::now();
+        let prune_plan =
+            engine3.bucket_dump_manifest_prune_plan_with_follower_cursors(1, Vec::new());
+        let prune_plan_ms = started.elapsed().as_secs_f64() * 1000.0;
+        let _ = prune_plan;
+
+        eprintln!(
+            "  [plan] {objects:>6}   of which: object_lifecycle_snapshot {lifecycle_ms:>8.1} ms | roll_forward_reports {roll_forward_ms:>7.1} ms | manifest_prune_PLAN {prune_plan_ms:>7.1} ms",
+        );
+
+        // The four sample builders the apply runs unconditionally at the end, purely to fill in
+        // REPORT fields. Timed under the same read lock the apply takes.
+        {
+            let shards = engine3.shards.read().expect("engine lock poisoned");
+            let shard = shards.get(&1).expect("shard 1 is loaded");
+
+            let started = std::time::Instant::now();
+            let index_snapshot = crate::engine::storage_bucket_internals::
+                storage_index_snapshot_with_samples(1, shard, Default::default());
+            let index_ms = started.elapsed().as_secs_f64() * 1000.0;
+            let _ = index_snapshot;
+
+            let started = std::time::Instant::now();
+            let watermark = crate::engine::storage_bucket_internals::
+                storage_watermark_snapshot_with_samples(1, shard, Default::default());
+            let watermark_ms = started.elapsed().as_secs_f64() * 1000.0;
+            let _ = watermark;
+
+            let started = std::time::Instant::now();
+            let gc = crate::engine::storage_bucket_internals::
+                storage_gc_snapshot_with_samples(1, shard, Default::default());
+            let gc_ms = started.elapsed().as_secs_f64() * 1000.0;
+            let _ = gc;
+
+            let started = std::time::Instant::now();
+            let topology = crate::engine::storage_bucket_internals::
+                storage_topology_snapshot_with_samples(1, shard, Default::default());
+            let topology_ms = started.elapsed().as_secs_f64() * 1000.0;
+            let _ = topology;
+
+            eprintln!(
+                "  [plan] {objects:>6}   SAMPLE BUILDERS: index {index_ms:>7.1} | watermark {watermark_ms:>7.1} | gc {gc_ms:>7.1} | topology {topology_ms:>7.1}  (sum {:>7.1} ms)",
+                index_ms + watermark_ms + gc_ms + topology_ms,
+            );
+        }
+    }
+}
+
 /// Where the reclaim_index stage's time actually goes.
 ///
 ///   cargo test --release -p temporalstore-rust --lib where_the_index_reclaim_time_goes -- --ignored --nocapture --test-threads=1


### PR DESCRIPTION
**This corrects the magnitudes published in `#1456` and `#1458`.** Both built a fresh engine for every measurement, so every stage cost they report includes first-call initialisation. A production server holds a shard for hours; startup is not what a 30-second maintenance tick pays.

**Probe only, `#[ignore]`d. No production code changes.**

## The discriminator

`apply_storage_lifecycle`, called three times on the **same** engine, 20,000 objects, release:

| call | ms |
|---|---|
| 1st (fresh engine) | 746.0 |
| **2nd** | **190.8** |
| 3rd | 185.9 |

At 5,000: 159.9 → 35.0 → 35.1.

So **~555 ms at 20k is one-time**, and the steady-state cost is ~186 ms. `#1458`'s "reclaim_index is 750 ms" is really "the first apply on a cold engine".

This also resolves an inconsistency `#1458` flagged but could not explain: three applies at ~635 ms would exceed a 1,336 ms cycle. With one init (746) plus two warm calls (186 each) it comes to ~1,118 ms and fits. **The arithmetic that looked wrong was the clue.**

## Five candidates eliminated first, all by measurement

Before running the discriminator I chased the missing time by inspection and was wrong three times. At 20k:

| candidate | ms |
|---|---|
| the lifecycle plan | 40 |
| `storage_object_lifecycle_snapshot` | 28 |
| `bucket_dump_install_roll_forward_reports` | 0.0 |
| `bucket_dump_manifest_prune_plan_*` — note: runs **unconditionally**, even with pruning off | 0.0 |
| all four `*_with_samples` report builders | 29 |
| **accounted for** | **97 of 685** |

Three wrong guesses in a row is the signal to stop narrowing by reading and design an experiment that separates two hypotheses in one measurement. Calling the same function twice separated "expensive per call" from "expensive once" immediately.

Worth keeping from the eliminations: the manifest prune **plan** is computed on every round even when `prune_bucket_dump_manifests` is false — only applying it is gated. It happens to be free here, but it is unconditional.

## What still stands from `#1456` / `#1458`

The **shape** is unchanged: `reclaim_wal` and `reclaim_index` are the costly stages, because they are the two that call `apply_storage_lifecycle`. Only the magnitudes were inflated by cold-start.

And one conclusion inverts in significance rather than direction: on a **warm** shard the three index-GC features are ~59 ms of ~186 ms — about a third, not a twelfth. The stage's name is less misleading than `#1458` claimed; the cold fixture was.

Full suite: **1757 passed, 1 failed** — `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the known baseline failure, unrelated and also failing on `main`.
