### PR TITLE
Bound expiry on the periodic loop, and resume past what it examined

### DIFF
--- a/crates/temporalstore-rust/src/data_node.rs
+++ b/crates/temporalstore-rust/src/data_node.rs
@@ -887,6 +887,20 @@ pub struct StorageManagerOptions {
     /// Drop rather than dump. Off by default: this is the arm that can lose unflushed state.
     #[serde(default)]
     pub eviction_delete_drop: bool,
+    /// How many hot buckets one expire stage may take. 0 means NO LIMIT, which is what this
+    /// loop has always passed -- so expiry walked the whole deadline map, hot and cold, on every
+    /// tick for every loaded shard. The on-demand cycle has always passed a bound (128) and
+    /// carried a cursor; this is what lets the periodic loop do the same.
+    ///
+    /// Left at 0 by default so the shipped behaviour is unchanged: with no limit the window
+    /// always reaches the end, so the cursor below stays `None` and nothing differs.
+    #[serde(default)]
+    #[serde(rename = "max_expire_hot_slots_per_round")]
+    pub max_expire_hot_buckets_per_round: usize,
+    /// The cold half of the same bound. 0 means no limit.
+    #[serde(default)]
+    #[serde(rename = "max_expire_cold_slots_per_round")]
+    pub max_expire_cold_buckets_per_round: usize,
 }
 
 /// Records that must be undumped before a dump is taken.
@@ -938,6 +952,9 @@ impl Default for StorageManagerOptions {
             eviction_batch_limit: 0,
             eviction_dump_before_evict: false,
             eviction_delete_drop: false,
+            // 0 = unbounded, the behaviour this loop has always had. See the field docs.
+            max_expire_hot_buckets_per_round: 0,
+            max_expire_cold_buckets_per_round: 0,
         }
     }
 }
