### PR TITLE
The periodic loop now reclaims the write-ahead log it dumps

### DIFF
--- a/crates/temporalstore-rust/src/data_node/runtime_storage.rs
+++ b/crates/temporalstore-rust/src/data_node/runtime_storage.rs
@@ -245,6 +245,32 @@ impl DataNodeRuntime {
                     "storage manager moved log-resident pages into the block store"
                 );
             }
+            // Dumping and spilling make the log RECLAIMABLE. Neither frees a byte of it.
+            //
+            // This stage was named for a reclaim it never performed: `gc_before_sequence` is the
+            // only thing that truncates the log, and nothing above reaches it. Its production
+            // callers were the cycle endpoint, an explicit /gc request, and the embedded proxy's
+            // own reclaim thread -- so a server started as shipped, with this scheduler running,
+            // grew its log for ever unless something outside asked. Measured on an identical
+            // fixture: six rounds of this loop freed 0 of 1,512 records, six rounds of the
+            // on-demand cycle freed 1,511.
+            //
+            // Same plan and same call the cycle applies, with the same empty retention inputs its
+            // default request carries, so this is the cycle's reclaim running on the timer rather
+            // than a second policy. `apply_storage_wal_reclaim` declines unless the plan proves
+            // itself safe, so the floor is the plan's, not this stage's.
+            let wal_reclaim_plan =
+                self.inner
+                    .engine
+                    .storage_wal_reclaim_plan(shard_id, Vec::new(), Vec::new());
+            let wal_reclaim = self.inner.engine.apply_storage_wal_reclaim(wal_reclaim_plan);
+            if wal_reclaim.applied {
+                tracing::debug!(
+                    shard_id,
+                    wal_records_removed = wal_reclaim.wal_records_removed,
+                    "storage manager reclaimed write-ahead log records"
+                );
+            }
             executed_stages.push("reclaim_wal".to_string());
         } else if !options.enable_wal_reclaim {
             skipped_stages.push("reclaim_wal_disabled".to_string());

--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -3506,3 +3506,162 @@ fn the_periodic_expire_stage_takes_a_bounded_window_and_resumes_past_it() {
          is not binding: removed {removed} of {EXPIRED}"
     );
 }
+
+/// Does the PERIODIC loop -- the one `bin/server.rs` starts -- actually reclaim the logs?
+///
+///   cargo test -p temporalstore-rust --lib what_the_periodic_loop_reclaims -- --ignored --nocapture
+///
+/// `bin/server.rs` says the scheduler runs "Dump, WAL and index-log reclaim ... the same phases
+/// the cycle endpoint runs", and its banner prints `phases=prepare,reclaim,...`. Reading the call
+/// graph says otherwise: `gc_before_sequence` is the only thing that truncates either log, and
+/// nothing the periodic loop calls reaches it. This measures rather than argues, and carries the
+/// on-demand cycle as a POSITIVE CONTROL so "nothing moved" cannot be mistaken for "the fixture
+/// had nothing to reclaim".
+#[test]
+#[ignore]
+fn what_the_periodic_loop_reclaims() {
+    fn first_record_offset(engine: &TemporalEngine, shard_id: crate::types::ShardId) -> u64 {
+        engine
+            .write_ahead_log_store()
+            .scan(shard_id, 0, u64::MAX, u64::MAX)
+            .expect("scan")
+            .first()
+            .map(|(offset, _)| *offset)
+            .unwrap_or(0)
+    }
+    fn record_count(engine: &TemporalEngine, shard_id: crate::types::ShardId) -> usize {
+        engine
+            .write_ahead_log_store()
+            .scan(shard_id, 0, u64::MAX, u64::MAX)
+            .expect("scan")
+            .len()
+    }
+
+    fn build(records: usize) -> TemporalEngine {
+        let engine = TemporalEngine::default();
+        engine.load_shard(1);
+        for index in 0..records {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("reclaim-{index:06}"),
+                    value: vec![b'v'; 64],
+                },
+            });
+        }
+        engine
+    }
+
+    let records = StorageManagerOptions::default().min_undumped_wal_records as usize + 512;
+
+    // ARM A: the periodic loop, run enough times that no threshold can be the explanation.
+    let periodic_engine = build(records);
+    let before_low = first_record_offset(&periodic_engine, 1);
+    let before_count = record_count(&periodic_engine, 1);
+    let runtime = DataNodeRuntime::new_without_workers_with_options(
+        periodic_engine,
+        DataNodeRuntimeOptions {
+            worker_threads: 0,
+            max_queue_depth: 4,
+            max_background_queue_depth: 2,
+        },
+    );
+    for _ in 0..6 {
+        runtime.run_storage_manager_once(1, StorageManagerOptions::default());
+    }
+    let periodic_engine = runtime.engine();
+    let after_low = first_record_offset(&periodic_engine, 1);
+    let after_count = record_count(&periodic_engine, 1);
+
+    // ARM B, the POSITIVE CONTROL: the same fixture through the on-demand cycle.
+    let cycle_engine = build(records);
+    let control_before = record_count(&cycle_engine, 1);
+    for _ in 0..6 {
+        cycle_engine.run_storage_manager_cycle(crate::engine::reports::StorageManagerCycleRequest {
+            shard_id: 1,
+            ..crate::engine::reports::StorageManagerCycleRequest::default()
+        });
+    }
+    let control_after = record_count(&cycle_engine, 1);
+    let control_low = first_record_offset(&cycle_engine, 1);
+
+    eprintln!("  [periodic]  {before_count:>6} records (first offset {before_low}) -> {after_count:>6} (first offset {after_low})");
+    eprintln!("  [cycle   ]  {control_before:>6} records -> {control_after:>6} (first offset {control_low})");
+    eprintln!(
+        "  periodic reclaimed {} records; the cycle reclaimed {}",
+        before_count.saturating_sub(after_count),
+        control_before.saturating_sub(control_after)
+    );
+}
+
+#[test]
+fn the_periodic_loop_actually_reclaims_the_write_ahead_log() {
+    // The stage was named `reclaim_wal` and reclaimed nothing. `gc_before_sequence` is the only
+    // thing that truncates the log, and its production callers were the cycle endpoint, an
+    // explicit /gc request, and the embedded proxy's own thread -- none of them this loop. So a
+    // server started as shipped grew its log for ever unless something outside asked.
+    //
+    // Measured before the fix, six rounds on 1,512 records: 0 reclaimed. Six rounds of the
+    // on-demand cycle on the same fixture: 1,511.
+    fn record_count(engine: &TemporalEngine) -> usize {
+        engine
+            .write_ahead_log_store()
+            .scan(1, 0, u64::MAX, u64::MAX)
+            .expect("scan")
+            .len()
+    }
+    fn build(records: usize) -> TemporalEngine {
+        let engine = TemporalEngine::default();
+        engine.load_shard(1);
+        for index in 0..records {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("reclaim-{index:06}"),
+                    value: vec![b'v'; 64],
+                },
+            });
+        }
+        engine
+    }
+    fn run(engine: TemporalEngine, options: StorageManagerOptions) -> TemporalEngine {
+        let runtime = DataNodeRuntime::new_without_workers_with_options(
+            engine,
+            DataNodeRuntimeOptions {
+                worker_threads: 0,
+                max_queue_depth: 4,
+                max_background_queue_depth: 2,
+            },
+        );
+        for _ in 0..4 {
+            runtime.run_storage_manager_once(1, options.clone());
+        }
+        runtime.engine()
+    }
+
+    let records = StorageManagerOptions::default().min_undumped_wal_records as usize + 256;
+
+    let engine = build(records);
+    let before = record_count(&engine);
+    let engine = run(engine, StorageManagerOptions::default());
+    let after = record_count(&engine);
+    assert!(
+        after < before,
+        "the periodic loop must reclaim the log it dumps: {before} records before, {after} after"
+    );
+
+    // CONTROL: the same rounds with the stage switched off must reclaim NOTHING. Without this,
+    // the assertion above would also pass on any unrelated path that happened to shrink the log,
+    // and it is the stage under test that has to be responsible.
+    let control = build(records);
+    let control_before = record_count(&control);
+    let control = run(
+        control,
+        StorageManagerOptions { enable_wal_reclaim: false, ..StorageManagerOptions::default() },
+    );
+    let control_after = record_count(&control);
+    assert_eq!(
+        control_after, control_before,
+        "with reclaim_wal disabled nothing may shrink the log: {control_before} -> {control_after}"
+    );
+}


