### PR TITLE
Pin that a slab descriptor carries the same number twice

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -2803,6 +2803,39 @@ mod tests {
     }
 
     #[test]
+    #[test]
+    fn a_slab_descriptor_carries_the_same_number_twice() {
+        // `band_id_for_slab` is the identity function, so a descriptor's `band_id` and its
+        // `block_slab_id` are ONE value under two names. Every construction site says so:
+        // band_id_for_slab(inner.block_slab_id), band_id_for_slab(band.block_slab_id),
+        // band_id_for_slab(new_slab_id).
+        //
+        // `rolled_slabs_stamp_new_band_ids` above pins that for an ADDRESS. This pins it for the
+        // DESCRIPTOR, which is the struct that actually stores both, and where a caller picks
+        // whichever name is nearer without it mattering today.
+        //
+        // Removing either field is a wire change -- both serialize and the compat corpora carry
+        // them -- so the duplication stays. What must not happen is the two diverging quietly.
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalBlockStore::new(dir.path());
+        store.append(b"first").unwrap();
+        store.roll_slab().unwrap();
+        store.append(b"second").unwrap();
+
+        let descriptors = store.band_descriptors();
+        assert!(
+            descriptors.len() >= 2,
+            "the roll should give at least two descriptors, got {}",
+            descriptors.len()
+        );
+        for descriptor in &descriptors {
+            assert_eq!(
+                descriptor.band_id, descriptor.block_slab_id,
+                "a band IS a slab: band_id and block_slab_id must never diverge"
+            );
+        }
+    }
+
     fn rolled_slabs_stamp_new_band_ids() {
         let dir = tempfile::tempdir().unwrap();
         let store = LocalBlockStore::new(dir.path());


### PR DESCRIPTION
Pin that a slab descriptor carries the same number twice

Slice 2 of band -> slab was meant to be the field names. It is not a rename:

    pub struct BlockStoreSlabDescriptor {
        pub band_id: u64,
        pub block_slab_id: u64,
    }

Those are the SAME u64. `band_id_for_slab` is the identity function, and every
construction site feeds it the slab id -- band_id_for_slab(inner.block_slab_id),
band_id_for_slab(band.block_slab_id), band_id_for_slab(new_slab_id). So renaming
band_id to slab_id cannot work: the destination field already exists holding the
identical value. StorageSlabSample repeats the pattern with slab_id and band.

`rolled_slabs_stamp_new_band_ids` already pins this for an ADDRESS. Nothing
pinned it for the DESCRIPTOR, which is the struct that actually stores both and
where a caller reaches for whichever name is nearer without it mattering today.

Mutation-verified: making band_id_for_slab return x + 1 fails this with "a band
IS a slab: band_id and block_slab_id must never diverge".

The duplication STAYS for now, deliberately. Both fields serialize and the compat
corpora carry them, so removing either is a wire break rather than a cleanup, and
that wants its own decision. What this test buys in the meantime is that the two
cannot drift apart quietly -- which is the actual hazard of a field that can
never differ.

Full suite: 1764 passed, 1 failed -- the known baseline failure.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
