### PR TITLE
band becomes slab in the type names

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -604,7 +604,7 @@ pub struct BlockStorePurgeDelayedDestroyReport {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum BlockStoreBandState {
+pub enum BlockStoreSlabState {
     Active,
     Sealed,
     DelayedDestroy,
@@ -615,7 +615,7 @@ pub enum BlockStoreBandState {
 /// Passed to [`LocalBlockStore::install_lazy_checkpoint_bands`] so a lazy-restore installs
 /// complete band descriptors before the first on-demand slab fetch.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct LazyCheckpointBand {
+pub struct LazyCheckpointSlab {
     pub block_slab_id: u64,
     pub physical_bytes: u64,
     pub logical_bytes: u64,
@@ -626,12 +626,12 @@ pub struct LazyCheckpointBand {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct BlockStoreBandDescriptor {
+pub struct BlockStoreSlabDescriptor {
     #[serde(alias = "extent_id", alias = "zone_id")]
     pub band_id: u64,
     #[serde(rename = "page_segment_id")]
     pub block_slab_id: u64,
-    pub state: BlockStoreBandState,
+    pub state: BlockStoreSlabState,
     pub physical_bytes: u64,
     pub logical_bytes: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -663,7 +663,7 @@ pub struct BlockStoreBandDescriptor {
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct BlockStoreBandSummary {
+pub struct BlockStoreSlabSummary {
     #[serde(alias = "active_zones")]
     pub active_bands: u64,
     #[serde(alias = "sealed_zones")]
@@ -718,7 +718,7 @@ pub struct BlockStoreBandSummary {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct BlockStoreBandUsage {
+pub struct BlockStoreSlabUsage {
     #[serde(alias = "extent_id", alias = "zone_id")]
     pub band_id: u64,
     #[serde(rename = "page_segment_id")]
@@ -728,7 +728,7 @@ pub struct BlockStoreBandUsage {
     #[serde(default)]
     #[serde(alias = "stream_segment_id")]
     pub stream_slab_id: u64,
-    pub state: BlockStoreBandState,
+    pub state: BlockStoreSlabState,
     #[serde(default)]
     pub used_bytes: u64,
     #[serde(default)]
@@ -748,7 +748,7 @@ pub struct BlockStoreBandUsage {
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct StreamBackedBandRuntimeReport {
+pub struct StreamBackedSlabRuntimeReport {
     pub runtime_ready: bool,
     #[serde(default)]
     pub band_lifecycle_states: Vec<String>,
@@ -765,7 +765,7 @@ pub struct StreamBackedBandRuntimeReport {
     #[serde(rename = "zone_stats_ready", default)]
     pub band_stats_ready: bool,
     #[serde(rename = "zone_usage", default)]
-    pub band_usage: Vec<BlockStoreBandUsage>,
+    pub band_usage: Vec<BlockStoreSlabUsage>,
     #[serde(alias = "stream_segment_count")]
     pub stream_slab_count: u64,
     pub physical_bytes: u64,
@@ -896,10 +896,10 @@ pub struct BlockStoreBlockIndexReport {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-struct BlockStoreBandManifest {
+struct BlockStoreSlabManifest {
     version: u32,
     #[serde(alias = "extents", alias = "zones")]
-    bands: Vec<BlockStoreBandDescriptor>,
+    bands: Vec<BlockStoreSlabDescriptor>,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -968,7 +968,7 @@ struct BlockStoreInner {
     write_offset: u64,
     next_page_id: u64,
     options: BlockStoreOptions,
-    bands: BTreeMap<u64, BlockStoreBandDescriptor>,
+    bands: BTreeMap<u64, BlockStoreSlabDescriptor>,
     /// Slab installs since the manifest was last written out. Writing it costs the whole manifest,
     /// so it is written every so often rather than every install; the load rebuilds from the slabs
     /// when what it reads does not match them.
@@ -1030,7 +1030,7 @@ impl LocalBlockStore {
             &mut bands,
             &root,
             block_slab_id,
-            BlockStoreBandState::Active,
+            BlockStoreSlabState::Active,
         );
         // Fence a torn tail on the ACTIVE slab. After a crash mid-append the raw file length
         // includes uncommitted/partial bytes past the last intact record; reconcile computed
@@ -1142,17 +1142,17 @@ impl LocalBlockStore {
         let now = now_unix_ms();
         // Any previously-active local band is now sealed; the reserved slab is active.
         for band in inner.bands.values_mut() {
-            if band.state == BlockStoreBandState::Active {
-                band.state = BlockStoreBandState::Sealed;
+            if band.state == BlockStoreSlabState::Active {
+                band.state = BlockStoreSlabState::Sealed;
                 band.updated_unix_ms = Some(now);
             }
         }
         inner.bands.insert(
             new_slab_id,
-            BlockStoreBandDescriptor {
+            BlockStoreSlabDescriptor {
                 band_id: band_id_for_slab(new_slab_id),
                 block_slab_id: new_slab_id,
-                state: BlockStoreBandState::Active,
+                state: BlockStoreSlabState::Active,
                 physical_bytes: 0,
                 logical_bytes: 0,
                 created_unix_ms: Some(now),
@@ -1181,7 +1181,7 @@ impl LocalBlockStore {
     /// checkpoint slab is correctly sealed.
     pub fn install_lazy_checkpoint_bands(
         &self,
-        bands: &[LazyCheckpointBand],
+        bands: &[LazyCheckpointSlab],
     ) -> Result<(), BlockStoreError> {
         let mut inner = self.inner.lock().expect("block store lock poisoned");
         let root = inner.root.clone();
@@ -1202,10 +1202,10 @@ impl LocalBlockStore {
             // `reserve_lazy_checkpoint_range` then seals; that stale empty descriptor must be
             // overwritten with the checkpoint's real band metadata, not skipped) a complete
             // SEALED descriptor so accounting is correct before any fetch.
-            let descriptor = BlockStoreBandDescriptor {
+            let descriptor = BlockStoreSlabDescriptor {
                 band_id: band_id_for_slab(band.block_slab_id),
                 block_slab_id: band.block_slab_id,
-                state: BlockStoreBandState::Sealed,
+                state: BlockStoreSlabState::Sealed,
                 physical_bytes: band.physical_bytes,
                 logical_bytes: band.logical_bytes,
                 created_unix_ms: band.created_unix_ms,
@@ -1349,7 +1349,7 @@ impl LocalBlockStore {
         Ok(ids)
     }
 
-    pub fn band_usage(&self) -> Vec<BlockStoreBandUsage> {
+    pub fn band_usage(&self) -> Vec<BlockStoreSlabUsage> {
         compute_band_usage(
             &self
                 .inner
@@ -1437,7 +1437,7 @@ impl LocalBlockStore {
             }
             purged_physical_bytes += bytes;
             fs::remove_file(entry.path())?;
-            set_band_state(&mut inner.bands, id, BlockStoreBandState::Purged);
+            set_band_state(&mut inner.bands, id, BlockStoreSlabState::Purged);
             purged.push(id);
         }
         purged.sort_unstable();
@@ -1602,13 +1602,13 @@ fn roll_slab_inner(
     sync_parent_dir(&path)?;
     let transition_unix_ms = now_unix_ms();
     if let Some(previous) = inner.bands.get_mut(&previous_block_slab_id) {
-        previous.state = BlockStoreBandState::Sealed;
+        previous.state = BlockStoreSlabState::Sealed;
         previous.updated_unix_ms = Some(transition_unix_ms);
     }
-    let new_band = BlockStoreBandDescriptor {
+    let new_band = BlockStoreSlabDescriptor {
         band_id: band_id_for_slab(inner.block_slab_id),
         block_slab_id: inner.block_slab_id,
-        state: BlockStoreBandState::Active,
+        state: BlockStoreSlabState::Active,
         physical_bytes: 0,
         logical_bytes: 0,
         created_unix_ms: Some(transition_unix_ms),
@@ -1630,7 +1630,7 @@ fn roll_slab_inner(
     })
 }
 
-fn band_lifecycle_states(summary: &BlockStoreBandSummary) -> Vec<String> {
+fn band_lifecycle_states(summary: &BlockStoreSlabSummary) -> Vec<String> {
     let mut states = Vec::new();
     if summary.active_bands > 0 {
         states.push("active".to_string());
@@ -1648,18 +1648,18 @@ fn band_lifecycle_states(summary: &BlockStoreBandSummary) -> Vec<String> {
 }
 
 fn compute_band_usage(
-    bands: &BTreeMap<u64, BlockStoreBandDescriptor>,
-) -> Vec<BlockStoreBandUsage> {
+    bands: &BTreeMap<u64, BlockStoreSlabDescriptor>,
+) -> Vec<BlockStoreSlabUsage> {
     #[derive(Debug, Clone)]
-    struct BandUsageAcc {
-        usage: BlockStoreBandUsage,
+    struct SlabUsageAcc {
+        usage: BlockStoreSlabUsage,
     }
 
     fn merged_band_state(
-        left: BlockStoreBandState,
-        right: BlockStoreBandState,
-    ) -> BlockStoreBandState {
-        use BlockStoreBandState::*;
+        left: BlockStoreSlabState,
+        right: BlockStoreSlabState,
+    ) -> BlockStoreSlabState {
+        use BlockStoreSlabState::*;
         match (left, right) {
             (Active, _) | (_, Active) => Active,
             (Sealed, _) | (_, Sealed) => Sealed,
@@ -1668,19 +1668,19 @@ fn compute_band_usage(
         }
     }
 
-    let mut usage_by_band = BTreeMap::<u64, BandUsageAcc>::new();
+    let mut usage_by_band = BTreeMap::<u64, SlabUsageAcc>::new();
     for band in bands.values() {
         let (live, reclaimable, purged) = match band.state {
-            BlockStoreBandState::Active | BlockStoreBandState::Sealed => {
+            BlockStoreSlabState::Active | BlockStoreSlabState::Sealed => {
                 (band.physical_bytes, 0, 0)
             }
-            BlockStoreBandState::DelayedDestroy => (0, band.physical_bytes, 0),
-            BlockStoreBandState::Purged => (0, 0, band.physical_bytes),
+            BlockStoreSlabState::DelayedDestroy => (0, band.physical_bytes, 0),
+            BlockStoreSlabState::Purged => (0, 0, band.physical_bytes),
         };
         let entry = usage_by_band
             .entry(band.band_id)
-            .or_insert_with(|| BandUsageAcc {
-                usage: BlockStoreBandUsage {
+            .or_insert_with(|| SlabUsageAcc {
+                usage: BlockStoreSlabUsage {
                     band_id: band.band_id,
                     block_slab_id: band.block_slab_id,
                     storage_band_id: band.band_id,
@@ -2371,7 +2371,7 @@ mod tests {
     #[test]
     fn band_catalog_folds_bands_and_install_reconstructs_lifecycle() {
         // MANIFEST-CONFORMANCE FOLD round-trip at the block-store layer: project the band catalog into
-        // the durable BandCatalogEntry subset, then reconstruct the band lifecycle from that projection
+        // the durable SlabCatalogEntry subset, then reconstruct the band lifecycle from that projection
         // with the band-manifest file deleted -- proving the folded catalog is a lossless source
         // of the durable band state (diagnostics are recomputed from the slab separately).
         let dir = tempfile::tempdir().unwrap();
@@ -2384,8 +2384,8 @@ mod tests {
         let catalog = store.band_catalog(7);
         // Two bands: the sealed first slab and the active second slab.
         assert_eq!(catalog.len(), 2);
-        assert!(catalog.iter().any(|z| z.state == crate::index_log::BandCatalogState::Sealed));
-        assert!(catalog.iter().any(|z| z.state == crate::index_log::BandCatalogState::Active));
+        assert!(catalog.iter().any(|z| z.state == crate::index_log::SlabCatalogState::Sealed));
+        assert!(catalog.iter().any(|z| z.state == crate::index_log::SlabCatalogState::Active));
         assert!(catalog.iter().all(|z| z.version == 7));
         // Delete the band-manifest file so the reopened store has no cached catalog file; it
         // reconstructs bands from the durable slabs (reconcile-on-open), then we install the
@@ -2394,7 +2394,7 @@ mod tests {
         std::fs::remove_file(band_manifest_path(dir.path())).ok();
         let changed = reopened.install_band_catalog(&catalog).unwrap();
         let recovered = reopened.band_catalog(0);
-        let state_of = |slab: u64, zs: &[crate::index_log::BandCatalogEntry]| {
+        let state_of = |slab: u64, zs: &[crate::index_log::SlabCatalogEntry]| {
             zs.iter().find(|z| z.block_slab_id == slab).map(|z| z.state)
         };
         for entry in &catalog {
@@ -2588,11 +2588,11 @@ mod tests {
         assert!(descriptors
             .iter()
             .any(|band| band.block_slab_id == first.block_slab_id
-                && band.state == BlockStoreBandState::Sealed));
+                && band.state == BlockStoreSlabState::Sealed));
         assert!(descriptors
             .iter()
             .any(|band| band.block_slab_id == second.block_slab_id
-                && band.state == BlockStoreBandState::Active));
+                && band.state == BlockStoreSlabState::Active));
         let report = reopened.stream_backed_band_runtime_report().unwrap();
         assert!(report.band_manifest_reconciled_on_open);
         assert!(report.band_manifest_disk_consistent);
@@ -2620,11 +2620,11 @@ mod tests {
         assert!(descriptors
             .iter()
             .any(|band| band.block_slab_id == first.block_slab_id
-                && band.state == BlockStoreBandState::Purged));
+                && band.state == BlockStoreSlabState::Purged));
         assert!(descriptors
             .iter()
             .any(|band| band.block_slab_id == second.block_slab_id
-                && band.state == BlockStoreBandState::Active));
+                && band.state == BlockStoreSlabState::Active));
         let report = reopened.stream_backed_band_runtime_report().unwrap();
         assert!(report.band_manifest_reconciled_on_open);
         assert!(report.band_manifest_disk_consistent);
@@ -2827,13 +2827,13 @@ mod tests {
         let bands = store.band_descriptors();
         assert_eq!(bands.len(), 2);
         assert_eq!(bands[0].block_slab_id, first.block_slab_id);
-        assert_eq!(bands[0].state, BlockStoreBandState::Sealed);
+        assert_eq!(bands[0].state, BlockStoreSlabState::Sealed);
         assert_eq!(bands[0].first_page_id, first.page_id());
         assert_eq!(bands[0].last_page_id, first.page_id());
         assert!(bands[0].created_unix_ms.is_some());
         assert!(bands[0].updated_unix_ms.is_some());
         assert_eq!(bands[1].block_slab_id, second.block_slab_id);
-        assert_eq!(bands[1].state, BlockStoreBandState::Active);
+        assert_eq!(bands[1].state, BlockStoreSlabState::Active);
         assert_eq!(bands[1].first_page_id, second.page_id());
         assert_eq!(bands[1].last_page_id, second.page_id());
         assert!(bands[1].created_unix_ms.is_some());
@@ -2887,7 +2887,7 @@ mod tests {
         // The band must survive a reopen unchanged. `verified_source_mtime_unix_ms` is excluded
         // because it is not part of the band: it records when the descriptor was last checked
         // against the file, and the two sides differ on that for a good reason, asserted below.
-        let strip = |band: &BlockStoreBandDescriptor| {
+        let strip = |band: &BlockStoreSlabDescriptor| {
             let mut band = band.clone();
             band.verified_source_mtime_unix_ms = None;
             band
@@ -2926,11 +2926,11 @@ mod tests {
             .unwrap();
         assert_eq!(report.delayed_destroy_block_slab_ids, vec![0]);
         let delayed = reopened.band_descriptors();
-        assert_eq!(delayed[0].state, BlockStoreBandState::DelayedDestroy);
+        assert_eq!(delayed[0].state, BlockStoreSlabState::DelayedDestroy);
         assert!(delayed[0].physical_bytes > 0);
         assert_eq!(delayed[0].created_unix_ms, bands[0].created_unix_ms);
         assert!(delayed[0].updated_unix_ms >= bands[0].updated_unix_ms);
-        assert_eq!(delayed[1].state, BlockStoreBandState::Active);
+        assert_eq!(delayed[1].state, BlockStoreSlabState::Active);
         let delayed_summary = reopened.band_summary();
         assert_eq!(delayed_summary.delayed_destroy_bands, 1);
         assert_eq!(delayed_summary.active_bands, 1);
@@ -2970,10 +2970,10 @@ mod tests {
         assert_eq!(purge.purged_block_slab_ids, vec![0]);
         assert!(purge.purged_physical_bytes > 0);
         let purged = LocalBlockStore::new(dir.path()).band_descriptors();
-        assert_eq!(purged[0].state, BlockStoreBandState::Purged);
+        assert_eq!(purged[0].state, BlockStoreSlabState::Purged);
         assert_eq!(purged[0].created_unix_ms, bands[0].created_unix_ms);
         assert!(purged[0].updated_unix_ms >= delayed[0].updated_unix_ms);
-        assert_eq!(purged[1].state, BlockStoreBandState::Active);
+        assert_eq!(purged[1].state, BlockStoreSlabState::Active);
         let purged_summary = LocalBlockStore::new(dir.path()).band_summary();
         assert_eq!(purged_summary.purged_bands, 1);
         assert_eq!(purged_summary.active_bands, 1);
@@ -3013,13 +3013,13 @@ mod tests {
 
         assert_eq!(bands.len(), 2);
         assert_eq!(bands[0].block_slab_id, first.block_slab_id);
-        assert_eq!(bands[0].state, BlockStoreBandState::Sealed);
+        assert_eq!(bands[0].state, BlockStoreSlabState::Sealed);
         assert_eq!(bands[0].first_page_id, first.page_id());
         assert_eq!(bands[0].last_page_id, first.page_id());
         assert!(bands[0].created_unix_ms.is_some());
         assert!(bands[0].updated_unix_ms.is_some());
         assert_eq!(bands[1].block_slab_id, second.block_slab_id);
-        assert_eq!(bands[1].state, BlockStoreBandState::Active);
+        assert_eq!(bands[1].state, BlockStoreSlabState::Active);
         assert_eq!(bands[1].first_page_id, second.page_id());
         assert_eq!(bands[1].last_page_id, second.page_id());
         assert!(bands[1].created_unix_ms.is_some());
@@ -3080,7 +3080,7 @@ mod tests {
             .iter()
             .find(|band| band.block_slab_id == first.block_slab_id)
             .unwrap();
-        assert_eq!(sealed.state, BlockStoreBandState::Sealed);
+        assert_eq!(sealed.state, BlockStoreSlabState::Sealed);
         assert!(sealed.has_corruption);
         assert_eq!(sealed.first_error_offset, Some(readable_prefix));
         assert_eq!(sealed.readable_prefix_physical_bytes, readable_prefix);
@@ -3358,12 +3358,12 @@ mod tests {
         assert!(report
             .band_usage
             .iter()
-            .any(|band| band.state == BlockStoreBandState::DelayedDestroy
+            .any(|band| band.state == BlockStoreSlabState::DelayedDestroy
                 && band.reclaimable_page_store_used_bytes > 0));
         assert!(report
             .band_usage
             .iter()
-            .any(|band| band.state == BlockStoreBandState::Active
+            .any(|band| band.state == BlockStoreSlabState::Active
                 && band.live_page_store_used_bytes > 0));
         assert!(report.envelope_checksum_ready);
         assert!(report.compression_stream_ready);
@@ -3403,7 +3403,7 @@ mod tests {
         assert!(purged
             .band_usage
             .iter()
-            .any(|band| band.state == BlockStoreBandState::Purged
+            .any(|band| band.state == BlockStoreSlabState::Purged
                 && band.purged_page_store_used_bytes > 0));
         assert!(purged.purge_lifecycle_ready);
         assert!(purged.append_roll_ready);

--- a/crates/temporalstore-rust/src/block_store/band_manifest.rs
+++ b/crates/temporalstore-rust/src/block_store/band_manifest.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 
 pub(super) fn load_band_manifest_at(
     root: &Path,
-) -> Result<BTreeMap<u64, BlockStoreBandDescriptor>, BlockStoreError> {
+) -> Result<BTreeMap<u64, BlockStoreSlabDescriptor>, BlockStoreError> {
     let current_path = band_manifest_path(root);
     let legacy_path = legacy_zone_manifest_path(root);
     let path = if current_path.exists() {
@@ -21,7 +21,7 @@ pub(super) fn load_band_manifest_at(
     if !path.exists() {
         return Ok(BTreeMap::new());
     }
-    let manifest: BlockStoreBandManifest =
+    let manifest: BlockStoreSlabManifest =
         serde_json::from_slice(&fs::read(path)?).map_err(|err| {
             BlockStoreError::CorruptPageEnvelope {
                 block_slab_id: 0,
@@ -38,7 +38,7 @@ pub(super) fn load_band_manifest_at(
 
 pub(super) fn rebuild_band_manifest_at(
     root: &Path,
-) -> Result<BTreeMap<u64, BlockStoreBandDescriptor>, BlockStoreError> {
+) -> Result<BTreeMap<u64, BlockStoreSlabDescriptor>, BlockStoreError> {
     let mut bands = BTreeMap::new();
     let latest = latest_slab_id_at(root)?;
     for block_slab_id in slab_ids_at(root)? {
@@ -47,13 +47,13 @@ pub(super) fn rebuild_band_manifest_at(
         let report = inspect_slab(&bytes, block_slab_id);
         bands.insert(
             block_slab_id,
-            BlockStoreBandDescriptor {
+            BlockStoreSlabDescriptor {
                 band_id: band_id_for_slab(block_slab_id),
                 block_slab_id,
                 state: if block_slab_id == latest {
-                    BlockStoreBandState::Active
+                    BlockStoreSlabState::Active
                 } else {
-                    BlockStoreBandState::Sealed
+                    BlockStoreSlabState::Sealed
                 },
                 physical_bytes: bytes.len() as u64,
                 logical_bytes: report.logical_bytes,
@@ -78,14 +78,14 @@ pub(super) fn rebuild_band_manifest_at(
         bands
             .entry(delayed.block_slab_id)
             .and_modify(|band| {
-                band.state = BlockStoreBandState::DelayedDestroy;
+                band.state = BlockStoreSlabState::DelayedDestroy;
                 band.updated_unix_ms = delayed.modified_unix_ms;
                 band.physical_bytes = delayed.physical_bytes;
             })
-            .or_insert(BlockStoreBandDescriptor {
+            .or_insert(BlockStoreSlabDescriptor {
                 band_id: band_id_for_slab(delayed.block_slab_id),
                 block_slab_id: delayed.block_slab_id,
-                state: BlockStoreBandState::DelayedDestroy,
+                state: BlockStoreSlabState::DelayedDestroy,
                 physical_bytes: delayed.physical_bytes,
                 logical_bytes: 0,
                 created_unix_ms: delayed.modified_unix_ms,
@@ -114,7 +114,7 @@ fn reverify_all_slabs() -> bool {
 
 pub(super) fn reconcile_band_manifest_with_disk(
     root: &Path,
-    bands: &mut BTreeMap<u64, BlockStoreBandDescriptor>,
+    bands: &mut BTreeMap<u64, BlockStoreSlabDescriptor>,
 ) -> Result<bool, BlockStoreError> {
     let mut changed = false;
     let live_slab_ids = slab_ids_at(root)?.into_iter().collect::<BTreeSet<_>>();
@@ -153,7 +153,7 @@ pub(super) fn reconcile_band_manifest_with_disk(
             let Some(band) = bands.get(block_slab_id) else {
                 return true;
             };
-            if band.has_corruption || band.state != BlockStoreBandState::Sealed {
+            if band.has_corruption || band.state != BlockStoreSlabState::Sealed {
                 return true;
             }
             let Some(verified_mtime) = band.verified_source_mtime_unix_ms else {
@@ -203,9 +203,9 @@ pub(super) fn reconcile_band_manifest_with_disk(
                 .take()
                 .expect("every slab in the batch is inspected exactly once")?;
             let desired_state = if *block_slab_id == latest {
-            BlockStoreBandState::Active
+            BlockStoreSlabState::Active
         } else {
-            BlockStoreBandState::Sealed
+            BlockStoreSlabState::Sealed
         };
         match bands.get_mut(block_slab_id) {
             Some(band) => {
@@ -245,7 +245,7 @@ pub(super) fn reconcile_band_manifest_with_disk(
             None => {
                 bands.insert(
                     *block_slab_id,
-                    BlockStoreBandDescriptor {
+                    BlockStoreSlabDescriptor {
                         band_id: band_id_for_slab(*block_slab_id),
                         block_slab_id: *block_slab_id,
                         state: desired_state,
@@ -274,10 +274,10 @@ pub(super) fn reconcile_band_manifest_with_disk(
         let old = bands.get(block_slab_id).cloned();
         bands.insert(
             *block_slab_id,
-            BlockStoreBandDescriptor {
+            BlockStoreSlabDescriptor {
                 band_id: band_id_for_slab(*block_slab_id),
                 block_slab_id: *block_slab_id,
-                state: BlockStoreBandState::DelayedDestroy,
+                state: BlockStoreSlabState::DelayedDestroy,
                 physical_bytes: report.physical_bytes,
                 logical_bytes: old.as_ref().map(|band| band.logical_bytes).unwrap_or(0),
                 created_unix_ms: old
@@ -305,8 +305,8 @@ pub(super) fn reconcile_band_manifest_with_disk(
             continue;
         }
         if let Some(band) = bands.get_mut(&block_slab_id) {
-            if band.state != BlockStoreBandState::Purged {
-                band.state = BlockStoreBandState::Purged;
+            if band.state != BlockStoreSlabState::Purged {
+                band.state = BlockStoreSlabState::Purged;
                 band.updated_unix_ms = Some(now_unix_ms());
                 changed = true;
             }
@@ -318,7 +318,7 @@ pub(super) fn reconcile_band_manifest_with_disk(
 
 pub(super) fn persist_band_manifest(
     root: &Path,
-    bands: &BTreeMap<u64, BlockStoreBandDescriptor>,
+    bands: &BTreeMap<u64, BlockStoreSlabDescriptor>,
 ) -> Result<(), BlockStoreError> {
     fs::create_dir_all(root)?;
     let path = band_manifest_path(root);
@@ -329,7 +329,7 @@ pub(super) fn persist_band_manifest(
             .map(|duration| duration.as_nanos())
             .unwrap_or_default()
     ));
-    let manifest = BlockStoreBandManifest {
+    let manifest = BlockStoreSlabManifest {
         version: 1,
         bands: bands.values().cloned().collect(),
     };
@@ -352,9 +352,9 @@ pub(super) fn persist_band_manifest(
 }
 
 pub(super) fn summarize_bands(
-    bands: &BTreeMap<u64, BlockStoreBandDescriptor>,
-) -> BlockStoreBandSummary {
-    let mut summary = BlockStoreBandSummary::default();
+    bands: &BTreeMap<u64, BlockStoreSlabDescriptor>,
+) -> BlockStoreSlabSummary {
+    let mut summary = BlockStoreSlabSummary::default();
     let now = now_unix_ms();
     for band in bands.values() {
         update_oldest_band_timestamp(&mut summary.oldest_known_band_unix_ms, band);
@@ -362,7 +362,7 @@ pub(super) fn summarize_bands(
             .total_known_physical_bytes
             .saturating_add(band.physical_bytes);
         match band.state {
-            BlockStoreBandState::Active => {
+            BlockStoreSlabState::Active => {
                 update_oldest_band_timestamp(&mut summary.oldest_live_band_unix_ms, band);
                 summary.active_bands = summary.active_bands.saturating_add(1);
                 summary.active_physical_bytes = summary
@@ -372,7 +372,7 @@ pub(super) fn summarize_bands(
                     .live_physical_bytes
                     .saturating_add(band.physical_bytes);
             }
-            BlockStoreBandState::Sealed => {
+            BlockStoreSlabState::Sealed => {
                 update_oldest_band_timestamp(&mut summary.oldest_live_band_unix_ms, band);
                 summary.sealed_bands = summary.sealed_bands.saturating_add(1);
                 summary.sealed_physical_bytes = summary
@@ -382,7 +382,7 @@ pub(super) fn summarize_bands(
                     .live_physical_bytes
                     .saturating_add(band.physical_bytes);
             }
-            BlockStoreBandState::DelayedDestroy => {
+            BlockStoreSlabState::DelayedDestroy => {
                 update_oldest_band_timestamp(
                     &mut summary.oldest_reclaimable_band_unix_ms,
                     band,
@@ -395,7 +395,7 @@ pub(super) fn summarize_bands(
                     .reclaimable_physical_bytes
                     .saturating_add(band.physical_bytes);
             }
-            BlockStoreBandState::Purged => {
+            BlockStoreSlabState::Purged => {
                 summary.purged_bands = summary.purged_bands.saturating_add(1);
                 summary.purged_physical_bytes = summary
                     .purged_physical_bytes
@@ -415,7 +415,7 @@ pub(super) fn summarize_bands(
     summary
 }
 
-pub(super) fn update_oldest_band_timestamp(target: &mut Option<u64>, band: &BlockStoreBandDescriptor) {
+pub(super) fn update_oldest_band_timestamp(target: &mut Option<u64>, band: &BlockStoreSlabDescriptor) {
     let Some(timestamp) = band.updated_unix_ms.or(band.created_unix_ms) else {
         return;
     };
@@ -425,17 +425,17 @@ pub(super) fn update_oldest_band_timestamp(target: &mut Option<u64>, band: &Bloc
 }
 
 pub(super) fn ensure_band_descriptor(
-    bands: &mut BTreeMap<u64, BlockStoreBandDescriptor>,
+    bands: &mut BTreeMap<u64, BlockStoreSlabDescriptor>,
     root: &Path,
     block_slab_id: u64,
-    state: BlockStoreBandState,
+    state: BlockStoreSlabState,
 ) {
     bands.entry(block_slab_id).or_insert_with(|| {
         let physical_bytes = slab_path(root, block_slab_id)
             .metadata()
             .map(|metadata| metadata.len())
             .unwrap_or_default();
-        BlockStoreBandDescriptor {
+        BlockStoreSlabDescriptor {
             band_id: band_id_for_slab(block_slab_id),
             block_slab_id,
             state,
@@ -458,15 +458,15 @@ pub(super) fn ensure_band_descriptor(
         if band.block_slab_id == block_slab_id {
             band.state = state;
             band.updated_unix_ms = Some(transition_unix_ms);
-        } else if band.state == BlockStoreBandState::Active {
-            band.state = BlockStoreBandState::Sealed;
+        } else if band.state == BlockStoreSlabState::Active {
+            band.state = BlockStoreSlabState::Sealed;
             band.updated_unix_ms = Some(transition_unix_ms);
         }
     }
 }
 
 pub(super) fn upsert_band_after_append(
-    bands: &mut BTreeMap<u64, BlockStoreBandDescriptor>,
+    bands: &mut BTreeMap<u64, BlockStoreSlabDescriptor>,
     block_slab_id: u64,
     physical_bytes: u64,
     logical_bytes_written: u64,
@@ -474,10 +474,10 @@ pub(super) fn upsert_band_after_append(
 ) {
     let band = bands
         .entry(block_slab_id)
-        .or_insert(BlockStoreBandDescriptor {
+        .or_insert(BlockStoreSlabDescriptor {
             band_id: band_id_for_slab(block_slab_id),
             block_slab_id,
-            state: BlockStoreBandState::Active,
+            state: BlockStoreSlabState::Active,
             physical_bytes: 0,
             logical_bytes: 0,
             created_unix_ms: Some(now_unix_ms()),
@@ -491,7 +491,7 @@ pub(super) fn upsert_band_after_append(
             first_error: None,
         });
     let updated_unix_ms = now_unix_ms();
-    band.state = BlockStoreBandState::Active;
+    band.state = BlockStoreSlabState::Active;
     band.physical_bytes = physical_bytes;
     band.readable_prefix_physical_bytes = physical_bytes;
     band.has_corruption = false;
@@ -515,9 +515,9 @@ pub(super) fn upsert_band_after_append(
 }
 
 pub(super) fn set_band_state(
-    bands: &mut BTreeMap<u64, BlockStoreBandDescriptor>,
+    bands: &mut BTreeMap<u64, BlockStoreSlabDescriptor>,
     block_slab_id: u64,
-    state: BlockStoreBandState,
+    state: BlockStoreSlabState,
 ) {
     bands
         .entry(block_slab_id)
@@ -525,7 +525,7 @@ pub(super) fn set_band_state(
             band.state = state;
             band.updated_unix_ms = Some(now_unix_ms());
         })
-        .or_insert(BlockStoreBandDescriptor {
+        .or_insert(BlockStoreSlabDescriptor {
             band_id: band_id_for_slab(block_slab_id),
             block_slab_id,
             state,

--- a/crates/temporalstore-rust/src/block_store/band_reports.rs
+++ b/crates/temporalstore-rust/src/block_store/band_reports.rs
@@ -5,28 +5,28 @@
 
 use super::*;
 
-/// Map a band descriptor's lifecycle state to the index-log `BandCatalogState` (1:1). Kept a free fn
+/// Map a band descriptor's lifecycle state to the index-log `SlabCatalogState` (1:1). Kept a free fn
 /// so both directions of the MANIFEST-CONFORMANCE FOLD conversion share one mapping.
-fn band_state_to_catalog_state(state: BlockStoreBandState) -> crate::index_log::BandCatalogState {
+fn band_state_to_catalog_state(state: BlockStoreSlabState) -> crate::index_log::SlabCatalogState {
     match state {
-        BlockStoreBandState::Active => crate::index_log::BandCatalogState::Active,
-        BlockStoreBandState::Sealed => crate::index_log::BandCatalogState::Sealed,
-        BlockStoreBandState::DelayedDestroy => crate::index_log::BandCatalogState::DelayedDestroy,
-        BlockStoreBandState::Purged => crate::index_log::BandCatalogState::Purged,
+        BlockStoreSlabState::Active => crate::index_log::SlabCatalogState::Active,
+        BlockStoreSlabState::Sealed => crate::index_log::SlabCatalogState::Sealed,
+        BlockStoreSlabState::DelayedDestroy => crate::index_log::SlabCatalogState::DelayedDestroy,
+        BlockStoreSlabState::Purged => crate::index_log::SlabCatalogState::Purged,
     }
 }
 
-fn catalog_state_to_band_state(state: crate::index_log::BandCatalogState) -> BlockStoreBandState {
+fn catalog_state_to_band_state(state: crate::index_log::SlabCatalogState) -> BlockStoreSlabState {
     match state {
-        crate::index_log::BandCatalogState::Active => BlockStoreBandState::Active,
-        crate::index_log::BandCatalogState::Sealed => BlockStoreBandState::Sealed,
-        crate::index_log::BandCatalogState::DelayedDestroy => BlockStoreBandState::DelayedDestroy,
-        crate::index_log::BandCatalogState::Purged => BlockStoreBandState::Purged,
+        crate::index_log::SlabCatalogState::Active => BlockStoreSlabState::Active,
+        crate::index_log::SlabCatalogState::Sealed => BlockStoreSlabState::Sealed,
+        crate::index_log::SlabCatalogState::DelayedDestroy => BlockStoreSlabState::DelayedDestroy,
+        crate::index_log::SlabCatalogState::Purged => BlockStoreSlabState::Purged,
     }
 }
 
 impl LocalBlockStore {
-    pub fn band_descriptors(&self) -> Vec<BlockStoreBandDescriptor> {
+    pub fn band_descriptors(&self) -> Vec<BlockStoreSlabDescriptor> {
         self.inner
             .lock()
             .expect("block store lock poisoned")
@@ -36,19 +36,19 @@ impl LocalBlockStore {
             .collect()
     }
 
-    /// MANIFEST-CONFORMANCE FOLD: project the in-memory band catalog into the DURABLE `BandCatalogEntry`
+    /// MANIFEST-CONFORMANCE FOLD: project the in-memory band catalog into the DURABLE `SlabCatalogEntry`
     /// subset kept in the index-log band catalog. Only the durable fields ride in
     /// the fold; the band descriptor's diagnostic fields (readable_prefix / corruption / errors)
     /// are deliberately dropped -- they are recomputed on load by scanning the slab, exactly as
     /// this design does not persist them. `band_version` stamps every entry so a folded anchor
     /// carries a monotonically-versioned snapshot.
-    pub fn band_catalog(&self, band_version: u64) -> Vec<crate::index_log::BandCatalogEntry> {
+    pub fn band_catalog(&self, band_version: u64) -> Vec<crate::index_log::SlabCatalogEntry> {
         self.inner
             .lock()
             .expect("block store lock poisoned")
             .bands
             .values()
-            .map(|band| crate::index_log::BandCatalogEntry {
+            .map(|band| crate::index_log::SlabCatalogEntry {
                 block_slab_id: band.block_slab_id,
                 state: band_state_to_catalog_state(band.state),
                 physical_bytes: band.physical_bytes,
@@ -62,7 +62,7 @@ impl LocalBlockStore {
             .collect()
     }
 
-    /// MANIFEST-CONFORMANCE FOLD recovery: seed the band catalog from a folded `BandCatalogEntry` snapshot
+    /// MANIFEST-CONFORMANCE FOLD recovery: seed the band catalog from a folded `SlabCatalogEntry` snapshot
     /// recovered from the index-log MetaItem. Applied on load AFTER the block store has already
     /// reconciled from durable pages (reconcile stays authoritative for on-disk physical bytes
     /// and diagnostics), so this only RESTORES the catalog fields a pure disk scan cannot infer:
@@ -73,7 +73,7 @@ impl LocalBlockStore {
     /// the merged manifest once. Returns whether anything changed.
     pub fn install_band_catalog(
         &self,
-        catalog: &[crate::index_log::BandCatalogEntry],
+        catalog: &[crate::index_log::SlabCatalogEntry],
     ) -> Result<bool, BlockStoreError> {
         let mut inner = self.inner.lock().expect("block store lock poisoned");
         let active = inner.block_slab_id;
@@ -104,7 +104,7 @@ impl LocalBlockStore {
                     // live file): install it from the fold so accounting/GC see the full history.
                     inner.bands.insert(
                         entry.block_slab_id,
-                        BlockStoreBandDescriptor {
+                        BlockStoreSlabDescriptor {
                             band_id: band_id_for_slab(entry.block_slab_id),
                             block_slab_id: entry.block_slab_id,
                             state,
@@ -132,7 +132,7 @@ impl LocalBlockStore {
         Ok(changed)
     }
 
-    pub fn band_summary(&self) -> BlockStoreBandSummary {
+    pub fn band_summary(&self) -> BlockStoreSlabSummary {
         summarize_bands(
             &self
                 .inner
@@ -144,7 +144,7 @@ impl LocalBlockStore {
 
     pub fn stream_backed_band_runtime_report(
         &self,
-    ) -> Result<StreamBackedBandRuntimeReport, BlockStoreError> {
+    ) -> Result<StreamBackedSlabRuntimeReport, BlockStoreError> {
         let inner = self.inner.lock().expect("block store lock poisoned");
         let bands = inner.bands.clone();
         let root = inner.root.clone();
@@ -185,7 +185,7 @@ impl LocalBlockStore {
         let manifest_missing_stream_bands = bands
             .values()
             .filter(|band| {
-                !matches!(band.state, BlockStoreBandState::Purged)
+                !matches!(band.state, BlockStoreSlabState::Purged)
                     && !live_slab_ids.contains(&band.block_slab_id)
                     && !delayed_slab_ids.contains(&band.block_slab_id)
             })
@@ -343,7 +343,7 @@ impl LocalBlockStore {
         }
 
         let runtime_ready = blockers.is_empty();
-        Ok(StreamBackedBandRuntimeReport {
+        Ok(StreamBackedSlabRuntimeReport {
             runtime_ready,
             band_lifecycle_states,
             band_count: bands.len() as u64,
@@ -392,7 +392,7 @@ impl LocalBlockStore {
                     .to_string(),
                 "open-time reconciliation repairs manifest/live stream divergence like band updates"
                     .to_string(),
-                "band usage reports map band ids to page-store used bytes like BandStats"
+                "band usage reports map band ids to page-store used bytes like SlabStats"
                     .to_string(),
             ],
         })

--- a/crates/temporalstore-rust/src/block_store/gc.rs
+++ b/crates/temporalstore-rust/src/block_store/gc.rs
@@ -341,7 +341,7 @@ impl LocalBlockStore {
                     set_band_state(
                         &mut inner.bands,
                         block_slab_id,
-                        BlockStoreBandState::DelayedDestroy,
+                        BlockStoreSlabState::DelayedDestroy,
                     );
                     delayed_destroy_ids.push(block_slab_id);
                     delayed_destroy_physical_bytes += slab_physical_bytes;
@@ -350,7 +350,7 @@ impl LocalBlockStore {
                     set_band_state(
                         &mut inner.bands,
                         block_slab_id,
-                        BlockStoreBandState::Purged,
+                        BlockStoreSlabState::Purged,
                     );
                 }
                 removed.push(block_slab_id);

--- a/crates/temporalstore-rust/src/block_store/read.rs
+++ b/crates/temporalstore-rust/src/block_store/read.rs
@@ -132,13 +132,13 @@ impl LocalBlockStore {
         let now = now_unix_ms();
         inner.bands.insert(
             block_slab_id,
-            BlockStoreBandDescriptor {
+            BlockStoreSlabDescriptor {
                 band_id: band_id_for_slab(block_slab_id),
                 block_slab_id,
                 state: if is_current_slab {
-                    BlockStoreBandState::Active
+                    BlockStoreSlabState::Active
                 } else {
-                    BlockStoreBandState::Sealed
+                    BlockStoreSlabState::Sealed
                 },
                 physical_bytes: bytes.len() as u64,
                 logical_bytes: band_summary.logical_bytes,
@@ -160,9 +160,9 @@ impl LocalBlockStore {
         if is_current_slab {
             for band in inner.bands.values_mut() {
                 if band.block_slab_id != block_slab_id
-                    && band.state == BlockStoreBandState::Active
+                    && band.state == BlockStoreSlabState::Active
                 {
-                    band.state = BlockStoreBandState::Sealed;
+                    band.state = BlockStoreSlabState::Sealed;
                 }
             }
         }

--- a/crates/temporalstore-rust/src/control.rs
+++ b/crates/temporalstore-rust/src/control.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::block_store::{BlockStoreBandSummary, BlockStoreStats};
+use crate::block_store::{BlockStoreSlabSummary, BlockStoreStats};
 use crate::types::{BatchExecuteResponse, Command, ExecuteResponse};
 use crate::types::{ShardId, Status};
 use crate::wal::WriteAheadLogStats;
@@ -310,11 +310,11 @@ pub struct ShardStats {
     #[serde(default)]
     pub page_store: BlockStoreStats,
     #[serde(default)]
-    pub page_store_zones: BlockStoreBandSummary,
+    pub page_store_zones: BlockStoreSlabSummary,
     pub block_store: BlockStoreStats,
     #[serde(default)]
     #[serde(alias = "block_store_zones")]
-    pub block_store_bands: BlockStoreBandSummary,
+    pub block_store_bands: BlockStoreSlabSummary,
     pub write_ahead_log: WriteAheadLogStats,
 }
 

--- a/crates/temporalstore-rust/src/engine/reports.rs
+++ b/crates/temporalstore-rust/src/engine/reports.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 use crate::block_store::{
-    BlockStoreSlabReport, BlockStoreStats, BlockStoreBandDescriptor, BlockStoreBandSummary,
+    BlockStoreSlabReport, BlockStoreStats, BlockStoreSlabDescriptor, BlockStoreSlabSummary,
 };
 use crate::storage_config::{
     StorageTuningConfig, TS_BLOCK_INDEX_CACHE_BYTES, TS_BLOCK_SLAB_TARGET_BYTES,
@@ -266,9 +266,9 @@ pub struct StorageRecoveryReport {
     #[serde(rename = "live_page_slab_ids")]
     pub live_block_slab_ids: Vec<u64>,
     #[serde(rename = "zone_descriptors")]
-    pub band_descriptors: Vec<BlockStoreBandDescriptor>,
+    pub band_descriptors: Vec<BlockStoreSlabDescriptor>,
     #[serde(rename = "zone_summary", default)]
-    pub band_summary: BlockStoreBandSummary,
+    pub band_summary: BlockStoreSlabSummary,
     #[serde(default)]
     #[serde(alias = "page_segment_reports")]
     #[serde(rename = "page_slab_reports")]
@@ -2096,10 +2096,10 @@ pub fn default_storage_index_snapshot() -> StorageIndexSnapshot {
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 /// A band's byte accounting and the slabs it holds.
 ///
-/// Keyed by `band_id`, the same key as [`StorageBandSample`], which carries that band's block
+/// Keyed by `band_id`, the same key as [`StorageSlabBandSample`], which carries that band's block
 /// range and reclaim state. Two shapes over one entity, not two levels -- "zone" was the older
 /// name for a band, and the wire still uses it.
-pub struct StorageBandUsageSample {
+pub struct StorageSlabUsageSample {
     #[serde(rename = "zone_id")]
     pub band_id: u64,
     pub total_bytes: u64,
@@ -2130,7 +2130,7 @@ pub struct StorageSlabSample {
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct StorageBandSample {
+pub struct StorageSlabBandSample {
     pub band: u64,
     pub block_range: Vec<u64>,
     pub reclaim_state: String,
@@ -2174,14 +2174,14 @@ pub struct StorageTopologySnapshot {
     pub append_log_reclaimed_records: u64,
     #[serde(default)]
     #[serde(rename = "storage_zone_samples")]
-    pub storage_band_usage_samples: Vec<StorageBandUsageSample>,
+    pub storage_band_usage_samples: Vec<StorageSlabUsageSample>,
     #[serde(default)]
     pub stream_samples: Vec<StorageStreamSample>,
     #[serde(default)]
     #[serde(alias = "segment_samples")]
     pub slab_samples: Vec<StorageSlabSample>,
     #[serde(default)]
-    pub band_samples: Vec<StorageBandSample>,
+    pub band_samples: Vec<StorageSlabBandSample>,
     #[serde(default)]
     #[serde(rename = "slot_samples")]
     pub bucket_samples: Vec<StorageBucketSample>,

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -550,7 +550,7 @@ pub(super) fn storage_topology_snapshot_with_samples(
 
     const MAX_STORAGE_TOPOLOGY_SAMPLES: usize = 8;
     #[derive(Default)]
-    struct BandUsageAcc {
+    struct SlabUsageAcc {
         used_bytes: u64,
         stale_bytes: u64,
         slabs: BTreeSet<u64>,
@@ -565,7 +565,7 @@ pub(super) fn storage_topology_snapshot_with_samples(
         live_refs: u64,
     }
     #[derive(Default)]
-    struct BandAcc {
+    struct SlabAccumulator {
         min_offset: u64,
         max_offset: u64,
         generation: u64,
@@ -580,9 +580,9 @@ pub(super) fn storage_topology_snapshot_with_samples(
         delete_markers: BTreeSet<String>,
     }
 
-    let mut bands_usage = BTreeMap::<u64, BandUsageAcc>::new();
+    let mut bands_usage = BTreeMap::<u64, SlabUsageAcc>::new();
     let mut slabs = BTreeMap::<u64, SlabAcc>::new();
-    let mut bands = BTreeMap::<u64, BandAcc>::new();
+    let mut bands = BTreeMap::<u64, SlabAccumulator>::new();
     let mut buckets = BTreeMap::<u32, BucketAcc>::new();
 
     for entry in &entries {
@@ -614,10 +614,10 @@ pub(super) fn storage_topology_snapshot_with_samples(
             slab.live_refs = slab.live_refs.saturating_add(1);
         }
 
-        let band = bands.entry(band_id).or_insert_with(|| BandAcc {
+        let band = bands.entry(band_id).or_insert_with(|| SlabAccumulator {
             min_offset: entry.address.offset,
             max_offset: entry.address.offset.saturating_add(entry.address.length),
-            ..BandAcc::default()
+            ..SlabAccumulator::default()
         });
         band.min_offset = band.min_offset.min(entry.address.offset);
         band.max_offset = band
@@ -667,7 +667,7 @@ pub(super) fn storage_topology_snapshot_with_samples(
     snapshot.storage_band_usage_samples = bands_usage
         .into_iter()
         .take(MAX_STORAGE_TOPOLOGY_SAMPLES)
-        .map(|(band_id, usage)| StorageBandUsageSample {
+        .map(|(band_id, usage)| StorageSlabUsageSample {
             band_id,
             total_bytes: usage.used_bytes.saturating_add(usage.stale_bytes),
             used_bytes: usage.used_bytes,
@@ -703,7 +703,7 @@ pub(super) fn storage_topology_snapshot_with_samples(
     snapshot.band_samples = bands
         .into_iter()
         .take(MAX_STORAGE_TOPOLOGY_SAMPLES)
-        .map(|(band_id, band)| StorageBandSample {
+        .map(|(band_id, band)| StorageSlabBandSample {
             band: band_id,
             block_range: vec![band.min_offset, band.max_offset],
             reclaim_state: if band.deleted_refs > 0 && band.live_refs == 0 {

--- a/crates/temporalstore-rust/src/engine/tests.rs
+++ b/crates/temporalstore-rust/src/engine/tests.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 MatrixArkAI
 
 use super::*;
-use crate::block_store::BlockStoreBandState;
+use crate::block_store::BlockStoreSlabState;
 use crate::engine::golden::{
     native_api_golden_corpus_report, native_feature_sequence_golden_corpus_report,
 };

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -2332,11 +2332,11 @@ fn crash_recovery_report_covers_wal_index_page_and_band_manifest() {
     assert_eq!(report.band_descriptors.len(), 2);
     assert_eq!(
         report.band_descriptors[0].state,
-        BlockStoreBandState::Sealed
+        BlockStoreSlabState::Sealed
     );
     assert_eq!(
         report.band_descriptors[1].state,
-        BlockStoreBandState::Active
+        BlockStoreSlabState::Active
     );
     assert_eq!(report.band_summary.sealed_bands, 1);
     assert_eq!(report.band_summary.active_bands, 1);
@@ -2645,11 +2645,11 @@ fn crash_recovery_rebuilds_missing_band_manifest_from_page_stream() {
         assert_eq!(report.band_descriptors.len(), 2);
         assert_eq!(
             report.band_descriptors[0].state,
-            BlockStoreBandState::Sealed
+            BlockStoreSlabState::Sealed
         );
         assert_eq!(
             report.band_descriptors[1].state,
-            BlockStoreBandState::Active
+            BlockStoreSlabState::Active
         );
         assert_eq!(report.band_summary.sealed_bands, 1);
         assert_eq!(report.band_summary.active_bands, 1);

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -17794,7 +17794,7 @@ fn the_band_usage_sample_still_serializes_under_its_zone_wire_names() {
     //
     // This asserts the pinning directly. A rename that dropped the #[serde(rename = ...)] would
     // compile, pass every type-level test, and silently change the exported shape.
-    let sample = crate::engine::reports::StorageBandUsageSample {
+    let sample = crate::engine::reports::StorageSlabUsageSample {
         band_id: 7,
         total_bytes: 300,
         used_bytes: 200,
@@ -17821,7 +17821,7 @@ fn the_band_usage_sample_still_serializes_under_its_zone_wire_names() {
     );
 
     // Reading back what the old name produced must still work, which is what a stored corpus is.
-    let decoded: crate::engine::reports::StorageBandUsageSample =
+    let decoded: crate::engine::reports::StorageSlabUsageSample =
         serde_json::from_str(r#"{"zone_id":9,"total_bytes":1,"used_bytes":1,"stale_bytes":0,"slabs":[]}"#)
             .expect("an old-name payload must still decode");
     assert_eq!(decoded.band_id, 9);

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -845,13 +845,13 @@ where
 }
 
 /// Band lifecycle state folded into the index-log MetaItem. 1:1 with
-/// `block_store::BlockStoreBandState` and with the on-disk band-state encoding
+/// `block_store::BlockStoreSlabState` and with the on-disk band-state encoding
 /// (INIT/CREATED/FROZEN/RECYCLED): Active==CREATED, Sealed==FROZEN, DelayedDestroy/Purged
 /// cover the RECYCLED grace. Serialized snake_case so it round-trips with the band manifest's
 /// own state enum.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum BandCatalogState {
+pub enum SlabCatalogState {
     Active,
     Sealed,
     DelayedDestroy,
@@ -866,11 +866,11 @@ pub enum BandCatalogState {
 /// (`inspect_slab`, driven by `rebuild_band_manifest_at` / reconcile-on-open), exactly as the
 /// are not persisted. So this is the lossless durable projection of a band.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct BandCatalogEntry {
+pub struct SlabCatalogEntry {
     #[serde(alias = "zone_id")]
     #[serde(rename = "page_slab_id")]
     pub block_slab_id: u64,
-    pub state: BandCatalogState,
+    pub state: SlabCatalogState,
     #[serde(alias = "total_bytes")]
     pub physical_bytes: u64,
     #[serde(default)]
@@ -908,7 +908,7 @@ pub struct MetaItem {
     #[serde(default)]
     pub timestamp_ms: u64,
     #[serde(rename = "zones", default)]
-    pub bands: Vec<BandCatalogEntry>,
+    pub bands: Vec<SlabCatalogEntry>,
     #[serde(rename = "zone_version", default)]
     pub band_version: u64,
 }
@@ -2446,9 +2446,9 @@ mod tests {
             start_wal_sequence: 1,
             timestamp_ms: 1,
             band_version: 1,
-            bands: vec![BandCatalogEntry {
+            bands: vec![SlabCatalogEntry {
                 block_slab_id: slab,
-                state: BandCatalogState::Active,
+                state: SlabCatalogState::Active,
                 physical_bytes: 1,
                 logical_bytes: 1,
                 created_unix_ms: None,
@@ -2872,9 +2872,9 @@ mod tests {
             timestamp_ms: 100,
             band_version: 3,
             bands: vec![
-                BandCatalogEntry {
+                SlabCatalogEntry {
                     block_slab_id: 0,
-                    state: BandCatalogState::Sealed,
+                    state: SlabCatalogState::Sealed,
                     physical_bytes: 4096,
                     logical_bytes: 4000,
                     created_unix_ms: Some(10),
@@ -2883,9 +2883,9 @@ mod tests {
                     last_page_id: Some(9),
                     version: 3,
                 },
-                BandCatalogEntry {
+                SlabCatalogEntry {
                     block_slab_id: 1,
-                    state: BandCatalogState::Active,
+                    state: SlabCatalogState::Active,
                     physical_bytes: 512,
                     logical_bytes: 512,
                     created_unix_ms: Some(30),
@@ -2904,7 +2904,7 @@ mod tests {
         let recovered = reopened.latest_band_catalog(4).unwrap().unwrap();
         assert_eq!(recovered, meta);
         assert_eq!(recovered.bands.len(), 2);
-        assert_eq!(recovered.bands[0].state, BandCatalogState::Sealed);
+        assert_eq!(recovered.bands[0].state, SlabCatalogState::Sealed);
         assert_eq!(recovered.bands[1].block_slab_id, 1);
     }
 
@@ -2917,9 +2917,9 @@ mod tests {
             start_wal_sequence: 1,
             timestamp_ms: 1,
             band_version: 1,
-            bands: vec![BandCatalogEntry {
+            bands: vec![SlabCatalogEntry {
                 block_slab_id: 0,
-                state: BandCatalogState::Active,
+                state: SlabCatalogState::Active,
                 physical_bytes: 1,
                 logical_bytes: 1,
                 created_unix_ms: None,
@@ -2934,9 +2934,9 @@ mod tests {
             start_wal_sequence: 9,
             timestamp_ms: 9,
             band_version: 2,
-            bands: vec![BandCatalogEntry {
+            bands: vec![SlabCatalogEntry {
                 block_slab_id: 0,
-                state: BandCatalogState::Sealed,
+                state: SlabCatalogState::Sealed,
                 physical_bytes: 2,
                 logical_bytes: 2,
                 created_unix_ms: None,

--- a/crates/temporalstore-rust/src/index_log_record.rs
+++ b/crates/temporalstore-rust/src/index_log_record.rs
@@ -85,7 +85,7 @@ pub struct IndexItem {
 /// Numbering matches this design exactly, including that RECYCLED is 4 and 3 is unused.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
-pub enum BandState {
+pub enum SlabState {
     /// Reserved and durable, but its stream does not exist yet.
     Init = 0,
     /// Stream created and accepting writes.
@@ -104,7 +104,7 @@ pub struct BandInfo {
     pub band_id: u32,
     #[prost(uint64, tag = "2")]
     pub total_bytes: u64,
-    #[prost(enumeration = "BandState", tag = "3")]
+    #[prost(enumeration = "SlabState", tag = "3")]
     pub state: i32,
     #[prost(uint64, tag = "4")]
     pub init_time_ms: u64,
@@ -179,10 +179,10 @@ mod tests {
     fn band_states_keep_their_on_disk_numbering() {
         // RECYCLED is 4, not 3 -- the gap is real and a renumber would silently reinterpret
         // existing records.
-        assert_eq!(BandState::Init as i32, 0);
-        assert_eq!(BandState::Created as i32, 1);
-        assert_eq!(BandState::Frozen as i32, 2);
-        assert_eq!(BandState::Recycled as i32, 4);
+        assert_eq!(SlabState::Init as i32, 0);
+        assert_eq!(SlabState::Created as i32, 1);
+        assert_eq!(SlabState::Frozen as i32, 2);
+        assert_eq!(SlabState::Recycled as i32, 4);
     }
 
     #[test]
@@ -237,7 +237,7 @@ mod tests {
             BandInfo {
                 band_id: 1,
                 total_bytes: 1 << 20,
-                state: BandState::Frozen as i32,
+                state: SlabState::Frozen as i32,
                 version: 7,
                 ..Default::default()
             },
@@ -257,7 +257,7 @@ mod tests {
         let (decoded, _): (IndexLogRecord, usize) = decode_framed_at(&framed, 0).unwrap();
         let meta = decoded.meta_item.expect("meta item");
         assert_eq!(meta.start_wal_id, 987_654);
-        assert_eq!(meta.bands[&1].state, BandState::Frozen as i32);
+        assert_eq!(meta.bands[&1].state, SlabState::Frozen as i32);
         assert_eq!(meta.bands[&1].version, 7);
     }
 

--- a/crates/temporalstore-rust/src/lib.rs
+++ b/crates/temporalstore-rust/src/lib.rs
@@ -62,7 +62,7 @@ pub mod index_log_record;
 pub mod wal_record;
 
 pub use block_store::{
-    BlockAddress, BlockStoreBandDescriptor, BlockStoreBandState, BlockStoreBandSummary,
+    BlockAddress, BlockStoreSlabDescriptor, BlockStoreSlabState, BlockStoreSlabSummary,
     BlockStoreOptions, BlockStoreSlabReport, BlockStoreStats, LocalBlockStore, SharedSlabSource,
 };
 pub use client::{

--- a/crates/temporalstore-rust/src/shared_store.rs
+++ b/crates/temporalstore-rust/src/shared_store.rs
@@ -17,7 +17,7 @@ use thiserror::Error;
 
 use tokio::sync::oneshot;
 
-use crate::block_store::{BlockStoreError, LazyCheckpointBand, LocalBlockStore, SharedSlabSource};
+use crate::block_store::{BlockStoreError, LazyCheckpointSlab, LocalBlockStore, SharedSlabSource};
 use crate::engine::TemporalEngine;
 use crate::sdk::{self, v1};
 use crate::types::{Command, ExecuteRequest, ShardId, Status};
@@ -2065,10 +2065,10 @@ where
             // GC/compaction accounting is complete immediately after restore, before the first
             // on-demand fetch materializes any slab locally. Runs AFTER the reserve so the freshly
             // reserved slab stays the active band and every checkpoint slab is sealed.
-            let lazy_bands: Vec<LazyCheckpointBand> = manifest
+            let lazy_bands: Vec<LazyCheckpointSlab> = manifest
                 .block_slabs
                 .iter()
-                .map(|slab| LazyCheckpointBand {
+                .map(|slab| LazyCheckpointSlab {
                     block_slab_id: slab.block_slab_id,
                     physical_bytes: slab.byte_size,
                     logical_bytes: slab.logical_bytes,
@@ -3857,7 +3857,7 @@ mod tests {
             .into_iter()
             .find(|b| b.block_slab_id == 0)
             .expect("restore must install a band descriptor for the lazily-backed slab 0");
-        assert_eq!(follower_band.state, crate::block_store::BlockStoreBandState::Sealed);
+        assert_eq!(follower_band.state, crate::block_store::BlockStoreSlabState::Sealed);
         assert_eq!(follower_band.logical_bytes, primary_band.logical_bytes);
         assert_eq!(follower_band.physical_bytes, slab0.byte_size);
         // The band summary counts the sealed shared band immediately (accounting is complete).


### PR DESCRIPTION
band becomes slab in the type names

`band_id_for_slab` is the identity function:

    pub(crate) fn band_id_for_slab(block_slab_id: u64) -> u64 { block_slab_id }

and a test in this file says it in words -- "the band is the slab, present either
way" -- asserting band_id() == block_slab_id. So zone, band and slab are one
level under three names, and the vocabulary should settle on one. This is the
first slice: TYPE names, 200 occurrences across 15 files, 186 insertions against
186 deletions.

The wire does not move here. Field names are untouched -- `pub band_id` is still
`pub band_id`, and the four serde attributes mentioning band are unchanged. Those
are the wire and each needs its own pin, which is a separate slice.

Two things this slice got wrong first, both worth keeping.

"Type names are never serialized" is FALSE in this tree. Prost embeds the Rust
type name in an attribute:

    #[prost(enumeration = "BandState", tag = "3")]

so renaming the enum while skipping string literals left the annotation pointing
at a type that no longer existed -- 28 errors. There are exactly three `Band`
strings in the tree, so the fix is to replace everywhere and restore the one that
is a DISPLAY LABEL rather than a type reference (`band: text("Band")` in a
report). Verified after: the annotation now reads "SlabState" and the label still
reads "Band".

BandInfo is NOT renamed, because `SlabInfo` already exists. The guard aborted
before writing a byte. That pair is a merge and wants its own decision; every
other target name was checked free first.

Full suite: 1763 passed, 1 failed -- the known baseline failure.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
