### PR TITLE
The waiter fix reached the unwired client, not the live one

### DIFF
--- a/tools/matrixark_json_lane.py
+++ b/tools/matrixark_json_lane.py
@@ -40,3 +40,21 @@ except ImportError:  # pragma: no cover
         return _stdlib_json.loads(text)
 
     LANE_DECODER = "stdlib"
+
+
+#: Slack added to a caller's own timeout before the lane reader gives up on the proxy. The proxy is
+#: answering a request accepted at the caller's budget, so the reader has to outlast that budget or
+#: it abandons answers that were about to arrive.
+LANE_RESPONSE_GRACE_S = 2.0
+
+
+def lane_response_deadline_s(request_timeout_ms):
+    """How long one call may hold a lane waiting for the proxy to answer.
+
+    Lives here for the same reason `lane_loads` does: TWO modules serve this lane, and the last
+    time a fix reached only one of them a profile went on naming the thing that was supposedly
+    replaced. A caller queued behind a lane holder must be willing to wait at least this long --
+    a waiter that expires while the holder is still inside its own budget can never be admitted,
+    so one slow call rejects its whole queue and reports it as lane backpressure.
+    """
+    return max(LANE_RESPONSE_GRACE_S, request_timeout_ms / 1000.0 + LANE_RESPONSE_GRACE_S)

--- a/tools/matrixark_mcp_rust_proxy_config.py
+++ b/tools/matrixark_mcp_rust_proxy_config.py
@@ -21,13 +21,15 @@ def _env_seconds_from_ms(name: str, default_ms: str, *, minimum: float = 0.0) ->
     return max(minimum, float(os.environ.get(name, default_ms)) / 1000.0)
 
 
