### PR TITLE
Bound a compaction round by page refs, not just bytes

### DIFF
--- a/crates/temporalstore-rust/src/engine/compaction.rs
+++ b/crates/temporalstore-rust/src/engine/compaction.rs
@@ -16,6 +16,24 @@ use super::*;
 /// relocates pages that have not moved yet rather than re-moving the last round's work.
 pub(super) const COMPACTION_ROUND_BYTES: u64 = 256 * 1024 * 1024;
 
+/// How many page refs one compaction round may relocate.
+///
+/// The stall this bounds tracks the NUMBER of refs moved, not their size: measured in release,
+/// a relocation costs ~200 us per ref almost regardless of page size. So a byte budget bounds it
+/// only through average page size, and the same byte constant gives wildly different stalls --
+/// 256 KiB is ~2,400 refs of 100-byte values but ~64 refs of 4 KiB ones. A ref budget bounds the
+/// stall directly.
+///
+/// 2,048 puts a round near 0.4 s of shard write lock at the measured per-ref cost. It is chosen
+/// to sit ABOVE every fixture the suite builds -- which are tens of objects, so they still
+/// compact in one round and their single-round assumptions hold -- and BELOW production scale,
+/// where 20k refs in one round measured 3.1 s. That is the difference from
+/// `COMPACTION_ROUND_BYTES`, which was sized only to clear the suite and so never binds anywhere.
+///
+/// A round that stops here stays open and the next one resumes onto the same slab, so bounding
+/// costs round count, not progress.
+pub(super) const COMPACTION_ROUND_PAGE_REFS: usize = 2_048;
+
 /// Blocks per slab, counted by header walk.
 ///
 /// Both callers below read `page_count` and nothing else off a slab report, and `slab_reports()`
@@ -244,6 +262,9 @@ pub(super) struct CompactionRewriteStats {
     /// Bytes this round may still relocate. Saturates at zero, and a round that reaches zero
     /// leaves the rest where it is for the next one.
     budget_bytes: u64,
+    /// Page refs this round may still relocate, the bound that actually tracks the stall.
+    /// Same saturating behaviour as `budget_bytes`; whichever runs out first ends the round.
+    budget_page_refs: usize,
     pub(super) skipped_by_budget: usize,
     pub(super) skipped_by_budget_bytes: u64,
 }