@@ -1408,6 +1425,12 @@ struct DataNodeRuntimeInner {
     stats: Mutex<MutableRuntimeStats>,
     meta_heartbeat: Mutex<DataNodeMetaHeartbeatReport>,
     lifecycle: Mutex<HashMap<ShardId, DataNodeShardLifecycleState>>,
+    /// Where each shard's expiry sweep left off, as (hot, cold).
+    ///
+    /// Only meaningful when a bound is set: an unbounded window always reaches the end and
+    /// returns `None`, so at the shipped default these stay `None` and cost nothing. Live-path
+    /// state, never persisted -- a reload re-derives deadlines and a fresh pass is correct.
+    expiry_cursors: Mutex<HashMap<ShardId, (Option<String>, Option<String>)>>,
     lifecycle_tokens: Mutex<HashMap<(ShardId, String), SchedulerLifecycleToken>>,
     lifecycle_snapshot_path: Option<PathBuf>,
     lifecycle_persistence: Mutex<DataNodeLifecyclePersistenceReport>,
@@ -1711,6 +1734,7 @@ impl DataNodeRuntime {
             stats: Mutex::default(),
             meta_heartbeat: Mutex::default(),
             lifecycle: Mutex::default(),
+            expiry_cursors: Mutex::default(),
             lifecycle_tokens: Mutex::default(),
             lifecycle_persistence: Mutex::new(lifecycle_persistence_report_for_path(
                 lifecycle_snapshot_path.as_ref(),
@@ -1834,6 +1858,7 @@ impl DataNodeRuntime {
             stats: Mutex::default(),
             meta_heartbeat: Mutex::default(),
             lifecycle: Mutex::default(),
+            expiry_cursors: Mutex::default(),
             lifecycle_tokens: Mutex::default(),
             lifecycle_persistence: Mutex::new(lifecycle_persistence_report_for_path(
                 lifecycle_snapshot_path.as_ref(),

--- a/crates/temporalstore-rust/src/data_node/runtime_storage.rs
+++ b/crates/temporalstore-rust/src/data_node/runtime_storage.rs
@@ -352,7 +352,10 @@ impl DataNodeRuntime {
         ));
 
         if options.enable_expire {
-            expired_records_removed = self.sweep_expired_records();
+            expired_records_removed = self.sweep_expired_records_bounded(
+                options.max_expire_hot_buckets_per_round,
+                options.max_expire_cold_buckets_per_round,
+            );
             self.inner
                 .stats
                 .lock()
@@ -1045,6 +1048,56 @@ impl DataNodeRuntime {
             report,
             handle: Some(handle),
         }
+    }
+
+    /// Sweep every loaded shard with a per-round bound, resuming each from where it stopped.
+    ///
+    /// `hot_limit` / `cold_limit` of 0 mean no limit, and then this is exactly
+    /// `sweep_expired_records`: the window reaches the end, returns no cursor, and the stored
+    /// cursor stays `None`. With a bound it takes a window per round and advances, which is what
+    /// keeps one tick from walking the whole deadline map.
+    pub fn sweep_expired_records_bounded(&self, hot_limit: usize, cold_limit: usize) -> usize {
+        let shard_ids = self.inner.engine.loaded_shard_ids();
+        let mut removed = 0usize;
+        for shard_id in shard_ids {
+            let (hot_cursor, cold_cursor) = self
+                .inner
+                .expiry_cursors
+                .lock()
+                .expect("expiry cursor lock poisoned")
+                .get(&shard_id)
+                .cloned()
+                .unwrap_or((None, None));
+            let Ok(report) = self.inner.engine.sweep_expired_records_with_request(
+                crate::engine::reports::ShardExpirySweepRequest {
+                    shard_id,
+                    hot_cursor,
+                    cold_cursor,
+                    max_hot_buckets_per_round: hot_limit,
+                    max_cold_buckets_per_round: cold_limit,
+                    load_cold_buckets: true,
+                },
+            ) else {
+                continue;
+            };
+            removed = removed.saturating_add(report.expired_records_removed);
+            self.inner
+                .expiry_cursors
+                .lock()
+                .expect("expiry cursor lock poisoned")
+                .insert(
+                    shard_id,
+                    (report.next_hot_cursor.clone(), report.next_cold_cursor.clone()),
+                );
+        }
+        let mut stats = self
+            .inner
+            .stats
+            .lock()
+            .expect("runtime stats lock poisoned");
+        stats.expiry_sweeps += 1;
+        stats.expired_records_removed += removed as u64;
+        removed
     }
 
     pub fn sweep_expired_records(&self) -> usize {

--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -3400,3 +3400,109 @@ fn the_periodic_loop_can_evict_when_the_operator_asks() {
         "the stage must be counted exactly once"
     );
 }
+
+#[test]
+fn the_periodic_expire_stage_takes_a_bounded_window_and_resumes_past_it() {
+    // The periodic loop passed `ShardExpirySweepRequest::default()`, whose limits are 0 -- and the
+    // window code says plainly that "zero limits mean no limit". So every tick walked the WHOLE
+    // deadline map, hot and cold, for every loaded shard, while the on-demand cycle passed 128 and
+    // carried a cursor. Measured by ablation, that stage was 201.5 ms at 20k objects.
+    //
+    // The fixture is built to make the CURSOR the thing under test. A first attempt used only
+    // expired keys and passed with resuming disabled -- removing a key deletes it, so the next
+    // round finds the next one whether or not it resumed. The cursor only earns its keep when a
+    // round EXAMINES keys it does not remove: here a long-lived prefix that the window selects
+    // (they exist) but the sweep never deletes (they are not due). Without resuming, every round
+    // re-examines that same prefix and never reaches anything expired.
+    const LIVE_PREFIX: usize = 20;
+    const EXPIRED: usize = 20;
+    const WINDOW: usize = 4;
+
+    fn runtime_with_a_live_prefix() -> DataNodeRuntime {
+        let engine = TemporalEngine::default();
+        engine.load_shard(1);
+        // Sorted before the expired ones, so they are what a window from the start lands on.
+        for index in 0..LIVE_PREFIX {
+            let key = format!("aaa-live-{index:04}");
+            assert!(engine
+                .execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringSet { key: key.clone(), value: vec![b'v'; 32] },
+                })
+                .status
+                .ok);
+            assert!(engine
+                .execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::CommonExpire { key, ttl_ms: 10 * 60 * 1000 },
+                })
+                .status
+                .ok);
+        }
+        for index in 0..EXPIRED {
+            let key = format!("zzz-dead-{index:04}");
+            assert!(engine
+                .execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringSet { key: key.clone(), value: vec![b'v'; 32] },
+                })
+                .status
+                .ok);
+            assert!(engine
+                .execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::CommonExpire { key, ttl_ms: 1 },
+                })
+                .status
+                .ok);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(30));
+        DataNodeRuntime::new_without_workers_with_options(
+            engine,
+            DataNodeRuntimeOptions {
+                worker_threads: 0,
+                max_queue_depth: 4,
+                max_background_queue_depth: 2,
+            },
+        )
+    }
+
+    // CONTROL: the shipped default is unbounded and must still clear every expired key in one
+    // round. This is what says the change is opt-in, not a silent slowdown of expiry.
+    let unbounded = runtime_with_a_live_prefix();
+    let cleared = unbounded.run_storage_manager_once(1, StorageManagerOptions::default());
+    assert!(
+        cleared.executed_stages.iter().any(|stage| stage == "expire"),
+        "expire must run: {:?}",
+        cleared.executed_stages
+    );
+    assert_eq!(
+        unbounded.stats().expired_records_removed,
+        EXPIRED as u64,
+        "the shipped default must still clear every expired key in one round"
+    );
+
+    // Bounded: each round takes a window of live-but-not-due keys and RESUMES past them, so it
+    // eventually reaches the expired tail. Without resuming this stays at 0 for ever.
+    let bounded = runtime_with_a_live_prefix();
+    let options = StorageManagerOptions {
+        max_expire_hot_buckets_per_round: WINDOW,
+        max_expire_cold_buckets_per_round: WINDOW,
+        ..StorageManagerOptions::default()
+    };
+    let rounds = LIVE_PREFIX / WINDOW + 3;
+    for _ in 0..rounds {
+        bounded.run_storage_manager_once(1, options.clone());
+    }
+    let removed = bounded.stats().expired_records_removed;
+    assert!(
+        removed > 0,
+        "after {rounds} bounded rounds the sweep must have resumed past the {LIVE_PREFIX} \
+         live keys and reached the expired tail, but removed {removed}"
+    );
+    assert!(
+        removed < EXPIRED as u64,
+        "a bounded sweep must not clear the whole tail at once -- that would mean the bound \
+         is not binding: removed {removed} of {EXPIRED}"
+    );
+}