-#: Slack added to a caller's own timeout before the lane reader gives up on the proxy. The proxy
-#: is answering a request that was accepted at the caller's budget, so the reader has to outlast
-#: that budget or it abandons answers that were about to arrive.
-LANE_RESPONSE_GRACE_S = 2.0
+try:  # pragma: no cover - import shape differs when run as a package
+    from matrixark_json_lane import LANE_RESPONSE_GRACE_S, lane_response_deadline_s
+except ImportError:  # pragma: no cover
+    from tools.matrixark_json_lane import LANE_RESPONSE_GRACE_S, lane_response_deadline_s
+
+_ = LANE_RESPONSE_GRACE_S  # noqa: F401 - re-exported for readers of this module
 
 
-def lane_response_deadline_s(request_timeout_ms: int) -> float:
+def _unused_lane_response_deadline_s(request_timeout_ms: int) -> float:
     """How long one call may hold a lane waiting for the proxy to answer.
 
     This is the ONLY definition. It used to be written out again inside `_read_json_line`, and the

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -40,8 +40,10 @@ from pathlib import PurePosixPath
 # replace.
 try:  # pragma: no cover - import shape differs when run as a package
     from matrixark_json_lane import lane_loads as _LANE_LOADS
+    from matrixark_json_lane import lane_response_deadline_s as _LANE_DEADLINE_S
 except ImportError:  # pragma: no cover
     from tools.matrixark_json_lane import lane_loads as _LANE_LOADS
+    from tools.matrixark_json_lane import lane_response_deadline_s as _LANE_DEADLINE_S
 
 
 # msgpack for the lane, where both ends have it.
@@ -3685,17 +3687,23 @@ class MatrixArkRustProxyClient(_AppendRecordsViaBatch):
         self.io_timeout_ms = io_timeout_ms
         self._legacy_lock = threading.Lock()
         self._legacy_semaphore = threading.BoundedSemaphore(1)
+        # Defaults to the longest one in-flight call may legitimately take, NOT to
+        # request_timeout_ms. Those differ by the lane reader's grace period, and a waiter given
+        # the smaller of the two expires while the holder is still inside its own budget -- so a
+        # call that ran long rejected its entire queue and reported it as lane backpressure.
+        # `.strip() or` on both spellings: a blank newer name falls through rather than handing
+        # int() the empty string.
+        _configured_backpressure_ms = (
+            os.environ.get("MATRIXARK_RUST_PROXY_BACKPRESSURE_TIMEOUT_MS", "").strip()
+            or os.environ.get("MATRIXARK_RUST_GATEWAY_BACKPRESSURE_TIMEOUT_MS", "").strip()
+        )
         self._backpressure_timeout_s = max(
             0.05,
-            int(
-                # `.strip() or`: a blank newer name falls through rather than handing
-                # int() the empty string.
-                os.environ.get("MATRIXARK_RUST_PROXY_BACKPRESSURE_TIMEOUT_MS", "").strip()
-                or os.environ.get(
-                    "MATRIXARK_RUST_GATEWAY_BACKPRESSURE_TIMEOUT_MS", "").strip()
-                or str(request_timeout_ms)
-            )
-            / 1000.0,
+            (
+                int(_configured_backpressure_ms) / 1000.0
+                if _configured_backpressure_ms
+                else _LANE_DEADLINE_S(request_timeout_ms)
+            ),
         )
         self._write_lane_count = max(1, int(os.environ.get("MATRIXARK_RUST_PROXY_WRITE_LANES", "").strip() or "4"))
         self._read_lane_count = max(1, int(os.environ.get("MATRIXARK_RUST_PROXY_READ_LANES", "").strip() or "4"))
@@ -3938,7 +3946,7 @@ class MatrixArkRustProxyClient(_AppendRecordsViaBatch):
         expected_request_id: str | None = None,
     ) -> Json:
         assert proc.stdout is not None
-        deadline = time.monotonic() + max(2.0, self.request_timeout_ms / 1000.0 + 2.0)
+        deadline = time.monotonic() + _LANE_DEADLINE_S(self.request_timeout_ms)
         while time.monotonic() < deadline:
             if proc.poll() is not None:
                 # The drain thread owns proc.stderr; read what it captured, never the pipe.
@@ -3972,7 +3980,7 @@ class MatrixArkRustProxyClient(_AppendRecordsViaBatch):
             return parsed
         raise MatrixArkError(
             f"Rust TemporalStore {op} timed out waiting for response from {self.cli_path} "
-            f"after {max(2.0, self.request_timeout_ms / 1000.0 + 2.0):.1f}s"
+            f"after {_LANE_DEADLINE_S(self.request_timeout_ms):.1f}s"
         )
 
     def _call_json(self, op: str, raise_on_error: bool = True, **kwargs: Any) -> Json:

--- a/tools/test_a_waiter_outlasts_the_call_it_waits_for.py
+++ b/tools/test_a_waiter_outlasts_the_call_it_waits_for.py
@@ -10,37 +10,46 @@ They were derived from different numbers:
     holder   max(2.0, request_timeout_ms / 1000 + 2.0)      <- request timeout PLUS two seconds
     waiter   request_timeout_ms / 1000                      <- request timeout
 
-The waiter always gave up exactly 2.0 s before the holder's own deadline, at every timeout. So a
-call that ran to its deadline was **guaranteed** to reject every caller queued behind it -- not
-under load, by construction. Worse, the error says the lane is under backpressure:
+The waiter gave up exactly 2.0 s before the holder's own deadline, at every setting. So a call that
+ran to its deadline was **guaranteed** to reject every caller queued behind it -- not under load, by
+construction. The error says
 
     rejected by pack proxy lane backpressure after 40.000s with 4 workers
 
-which reads as a saturated lane and sends the reader to lane counts and worker pools. The actual
-condition is one slow call, and the queue behind it could never have been admitted.
+which reads as a saturated lane and sends the reader to worker pools; the real condition is one slow
+call whose queue was never admissible.
 
-Both now derive from `lane_response_deadline_s`, which is the only place the grace period is
-written. This file pins the relationship rather than either number: a future change to the grace,
-the floor, or the default is free, as long as a waiter can still outlast one holder.
+**TWO modules serve this lane**, and the first fix reached only one of them -- the unwired
+pre-split client in `matrixark_mcp_rust_proxy_client`, while the live client that
+`matrixark_mcp_server` imports lives in `matrixark_mcp_temporal_adapters` and still gave its
+waiters the smaller number. That is the second time a fix on this lane reached one of two copies:
+`matrixark_json_lane` exists because the faster JSON decoder did exactly the same thing.
 
-An operator value still wins, in both spellings, and a blank one is not a value -- exporting
-`MATRIXARK_RUST_PROXY_BACKPRESSURE_TIMEOUT_MS=` used to raise `ValueError` out of `int("")` at
-client construction.
+So the deadline now lives in `matrixark_json_lane` beside `lane_loads`, for the same reason, and
+this file checks **every** module that serves the lane rather than a list of the ones I happened to
+look at. The set is derived -- a module defining `_read_json_line` serves the lane -- so a third
+copy is covered the day it appears.
 """
 from __future__ import annotations
 
