### PR TITLE
Say in the code that band_id and block_slab_id are one number

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -629,6 +629,15 @@ pub struct LazyCheckpointSlab {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BlockStoreSlabDescriptor {
+    /// The same number as [`Self::block_slab_id`], always.
+    ///
+    /// A band IS a slab: `band_id_for_slab` is the identity function, and every construction site
+    /// passes the slab id into it. `band` is simply the older name -- the aliases below record
+    /// the lineage `zone_id` -> `extent_id` -> `band_id`.
+    ///
+    /// It stays because it SERIALIZES and the compat corpora carry it, so dropping it is a wire
+    /// break rather than a cleanup. Read `block_slab_id` in new code; the two cannot diverge, and
+    /// `a_slab_descriptor_carries_the_same_number_twice` fails if they ever do.
     #[serde(alias = "extent_id", alias = "zone_id")]
     pub band_id: u64,
     #[serde(rename = "page_segment_id")]

--- a/crates/temporalstore-rust/src/engine/reports.rs
+++ b/crates/temporalstore-rust/src/engine/reports.rs
@@ -2123,6 +2123,9 @@ pub struct StorageStreamSample {
 pub struct StorageSlabSample {
     #[serde(alias = "segment_id")]
     pub slab_id: u64,
+    /// The same number as [`Self::slab_id`], always -- see
+    /// [`crate::block_store::BlockStoreSlabDescriptor::band_id`]. Kept because it serializes and
+    /// the compat corpora carry it.
     pub band: u64,
     pub start_offset: u64,
     pub sealed: bool,


### PR DESCRIPTION
Say in the code that band_id and block_slab_id are one number

The band -> slab consolidation renamed the types (#1479) and every field with no
colliding twin (#1482). What is left cannot be renamed: `band_id` sits beside
`block_slab_id` in BlockStoreSlabDescriptor, and `band` beside `slab_id` in
StorageSlabSample, holding the IDENTICAL value -- `band_id_for_slab` is the
identity function and every construction site feeds it the slab id.

Removing either is a wire break: both serialize and the compat corpora carry
them. So they stay, and this makes the situation legible where someone will
actually meet it -- on the fields themselves, rather than in a commit message
nobody reads at the point of use.

Each now says it is the same number as its twin, why it remains, which one to
read in new code, and which test fails if they ever diverge
(a_slab_descriptor_carries_the_same_number_twice, #1481).

The hazard being documented is specific: a field that can never differ is an
invitation to read the wrong one. Nothing stops the two drifting apart except
that test, and a caller reaching for whichever name is nearer has no way to know
today that it does not matter.

Documentation only -- every added line is a doc comment, verified by diff, and
both crates compile clean. No behaviour, no wire, no test changes, so the library
suite cannot be reached by it.

Still open, and the last piece of this consolidation: whether to DROP the
duplicates and accept the wire break, or keep them permanently. That is a
published-format decision rather than a rename.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
