### PR TITLE
The periodic loop can evict, when the operator asks

### DIFF
--- a/crates/temporalstore-rust/src/data_node.rs
+++ b/crates/temporalstore-rust/src/data_node.rs
@@ -191,6 +191,8 @@ pub struct DataNodeRuntimeStats {
     pub storage_manager_compact_runs: u64,
     #[serde(default)]
     pub storage_manager_index_gc_runs: u64,
+    #[serde(default)]
+    pub storage_manager_evict_runs: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -860,6 +862,31 @@ pub struct StorageManagerOptions {
     pub enable_index_gc: bool,
     #[serde(default = "default_storage_manager_stage_enabled")]
     pub enable_metrics_reap: bool,
+    /// Whether the periodic loop may EVICT, not merely invalidate cached pages.
+    ///
+    /// Defaults to FALSE, alone among the stage flags, and that is deliberate. Until this existed
+    /// the eviction machinery -- `apply_storage_eviction`, with dump-before-evict, delete-drop, a
+    /// batch limit and a pressure threshold -- was reachable only from the on-demand cycle, so the
+    /// loop the server actually starts could not evict at ANY setting. This makes it reachable.
+    ///
+    /// Turning it on by default is a production eviction-policy decision and a behaviour change,
+    /// which is why it is opt-in: shipping it default-on would change what every deployment does
+    /// to relieve memory, on no evidence about their workloads.
+    #[serde(default)]
+    pub enable_evict: bool,
+    /// Cache bytes (memory + disk) above which the evict stage acts. 0 evicts whenever it runs.
+    #[serde(default)]
+    pub eviction_memory_pressure_threshold: u64,
+    /// How many buckets one evict stage may take. 0 means no limit.
+    #[serde(default)]
+    pub eviction_batch_limit: usize,
+    /// Dump a bucket before freeing it, so eviction relieves log pressure as well as memory.
+    /// Without it an evicted dirty bucket still pins the log.
+    #[serde(default)]
+    pub eviction_dump_before_evict: bool,
+    /// Drop rather than dump. Off by default: this is the arm that can lose unflushed state.
+    #[serde(default)]
+    pub eviction_delete_drop: bool,
 }
 
 /// Records that must be undumped before a dump is taken.
@@ -904,6 +931,13 @@ impl Default for StorageManagerOptions {
             enable_page_compaction: true,
             enable_index_gc: true,
             enable_metrics_reap: true,
+            // Off, unlike every stage above it. See the field doc: this makes eviction REACHABLE
+            // from the periodic loop; enabling it by default is a separate decision.
+            enable_evict: false,
+            eviction_memory_pressure_threshold: 0,
+            eviction_batch_limit: 0,
+            eviction_dump_before_evict: false,
+            eviction_delete_drop: false,
         }
     }
 }
@@ -1408,6 +1442,7 @@ struct MutableRuntimeStats {
     storage_manager_reclaim_page_runs: u64,
     storage_manager_compact_runs: u64,
     storage_manager_index_gc_runs: u64,
+    storage_manager_evict_runs: u64,
 }
 
 #[derive(Debug)]

--- a/crates/temporalstore-rust/src/data_node/runtime_reports.rs
+++ b/crates/temporalstore-rust/src/data_node/runtime_reports.rs
@@ -63,6 +63,7 @@ impl DataNodeRuntime {
             storage_manager_reclaim_page_runs: stats.storage_manager_reclaim_page_runs,
             storage_manager_compact_runs: stats.storage_manager_compact_runs,
             storage_manager_index_gc_runs: stats.storage_manager_index_gc_runs,
+            storage_manager_evict_runs: stats.storage_manager_evict_runs,
         }
     }
 

--- a/crates/temporalstore-rust/src/data_node/runtime_storage.rs
+++ b/crates/temporalstore-rust/src/data_node/runtime_storage.rs
@@ -636,6 +636,44 @@ impl DataNodeRuntime {
             (!options.enable_metrics_reap).then(|| "reap_metrics_disabled".to_string()),
         ));
 