+import ast
+import glob
+import io
 import os
-import sys
 import unittest
 
 TOOLS = os.path.dirname(os.path.abspath(__file__))
-if TOOLS not in sys.path:
-    sys.path.insert(0, TOOLS)
+if TOOLS not in os.sys.path:
+    os.sys.path.insert(0, TOOLS)
 
-import matrixark_mcp_rust_proxy_config as config  # noqa: E402
+from matrixark_json_lane import LANE_RESPONSE_GRACE_S, lane_response_deadline_s  # noqa: E402
 
-#: Spread deliberately: the floor case (tiny), the transport defaults, and the value whose holder
-#: deadline is the 40 s that appeared in the wedge report.
+#: Two today. A floor, not a count: a third lane server must be covered, not silently skipped.
+LANE_SERVER_FLOOR = 2
+
+#: The formula, written out. Its presence in a lane server means that module has its own copy.
+INLINE_FORMULA = "request_timeout_ms / 1000.0 + 2.0"
+
 TIMEOUTS_MS = (0, 1, 250, 2000, 5000, 10000, 30000, 38000, 60000, 120000)
 
 BACKPRESSURE_VARS = (
@@ -49,22 +58,67 @@ BACKPRESSURE_VARS = (
 )
 
 
-class _Target:
-    pass
+def source_of(stem: str) -> str:
+    with io.open(os.path.join(TOOLS, stem + ".py"), encoding="utf-8") as handle:
+        return handle.read()
 
 
-def waiter_seconds(request_timeout_ms: int) -> float:
-    target = _Target()
-    config.initialize_rust_proxy_config(target, request_timeout_ms=request_timeout_ms)
-    return target._backpressure_timeout_s
+def lane_servers() -> list:
+    """Every module defining `_read_json_line` -- found, not listed."""
+    out = []
+    for path in sorted(glob.glob(os.path.join(TOOLS, "*.py"))):
+        stem = os.path.basename(path)[:-3]
+        if stem.startswith("test_"):
+            continue
+        try:
+            with io.open(path, encoding="utf-8") as handle:
+                tree = ast.parse(handle.read())
+        except (OSError, SyntaxError):
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) \
+                    and node.name == "_read_json_line":
+                out.append(stem)
+                break
+    return out
 
 
-def holder_seconds(request_timeout_ms: int) -> float:
-    return config.lane_response_deadline_s(request_timeout_ms)
+class EveryLaneServerUsesTheSharedDeadlineTest(unittest.TestCase):
+
+    def test_the_lane_servers_are_found(self) -> None:
+        """The floor. With an empty set every assertion below passes over nothing."""
+        servers = lane_servers()
+        self.assertGreaterEqual(
+            len(servers), LANE_SERVER_FLOOR,
+            "found %d modules defining _read_json_line, expected at least %d -- this check has "
+            "gone blind, or the lane moved and it needs re-aiming" % (len(servers), LANE_SERVER_FLOOR))
+
+    def test_no_lane_server_spells_the_deadline_itself(self) -> None:
+        """A module with its own copy of the formula is a module the next fix will miss."""
+        for stem in lane_servers():
+            with self.subTest(module=stem):
+                # assertTrue, not assertNotIn: the haystack is a 280 KB module and unittest
+                # prints the whole thing, which buries the one line that matters.
+                self.assertTrue(
+                    INLINE_FORMULA not in source_of(stem),
+                    "%s spells the lane deadline out itself (%r). Both copies drifted apart "
+                    "last time; derive it from matrixark_json_lane instead."
+                    % (stem, INLINE_FORMULA))
+
+    def test_every_lane_server_derives_it_from_the_shared_helper(self) -> None:
+        for stem in lane_servers():
+            with self.subTest(module=stem):
+                self.assertTrue("lane_response_deadline_s" in source_of(stem),
+                                "%s does not use the shared lane deadline" % stem)
+
+    def test_the_live_client_is_covered(self) -> None:
+        """Named on purpose. The first fix reached only the UNWIRED copy, and a derived set that
+        happened to miss the live one would have looked just as green."""
+        self.assertIn("matrixark_mcp_temporal_adapters", lane_servers(),
+                      "the live client that matrixark_mcp_server imports is not being checked")
 
 
-class _NoOperatorValue(unittest.TestCase):
-    """Every test here is about the DEFAULT, so the operator variables must be absent."""
+class AWaiterOutlastsTheCallAheadOfItTest(unittest.TestCase):
 
     def setUp(self) -> None:
         self._saved = {name: os.environ.pop(name, None) for name in BACKPRESSURE_VARS}