### PR DESCRIPTION
Bound expiry on the periodic loop, and resume past what it examined

The periodic scheduler passed ShardExpirySweepRequest::default() to its expire
stage. Those limits are 0, and the window code says plainly that "zero limits
mean no limit" -- so every tick walked the WHOLE deadline map, hot and cold, for
every loaded shard, and threw away the cursor it got back. The on-demand cycle
has always passed a bound (128) and carried cursors. Measured by ablation, the
expire stage was 201.5 ms at 20k objects, which is what a full walk costs.

This adds max_expire_hot_buckets_per_round and max_expire_cold_buckets_per_round
to StorageManagerOptions, keeps a per-shard (hot, cold) cursor on the runtime,
and passes both into the sweep.

Both default to 0, so the shipped behaviour is UNCHANGED, and that is safe by
construction rather than by inspection: with no limit the window always reaches
the end, so it returns no cursor, so the stored cursor stays None and the call is
exactly what it was. The control in the test asserts it -- the default still
clears every expired key in one round.

The test needed rebuilding after a mutation survived. The first version used only
expired keys and asserted the second round removed more than the first, which
passes with resuming DISABLED: removing a key deletes it, so a round starting
from the beginning finds the next one regardless. It tested deletion, not the
cursor.

The code comment names what the cursor is actually for -- the keys the filter
rejected were looked at, and looking at them again next round is how a sweep
fails to make progress -- so the fixture now puts a live-but-not-due prefix ahead
of the expired tail: keys the window selects (they exist) and never removes (they
are not due). Without resuming, every round re-examines that prefix and never
reaches anything expired. The mutation now dies with "after 8 bounded rounds the
sweep must have resumed past the 20 live keys and reached the expired tail, but
removed 0".

Full suite: 1760 passed, 1 failed -- the known baseline failure.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
