### PR TITLE
Measure what a packed page looks like in the index

### DIFF
--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -17864,3 +17864,62 @@ fn the_delete_marker_rename_did_not_move_any_wire_name() {
     .expect("an old-name payload must still decode");
     assert_eq!(decoded.delete_marked_object_ids, 7);
 }
+
+/// Do a packed page's timestamps share ONE address, or several?
+///
+///   cargo test -p temporalstore-rust --lib what_a_packed_page_looks_like_in_the_index -- --ignored --nocapture
+///
+/// This settles which side of the corpus mismatch is right. `install_bucket_dump_manifest`
+/// cross-checks two derivations of one report: the model-map one dedupes a series' addresses
+/// through a HashSet, the bucket-index one does not. On
+/// `native_logical_storage_models_packed_timestamped_pages` they read 10 and 12, and the case has
+/// exactly two packed operations.
+///
+/// If the timestamps of one packed append share a single address, the dedup is right and the
+/// bucket index is carrying duplicate refs. If they carry distinct addresses (different offsets
+/// into one page), the dedup is collapsing pages that are genuinely separate entries and the
+/// invariant never held for packed pages.
+#[test]
+#[ignore]
+fn what_a_packed_page_looks_like_in_the_index() {
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+
+    // One append carrying several points -- the shape `feature_append_packed_page` uses.
+    let response = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::FeatureAppend {
+            key: "packed:feature".to_string(),
+            points: (0..5)
+                .map(|index| crate::types::FeaturePoint {
+                    timestamp_ms: 1_000 + index,
+                    value: vec![b'v'; 16],
+                })
+                .collect(),
+        },
+    });
+    assert!(response.status.ok, "append failed: {:?}", response.status);
+
+    let shards = engine.shards.read().expect("engine lock poisoned");
+    let shard = shards.get(&1).expect("shard loaded");
+    let series = shard.features.get("packed:feature").expect("series present");
+
+    eprintln!("  timestamps in the series: {}", series.len());
+    let mut distinct = std::collections::HashSet::new();
+    for (timestamp, address) in series.iter() {
+        eprintln!(
+            "    ts={timestamp} slab={} off={} len={} page_id={:?}",
+            address.block_slab_id,
+            address.offset,
+            address.length,
+            address.page_id()
+        );
+        distinct.insert(address.clone());
+    }
+    eprintln!("  DISTINCT addresses: {}", distinct.len());
+    eprintln!(
+        "  so the model-map derivation would count {} and the bucket index {}",
+        distinct.len(),
+        series.len()
+    );
+}


### PR DESCRIPTION
Measure what a packed page looks like in the index

rust_executes_temporalstore_corpus fails on clean main, and has for a while:
install_bucket_dump_manifest cross-checks two derivations of one lifecycle report
and they disagree on case
native_logical_storage_models_packed_timestamped_pages -- manifest and
bucket-index derivation say 12 live objects and page refs, the model-map
derivation says 10.

It does not appear in the usual gate because cargo test --lib does not run
tests/.

The two derivations differ in one place. The model-map arm dedupes a series'
addresses through a HashSet (unique_timestamped_kv_page_addresses); the
bucket-index arm does not. The failing case has exactly two packed operations,
feature_append_packed_page and sequence_add_packed_page, and the counts differ by
exactly two.

This probe settles which side is right, because reading could not: one
FeatureAppend carrying five points, then print the series.

    timestamps in the series: 5
      ts=1000 slab=0 off=0 len=163 page_id=Some(0)
      ts=1001 slab=0 off=0 len=163 page_id=Some(0)
      ts=1002 slab=0 off=0 len=163 page_id=Some(0)
      ts=1003 slab=0 off=0 len=163 page_id=Some(0)
      ts=1004 slab=0 off=0 len=163 page_id=Some(0)
    DISTINCT addresses: 1

A packed page IS one page: every timestamp in it carries the SAME address, down
to the offset and the page id. So the dedup is right and the bucket-index
derivation over-counts -- it emits one live page ref per series ENTRY where there
is one page. The corpus arithmetic agrees: two packed operations of two points
each give 2 x (2 - 1) = 2, which is the gap.

That is the opposite of what the two agreeing numbers suggested. I had read the
manifest as authoritative BECAUSE the bucket-index derivation agreed with it --
but those two share a source, so their agreement is not evidence. Two derivations
can agree and both be wrong.

Probe only, #[ignore]d. No production code changes, and deliberately no fix: the
direction is to count DISTINCT addresses in the bucket-index derivation, but
live_object_ids and live_page_refs appear in the compat corpora, so changing what
they count is wire-visible and wants its own decision. The cross-check itself
should not be relaxed -- its comment says it exists to catch a tampered
object_id, which is exactly the kind of check that should not be loosened to make
a corpus pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
