### PR TITLE
zone becomes band in the topology snapshot, with the wire pinned

### DIFF
--- a/crates/temporalstore-rust/src/engine/reports.rs
+++ b/crates/temporalstore-rust/src/engine/reports.rs
@@ -2076,8 +2076,14 @@ pub fn default_storage_index_snapshot() -> StorageIndexSnapshot {
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct StorageZoneSample {
-    pub zone_id: u64,
+/// A band's byte accounting and the slabs it holds.
+///
+/// Keyed by `band_id`, the same key as [`StorageBandSample`], which carries that band's block
+/// range and reclaim state. Two shapes over one entity, not two levels -- "zone" was the older
+/// name for a band, and the wire still uses it.
+pub struct StorageBandUsageSample {
+    #[serde(rename = "zone_id")]
+    pub band_id: u64,
     pub total_bytes: u64,
     pub used_bytes: u64,
     pub stale_bytes: u64,
@@ -2148,7 +2154,8 @@ pub struct StorageTopologySnapshot {
     pub append_log_replay_records: u64,
     pub append_log_reclaimed_records: u64,
     #[serde(default)]
-    pub storage_zone_samples: Vec<StorageZoneSample>,
+    #[serde(rename = "storage_zone_samples")]
+    pub storage_band_usage_samples: Vec<StorageBandUsageSample>,
     #[serde(default)]
     pub stream_samples: Vec<StorageStreamSample>,
     #[serde(default)]
@@ -2177,7 +2184,7 @@ pub fn storage_topology_snapshot_from_metrics(
         storage_band_stale_bytes: metric(metrics, "storage_zone_stale_bytes"),
         append_log_replay_records: metric(metrics, "append_log_replay_records"),
         append_log_reclaimed_records: metric(metrics, "append_log_reclaimed_records"),
-        storage_zone_samples: Vec::new(),
+        storage_band_usage_samples: Vec::new(),
         stream_samples: Vec::new(),
         slab_samples: Vec::new(),
         band_samples: Vec::new(),

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -550,7 +550,7 @@ pub(super) fn storage_topology_snapshot_with_samples(
 
     const MAX_STORAGE_TOPOLOGY_SAMPLES: usize = 8;
     #[derive(Default)]
-    struct ZoneAcc {
+    struct BandUsageAcc {
         used_bytes: u64,
         stale_bytes: u64,
         slabs: BTreeSet<u64>,
@@ -580,7 +580,7 @@ pub(super) fn storage_topology_snapshot_with_samples(
         tombstones: BTreeSet<String>,
     }
 
-    let mut zones = BTreeMap::<u64, ZoneAcc>::new();
+    let mut bands_usage = BTreeMap::<u64, BandUsageAcc>::new();
     let mut slabs = BTreeMap::<u64, SlabAcc>::new();
     let mut bands = BTreeMap::<u64, BandAcc>::new();
     let mut buckets = BTreeMap::<u32, BucketAcc>::new();
@@ -592,13 +592,13 @@ pub(super) fn storage_topology_snapshot_with_samples(
             .unwrap_or(entry.address.block_slab_id);
         let slab_id = entry.address.block_slab_id;
         let generation = entry.address.object_id().unwrap_or(0);
-        let zone = zones.entry(band_id).or_default();
-        zone.slabs.insert(slab_id);
-        zone.generation = zone.generation.max(generation);
+        let usage = bands_usage.entry(band_id).or_default();
+        usage.slabs.insert(slab_id);
+        usage.generation = usage.generation.max(generation);
         if entry.deleted {
-            zone.stale_bytes = zone.stale_bytes.saturating_add(entry.address.length);
+            usage.stale_bytes = usage.stale_bytes.saturating_add(entry.address.length);
         } else {
-            zone.used_bytes = zone.used_bytes.saturating_add(entry.address.length);
+            usage.used_bytes = usage.used_bytes.saturating_add(entry.address.length);
         }
 
         let slab = slabs.entry(slab_id).or_insert_with(|| SlabAcc {
@@ -664,15 +664,15 @@ pub(super) fn storage_topology_snapshot_with_samples(
         }
     }
 
-    snapshot.storage_zone_samples = zones
+    snapshot.storage_band_usage_samples = bands_usage
         .into_iter()
         .take(MAX_STORAGE_TOPOLOGY_SAMPLES)
-        .map(|(zone_id, zone)| StorageZoneSample {
-            zone_id,
-            total_bytes: zone.used_bytes.saturating_add(zone.stale_bytes),
-            used_bytes: zone.used_bytes,
-            stale_bytes: zone.stale_bytes,
-            slabs: zone.slabs.into_iter().collect(),
+        .map(|(band_id, usage)| StorageBandUsageSample {
+            band_id,
+            total_bytes: usage.used_bytes.saturating_add(usage.stale_bytes),
+            used_bytes: usage.used_bytes,
+            stale_bytes: usage.stale_bytes,
+            slabs: usage.slabs.into_iter().collect(),
         })
         .collect();
     let stream_slabs = slabs.keys().copied().collect::<Vec<_>>();

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -17783,3 +17783,46 @@ fn a_compaction_round_stops_at_the_page_ref_budget() {
          is what stopped the round above"
     );
 }
+
+#[test]
+fn the_band_usage_sample_still_serializes_under_its_zone_wire_names() {
+    // `zone` was the older name for a band, and `zones` is keyed by `band_id`
+    // (storage_bucket_internals.rs) -- so the aggregate is the BAND level reported under an old
+    // name, not a separate level. The Rust identifiers moved to band; the WIRE must not, because
+    // the compat corpora pin "zone_id" 31 times and "storage_zone_samples" twice, and Python
+    // readers use those names.
+    //
+    // This asserts the pinning directly. A rename that dropped the #[serde(rename = ...)] would
+    // compile, pass every type-level test, and silently change the exported shape.
+    let sample = crate::engine::reports::StorageBandUsageSample {
+        band_id: 7,
+        total_bytes: 300,
+        used_bytes: 200,
+        stale_bytes: 100,
+        slabs: vec![1, 2],
+    };
+    let encoded = serde_json::to_value(&sample).expect("serialize");
+    assert!(
+        encoded.get("zone_id").is_some(),
+        "the band id must still go out as zone_id: {encoded}"
+    );
+    assert!(
+        encoded.get("band_id").is_none(),
+        "band_id must NOT appear on the wire -- that would be a format change: {encoded}"
+    );
+
+    // And the collection it sits in keeps its own wire name.
+    let mut snapshot = crate::engine::reports::StorageTopologySnapshot::default();
+    snapshot.storage_band_usage_samples = vec![sample];
+    let encoded = serde_json::to_value(&snapshot).expect("serialize");
+    assert!(
+        encoded.get("storage_zone_samples").is_some(),
+        "the collection must still go out as storage_zone_samples: {encoded}"
+    );
+
+    // Reading back what the old name produced must still work, which is what a stored corpus is.
+    let decoded: crate::engine::reports::StorageBandUsageSample =
+        serde_json::from_str(r#"{"zone_id":9,"total_bytes":1,"used_bytes":1,"stale_bytes":0,"slabs":[]}"#)
+            .expect("an old-name payload must still decode");
+    assert_eq!(decoded.band_id, 9);
+}


### PR DESCRIPTION
zone becomes band in the topology snapshot, with the wire pinned

`zone` was the older name for a band, and the block store finished that rename a
while ago: `band_id` carries `#[serde(alias = "extent_id", alias = "zone_id")]`
and block_store.rs documents the lineage zone_id -> extent_id -> band_id. The
topology snapshot never got the sweep, so `StorageZoneSample`, `ZoneAcc` and
`storage_zone_samples` were still there.

The thing that settles it is the KEY, not the fields:

    let usage = bands_usage.entry(band_id)...   // storage_bucket_internals.rs
    let band  = bands.entry(band_id)...

Both are keyed by `band_id`. So the "zone" aggregate is the band level
accumulated a second time into a different shape -- byte totals and the slab list
on one side, block range and reclaim state on the other -- and not a level of its
own. I had read the struct fields first and concluded they were separate levels;
the keys say otherwise.

Renamed to `StorageBandUsageSample` rather than `StorageBandSample`, which
already exists and holds that band's other half.

Every wire name is pinned, because the compat corpora hold "zone_id" 31 times and
"storage_zone_samples" twice, and Python readers use those names:

    #[serde(rename = "zone_id")]        pub band_id: u64,
    #[serde(rename = "storage_zone_samples")]
    pub storage_band_usage_samples: Vec<StorageBandUsageSample>,

That is the convention this file already used three times for the same word.

`zone` is now absent from storage_bucket_internals.rs; what is left in reports.rs
is the serde strings, which are the pins.

the_band_usage_sample_still_serializes_under_its_zone_wire_names asserts the
serialized shape directly rather than trusting the attribute: zone_id present,
band_id absent, the collection still storage_zone_samples, and an old-name
payload still decoding. Mutation-verified -- removing the pin fails it with
{"band_id":7,...} in place of {"zone_id":7,...}, which is a silent format change
that compiles and passes every type-level test.

For the record, since the same question will come up again: blocks live in slabs,
slabs belong to bands, and the band is what GC reclaims -- that is why
page_gc_min_band_garbage_basis_points selects on a band's garbage ratio. WAL and
raft "segments" are log-file pieces and a different concept entirely; the
comparison tree has no `segment` at all, only `zone`.

Full suite: 1762 passed, 1 failed -- the known baseline failure.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