### PR DESCRIPTION
The periodic loop now reclaims the write-ahead log it dumps

The stage is called reclaim_wal and it reclaimed nothing. gc_before_sequence is
the only thing that truncates the log, and its production callers were the cycle
endpoint, an explicit /gc request, and the embedded proxy's own reclaim thread.
The periodic scheduler -- the loop bin/server.rs starts, and the only maintenance
a server started as shipped runs -- reached none of them. It dumped buckets,
pruned manifests, rolled forward installs and spilled log-resident pages, all of
which make the log RECLAIMABLE without freeing a byte of it.

Measured on identical fixtures, six rounds each:

  periodic loop    1512 records -> 1512    reclaimed 0
  on-demand cycle  1512 records ->    1    reclaimed 1511

The cycle arm is a positive control: the fixture plainly has reclaimable records,
so "nothing moved" on the periodic arm is the loop's behaviour and not the
fixture's.

That makes two claims in the tree wrong. bin/server.rs says the scheduler runs
"Dump, WAL and index-log reclaim ... the same phases the cycle endpoint runs",
and its banner prints phases=prepare,reclaim,evict,... . Neither reclaim nor
evict was there; evict was wired in #1467 and this is reclaim. The comment also
describes the symptom this was meant to fix -- a log that "grew until the disk
did" -- and notes the embedded proxy escaped it by spawning a reclaim thread of
its own, which is why nobody felt it.

This applies the same plan the cycle applies, with the same empty retention
inputs its default request carries, so it is the cycle's reclaim running on the
timer rather than a second policy. apply_storage_wal_reclaim declines unless the
plan proves itself safe, so the floor is the plan's.

After the fix the periodic arm reclaims 535 of 1,512. It reclaims less than the
cycle for a correct reason: its dump is capped at max_dump_buckets_per_round
(64), so the floor advances only as far as those dumps allow, which is the
bounded lag #1446 established. The cycle's default cap is 0, unbounded.

the_periodic_loop_actually_reclaims_the_write_ahead_log asserts the log shrinks,
with a control that runs the same rounds with enable_wal_reclaim off and asserts
nothing shrinks -- so the stage under test is provably the one responsible.
Mutation-verified: removing the reclaim call fails it with "1256 records before,
1256 after".

Still open, and deliberately not in this commit: the index log. Its truncation
runs through storage_index_gc_report, which takes a cycle request for its
thresholds, so wiring it is a larger change than this one.

Full suite: 1761 passed, 1 failed -- the known baseline failure.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