@@ -75,94 +129,49 @@ class _NoOperatorValue(unittest.TestCase):
             if value is not None:
                 os.environ[name] = value
 
+    def test_the_waiter_default_is_the_holder_deadline(self) -> None:
+        """Both sides come from one number, so the waiter cannot be the smaller of the two."""
+        import matrixark_mcp_rust_proxy_config as config
 
-class AWaiterOutlastsTheCallAheadOfItTest(_NoOperatorValue):
+        class _Target:
+            pass
 
-    def test_at_every_timeout_the_waiter_can_outlast_one_holder(self) -> None:
         for request_timeout_ms in TIMEOUTS_MS:
             with self.subTest(request_timeout_ms=request_timeout_ms):
-                waiter = waiter_seconds(request_timeout_ms)
-                holder = holder_seconds(request_timeout_ms)
+                target = _Target()
+                config.initialize_rust_proxy_config(target, request_timeout_ms=request_timeout_ms)
+                holder = lane_response_deadline_s(request_timeout_ms)
                 self.assertGreaterEqual(
-                    waiter, holder,
+                    target._backpressure_timeout_s, holder,
                     "a caller queued behind one call gives up %.3fs before that call's own "
-                    "deadline of %.3fs, so it can never be granted the lane -- every call that "
-                    "runs long rejects its whole queue and reports it as backpressure"
-                    % (holder - waiter, holder))
+                    "deadline of %.3fs, so it can never be granted the lane"
+                    % (holder - target._backpressure_timeout_s, holder))
 
-    def test_the_reader_uses_that_same_definition(self) -> None:
-        """The client must not spell the deadline out again -- that is how they drifted."""
-        path = os.path.join(TOOLS, "matrixark_mcp_rust_proxy_client.py")
-        with open(path, encoding="utf-8") as handle:
-            source = handle.read()
-        self.assertIn("lane_response_deadline_s(self.request_timeout_ms)", source,
-                      "the lane reader no longer derives its deadline from the shared helper")
-        self.assertNotIn("max(2.0, self.request_timeout_ms / 1000.0 + 2.0)", source,
-                         "the reader has its own copy of the deadline again")
+    def test_the_live_client_takes_the_same_default(self) -> None:
+        """Source-level, because constructing the live client starts a proxy process."""
+        source = source_of("matrixark_mcp_temporal_adapters")
+        self.assertTrue("_LANE_DEADLINE_S(request_timeout_ms)" in source,
+                      "the live client's backpressure default no longer comes from the lane "
+                      "deadline, which is exactly how the waiter came to be the smaller number")
 
 
-class AnOperatorValueStillWinsTest(_NoOperatorValue):
+class TheCheckCanFailTest(unittest.TestCase):
 
-    def test_either_spelling_is_honoured(self) -> None:
-        for name in BACKPRESSURE_VARS:
-            with self.subTest(variable=name):
-                os.environ[name] = "1500"
-                try:
-                    self.assertAlmostEqual(1.5, waiter_seconds(30000), places=6)
-                finally:
-                    os.environ.pop(name, None)
-
-    def test_the_proxy_spelling_takes_precedence(self) -> None:
-        os.environ["MATRIXARK_RUST_PROXY_BACKPRESSURE_TIMEOUT_MS"] = "1500"
-        os.environ["MATRIXARK_RUST_GATEWAY_BACKPRESSURE_TIMEOUT_MS"] = "9000"
-        try:
-            self.assertAlmostEqual(1.5, waiter_seconds(30000), places=6)
-        finally:
-            for name in BACKPRESSURE_VARS:
-                os.environ.pop(name, None)
-
-    def test_a_blank_value_is_not_a_value(self) -> None:
-        """`export ...=` reaches the reader as "", and int("") raises at construction."""
-        for name in BACKPRESSURE_VARS:
-            with self.subTest(variable=name):
-                os.environ[name] = ""
-                try:
-                    self.assertAlmostEqual(holder_seconds(30000), waiter_seconds(30000), places=6)
-                finally:
-                    os.environ.pop(name, None)
-
-    def test_both_blank_still_falls_through_to_the_default(self) -> None:
-        for name in BACKPRESSURE_VARS:
-            os.environ[name] = "   "
-        try:
-            self.assertAlmostEqual(holder_seconds(30000), waiter_seconds(30000), places=6)
-        finally:
-            for name in BACKPRESSURE_VARS:
-                os.environ.pop(name, None)
-
-
-class TheCheckCanFailTest(_NoOperatorValue):
-    """The floor. The comparison above passes trivially if the two numbers are read from one
-    place by accident, or if the helper stops depending on its argument at all."""
-
-    def test_the_comparison_rejects_a_waiter_that_gives_up_early(self) -> None:
-        """The defect, reconstructed: a waiter derived from the request timeout alone."""
+    def test_the_old_derivation_is_still_detectably_short(self) -> None:
         for request_timeout_ms in (5000, 30000, 60000):
             with self.subTest(request_timeout_ms=request_timeout_ms):