@@ -255,11 +276,17 @@ pub(super) struct ModelCompactionRewriteStats {
 }
 
 impl CompactionRewriteStats {
-    /// A round that relocates onto `target_block_slab_id` and may spend `budget_bytes`.
-    pub(super) fn for_round(target_block_slab_id: u64, budget_bytes: u64) -> Self {
+    /// A round that relocates onto `target_block_slab_id`, spending at most `budget_bytes` and
+    /// `budget_page_refs`. Whichever runs out first ends the round.
+    pub(super) fn for_round(
+        target_block_slab_id: u64,
+        budget_bytes: u64,
+        budget_page_refs: usize,
+    ) -> Self {
         Self {
             target_block_slab_id,
             budget_bytes,
+            budget_page_refs,
             ..Self::default()
         }
     }
@@ -274,13 +301,14 @@ impl CompactionRewriteStats {
         if address.block_slab_id == self.target_block_slab_id {
             return false;
         }
-        if address.length > self.budget_bytes {
+        if address.length > self.budget_bytes || self.budget_page_refs == 0 {
             self.skipped_by_budget = self.skipped_by_budget.saturating_add(1);
             self.skipped_by_budget_bytes =
                 self.skipped_by_budget_bytes.saturating_add(address.length);
             return false;
         }
         self.budget_bytes = self.budget_bytes.saturating_sub(address.length);
+        self.budget_page_refs = self.budget_page_refs.saturating_sub(1);
         true
     }
 

--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -609,7 +609,11 @@ fn expiry_scan_budget(limit: usize) -> usize {
     }
 
     pub fn compact_shard_pages(&self, shard_id: ShardId) -> Result<ShardCompactionReport, Status> {
-        self.compact_shard_pages_with_budget(shard_id, COMPACTION_ROUND_BYTES)
+        self.compact_shard_pages_with_budgets(
+            shard_id,
+            COMPACTION_ROUND_BYTES,
+            COMPACTION_ROUND_PAGE_REFS,
+        )
     }
 
     /// Compact, relocating at most `budget_bytes` of pages this round.
@@ -619,10 +623,23 @@ fn expiry_scan_budget(limit: usize) -> usize {
     /// no test would reach, and the rules that make a bounded round correct -- a round resumes
     /// onto the slab it was filling rather than rolling again, and rounds together still move
     /// every page -- all live at that boundary.
+    /// Compact with a byte budget only, leaving the ref count unbounded.
+    ///
+    /// This is what the byte-budget probe measures and what every existing caller wants: adding
+    /// a ref bound here would silently change what those measurements mean.
     pub(crate) fn compact_shard_pages_with_budget(
         &self,
         shard_id: ShardId,
         budget_bytes: u64,
+    ) -> Result<ShardCompactionReport, Status> {
+        self.compact_shard_pages_with_budgets(shard_id, budget_bytes, usize::MAX)
+    }
+
+    pub(crate) fn compact_shard_pages_with_budgets(
+        &self,
+        shard_id: ShardId,
+        budget_bytes: u64,
+        budget_page_refs: usize,
     ) -> Result<ShardCompactionReport, Status> {
         let (start_routing_bucket, end_routing_bucket) = self
             .infos
@@ -677,7 +694,7 @@ fn expiry_scan_budget(limit: usize) -> usize {
             }
         };
         let mut rewrite_stats =
-            CompactionRewriteStats::for_round(target_block_slab_id, budget_bytes);
+            CompactionRewriteStats::for_round(target_block_slab_id, budget_bytes, budget_page_refs);
 
         // Relocate every model's live pages onto the freshly rolled slab. A mid-way failure
         // (append ENOSPC / an unreadable torn page) is caught below so we can durably commit the

--- a/crates/temporalstore-rust/src/engine/reports.rs
+++ b/crates/temporalstore-rust/src/engine/reports.rs
@@ -63,11 +63,13 @@ pub struct ShardCompactionReport {
     #[serde(rename = "compacted_page_slab_id")]
     pub compacted_block_slab_id: u64,
     pub rewritten_page_refs: usize,
-    /// Pages this round left where they were because it spent its byte budget.
+    /// Pages this round left where they were because it spent a budget -- bytes OR page refs,
+    /// whichever ran out first. In practice it is the ref budget: the byte one is 256 MiB and a
+    /// store that large is rare, while the ref budget is sized to bound the shard write lock.
     ///
     /// Non-zero means the round did NOT finish, and the next one continues filling the same slab
     /// rather than rolling a new one. Zero means compaction completed inside one round, which is
-    /// what every store small enough for the default budget does.
+    /// what every store smaller than a round's budget does.
     #[serde(default)]
     pub pages_left_by_budget: usize,
     #[serde(default)]

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -17731,3 +17731,55 @@ fn a_reclaim_that_drops_whole_segments_reports_them() {
         "the freed total must exceed the active-file delta once segments are counted: {report:?}"
     );
 }
+
+#[test]
+fn a_compaction_round_stops_at_the_page_ref_budget() {
+    // `COMPACTION_ROUND_BYTES` is 256 MiB and never binds in practice -- a store of a few MiB is
+    // nowhere near it -- so before this a round relocated the WHOLE shard while holding the shard
+    // write lock. Measured in release that is 3.1 s at 20k refs, on the periodic path.
+    //
+    // The stall tracks the NUMBER of refs moved (~200 us each, near enough regardless of page
+    // size), so the ref budget is the bound that actually caps it.
+    use crate::engine::compaction::COMPACTION_ROUND_PAGE_REFS;
+
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+    // Enough to exceed the cap and still leave a remainder for the control round.
+    let objects = COMPACTION_ROUND_PAGE_REFS + 600;
+    for index in 0..objects {
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("ref-budget-{index:07}"),
+                value: vec![b'v'; 64],
+            },
+        });
+        assert!(response.status.ok, "write {index} failed: {:?}", response.status);
+    }
+
+    let bounded = engine
+        .compact_shard_pages(1)
+        .expect("compaction runs");
+    assert!(
+        bounded.rewritten_page_refs <= COMPACTION_ROUND_PAGE_REFS,
+        "a round must not relocate more than its ref budget: moved {} with a budget of {}",
+        bounded.rewritten_page_refs,
+        COMPACTION_ROUND_PAGE_REFS
+    );
+    assert!(
+        bounded.pages_left_by_budget > 0,
+        "the round must leave the rest for the next one, so compaction still progresses"
+    );
+
+    // CONTROL. The same store, same open round, with the ref budget lifted: it now FINISHES.
+    // Without this the assertions above would also pass on a fixture too small to reach the cap,
+    // which is exactly the way a budget test passes while proving nothing.
+    let unbounded = engine
+        .compact_shard_pages_with_budget(1, u64::MAX)
+        .expect("compaction runs");
+    assert_eq!(
+        unbounded.pages_left_by_budget, 0,
+        "with the ref budget lifted the round must complete, which is what shows the budget \
+         is what stopped the round above"
+    );
+}


### PR DESCRIPTION
`COMPACTION_ROUND_BYTES` is 256 MiB. A store that large is rare, so the budget never binds and a round relocates the **whole shard** while holding the shard write lock — measured **3.1 s at 20k page refs in release**, on the periodic maintenance path, gated on ≥1 reclaimable byte.

## Why a byte budget cannot fix this

The stall tracks the **number of refs moved**, not their size: ~200 µs per ref in release, near enough regardless of page size. So a byte budget bounds it only through average page size, and the same constant gives wildly different stalls:

| budget | 100-byte values | 4 KiB values |
|---|---|---|
| 256 KiB | ~2,400 refs (~0.5 s) | ~64 refs (~13 ms) |

A ref budget bounds it directly. `COMPACTION_ROUND_PAGE_REFS = 2_048` puts a round near **0.4 s** at the measured per-ref cost. Whichever budget runs out first ends the round.

## The value is chosen the way the old one was not

- **Above** every fixture the suite builds — those are tens of objects, so they still compact in one round and their single-round assumptions hold.
- **Below** production scale, where 20k refs in one round measured 3.1 s.

That is the whole difference from `COMPACTION_ROUND_BYTES`, which was sized only to clear the suite and therefore never binds anywhere.

Bounding costs round count, not progress: a round that stops stays open and the next resumes onto the same slab. That machinery already existed.

## Existing callers are untouched

`compact_shard_pages_with_budget(shard, bytes)` now delegates with `usize::MAX` refs. The byte-budget probe still measures exactly what it measured — adding a ref bound there would have silently changed what those published numbers mean.

## The test needed a control, and the mutation had to change

`a_compaction_round_stops_at_the_page_ref_budget` writes `COMPACTION_ROUND_PAGE_REFS + 600` objects, compacts, and asserts the round relocated no more than its budget **and** left work behind.

That alone proves nothing — "≤ 2048 relocated" passes trivially on a fixture too small to reach the cap. So it then lifts the budget on the **same open round** and asserts it now completes. That is what shows the budget stopped the first round rather than exhaustion.

Mutating the constant to `usize::MAX` does not compile, because the fixture sizes itself from the constant — a property worth keeping, since raising the constant keeps the test exercising it. So the mutation targets the mechanism instead, dropping the ref charge. It dies with exactly the pre-fix behaviour:

```
a round must not relocate more than its ref budget: moved 2648 with a budget of 2048
```

Full suite: **1758 passed, 1 failed** — `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the known baseline failure, unrelated and also failing on `main`.