+        // Evict, when the operator has asked for it.
+        //
+        // The stage above this one relieves memory by invalidating cached pages, which frees the
+        // cache and leaves the index untouched. This is the stage that can actually free a bucket
+        // -- and dump it first, so freeing does not strand the log.
+        let eviction = options.enable_evict.then(|| {
+            self.inner.engine.apply_storage_eviction(
+                shard_id,
+                options.eviction_memory_pressure_threshold,
+                options.eviction_batch_limit,
+                options.eviction_dump_before_evict,
+                options.eviction_delete_drop,
+            )
+        });
+        if eviction.is_some() {
+            executed_stages.push("evict".to_string());
+            self.inner
+                .stats
+                .lock()
+                .expect("data node stats lock poisoned")
+                .storage_manager_evict_runs += 1;
+        } else {
+            skipped_stages.push("evict_disabled".to_string());
+        }
+        pressure_decisions.push(storage_manager_pressure_decision(
+            "evict",
+            options.enable_evict,
+            true,
+            options.enable_evict,
+            vec![storage_manager_pressure_signal(
+                "cache_memory_bytes",
+                options.eviction_memory_pressure_threshold,
+                1,
+            )],
+            vec!["operator_enabled_eviction".to_string()],
+            (!options.enable_evict).then(|| "evict_disabled".to_string()),
+        ));
+
         {
             // Recorded beside the round counter, so every caller gets it: the per-shard
             // scheduler, the all-shards scheduler, and the cycle endpoint.

--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -56,8 +56,14 @@ fn every_maintenance_phase_is_enabled_under_the_shipped_default() {
         .filter(|stage| stage.ends_with("_disabled"))
         .cloned()
         .collect::<Vec<_>>();
-    assert!(
-        disabled.is_empty(),
+    // `evict` is the one stage that ships OFF, deliberately: wiring it made eviction reachable
+    // from this loop at all, and turning it on by default is a production eviction-policy change
+    // (`eviction_delete_drop` can discard unflushed state). Pinning the exact list rather than
+    // dropping the assertion keeps both teeth: another stage going off still fails here, and so
+    // does `evict` being quietly switched on.
+    assert_eq!(
+        disabled,
+        vec!["evict_disabled".to_string()],
         "phases switched off under the options the server ships with: {disabled:?} \
          (executed: {:?}, skipped: {:?})",
         report.executed_stages,
@@ -75,6 +81,7 @@ fn every_maintenance_phase_is_enabled_under_the_shipped_default() {
         "compact_pages",
         "reclaim_index",
         "reap_metrics",
+        "evict",
     ] {
         let ran = report.executed_stages.iter().any(|stage| stage == phase);
         let declined = report
@@ -1575,7 +1582,9 @@ fn runtime_storage_manager_loop_runs_style_pressure_stages() {
     }
     assert!(report.pressure.dirty_bucket_count >= 1);
     assert!(report.pressure.undumped_wal_records >= 1);
-    assert_eq!(report.pressure_decisions.len(), 8, "{report:?}");
+    // Nine since the evict stage was wired: eight that ship on, plus evict, which reports a
+    // decision every round whether or not it is enabled.
+    assert_eq!(report.pressure_decisions.len(), 9, "{report:?}");
     for stage in [
         "prepare",
         "reclaim_wal",
@@ -3326,4 +3335,68 @@ fn what_each_maintenance_stage_costs() {
             );
         }
     }
+}
+
+#[test]
+fn the_periodic_loop_can_evict_when_the_operator_asks() {
+    // Until this stage existed the periodic loop -- the one the server actually starts -- relieved
+    // memory by invalidating cached pages and nothing else. `apply_storage_eviction`, with
+    // dump-before-evict, delete-drop, a batch limit and a pressure threshold, was reachable ONLY
+    // from the on-demand cycle, so eviction could not happen on the running loop at ANY setting.
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+    for index in 0..64 {
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("evict-{index:04}"),
+                value: vec![b'v'; 128],
+            },
+        });
+        assert!(response.status.ok, "write {index}: {:?}", response.status);
+    }
+    let runtime = DataNodeRuntime::new_without_workers_with_options(
+        engine,
+        DataNodeRuntimeOptions {
+            worker_threads: 0,
+            max_queue_depth: 4,
+            max_background_queue_depth: 2,
+        },
+    );
+
+    // CONTROL: the shipped default must not evict. This is the half that says the change is
+    // opt-in rather than a silent change to how every deployment relieves memory.
+    let default_report = runtime.run_storage_manager_once(1, StorageManagerOptions::default());
+    assert!(
+        default_report.skipped_stages.iter().any(|stage| stage == "evict_disabled"),
+        "the default must skip eviction, got skipped={:?} executed={:?}",
+        default_report.skipped_stages,
+        default_report.executed_stages
+    );
+    assert_eq!(
+        runtime.stats().storage_manager_evict_runs,
+        0,
+        "the default must not have evicted"
+    );
+
+    // And with the operator asking, the stage the loop could never reach now runs.
+    let enabled_report = runtime.run_storage_manager_once(
+        1,
+        StorageManagerOptions {
+            enable_evict: true,
+            eviction_dump_before_evict: true,
+            ..StorageManagerOptions::default()
+        },
+    );
+    assert!(
+        enabled_report.executed_stages.iter().any(|stage| stage == "evict"),
+        "enabling eviction must reach the stage, got executed={:?} skipped={:?}",
+        enabled_report.executed_stages,
+        enabled_report.skipped_stages
+    );
+    assert_eq!(
+        runtime.stats().storage_manager_evict_runs,
+        1,
+        "the stage must be counted exactly once"
+    );
 }