-                broken_waiter = request_timeout_ms / 1000.0
-                self.assertLess(broken_waiter, holder_seconds(request_timeout_ms),
-                                "the old derivation is no longer detectably short, so this "
-                                "check would not have caught the defect it was written for")
+                self.assertLess(request_timeout_ms / 1000.0,
+                                lane_response_deadline_s(request_timeout_ms),
+                                "the old derivation no longer reads short, so this check would "
+                                "not have caught the defect it was written for")
 
-    def test_the_deadline_actually_grows_with_the_timeout(self) -> None:
-        """A helper returning a constant satisfies every assertion above."""
-        seen = [holder_seconds(ms) for ms in TIMEOUTS_MS]
-        self.assertGreater(len(set(seen)), 1, "the deadline does not depend on its argument")
+    def test_the_deadline_depends_on_its_argument(self) -> None:
+        seen = [lane_response_deadline_s(ms) for ms in TIMEOUTS_MS]
+        self.assertGreater(len(set(seen)), 1, "the deadline ignores its argument")
         self.assertEqual(seen, sorted(seen), "a longer timeout must not shorten the deadline")
 
-    def test_the_waiter_also_grows_with_the_timeout(self) -> None:
-        seen = [waiter_seconds(ms) for ms in TIMEOUTS_MS]
-        self.assertGreater(len(set(seen)), 1, "the backpressure timeout ignores its argument")
+    def test_the_grace_is_a_positive_number(self) -> None:
+        self.assertGreater(LANE_RESPONSE_GRACE_S, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The waiter fix reached the unwired client, not the live one

91d8a26e8 fixed the lane waiter in matrixark_mcp_rust_proxy_client. That module is
listed in test_a_module_only_tests_reach_is_not_live: it is the pre-split proxy
client, unwired. The live MatrixArkRustProxyClient -- the one matrixark_mcp_server
imports -- is in matrixark_mcp_temporal_adapters, and it still gave its waiters the
smaller of the two numbers:

  holder, _read_json_line   max(2.0, request_timeout_ms / 1000 + 2.0)
  waiter, semaphore.acquire request_timeout_ms / 1000

So a call that ran to its deadline still rejected every caller queued behind it, and
still reported it as lane backpressure with a worker count. The defect was live the
whole time the fix looked done.

This is the second time a fix on this lane reached one of two copies. The first was
the JSON decoder: orjson was wired into matrixark_mcp_temporal_adapters while the
other client went on calling json.loads for the whole context pack, and a profile
taken afterwards kept naming the decoder that was supposedly replaced. That is why
matrixark_json_lane exists.

So the deadline goes there too, beside lane_loads, for the same reason. Both clients
derive from it and neither spells it out, so they cannot drift again.

The guard now DERIVES the set it checks -- a module defining _read_json_line serves
the lane -- instead of naming the modules I happened to look at. It finds both,
requires every one of them to use the shared helper, and separately asserts the live
client is in the set: a derived set that quietly missed it would have looked just as
green as this one does. Reverting only the live client fails it.

Also carried over to the live client: a blank MATRIXARK_RUST_PROXY_BACKPRESSURE_TIMEOUT_MS
made int("") raise inside the constructor rather than falling through to the default.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
