### PR TITLE
Drop the last oplog names from the Rust tree

### DIFF
--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -195,10 +195,9 @@ fn what_a_stored_object_costs_in_memory() {
 
 /// What a dump costs as the shard grows, and whether it costs the shard or the change.
 ///
-/// `flush_shard_index` writes the index out. The counterpart in the design this follows dumps a
-/// BOUNDED set of dirty slots per round -- `ReclaimOpLogWithLimit(N)` hands `DumpSlots` a capped
-/// list -- so the work of one dump is a function of the round limit, not of how much the shard
-/// holds. Ours has no such limit, and this measures what that means: if the time grows with the
+/// `flush_shard_index` writes the index out. A bounded dump takes a capped set of dirty buckets
+/// per round, so the work of one dump is a function of that cap and not of how much the shard
+/// holds. Ours has no such cap, and this measures what that means: if the time grows with the
 /// shard rather than with what changed since the last dump, then a store pays more to checkpoint
 /// the larger it gets, forever.
 ///

--- a/crates/temporalstore-snapshot/src/object_store.rs
+++ b/crates/temporalstore-snapshot/src/object_store.rs
@@ -802,16 +802,16 @@ mod tests {
         let store = FileObjectStore::new(dir.path().join("objects"));
 
         store
-            .put("shards/1/oplog/0001.json", Bytes::from_static(b"durable"))
+            .put("shards/1/wal/0001.json", Bytes::from_static(b"durable"))
             .await
             .unwrap();
 
-        let reopened = tokio::fs::read(dir.path().join("objects/shards/1/oplog/0001.json"))
+        let reopened = tokio::fs::read(dir.path().join("objects/shards/1/wal/0001.json"))
             .await
             .unwrap();
         assert_eq!(reopened, b"durable");
         assert_eq!(
-            store.get("shards/1/oplog/0001.json").await.unwrap(),
+            store.get("shards/1/wal/0001.json").await.unwrap(),
             Bytes::from_static(b"durable")
         );
     }


### PR DESCRIPTION
Drop the last oplog names from the Rust tree

`oplog` is not what this codebase calls its log. The rename to `wal` was done
long ago -- the live setting is TS_INDEX_DUMP_WAL_GAP_BYTES -- and what was left
in Rust was four stragglers and two deliberate keeps.

The one worth fixing names functions that do not exist here:

    -- `ReclaimOpLogWithLimit(N)` hands `DumpSlots` a capped list --

Same class as the parenthetical removed in #1449, which named two symbols from
another implementation. The comment is contrasting a BOUNDED dump against ours,
and the property is the point; the foreign spelling is not. It now states the
property.

The other three were object-store fixture keys, "shards/1/oplog/0001.json",
naming a log this codebase does not have. They are arbitrary paths in a test, so
they simply say wal now.

Two occurrences stay, and both are load-bearing:

    TS_INDEX_DUMP_GAP_BYTES_PREVIOUS_NAME = "TS_INDEX_DUMP_OPLOG_GAP_BYTES"

That is the previous env var name, still honoured so a deployment that sets it
keeps working, plus the test that pins it in the full name list. Renaming either
would break exactly the deployments the constant exists to protect. Same pattern
as TS_BLOCK_SEGMENT_TARGET_BYTES sitting beside TS_BLOCK_SLAB_TARGET_BYTES.

So after this, every `oplog` left in the Rust tree is a compatibility name that
is meant to be there.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


Gated proportionately: this is a doc comment plus three fixture strings inside one
test, so it cannot reach the library suite. Both crates compile clean with
--all-targets, and the test that owns those fixture paths
(file_object_store_put_is_reopen_readable_after_durable_write) passes, as do all
8 snapshot-crate tests.