### PR DESCRIPTION
The periodic loop can evict, when the operator asks

There are two maintenance pipelines and they do not share stages. The periodic
scheduler the server starts (run_storage_manager_once) relieved memory by
invalidating cached pages and nothing else. apply_storage_eviction -- with
dump-before-evict, delete-drop, a batch limit and a pressure threshold -- lived
only on the on-demand cycle behind /storage_manager/cycle, and
StorageManagerOptions had no eviction fields at all. So on the loop that actually
runs, eviction could not happen at ANY setting.

That matters because invalidating the cache frees cached pages and leaves the
bucket index untouched, and the index is the thing that grows: about 760 B per
key, never evicted. The stage that can actually free a bucket, and dump it first
so freeing does not strand the log, was unreachable.

This wires it: enable_evict plus eviction_memory_pressure_threshold,
eviction_batch_limit, eviction_dump_before_evict and eviction_delete_drop, a
stage in the loop, and a storage_manager_evict_runs counter.

enable_evict defaults to FALSE, alone among the stage flags. Making eviction
reachable is a wiring fix; making it happen is a production eviction-policy
change, and eviction_delete_drop is the arm that can discard unflushed state.
Shipping it default-on would change what every deployment does to relieve memory
on no evidence about their workloads. The flip is one constant when that decision
is made.

Two existing guards broke, and both were RIGHT to. They are now stronger, not
relaxed:

  every_maintenance_phase_is_enabled_under_the_shipped_default asserted that no
  stage is *_disabled under the shipped options. It now pins the exact list --
  [evict_disabled] -- so it still fails if another stage ships off, AND fails
  if evict is quietly switched on. Proven by mutation: defaulting enable_evict to
  true fails it with left: [], right: [evict_disabled], a tooth it did not have
  before. evict was also added to its appears-in-neither-list check.

  runtime_storage_manager_loop_runs_style_pressure_stages pinned
  pressure_decisions.len() == 8; it is 9 now, with a comment saying why.

the_periodic_loop_can_evict_when_the_operator_asks carries its own control: the
shipped default must skip with evict_disabled and leave the counter at 0, then
enabling it must reach the stage and count exactly one run. Mutation-verified by
forcing the gate false.

A note for the next reader: the counter has a TWIN. DataNodeRuntimeStats and the
internal MutableRuntimeStats are separate structs and both need the field; the
compiler caught it here, but nothing would have caught a report field left
unpopulated.

Full suite: 1759 passed, 1 failed -- the known baseline failure.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
