### PR TITLE
band becomes slab everywhere else it can

### DIFF
--- a/crates/temporalstore-rust/examples/shared_store_append_blob_conformance_report.rs
+++ b/crates/temporalstore-rust/examples/shared_store_append_blob_conformance_report.rs
@@ -96,11 +96,11 @@ struct AuthoritativeOffsetLookupReport {
     range_bytes_read: u64,
     exact_offset_slice_reads: u64,
     range_reads_smaller_than_blob: u64,
-    band_metadata_entries: u64,
+    slab_metadata_entries: u64,
     first_physical_offset_entries: u64,
     all_wal_indexes_directly_read_from_offset_metadata: bool,
     all_direct_reads_match_expected_entries: bool,
-    all_direct_reads_have_band_metadata: bool,
+    all_direct_reads_have_slab_metadata: bool,
     lower_layer_range_reads_exact_offset_slices: bool,
     lower_layer_range_reads_avoid_full_blob_scans: bool,
     lower_layer_blob_offset_reads_proven: bool,
@@ -208,7 +208,7 @@ struct Summary {
     direct_offset_index_maps_wal_to_blob_offsets: bool,
     authoritative_offset_lookup_reads_all_records: bool,
     authoritative_offset_lookup_matches_all_records: bool,
-    authoritative_offset_lookup_has_band_metadata: bool,
+    authoritative_offset_lookup_has_slab_metadata: bool,
     lower_layer_blob_offset_reads_proven: bool,
     lower_layer_range_reads_avoid_full_blob_scans: bool,
     snapshot_reopen_restores_offset_metadata: bool,
@@ -345,15 +345,15 @@ async fn main() {
             && async_writer
                 .authoritative_offset_lookup
                 .all_direct_reads_match_expected_entries,
-        authoritative_offset_lookup_has_band_metadata: direct_publish
+        authoritative_offset_lookup_has_slab_metadata: direct_publish
             .authoritative_offset_lookup
-            .all_direct_reads_have_band_metadata
+            .all_direct_reads_have_slab_metadata
             && sync_writer
                 .authoritative_offset_lookup
-                .all_direct_reads_have_band_metadata
+                .all_direct_reads_have_slab_metadata
             && async_writer
                 .authoritative_offset_lookup
-                .all_direct_reads_have_band_metadata,
+                .all_direct_reads_have_slab_metadata,
         lower_layer_blob_offset_reads_proven: direct_publish
             .authoritative_offset_lookup
             .lower_layer_blob_offset_reads_proven
@@ -943,7 +943,7 @@ async fn validate_authoritative_offset_lookup(
     let mut range_bytes_read = 0u64;
     let mut exact_offset_slice_reads = 0u64;
     let mut range_reads_smaller_than_blob = 0u64;
-    let mut band_metadata_entries = 0u64;
+    let mut slab_metadata_entries = 0u64;
     let mut first_physical_offset_entries = 0u64;
     let mut errors = Vec::new();
     for index in 1..=entry_count {
@@ -972,7 +972,7 @@ async fn validate_authoritative_offset_lookup(
                     range_reads_smaller_than_blob += 1;
                 }
                 if read.metadata.wal_blob_physical_slab_count > 0 {
-                    band_metadata_entries += 1;
+                    slab_metadata_entries += 1;
                 }
                 if read.metadata.wal_blob_first_physical_offset.is_some() {
                     first_physical_offset_entries += 1;
@@ -997,12 +997,12 @@ async fn validate_authoritative_offset_lookup(
         range_bytes_read,
         exact_offset_slice_reads,
         range_reads_smaller_than_blob,
-        band_metadata_entries,
+        slab_metadata_entries,
         first_physical_offset_entries,
         all_wal_indexes_directly_read_from_offset_metadata: metadata_hits == entry_count
             && decoded_entries == entry_count,
         all_direct_reads_match_expected_entries: matched_entries == entry_count,
-        all_direct_reads_have_band_metadata: band_metadata_entries == entry_count
+        all_direct_reads_have_slab_metadata: slab_metadata_entries == entry_count
             && first_physical_offset_entries == entry_count,
         lower_layer_range_reads_exact_offset_slices: exact_offset_slice_reads == entry_count,
         lower_layer_range_reads_avoid_full_blob_scans: range_reads_smaller_than_blob

--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -35,7 +35,7 @@ pub(crate) use record::BLOCK_RECORD_HEADER_LEN;
 pub(crate) use record::block_index_checksums_enabled;
 
 use paths::{
-    delayed_destroy_dir, delayed_destroy_path, band_manifest_path, file_created_unix_ms,
+    delayed_destroy_dir, delayed_destroy_path, slab_manifest_path, file_created_unix_ms,
     file_modified_unix_ms, legacy_zone_manifest_path, now_unix_ms, slab_path, sync_dir,
     sync_parent_dir, system_time_unix_ms,
 };
@@ -344,8 +344,8 @@ impl BlockAddress {
 
     pub fn from_compact_slab_address(compact_slab_address: u64, length: u64) -> Self {
         Self::from_parts(
-            compact_extract_band_id(compact_slab_address) as u64,
-            compact_extract_band_offset(compact_slab_address) as u64,
+            compact_extract_slab_id(compact_slab_address) as u64,
+            compact_extract_slab_offset(compact_slab_address) as u64,
             length,
             None,
             None,
@@ -525,7 +525,7 @@ impl BlockStoreGcPolicy {
     /// Reclaim eligible bands whose garbage ratio is at least
     /// `min_band_garbage_basis_points`, highest-garbage first, optionally bounded by a
     /// minimum band age. Mirrors selecting the maximum-garbage-rate zone under GC.
-    pub fn with_band_garbage_floor(
+    pub fn with_slab_garbage_floor(
         min_slab_garbage_basis_points: u64,
         min_age_ms: Option<u64>,
     ) -> Self {
@@ -713,25 +713,29 @@ pub struct BlockStoreSlabSummary {
         alias = "oldest_live_zone_unix_ms",
         skip_serializing_if = "Option::is_none"
     )]
-    pub oldest_live_band_unix_ms: Option<u64>,
+    #[serde(rename = "oldest_live_band_unix_ms")]
+    pub oldest_live_slab_unix_ms: Option<u64>,
     #[serde(
         default,
         alias = "oldest_live_zone_age_ms",
         skip_serializing_if = "Option::is_none"
     )]
-    pub oldest_live_band_age_ms: Option<u64>,
+    #[serde(rename = "oldest_live_band_age_ms")]
+    pub oldest_live_slab_age_ms: Option<u64>,
     #[serde(
         default,
         alias = "oldest_reclaimable_zone_unix_ms",
         skip_serializing_if = "Option::is_none"
     )]
-    pub oldest_reclaimable_band_unix_ms: Option<u64>,
+    #[serde(rename = "oldest_reclaimable_band_unix_ms")]
+    pub oldest_reclaimable_slab_unix_ms: Option<u64>,
     #[serde(
         default,
         alias = "oldest_reclaimable_zone_age_ms",
         skip_serializing_if = "Option::is_none"
     )]
-    pub oldest_reclaimable_band_age_ms: Option<u64>,
+    #[serde(rename = "oldest_reclaimable_band_age_ms")]
+    pub oldest_reclaimable_slab_age_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -768,7 +772,8 @@ pub struct BlockStoreSlabUsage {
 pub struct StreamBackedSlabRuntimeReport {
     pub runtime_ready: bool,
     #[serde(default)]
-    pub band_lifecycle_states: Vec<String>,
+    #[serde(rename = "band_lifecycle_states")]
+    pub slab_lifecycle_states: Vec<String>,
     #[serde(alias = "extent_count", alias = "zone_count")]
     pub band_count: u64,
     #[serde(alias = "active_zones")]
@@ -784,9 +789,9 @@ pub struct StreamBackedSlabRuntimeReport {
     #[serde(rename = "purged_bands")]
     pub purged_slabs: u64,
     #[serde(rename = "zone_stats_ready", default)]
-    pub band_stats_ready: bool,
+    pub slab_stats_ready: bool,
     #[serde(rename = "zone_usage", default)]
-    pub band_usage: Vec<BlockStoreSlabUsage>,
+    pub slab_usage: Vec<BlockStoreSlabUsage>,
     #[serde(alias = "stream_segment_count")]
     pub stream_slab_count: u64,
     pub physical_bytes: u64,
@@ -802,29 +807,39 @@ pub struct StreamBackedSlabRuntimeReport {
     #[serde(default)]
     pub logical_stream_bytes_read: u64,
     #[serde(default)]
-    pub band_state_transition_count: u64,
+    #[serde(rename = "band_state_transition_count")]
+    pub slab_state_transition_count: u64,
     pub logical_stream_read_ready: bool,
     pub append_roll_ready: bool,
     #[serde(alias = "extent_manifest_ready", alias = "zone_manifest_ready")]
-    pub band_manifest_ready: bool,
+    #[serde(rename = "band_manifest_ready")]
+    pub slab_manifest_ready: bool,
     #[serde(default)]
-    pub band_manifest_rebuild_ready: bool,
+    #[serde(rename = "band_manifest_rebuild_ready")]
+    pub slab_manifest_rebuild_ready: bool,
     #[serde(default)]
-    pub band_manifest_reconciled_on_open: bool,
+    #[serde(rename = "band_manifest_reconciled_on_open")]
+    pub slab_manifest_reconciled_on_open: bool,
     #[serde(default)]
-    pub band_manifest_disk_consistent: bool,
+    #[serde(rename = "band_manifest_disk_consistent")]
+    pub slab_manifest_disk_consistent: bool,
     #[serde(default)]
-    pub manifest_missing_stream_bands: u64,
+    #[serde(rename = "manifest_missing_stream_bands")]
+    pub manifest_missing_stream_slabs: u64,
     #[serde(default)]
-    pub manifest_extra_stream_bands: u64,
+    #[serde(rename = "manifest_extra_stream_bands")]
+    pub manifest_extra_stream_slabs: u64,
     #[serde(default)]
-    pub corrupt_band_count: u64,
+    #[serde(rename = "corrupt_band_count")]
+    pub corrupt_slab_count: u64,
     #[serde(default)]
-    pub partial_band_count: u64,
+    #[serde(rename = "partial_band_count")]
+    pub partial_slab_count: u64,
     #[serde(default)]
     pub readable_prefix_physical_bytes: u64,
     #[serde(default)]
-    pub partial_band_recovery_ready: bool,
+    #[serde(rename = "partial_band_recovery_ready")]
+    pub partial_slab_recovery_ready: bool,
     pub envelope_checksum_ready: bool,
     pub compression_stream_ready: bool,
     pub delayed_destroy_ready: bool,
@@ -994,7 +1009,7 @@ struct BlockStoreInner {
     /// so it is written every so often rather than every install; the load rebuilds from the slabs
     /// when what it reads does not match them.
     slabs_unwritten: usize,
-    band_manifest_reconciled_on_open: bool,
+    slab_manifest_reconciled_on_open: bool,
     stats: BlockStoreStats,
     // Optional shared-storage read-through (on-demand lazy recovery): set by
     // attach_shared_slab_source() after a metadata-only restore. When present, a
@@ -1026,14 +1041,14 @@ impl LocalBlockStore {
             .map(|metadata| metadata.len())
             .unwrap_or_default();
         let manifest_exists =
-            band_manifest_path(&root).exists() || legacy_zone_manifest_path(&root).exists();
+            slab_manifest_path(&root).exists() || legacy_zone_manifest_path(&root).exists();
         let (mut bands, mut manifest_rebuilt) = if manifest_exists {
-            match load_band_manifest_at(&root) {
+            match load_slab_manifest_at(&root) {
                 Ok(bands) => (bands, false),
-                Err(_) => (rebuild_band_manifest_at(&root).unwrap_or_default(), true),
+                Err(_) => (rebuild_slab_manifest_at(&root).unwrap_or_default(), true),
             }
         } else {
-            (rebuild_band_manifest_at(&root).unwrap_or_default(), true)
+            (rebuild_slab_manifest_at(&root).unwrap_or_default(), true)
         };
         // Loaded BEFORE the page-id scan on purpose: the manifest already records `last_page_id`
         // per slab, and reading it turns a walk over every page record header -- 90% of a
@@ -1044,10 +1059,10 @@ impl LocalBlockStore {
         // counter here used to mean reading every block header in every slab to work out one
         // integer -- on a live-store copy, the bulk of a steady-state open.
         let next_page_id = 0;
-        let band_manifest_reconciled_on_open =
-            reconcile_band_manifest_with_disk(&root, &mut bands).unwrap_or_default();
-        manifest_rebuilt |= band_manifest_reconciled_on_open;
-        ensure_band_descriptor(
+        let slab_manifest_reconciled_on_open =
+            reconcile_slab_manifest_with_disk(&root, &mut bands).unwrap_or_default();
+        manifest_rebuilt |= slab_manifest_reconciled_on_open;
+        ensure_slab_descriptor(
             &mut bands,
             &root,
             block_slab_id,
@@ -1086,7 +1101,7 @@ impl LocalBlockStore {
             }
         }
         if manifest_rebuilt {
-            let _ = persist_band_manifest(&root, &bands);
+            let _ = persist_slab_manifest(&root, &bands);
         }
         Self {
             inner: Arc::new(Mutex::new(BlockStoreInner {
@@ -1098,7 +1113,7 @@ impl LocalBlockStore {
                 options,
                 bands,
                 slabs_unwritten: 0,
-                band_manifest_reconciled_on_open,
+                slab_manifest_reconciled_on_open,
                 stats: BlockStoreStats::default(),
                 shared_slab_source: None,
                 scratch: None,
@@ -1187,7 +1202,7 @@ impl LocalBlockStore {
                 first_error: None,
             },
         );
-        persist_band_manifest(&inner.root, &inner.bands)?;
+        persist_slab_manifest(&inner.root, &inner.bands)?;
         Ok(())
     }
 
@@ -1200,7 +1215,7 @@ impl LocalBlockStore {
     /// has a descriptor (e.g. it was fetched or is local), is left untouched. Call AFTER
     /// [`reserve_lazy_checkpoint_range`] so the reserved slab is the active one and every
     /// checkpoint slab is correctly sealed.
-    pub fn install_lazy_checkpoint_bands(
+    pub fn install_lazy_checkpoint_slabs(
         &self,
         bands: &[LazyCheckpointSlab],
     ) -> Result<(), BlockStoreError> {
@@ -1245,7 +1260,7 @@ impl LocalBlockStore {
             }
         }
         if changed {
-            persist_band_manifest(&inner.root, &inner.bands)?;
+            persist_slab_manifest(&inner.root, &inner.bands)?;
         }
         Ok(())
     }
@@ -1370,8 +1385,8 @@ impl LocalBlockStore {
         Ok(ids)
     }
 
-    pub fn band_usage(&self) -> Vec<BlockStoreSlabUsage> {
-        compute_band_usage(
+    pub fn slab_usage(&self) -> Vec<BlockStoreSlabUsage> {
+        compute_slab_usage(
             &self
                 .inner
                 .lock()
@@ -1458,12 +1473,12 @@ impl LocalBlockStore {
             }
             purged_physical_bytes += bytes;
             fs::remove_file(entry.path())?;
-            set_band_state(&mut inner.bands, id, BlockStoreSlabState::Purged);
+            set_slab_state(&mut inner.bands, id, BlockStoreSlabState::Purged);
             purged.push(id);
         }
         purged.sort_unstable();
         sync_dir(&trash_dir)?;
-        persist_band_manifest(&inner.root, &inner.bands)?;
+        persist_slab_manifest(&inner.root, &inner.bands)?;
         retained_too_young.sort_unstable();
         Ok(BlockStorePurgeDelayedDestroyReport {
             purged_block_slab_ids: purged,
@@ -1626,7 +1641,7 @@ fn roll_slab_inner(
         previous.state = BlockStoreSlabState::Sealed;
         previous.updated_unix_ms = Some(transition_unix_ms);
     }
-    let new_band = BlockStoreSlabDescriptor {
+    let new_slab = BlockStoreSlabDescriptor {
         band_id: band_id_for_slab(inner.block_slab_id),
         block_slab_id: inner.block_slab_id,
         state: BlockStoreSlabState::Active,
@@ -1643,15 +1658,15 @@ fn roll_slab_inner(
         first_error: None,
     };
     let block_slab_id = inner.block_slab_id;
-    inner.bands.insert(block_slab_id, new_band);
-    persist_band_manifest(&inner.root, &inner.bands)?;
+    inner.bands.insert(block_slab_id, new_slab);
+    persist_slab_manifest(&inner.root, &inner.bands)?;
     Ok(BlockStoreRollReport {
         previous_block_slab_id,
         new_block_slab_id: inner.block_slab_id,
     })
 }
 
-fn band_lifecycle_states(summary: &BlockStoreSlabSummary) -> Vec<String> {
+fn slab_lifecycle_states(summary: &BlockStoreSlabSummary) -> Vec<String> {
     let mut states = Vec::new();
     if summary.active_slabs > 0 {
         states.push("active".to_string());
@@ -1668,7 +1683,7 @@ fn band_lifecycle_states(summary: &BlockStoreSlabSummary) -> Vec<String> {
     states
 }
 
-fn compute_band_usage(
+fn compute_slab_usage(
     bands: &BTreeMap<u64, BlockStoreSlabDescriptor>,
 ) -> Vec<BlockStoreSlabUsage> {
     #[derive(Debug, Clone)]
@@ -1676,7 +1691,7 @@ fn compute_band_usage(
         usage: BlockStoreSlabUsage,
     }
 
-    fn merged_band_state(
+    fn merged_slab_state(
         left: BlockStoreSlabState,
         right: BlockStoreSlabState,
     ) -> BlockStoreSlabState {
@@ -1689,7 +1704,7 @@ fn compute_band_usage(
         }
     }
 
-    let mut usage_by_band = BTreeMap::<u64, SlabUsageAcc>::new();
+    let mut usage_by_slab = BTreeMap::<u64, SlabUsageAcc>::new();
     for band in bands.values() {
         let (live, reclaimable, purged) = match band.state {
             BlockStoreSlabState::Active | BlockStoreSlabState::Sealed => {
@@ -1698,7 +1713,7 @@ fn compute_band_usage(
             BlockStoreSlabState::DelayedDestroy => (0, band.physical_bytes, 0),
             BlockStoreSlabState::Purged => (0, 0, band.physical_bytes),
         };
-        let entry = usage_by_band
+        let entry = usage_by_slab
             .entry(band.band_id)
             .or_insert_with(|| SlabUsageAcc {
                 usage: BlockStoreSlabUsage {
@@ -1722,7 +1737,7 @@ fn compute_band_usage(
         let usage = &mut entry.usage;
         usage.block_slab_id = usage.block_slab_id.min(band.block_slab_id);
         usage.stream_slab_id = usage.stream_slab_id.min(band.block_slab_id);
-        usage.state = merged_band_state(usage.state, band.state);
+        usage.state = merged_slab_state(usage.state, band.state);
         usage.used_bytes = usage.used_bytes.saturating_add(band.physical_bytes);
         usage.live_bytes = usage.live_bytes.saturating_add(live);
         usage.reclaimable_bytes = usage.reclaimable_bytes.saturating_add(reclaimable);
@@ -1747,7 +1762,7 @@ fn compute_band_usage(
             (left, None) => left,
         };
     }
-    usage_by_band.into_values().map(|acc| acc.usage).collect()
+    usage_by_slab.into_values().map(|acc| acc.usage).collect()
 }
 
 impl Default for LocalBlockStore {
@@ -2357,7 +2372,7 @@ mod tests {
     }
 
     #[test]
-    fn per_append_does_not_reserialize_the_band_manifest_on_the_default_path() {
+    fn per_append_does_not_reserialize_the_slab_manifest_on_the_default_path() {
         // MANIFEST-CONFORMANCE FOLD no-O(n) proof: on the default single-barrier path the per-append
         // band-manifest full re-serialize (the measured O(n) aging driver -- ~961 B rewritten per
         // write, growing with the band count) is OFF the write path. Appending many records must
@@ -2366,7 +2381,7 @@ mod tests {
         // byte-identical across a burst of appends, then changing exactly once at sync_durable.
         let dir = tempfile::tempdir().unwrap();
         let store = LocalBlockStore::new(dir.path());
-        let manifest = band_manifest_path(dir.path());
+        let manifest = slab_manifest_path(dir.path());
         // Land one append so the manifest exists at a known state, then snapshot it.
         store.append(b"seed").unwrap();
         store.sync_durable().unwrap();
@@ -2390,7 +2405,7 @@ mod tests {
     }
 
     #[test]
-    fn band_catalog_folds_bands_and_install_reconstructs_lifecycle() {
+    fn slab_catalog_folds_slabs_and_install_reconstructs_lifecycle() {
         // MANIFEST-CONFORMANCE FOLD round-trip at the block-store layer: project the band catalog into
         // the durable SlabCatalogEntry subset, then reconstruct the band lifecycle from that projection
         // with the band-manifest file deleted -- proving the folded catalog is a lossless source
@@ -2402,7 +2417,7 @@ mod tests {
         store.roll_slab().unwrap();
         store.append(b"b").unwrap();
         store.sync_durable().unwrap();
-        let catalog = store.band_catalog(7);
+        let catalog = store.slab_catalog(7);
         // Two bands: the sealed first slab and the active second slab.
         assert_eq!(catalog.len(), 2);
         assert!(catalog.iter().any(|z| z.state == crate::index_log::SlabCatalogState::Sealed));
@@ -2412,9 +2427,9 @@ mod tests {
         // reconstructs bands from the durable slabs (reconcile-on-open), then we install the
         // folded catalog on top. The lifecycle states must match the pre-crash projection.
         let reopened = LocalBlockStore::new(dir.path());
-        std::fs::remove_file(band_manifest_path(dir.path())).ok();
-        let changed = reopened.install_band_catalog(&catalog).unwrap();
-        let recovered = reopened.band_catalog(0);
+        std::fs::remove_file(slab_manifest_path(dir.path())).ok();
+        let changed = reopened.install_slab_catalog(&catalog).unwrap();
+        let recovered = reopened.slab_catalog(0);
         let state_of = |slab: u64, zs: &[crate::index_log::SlabCatalogEntry]| {
             zs.iter().find(|z| z.block_slab_id == slab).map(|z| z.state)
         };
@@ -2579,7 +2594,7 @@ mod tests {
 
     // shared-corpus: storage_stream_manifest_disk_reconciliation;
     #[test]
-    fn reopen_reconciles_manifest_missing_existing_stream_band() {
+    fn reopen_reconciles_manifest_missing_existing_stream_slab() {
         let dir = tempfile::tempdir().unwrap();
         let store = LocalBlockStore::new(dir.path());
         let first = store.append(b"first").unwrap();
@@ -2587,7 +2602,7 @@ mod tests {
         let second = store.append(b"second").unwrap();
         drop(store);
 
-        let manifest_path = band_manifest_path(dir.path());
+        let manifest_path = slab_manifest_path(dir.path());
         let mut manifest: serde_json::Value =
             serde_json::from_slice(&fs::read(&manifest_path).unwrap()).unwrap();
         manifest["bands"] = serde_json::json!([manifest["bands"]
@@ -2604,7 +2619,7 @@ mod tests {
         .unwrap();
 
         let reopened = LocalBlockStore::new(dir.path());
-        let descriptors = reopened.band_descriptors();
+        let descriptors = reopened.slab_descriptors();
 
         assert!(descriptors
             .iter()
@@ -2614,18 +2629,18 @@ mod tests {
             .iter()
             .any(|band| band.block_slab_id == second.block_slab_id
                 && band.state == BlockStoreSlabState::Active));
-        let report = reopened.stream_backed_band_runtime_report().unwrap();
-        assert!(report.band_manifest_reconciled_on_open);
-        assert!(report.band_manifest_disk_consistent);
-        assert_eq!(report.manifest_extra_stream_bands, 0);
-        assert_eq!(report.manifest_missing_stream_bands, 0);
+        let report = reopened.stream_backed_slab_runtime_report().unwrap();
+        assert!(report.slab_manifest_reconciled_on_open);
+        assert!(report.slab_manifest_disk_consistent);
+        assert_eq!(report.manifest_extra_stream_slabs, 0);
+        assert_eq!(report.manifest_missing_stream_slabs, 0);
         assert_eq!(reopened.read(&first).unwrap(), b"first");
         assert_eq!(reopened.read(&second).unwrap(), b"second");
     }
 
     // shared-corpus: storage_stream_manifest_disk_reconciliation;
     #[test]
-    fn reopen_marks_manifest_band_without_stream_file_as_purged() {
+    fn reopen_marks_manifest_slab_without_stream_file_as_purged() {
         let dir = tempfile::tempdir().unwrap();
         let store = LocalBlockStore::new(dir.path());
         let first = store.append(b"first").unwrap();
@@ -2636,7 +2651,7 @@ mod tests {
         fs::remove_file(slab_path(dir.path(), first.block_slab_id)).unwrap();
 
         let reopened = LocalBlockStore::new(dir.path());
-        let descriptors = reopened.band_descriptors();
+        let descriptors = reopened.slab_descriptors();
 
         assert!(descriptors
             .iter()
@@ -2646,11 +2661,11 @@ mod tests {
             .iter()
             .any(|band| band.block_slab_id == second.block_slab_id
                 && band.state == BlockStoreSlabState::Active));
-        let report = reopened.stream_backed_band_runtime_report().unwrap();
-        assert!(report.band_manifest_reconciled_on_open);
-        assert!(report.band_manifest_disk_consistent);
-        assert_eq!(report.manifest_extra_stream_bands, 0);
-        assert_eq!(report.manifest_missing_stream_bands, 0);
+        let report = reopened.stream_backed_slab_runtime_report().unwrap();
+        assert!(report.slab_manifest_reconciled_on_open);
+        assert!(report.slab_manifest_disk_consistent);
+        assert_eq!(report.manifest_extra_stream_slabs, 0);
+        assert_eq!(report.manifest_missing_stream_slabs, 0);
         assert_eq!(reopened.read(&second).unwrap(), b"second");
     }
 
@@ -2843,7 +2858,7 @@ mod tests {
         store.roll_slab().unwrap();
         store.append(b"second").unwrap();
 
-        let descriptors = store.band_descriptors();
+        let descriptors = store.slab_descriptors();
         assert!(
             descriptors.len() >= 2,
             "the roll should give at least two descriptors, got {}",
@@ -2857,7 +2872,7 @@ mod tests {
         }
     }
 
-    fn rolled_slabs_stamp_new_band_ids() {
+    fn rolled_slabs_stamp_new_slab_ids() {
         let dir = tempfile::tempdir().unwrap();
         let store = LocalBlockStore::new(dir.path());
         let first = store.append(b"first-band").unwrap();
@@ -2871,14 +2886,14 @@ mod tests {
     }
 
     #[test]
-    fn band_manifest_tracks_roll_reopen_gc_and_purge() {
+    fn slab_manifest_tracks_roll_reopen_gc_and_purge() {
         let dir = tempfile::tempdir().unwrap();
         let store = LocalBlockStore::new(dir.path());
         let first = store.append(b"first-band").unwrap();
         store.roll_slab().unwrap();
         let second = store.append(b"second-band").unwrap();
 
-        let bands = store.band_descriptors();
+        let bands = store.slab_descriptors();
         assert_eq!(bands.len(), 2);
         assert_eq!(bands[0].block_slab_id, first.block_slab_id);
         assert_eq!(bands[0].state, BlockStoreSlabState::Sealed);
@@ -2892,8 +2907,8 @@ mod tests {
         assert_eq!(bands[1].last_page_id, second.page_id());
         assert!(bands[1].created_unix_ms.is_some());
         assert!(bands[1].updated_unix_ms.is_some());
-        assert!(band_manifest_path(dir.path()).exists());
-        let initial_summary = store.band_summary();
+        assert!(slab_manifest_path(dir.path()).exists());
+        let initial_summary = store.slab_summary();
         assert_eq!(initial_summary.sealed_slabs, 1);
         assert_eq!(initial_summary.active_slabs, 1);
         assert_eq!(initial_summary.delayed_destroy_slabs, 0);
@@ -2913,31 +2928,31 @@ mod tests {
         assert_eq!(initial_summary.reclaimable_physical_bytes, 0);
         assert!(initial_summary.oldest_known_slab_unix_ms.is_some());
         assert!(initial_summary.oldest_known_slab_age_ms.is_some());
-        assert!(initial_summary.oldest_live_band_unix_ms.is_some());
-        assert!(initial_summary.oldest_live_band_age_ms.is_some());
-        assert!(initial_summary.oldest_reclaimable_band_unix_ms.is_none());
-        assert!(initial_summary.oldest_reclaimable_band_age_ms.is_none());
-        let initial_band_usage = store.band_usage();
-        assert_eq!(initial_band_usage.len(), 2);
-        assert_eq!(initial_band_usage[0].band_id, bands[0].band_id);
+        assert!(initial_summary.oldest_live_slab_unix_ms.is_some());
+        assert!(initial_summary.oldest_live_slab_age_ms.is_some());
+        assert!(initial_summary.oldest_reclaimable_slab_unix_ms.is_none());
+        assert!(initial_summary.oldest_reclaimable_slab_age_ms.is_none());
+        let initial_slab_usage = store.slab_usage();
+        assert_eq!(initial_slab_usage.len(), 2);
+        assert_eq!(initial_slab_usage[0].band_id, bands[0].band_id);
         assert_eq!(
-            initial_band_usage[0].block_slab_id,
+            initial_slab_usage[0].block_slab_id,
             bands[0].block_slab_id
         );
         assert_eq!(
-            initial_band_usage[0].page_store_used_bytes,
+            initial_slab_usage[0].page_store_used_bytes,
             bands[0].physical_bytes
         );
         assert_eq!(
-            initial_band_usage[0].live_page_store_used_bytes,
+            initial_slab_usage[0].live_page_store_used_bytes,
             bands[0].physical_bytes
         );
-        assert_eq!(initial_band_usage[0].reclaimable_page_store_used_bytes, 0);
-        assert_eq!(initial_band_usage[0].purged_page_store_used_bytes, 0);
+        assert_eq!(initial_slab_usage[0].reclaimable_page_store_used_bytes, 0);
+        assert_eq!(initial_slab_usage[0].purged_page_store_used_bytes, 0);
 
         let reopened = LocalBlockStore::new(dir.path());
-        let reopened_bands = reopened.band_descriptors();
-        assert_eq!(reopened_bands.len(), bands.len());
+        let reopened_slabs = reopened.slab_descriptors();
+        assert_eq!(reopened_slabs.len(), bands.len());
         // The band must survive a reopen unchanged. `verified_source_mtime_unix_ms` is excluded
         // because it is not part of the band: it records when the descriptor was last checked
         // against the file, and the two sides differ on that for a good reason, asserted below.
@@ -2946,7 +2961,7 @@ mod tests {
             band.verified_source_mtime_unix_ms = None;
             band
         };
-        assert_eq!(strip(&reopened_bands[0]), strip(&bands[0]));
+        assert_eq!(strip(&reopened_slabs[0]), strip(&bands[0]));
         // The original store wrote and sealed this slab without ever inspecting it, so it has
         // nothing verified to record; the reopen reconciled, which inspected it, so it does.
         assert!(
@@ -2955,37 +2970,37 @@ mod tests {
             bands[0]
         );
         assert!(
-            reopened_bands[0].verified_source_mtime_unix_ms.is_some(),
+            reopened_slabs[0].verified_source_mtime_unix_ms.is_some(),
             "reopening inspected this slab, so the identity it verified should be recorded: {:?}",
-            reopened_bands[0]
+            reopened_slabs[0]
         );
         assert_eq!(
-            reopened_bands[1].block_slab_id,
+            reopened_slabs[1].block_slab_id,
             bands[1].block_slab_id
         );
-        assert_eq!(reopened_bands[1].state, bands[1].state);
+        assert_eq!(reopened_slabs[1].state, bands[1].state);
         assert_eq!(
-            reopened_bands[1].physical_bytes,
+            reopened_slabs[1].physical_bytes,
             bands[1].physical_bytes
         );
-        assert_eq!(reopened_bands[1].logical_bytes, bands[1].logical_bytes);
+        assert_eq!(reopened_slabs[1].logical_bytes, bands[1].logical_bytes);
         assert_eq!(
-            reopened_bands[1].created_unix_ms,
+            reopened_slabs[1].created_unix_ms,
             bands[1].created_unix_ms
         );
-        assert!(reopened_bands[1].updated_unix_ms >= bands[1].updated_unix_ms);
+        assert!(reopened_slabs[1].updated_unix_ms >= bands[1].updated_unix_ms);
 
         let report = reopened
             .gc_slabs_before_with_live_refs_delayed_destroy(1, std::iter::empty())
             .unwrap();
         assert_eq!(report.delayed_destroy_block_slab_ids, vec![0]);
-        let delayed = reopened.band_descriptors();
+        let delayed = reopened.slab_descriptors();
         assert_eq!(delayed[0].state, BlockStoreSlabState::DelayedDestroy);
         assert!(delayed[0].physical_bytes > 0);
         assert_eq!(delayed[0].created_unix_ms, bands[0].created_unix_ms);
         assert!(delayed[0].updated_unix_ms >= bands[0].updated_unix_ms);
         assert_eq!(delayed[1].state, BlockStoreSlabState::Active);
-        let delayed_summary = reopened.band_summary();
+        let delayed_summary = reopened.slab_summary();
         assert_eq!(delayed_summary.delayed_destroy_slabs, 1);
         assert_eq!(delayed_summary.active_slabs, 1);
         assert_eq!(
@@ -3001,14 +3016,14 @@ mod tests {
             delayed[1].physical_bytes
         );
         assert!(delayed_summary.oldest_known_slab_unix_ms.is_some());
-        assert!(delayed_summary.oldest_live_band_unix_ms.is_some());
+        assert!(delayed_summary.oldest_live_slab_unix_ms.is_some());
         assert_eq!(
-            delayed_summary.oldest_reclaimable_band_unix_ms,
+            delayed_summary.oldest_reclaimable_slab_unix_ms,
             delayed[0].updated_unix_ms
         );
-        assert!(delayed_summary.oldest_reclaimable_band_age_ms.is_some());
-        let delayed_band_usage = reopened.band_usage();
-        let delayed_first = delayed_band_usage
+        assert!(delayed_summary.oldest_reclaimable_slab_age_ms.is_some());
+        let delayed_slab_usage = reopened.slab_usage();
+        let delayed_first = delayed_slab_usage
             .iter()
             .find(|band| band.block_slab_id == first.block_slab_id)
             .unwrap();
@@ -3023,12 +3038,12 @@ mod tests {
             .unwrap();
         assert_eq!(purge.purged_block_slab_ids, vec![0]);
         assert!(purge.purged_physical_bytes > 0);
-        let purged = LocalBlockStore::new(dir.path()).band_descriptors();
+        let purged = LocalBlockStore::new(dir.path()).slab_descriptors();
         assert_eq!(purged[0].state, BlockStoreSlabState::Purged);
         assert_eq!(purged[0].created_unix_ms, bands[0].created_unix_ms);
         assert!(purged[0].updated_unix_ms >= delayed[0].updated_unix_ms);
         assert_eq!(purged[1].state, BlockStoreSlabState::Active);
-        let purged_summary = LocalBlockStore::new(dir.path()).band_summary();
+        let purged_summary = LocalBlockStore::new(dir.path()).slab_summary();
         assert_eq!(purged_summary.purged_slabs, 1);
         assert_eq!(purged_summary.active_slabs, 1);
         assert_eq!(
@@ -3037,8 +3052,8 @@ mod tests {
         );
         assert_eq!(purged_summary.live_physical_bytes, purged[1].physical_bytes);
         assert_eq!(purged_summary.reclaimable_physical_bytes, 0);
-        let purged_band_usage = LocalBlockStore::new(dir.path()).band_usage();
-        let purged_first = purged_band_usage
+        let purged_slab_usage = LocalBlockStore::new(dir.path()).slab_usage();
+        let purged_first = purged_slab_usage
             .iter()
             .find(|band| band.block_slab_id == first.block_slab_id)
             .unwrap();
@@ -3048,22 +3063,22 @@ mod tests {
         );
         assert_eq!(purged_first.reclaimable_page_store_used_bytes, 0);
         assert!(purged_summary.oldest_known_slab_unix_ms.is_some());
-        assert!(purged_summary.oldest_live_band_unix_ms.is_some());
-        assert!(purged_summary.oldest_reclaimable_band_unix_ms.is_none());
-        assert!(purged_summary.oldest_reclaimable_band_age_ms.is_none());
+        assert!(purged_summary.oldest_live_slab_unix_ms.is_some());
+        assert!(purged_summary.oldest_reclaimable_slab_unix_ms.is_none());
+        assert!(purged_summary.oldest_reclaimable_slab_age_ms.is_none());
     }
 
     #[test]
-    fn missing_band_manifest_rebuilds_from_existing_slabs() {
+    fn missing_slab_manifest_rebuilds_from_existing_slabs() {
         let dir = tempfile::tempdir().unwrap();
         let store = LocalBlockStore::new(dir.path());
         let first = store.append(b"first-band").unwrap();
         store.roll_slab().unwrap();
         let second = store.append(b"second-band").unwrap();
-        fs::remove_file(band_manifest_path(dir.path())).unwrap();
+        fs::remove_file(slab_manifest_path(dir.path())).unwrap();
 
         let rebuilt = LocalBlockStore::new(dir.path());
-        let bands = rebuilt.band_descriptors();
+        let bands = rebuilt.slab_descriptors();
 
         assert_eq!(bands.len(), 2);
         assert_eq!(bands[0].block_slab_id, first.block_slab_id);
@@ -3078,36 +3093,36 @@ mod tests {
         assert_eq!(bands[1].last_page_id, second.page_id());
         assert!(bands[1].created_unix_ms.is_some());
         assert!(bands[1].updated_unix_ms.is_some());
-        assert!(band_manifest_path(dir.path()).exists());
+        assert!(slab_manifest_path(dir.path()).exists());
 
-        let report = rebuilt.stream_backed_band_runtime_report().unwrap();
+        let report = rebuilt.stream_backed_slab_runtime_report().unwrap();
         assert!(report.runtime_ready, "{report:?}");
-        assert_eq!(report.band_lifecycle_states, vec!["active", "sealed"]);
-        assert!(report.band_manifest_ready);
-        assert!(report.band_manifest_rebuild_ready);
-        assert!(report.band_stats_ready);
-        assert_eq!(report.band_usage.len(), 2);
+        assert_eq!(report.slab_lifecycle_states, vec!["active", "sealed"]);
+        assert!(report.slab_manifest_ready);
+        assert!(report.slab_manifest_rebuild_ready);
+        assert!(report.slab_stats_ready);
+        assert_eq!(report.slab_usage.len(), 2);
         assert_eq!(
             report
-                .band_usage
+                .slab_usage
                 .iter()
                 .map(|band| band.page_store_used_bytes)
                 .sum::<u64>(),
             report.physical_bytes
         );
-        assert!(!report.band_manifest_reconciled_on_open);
-        assert!(report.band_manifest_disk_consistent);
-        assert_eq!(report.manifest_missing_stream_bands, 0);
-        assert_eq!(report.manifest_extra_stream_bands, 0);
-        assert_eq!(report.corrupt_band_count, 0);
-        assert_eq!(report.partial_band_count, 0);
-        assert!(report.partial_band_recovery_ready);
+        assert!(!report.slab_manifest_reconciled_on_open);
+        assert!(report.slab_manifest_disk_consistent);
+        assert_eq!(report.manifest_missing_stream_slabs, 0);
+        assert_eq!(report.manifest_extra_stream_slabs, 0);
+        assert_eq!(report.corrupt_slab_count, 0);
+        assert_eq!(report.partial_slab_count, 0);
+        assert!(report.partial_slab_recovery_ready);
         assert_eq!(report.readable_prefix_physical_bytes, report.physical_bytes);
     }
 
     // shared-corpus: storage_stream_partial_band_rebuild;
     #[test]
-    fn partial_band_manifest_rebuild_preserves_readable_prefix_and_reports_corruption() {
+    fn partial_slab_manifest_rebuild_preserves_readable_prefix_and_reports_corruption() {
         let dir = tempfile::tempdir().unwrap();
         let store = LocalBlockStore::new(dir.path());
         let first_payload = b"sealed-readable-prefix".repeat(64);
@@ -3123,13 +3138,13 @@ mod tests {
             .unwrap()
             .write_all(b"partial-corrupt-tail")
             .unwrap();
-        fs::remove_file(band_manifest_path(dir.path())).unwrap();
+        fs::remove_file(slab_manifest_path(dir.path())).unwrap();
 
         let rebuilt = LocalBlockStore::new(dir.path());
         assert_eq!(rebuilt.read(&first).unwrap(), first_payload);
         assert_eq!(rebuilt.read(&second).unwrap(), b"active-clean-tail");
 
-        let bands = rebuilt.band_descriptors();
+        let bands = rebuilt.slab_descriptors();
         let sealed = bands
             .iter()
             .find(|band| band.block_slab_id == first.block_slab_id)
@@ -3145,24 +3160,24 @@ mod tests {
             .as_deref()
             .unwrap_or_default()
             .contains("mixed raw bytes"));
-        assert!(band_manifest_path(dir.path()).exists());
+        assert!(slab_manifest_path(dir.path()).exists());
 
-        let report = rebuilt.stream_backed_band_runtime_report().unwrap();
+        let report = rebuilt.stream_backed_slab_runtime_report().unwrap();
         assert!(!report.runtime_ready, "{report:?}");
-        assert!(report.band_manifest_ready);
-        assert!(report.band_manifest_rebuild_ready);
-        assert!(!report.band_manifest_reconciled_on_open);
-        assert!(report.band_manifest_disk_consistent);
-        assert_eq!(report.manifest_missing_stream_bands, 0);
-        assert_eq!(report.manifest_extra_stream_bands, 0);
-        assert_eq!(report.band_lifecycle_states, vec!["active", "sealed"]);
-        assert_eq!(report.corrupt_band_count, 1);
-        assert_eq!(report.partial_band_count, 1);
+        assert!(report.slab_manifest_ready);
+        assert!(report.slab_manifest_rebuild_ready);
+        assert!(!report.slab_manifest_reconciled_on_open);
+        assert!(report.slab_manifest_disk_consistent);
+        assert_eq!(report.manifest_missing_stream_slabs, 0);
+        assert_eq!(report.manifest_extra_stream_slabs, 0);
+        assert_eq!(report.slab_lifecycle_states, vec!["active", "sealed"]);
+        assert_eq!(report.corrupt_slab_count, 1);
+        assert_eq!(report.partial_slab_count, 1);
         assert_eq!(
             report.readable_prefix_physical_bytes,
             readable_prefix + second.length
         );
-        assert!(report.partial_band_recovery_ready);
+        assert!(report.partial_slab_recovery_ready);
         assert!(!report.envelope_checksum_ready);
         assert!(report
             .blockers
@@ -3330,7 +3345,7 @@ mod tests {
 
     // shared-corpus: storage_stream_backed_band_runtime;
     #[test]
-    fn stream_backed_band_runtime_report_covers_roll_read_manifest_and_delayed_destroy() {
+    fn stream_backed_slab_runtime_report_covers_roll_read_manifest_and_delayed_destroy() {
         let dir = tempfile::tempdir().unwrap();
         let store = LocalBlockStore::new(dir.path());
         let first_payload = b"band-stream-first-".repeat(96);
@@ -3358,28 +3373,28 @@ mod tests {
             .append_with_page_metadata(&third_payload, Some(13), Some(8))
             .unwrap();
         assert_eq!(third.block_slab_id, roll.new_block_slab_id);
-        let before_gc = store.stream_backed_band_runtime_report().unwrap();
+        let before_gc = store.stream_backed_slab_runtime_report().unwrap();
         assert!(before_gc.runtime_ready, "{before_gc:?}");
         assert_eq!(before_gc.active_slabs, 1);
         assert_eq!(before_gc.sealed_slabs, 1);
-        assert_eq!(before_gc.band_lifecycle_states, vec!["active", "sealed"]);
+        assert_eq!(before_gc.slab_lifecycle_states, vec!["active", "sealed"]);
         assert_eq!(before_gc.stream_record_count, 3);
         assert_eq!(before_gc.first_page_id, first.page_id());
         assert_eq!(before_gc.last_page_id, third.page_id());
         assert!(before_gc.page_id_continuity_ready);
-        assert!(before_gc.band_manifest_rebuild_ready);
-        assert!(before_gc.band_stats_ready);
-        assert_eq!(before_gc.band_usage.len(), 2);
+        assert!(before_gc.slab_manifest_rebuild_ready);
+        assert!(before_gc.slab_stats_ready);
+        assert_eq!(before_gc.slab_usage.len(), 2);
         assert_eq!(
             before_gc
-                .band_usage
+                .slab_usage
                 .iter()
                 .map(|band| band.page_store_used_bytes)
                 .sum::<u64>(),
             before_gc.physical_bytes
         );
         assert!(before_gc.logical_stream_bytes_read >= 16);
-        assert!(before_gc.band_state_transition_count >= 2);
+        assert!(before_gc.slab_state_transition_count >= 2);
 
         let delayed = store
             .gc_slabs_before_with_live_refs_delayed_destroy(
@@ -3394,28 +3409,28 @@ mod tests {
 
         let reopened = LocalBlockStore::new(dir.path());
         assert_eq!(reopened.read(&third).unwrap(), third_payload);
-        let report = reopened.stream_backed_band_runtime_report().unwrap();
+        let report = reopened.stream_backed_slab_runtime_report().unwrap();
         assert!(report.runtime_ready, "{report:?}");
         assert_eq!(report.active_slabs, 1);
         assert_eq!(report.delayed_destroy_slabs, 1);
         assert_eq!(
-            report.band_lifecycle_states,
+            report.slab_lifecycle_states,
             vec!["active", "delayed_destroy"]
         );
         assert!(report.band_count >= 2);
         assert!(report.stream_slab_count >= 1);
         assert!(report.logical_stream_read_ready);
         assert!(report.append_roll_ready);
-        assert!(report.band_manifest_ready);
-        assert!(report.band_manifest_rebuild_ready);
-        assert!(report.band_stats_ready);
+        assert!(report.slab_manifest_ready);
+        assert!(report.slab_manifest_rebuild_ready);
+        assert!(report.slab_stats_ready);
         assert!(report
-            .band_usage
+            .slab_usage
             .iter()
             .any(|band| band.state == BlockStoreSlabState::DelayedDestroy
                 && band.reclaimable_page_store_used_bytes > 0));
         assert!(report
-            .band_usage
+            .slab_usage
             .iter()
             .any(|band| band.state == BlockStoreSlabState::Active
                 && band.live_page_store_used_bytes > 0));
@@ -3446,16 +3461,16 @@ mod tests {
             vec![roll.previous_block_slab_id]
         );
         let purged = LocalBlockStore::new(dir.path())
-            .stream_backed_band_runtime_report()
+            .stream_backed_slab_runtime_report()
             .unwrap();
         assert!(purged.runtime_ready, "{purged:?}");
         assert_eq!(purged.active_slabs, 1);
         assert_eq!(purged.delayed_destroy_slabs, 0);
         assert_eq!(purged.purged_slabs, 1);
-        assert_eq!(purged.band_lifecycle_states, vec!["active", "purged"]);
-        assert!(purged.band_stats_ready);
+        assert_eq!(purged.slab_lifecycle_states, vec!["active", "purged"]);
+        assert!(purged.slab_stats_ready);
         assert!(purged
-            .band_usage
+            .slab_usage
             .iter()
             .any(|band| band.state == BlockStoreSlabState::Purged
                 && band.purged_page_store_used_bytes > 0));
@@ -3881,7 +3896,7 @@ mod tests {
     }
 
     #[test]
-    fn band_garbage_floor_gates_reclaim_by_garbage_ratio() {
+    fn slab_garbage_floor_gates_reclaim_by_garbage_ratio() {
         // garbage-ratio GC conformance: reclaim is gated on a minimum band garbage ratio
         // (garbage = 10_000 - band live-fraction). Floor 0 (the default) reclaims every
         // eligible band as before; a floor above a band's garbage ratio excludes it.
@@ -3894,7 +3909,7 @@ mod tests {
             .gc_policy_plan(
                 2,
                 Vec::<u64>::new(),
-                &BlockStoreGcPolicy::with_band_garbage_floor(0, None),
+                &BlockStoreGcPolicy::with_slab_garbage_floor(0, None),
             )
             .unwrap();
         assert_eq!(floor_zero.selected_block_slab_ids, vec![0, 1]);
@@ -3903,7 +3918,7 @@ mod tests {
             .gc_policy_plan(
                 2,
                 Vec::<u64>::new(),
-                &BlockStoreGcPolicy::with_band_garbage_floor(10_001, None),
+                &BlockStoreGcPolicy::with_slab_garbage_floor(10_001, None),
             )
             .unwrap();
         assert!(floor_impossible.selected_block_slab_ids.is_empty());

--- a/crates/temporalstore-rust/src/block_store/append.rs
+++ b/crates/temporalstore-rust/src/block_store/append.rs
@@ -18,7 +18,7 @@ impl LocalBlockStore {
         if let Ok(file) = OpenOptions::new().append(true).open(&path) {
             file.sync_data()?;
         }
-        persist_band_manifest(&inner.root, &inner.bands)?;
+        persist_slab_manifest(&inner.root, &inner.bands)?;
         inner.relaxed_dirty = false;
         Ok(())
     }
@@ -109,7 +109,7 @@ impl LocalBlockStore {
         inner.write_offset += address.length;
         let block_slab_id = inner.block_slab_id;
         let write_offset = inner.write_offset;
-        upsert_band_after_append(
+        upsert_slab_after_append(
             &mut inner.bands,
             block_slab_id,
             write_offset,
@@ -119,7 +119,7 @@ impl LocalBlockStore {
         if defer_manifest {
             inner.relaxed_dirty = true;
         } else {
-            persist_band_manifest(&inner.root, &inner.bands)?;
+            persist_slab_manifest(&inner.root, &inner.bands)?;
         }
         inner.stats.writes += 1;
         inner.stats.bytes_written += address.length;
@@ -192,7 +192,7 @@ impl LocalBlockStore {
             inner.write_offset += address.length;
             let block_slab_id = inner.block_slab_id;
             let write_offset = inner.write_offset;
-            upsert_band_after_append(
+            upsert_slab_after_append(
                 &mut inner.bands,
                 block_slab_id,
                 write_offset,
@@ -226,7 +226,7 @@ impl LocalBlockStore {
         if defer_manifest {
             inner.relaxed_dirty = true;
         } else {
-            persist_band_manifest(&inner.root, &inner.bands)?;
+            persist_slab_manifest(&inner.root, &inner.bands)?;
         }
         inner.stats.writes = inner.stats.writes.saturating_add(writes);
         inner.stats.bytes_written = inner.stats.bytes_written.saturating_add(bytes_written);

--- a/crates/temporalstore-rust/src/block_store/band_manifest.rs
+++ b/crates/temporalstore-rust/src/block_store/band_manifest.rs
@@ -8,10 +8,10 @@ use super::slab_ids::*;
 use std::fs::{self, File};
 use std::path::Path;
 
-pub(super) fn load_band_manifest_at(
+pub(super) fn load_slab_manifest_at(
     root: &Path,
 ) -> Result<BTreeMap<u64, BlockStoreSlabDescriptor>, BlockStoreError> {
-    let current_path = band_manifest_path(root);
+    let current_path = slab_manifest_path(root);
     let legacy_path = legacy_zone_manifest_path(root);
     let path = if current_path.exists() {
         current_path
@@ -36,7 +36,7 @@ pub(super) fn load_band_manifest_at(
         .collect())
 }
 
-pub(super) fn rebuild_band_manifest_at(
+pub(super) fn rebuild_slab_manifest_at(
     root: &Path,
 ) -> Result<BTreeMap<u64, BlockStoreSlabDescriptor>, BlockStoreError> {
     let mut bands = BTreeMap::new();
@@ -112,7 +112,7 @@ fn reverify_all_slabs() -> bool {
         .unwrap_or(false)
 }
 
-pub(super) fn reconcile_band_manifest_with_disk(
+pub(super) fn reconcile_slab_manifest_with_disk(
     root: &Path,
     bands: &mut BTreeMap<u64, BlockStoreSlabDescriptor>,
 ) -> Result<bool, BlockStoreError> {
@@ -316,12 +316,12 @@ pub(super) fn reconcile_band_manifest_with_disk(
     Ok(changed)
 }
 
-pub(super) fn persist_band_manifest(
+pub(super) fn persist_slab_manifest(
     root: &Path,
     bands: &BTreeMap<u64, BlockStoreSlabDescriptor>,
 ) -> Result<(), BlockStoreError> {
     fs::create_dir_all(root)?;
-    let path = band_manifest_path(root);
+    let path = slab_manifest_path(root);
     let temp_path = path.with_extension(format!(
         "json.tmp.{}",
         std::time::SystemTime::now()
@@ -351,19 +351,19 @@ pub(super) fn persist_band_manifest(
     Ok(())
 }
 
-pub(super) fn summarize_bands(
+pub(super) fn summarize_slabs(
     bands: &BTreeMap<u64, BlockStoreSlabDescriptor>,
 ) -> BlockStoreSlabSummary {
     let mut summary = BlockStoreSlabSummary::default();
     let now = now_unix_ms();
     for band in bands.values() {
-        update_oldest_band_timestamp(&mut summary.oldest_known_slab_unix_ms, band);
+        update_oldest_slab_timestamp(&mut summary.oldest_known_slab_unix_ms, band);
         summary.total_known_physical_bytes = summary
             .total_known_physical_bytes
             .saturating_add(band.physical_bytes);
         match band.state {
             BlockStoreSlabState::Active => {
-                update_oldest_band_timestamp(&mut summary.oldest_live_band_unix_ms, band);
+                update_oldest_slab_timestamp(&mut summary.oldest_live_slab_unix_ms, band);
                 summary.active_slabs = summary.active_slabs.saturating_add(1);
                 summary.active_physical_bytes = summary
                     .active_physical_bytes
@@ -373,7 +373,7 @@ pub(super) fn summarize_bands(
                     .saturating_add(band.physical_bytes);
             }
             BlockStoreSlabState::Sealed => {
-                update_oldest_band_timestamp(&mut summary.oldest_live_band_unix_ms, band);
+                update_oldest_slab_timestamp(&mut summary.oldest_live_slab_unix_ms, band);
                 summary.sealed_slabs = summary.sealed_slabs.saturating_add(1);
                 summary.sealed_physical_bytes = summary
                     .sealed_physical_bytes
@@ -383,8 +383,8 @@ pub(super) fn summarize_bands(
                     .saturating_add(band.physical_bytes);
             }
             BlockStoreSlabState::DelayedDestroy => {
-                update_oldest_band_timestamp(
-                    &mut summary.oldest_reclaimable_band_unix_ms,
+                update_oldest_slab_timestamp(
+                    &mut summary.oldest_reclaimable_slab_unix_ms,
                     band,
                 );
                 summary.delayed_destroy_slabs = summary.delayed_destroy_slabs.saturating_add(1);
@@ -406,16 +406,16 @@ pub(super) fn summarize_bands(
     summary.oldest_known_slab_age_ms = summary
         .oldest_known_slab_unix_ms
         .map(|timestamp| now.saturating_sub(timestamp));
-    summary.oldest_live_band_age_ms = summary
-        .oldest_live_band_unix_ms
+    summary.oldest_live_slab_age_ms = summary
+        .oldest_live_slab_unix_ms
         .map(|timestamp| now.saturating_sub(timestamp));
-    summary.oldest_reclaimable_band_age_ms = summary
-        .oldest_reclaimable_band_unix_ms
+    summary.oldest_reclaimable_slab_age_ms = summary
+        .oldest_reclaimable_slab_unix_ms
         .map(|timestamp| now.saturating_sub(timestamp));
     summary
 }
 
-pub(super) fn update_oldest_band_timestamp(target: &mut Option<u64>, band: &BlockStoreSlabDescriptor) {
+pub(super) fn update_oldest_slab_timestamp(target: &mut Option<u64>, band: &BlockStoreSlabDescriptor) {
     let Some(timestamp) = band.updated_unix_ms.or(band.created_unix_ms) else {
         return;
     };
@@ -424,7 +424,7 @@ pub(super) fn update_oldest_band_timestamp(target: &mut Option<u64>, band: &Bloc
     }
 }
 
-pub(super) fn ensure_band_descriptor(
+pub(super) fn ensure_slab_descriptor(
     bands: &mut BTreeMap<u64, BlockStoreSlabDescriptor>,
     root: &Path,
     block_slab_id: u64,
@@ -465,7 +465,7 @@ pub(super) fn ensure_band_descriptor(
     }
 }
 
-pub(super) fn upsert_band_after_append(
+pub(super) fn upsert_slab_after_append(
     bands: &mut BTreeMap<u64, BlockStoreSlabDescriptor>,
     block_slab_id: u64,
     physical_bytes: u64,
@@ -514,7 +514,7 @@ pub(super) fn upsert_band_after_append(
     );
 }
 
-pub(super) fn set_band_state(
+pub(super) fn set_slab_state(
     bands: &mut BTreeMap<u64, BlockStoreSlabDescriptor>,
     block_slab_id: u64,
     state: BlockStoreSlabState,

--- a/crates/temporalstore-rust/src/block_store/band_reports.rs
+++ b/crates/temporalstore-rust/src/block_store/band_reports.rs
@@ -7,7 +7,7 @@ use super::*;
 
 /// Map a band descriptor's lifecycle state to the index-log `SlabCatalogState` (1:1). Kept a free fn
 /// so both directions of the MANIFEST-CONFORMANCE FOLD conversion share one mapping.
-fn band_state_to_catalog_state(state: BlockStoreSlabState) -> crate::index_log::SlabCatalogState {
+fn slab_state_to_catalog_state(state: BlockStoreSlabState) -> crate::index_log::SlabCatalogState {
     match state {
         BlockStoreSlabState::Active => crate::index_log::SlabCatalogState::Active,
         BlockStoreSlabState::Sealed => crate::index_log::SlabCatalogState::Sealed,
@@ -16,7 +16,7 @@ fn band_state_to_catalog_state(state: BlockStoreSlabState) -> crate::index_log::
     }
 }
 
-fn catalog_state_to_band_state(state: crate::index_log::SlabCatalogState) -> BlockStoreSlabState {
+fn catalog_state_to_slab_state(state: crate::index_log::SlabCatalogState) -> BlockStoreSlabState {
     match state {
         crate::index_log::SlabCatalogState::Active => BlockStoreSlabState::Active,
         crate::index_log::SlabCatalogState::Sealed => BlockStoreSlabState::Sealed,
@@ -26,7 +26,7 @@ fn catalog_state_to_band_state(state: crate::index_log::SlabCatalogState) -> Blo
 }
 
 impl LocalBlockStore {
-    pub fn band_descriptors(&self) -> Vec<BlockStoreSlabDescriptor> {
+    pub fn slab_descriptors(&self) -> Vec<BlockStoreSlabDescriptor> {
         self.inner
             .lock()
             .expect("block store lock poisoned")
@@ -42,7 +42,7 @@ impl LocalBlockStore {
     /// are deliberately dropped -- they are recomputed on load by scanning the slab, exactly as
     /// this design does not persist them. `band_version` stamps every entry so a folded anchor
     /// carries a monotonically-versioned snapshot.
-    pub fn band_catalog(&self, slab_version: u64) -> Vec<crate::index_log::SlabCatalogEntry> {
+    pub fn slab_catalog(&self, slab_version: u64) -> Vec<crate::index_log::SlabCatalogEntry> {
         self.inner
             .lock()
             .expect("block store lock poisoned")
@@ -50,7 +50,7 @@ impl LocalBlockStore {
             .values()
             .map(|band| crate::index_log::SlabCatalogEntry {
                 block_slab_id: band.block_slab_id,
-                state: band_state_to_catalog_state(band.state),
+                state: slab_state_to_catalog_state(band.state),
                 physical_bytes: band.physical_bytes,
                 logical_bytes: band.logical_bytes,
                 created_unix_ms: band.created_unix_ms,
@@ -71,7 +71,7 @@ impl LocalBlockStore {
     /// downgrades physical bytes below what the slab actually holds -- so it cannot lose durable
     /// state; it is a metadata refinement layered on the lossless disk-derived catalog. Persists
     /// the merged manifest once. Returns whether anything changed.
-    pub fn install_band_catalog(
+    pub fn install_slab_catalog(
         &self,
         catalog: &[crate::index_log::SlabCatalogEntry],
     ) -> Result<bool, BlockStoreError> {
@@ -79,7 +79,7 @@ impl LocalBlockStore {
         let active = inner.block_slab_id;
         let mut changed = false;
         for entry in catalog {
-            let state = catalog_state_to_band_state(entry.state);
+            let state = catalog_state_to_slab_state(entry.state);
             match inner.bands.get_mut(&entry.block_slab_id) {
                 Some(band) => {
                     let before = band.clone();
@@ -127,13 +127,13 @@ impl LocalBlockStore {
         }
         if changed {
             let root = inner.root.clone();
-            persist_band_manifest(&root, &inner.bands)?;
+            persist_slab_manifest(&root, &inner.bands)?;
         }
         Ok(changed)
     }
 
-    pub fn band_summary(&self) -> BlockStoreSlabSummary {
-        summarize_bands(
+    pub fn slab_summary(&self) -> BlockStoreSlabSummary {
+        summarize_slabs(
             &self
                 .inner
                 .lock()
@@ -142,7 +142,7 @@ impl LocalBlockStore {
         )
     }
 
-    pub fn stream_backed_band_runtime_report(
+    pub fn stream_backed_slab_runtime_report(
         &self,
     ) -> Result<StreamBackedSlabRuntimeReport, BlockStoreError> {
         let inner = self.inner.lock().expect("block store lock poisoned");
@@ -150,12 +150,12 @@ impl LocalBlockStore {
         let root = inner.root.clone();
         let options = inner.options;
         let stats = inner.stats;
-        let band_manifest_reconciled_on_open = inner.band_manifest_reconciled_on_open;
+        let slab_manifest_reconciled_on_open = inner.slab_manifest_reconciled_on_open;
         drop(inner);
 
-        let summary = summarize_bands(&bands);
-        let band_usage = compute_band_usage(&bands);
-        let band_stats_ready = band_usage.iter().all(|band| {
+        let summary = summarize_slabs(&bands);
+        let slab_usage = compute_slab_usage(&bands);
+        let slab_stats_ready = slab_usage.iter().all(|band| {
             band.band_id == band_id_for_slab(band.block_slab_id)
                 && band.page_store_used_bytes
                     == band
@@ -182,7 +182,7 @@ impl LocalBlockStore {
             .into_iter()
             .map(|report| report.block_slab_id)
             .collect::<BTreeSet<_>>();
-        let manifest_missing_stream_bands = bands
+        let manifest_missing_stream_slabs = bands
             .values()
             .filter(|band| {
                 !matches!(band.state, BlockStoreSlabState::Purged)
@@ -190,12 +190,12 @@ impl LocalBlockStore {
                     && !delayed_slab_ids.contains(&band.block_slab_id)
             })
             .count() as u64;
-        let manifest_extra_stream_bands = live_slab_ids
+        let manifest_extra_stream_slabs = live_slab_ids
             .iter()
             .filter(|block_slab_id| !bands.contains_key(block_slab_id))
             .count() as u64;
-        let band_manifest_disk_consistent =
-            manifest_missing_stream_bands == 0 && manifest_extra_stream_bands == 0;
+        let slab_manifest_disk_consistent =
+            manifest_missing_stream_slabs == 0 && manifest_extra_stream_slabs == 0;
         let physical_bytes = slab_reports
             .iter()
             .map(|report| report.physical_bytes)
@@ -208,11 +208,11 @@ impl LocalBlockStore {
             .iter()
             .map(|report| report.page_count)
             .sum::<u64>();
-        let corrupt_band_count = slab_reports
+        let corrupt_slab_count = slab_reports
             .iter()
             .filter(|report| report.has_corruption)
             .count() as u64;
-        let partial_band_count = slab_reports
+        let partial_slab_count = slab_reports
             .iter()
             .filter(|report| {
                 report.has_corruption
@@ -247,12 +247,12 @@ impl LocalBlockStore {
                 .saturating_add(summary.delayed_destroy_slabs)
                 .saturating_add(summary.purged_slabs)
                 > 0;
-        let band_manifest_ready = band_manifest_path(&root).exists()
+        let slab_manifest_ready = slab_manifest_path(&root).exists()
             && !bands.is_empty()
             && bands
                 .values()
                 .all(|band| band.band_id == band_id_for_slab(band.block_slab_id));
-        let band_manifest_rebuild_ready = band_manifest_ready
+        let slab_manifest_rebuild_ready = slab_manifest_ready
             && slab_reports.iter().all(|report| {
                 bands
                     .get(&report.block_slab_id)
@@ -266,7 +266,7 @@ impl LocalBlockStore {
                     })
                     .unwrap_or(false)
             });
-        let partial_band_recovery_ready = corrupt_band_count == 0
+        let partial_slab_recovery_ready = corrupt_slab_count == 0
             || slab_reports
                 .iter()
                 .filter(|report| report.has_corruption)
@@ -294,8 +294,8 @@ impl LocalBlockStore {
         let delayed_destroy_ready =
             summary.delayed_destroy_slabs > 0 || summary.purged_slabs > 0;
         let purge_lifecycle_ready = summary.purged_slabs > 0;
-        let band_lifecycle_states = band_lifecycle_states(&summary);
-        let band_state_transition_count = [
+        let slab_lifecycle_states = slab_lifecycle_states(&summary);
+        let slab_state_transition_count = [
             summary.active_slabs,
             summary.sealed_slabs,
             summary.delayed_destroy_slabs,
@@ -315,24 +315,24 @@ impl LocalBlockStore {
                     .to_string(),
             );
         }
-        if !band_manifest_ready {
+        if !slab_manifest_ready {
             blockers.push("band manifest is missing or inconsistent".to_string());
         }
-        if !band_manifest_rebuild_ready {
+        if !slab_manifest_rebuild_ready {
             blockers.push("band manifest does not match what the slabs hold".to_string());
         }
-        if !band_manifest_disk_consistent {
+        if !slab_manifest_disk_consistent {
             blockers.push(
                 "band manifest still diverges from live/delayed-destroy stream files".to_string(),
             );
         }
-        if !band_stats_ready {
+        if !slab_stats_ready {
             blockers.push("page-store band usage accounting is inconsistent".to_string());
         }
         if !envelope_checksum_ready {
             blockers.push("stream record envelope/checksum inspection is not clean".to_string());
         }
-        if corrupt_band_count > 0 && partial_band_recovery_ready {
+        if corrupt_slab_count > 0 && partial_slab_recovery_ready {
             blockers.push(
                 "corrupt stream band detected; readable prefix was preserved in rebuilt manifest"
                     .to_string(),
@@ -345,14 +345,14 @@ impl LocalBlockStore {
         let runtime_ready = blockers.is_empty();
         Ok(StreamBackedSlabRuntimeReport {
             runtime_ready,
-            band_lifecycle_states,
+            slab_lifecycle_states,
             band_count: bands.len() as u64,
             active_slabs: summary.active_slabs,
             sealed_slabs: summary.sealed_slabs,
             delayed_destroy_slabs: summary.delayed_destroy_slabs,
             purged_slabs: summary.purged_slabs,
-            band_stats_ready,
-            band_usage,
+            slab_stats_ready,
+            slab_usage,
             stream_slab_count,
             physical_bytes,
             logical_bytes,
@@ -361,19 +361,19 @@ impl LocalBlockStore {
             last_page_id,
             page_id_continuity_ready,
             logical_stream_bytes_read: stats.logical_bytes_read,
-            band_state_transition_count,
+            slab_state_transition_count,
             logical_stream_read_ready,
             append_roll_ready,
-            band_manifest_ready,
-            band_manifest_rebuild_ready,
-            band_manifest_reconciled_on_open,
-            band_manifest_disk_consistent,
-            manifest_missing_stream_bands,
-            manifest_extra_stream_bands,
-            corrupt_band_count,
-            partial_band_count,
+            slab_manifest_ready,
+            slab_manifest_rebuild_ready,
+            slab_manifest_reconciled_on_open,
+            slab_manifest_disk_consistent,
+            manifest_missing_stream_slabs,
+            manifest_extra_stream_slabs,
+            corrupt_slab_count,
+            partial_slab_count,
             readable_prefix_physical_bytes,
-            partial_band_recovery_ready,
+            partial_slab_recovery_ready,
             envelope_checksum_ready,
             compression_stream_ready,
             delayed_destroy_ready,

--- a/crates/temporalstore-rust/src/block_store/gc.rs
+++ b/crates/temporalstore-rust/src/block_store/gc.rs
@@ -189,8 +189,8 @@ impl LocalBlockStore {
         let current_block_slab_id = inner.block_slab_id;
         let live_block_slab_ids = live_block_slab_ids.into_iter().collect::<BTreeSet<_>>();
         let slab_ids = slab_ids_at(&inner.root)?;
-        let mut band_total_bytes = BTreeMap::<u64, u64>::new();
-        let mut band_used_bytes = BTreeMap::<u64, u64>::new();
+        let mut slab_total_bytes = BTreeMap::<u64, u64>::new();
+        let mut slab_used_bytes = BTreeMap::<u64, u64>::new();
         for block_slab_id in &slab_ids {
             let bytes = slab_path(&inner.root, *block_slab_id)
                 .metadata()
@@ -201,7 +201,7 @@ impl LocalBlockStore {
                 .get(block_slab_id)
                 .map(|band| band.band_id)
                 .unwrap_or_else(|| band_id_for_slab(*block_slab_id));
-            *band_total_bytes.entry(band_id).or_default() = band_total_bytes
+            *slab_total_bytes.entry(band_id).or_default() = slab_total_bytes
                 .get(&band_id)
                 .copied()
                 .unwrap_or_default()
@@ -210,7 +210,7 @@ impl LocalBlockStore {
             let is_current = *block_slab_id == current_block_slab_id;
             let is_live = live_block_slab_ids.contains(block_slab_id);
             if !below_retention_floor || is_current || is_live {
-                *band_used_bytes.entry(band_id).or_default() = band_used_bytes
+                *slab_used_bytes.entry(band_id).or_default() = slab_used_bytes
                     .get(&band_id)
                     .copied()
                     .unwrap_or_default()
@@ -237,8 +237,8 @@ impl LocalBlockStore {
                 let band_id = band
                     .map(|band| band.band_id)
                     .unwrap_or_else(|| band_id_for_slab(block_slab_id));
-                let total_bytes = band_total_bytes.get(&band_id).copied().unwrap_or(bytes);
-                let used_bytes = band_used_bytes.get(&band_id).copied().unwrap_or_default();
+                let total_bytes = slab_total_bytes.get(&band_id).copied().unwrap_or(bytes);
+                let used_bytes = slab_used_bytes.get(&band_id).copied().unwrap_or_default();
                 let stale_bytes = total_bytes.saturating_sub(used_bytes);
                 let utility_basis_points = if total_bytes == 0 {
                     0
@@ -338,7 +338,7 @@ impl LocalBlockStore {
                 removed_physical_bytes += slab_physical_bytes;
                 if delayed_destroy {
                     move_slab_to_delayed_destroy(&inner.root, block_slab_id)?;
-                    set_band_state(
+                    set_slab_state(
                         &mut inner.bands,
                         block_slab_id,
                         BlockStoreSlabState::DelayedDestroy,
@@ -347,7 +347,7 @@ impl LocalBlockStore {
                     delayed_destroy_physical_bytes += slab_physical_bytes;
                 } else {
                     fs::remove_file(slab_path(&inner.root, block_slab_id))?;
-                    set_band_state(
+                    set_slab_state(
                         &mut inner.bands,
                         block_slab_id,
                         BlockStoreSlabState::Purged,
@@ -367,7 +367,7 @@ impl LocalBlockStore {
                 retained.push(block_slab_id);
             }
         }
-        persist_band_manifest(&inner.root, &inner.bands)?;
+        persist_slab_manifest(&inner.root, &inner.bands)?;
         Ok(BlockStoreGcReport {
             retain_from_block_slab_id,
             removed_block_slab_ids: removed,

--- a/crates/temporalstore-rust/src/block_store/paths.rs
+++ b/crates/temporalstore-rust/src/block_store/paths.rs
@@ -8,7 +8,7 @@ pub(super) fn slab_path(root: &Path, block_slab_id: u64) -> PathBuf {
     root.join(format!("page_segment_{block_slab_id:020}.seg"))
 }
 
-pub(super) fn band_manifest_path(root: &Path) -> PathBuf {
+pub(super) fn slab_manifest_path(root: &Path) -> PathBuf {
     root.join("page_extent_manifest.json")
 }
 

--- a/crates/temporalstore-rust/src/block_store/read.rs
+++ b/crates/temporalstore-rust/src/block_store/read.rs
@@ -124,8 +124,8 @@ impl LocalBlockStore {
             inner.block_slab_id = block_slab_id;
             inner.write_offset = bytes.len() as u64;
         }
-        let band_summary = summarize_slab(bytes, block_slab_id)?;
-        if let Some(max_page_id) = band_summary.last_page_id {
+        let slab_summary = summarize_slab(bytes, block_slab_id)?;
+        if let Some(max_page_id) = slab_summary.last_page_id {
             inner.next_page_id = inner.next_page_id.max(max_page_id.saturating_add(1));
         }
         let is_current_slab = block_slab_id == inner.block_slab_id;
@@ -141,15 +141,15 @@ impl LocalBlockStore {
                     BlockStoreSlabState::Sealed
                 },
                 physical_bytes: bytes.len() as u64,
-                logical_bytes: band_summary.logical_bytes,
+                logical_bytes: slab_summary.logical_bytes,
                 created_unix_ms: Some(
                     file_modified_unix_ms(&path)
                         .or_else(|| file_created_unix_ms(&path))
                         .unwrap_or(now),
                 ),
                 updated_unix_ms: Some(now),
-                first_page_id: band_summary.first_page_id,
-                last_page_id: band_summary.last_page_id,
+                first_page_id: slab_summary.first_page_id,
+                last_page_id: slab_summary.last_page_id,
                 readable_prefix_physical_bytes: bytes.len() as u64,
                 verified_source_mtime_unix_ms: None,
                 has_corruption: false,
@@ -174,7 +174,7 @@ impl LocalBlockStore {
         if inner.slabs_unwritten >= BANDS_UNWRITTEN_BEFORE_PERSIST {
             inner.slabs_unwritten = 0;
             inner.stats.slab_manifest_writes = inner.stats.slab_manifest_writes.saturating_add(1);
-            persist_band_manifest(&inner.root, &inner.bands)?;
+            persist_slab_manifest(&inner.root, &inner.bands)?;
         }
         Ok(())
     }

--- a/crates/temporalstore-rust/src/block_store/record.rs
+++ b/crates/temporalstore-rust/src/block_store/record.rs
@@ -336,13 +336,13 @@ pub(super) fn decode_page_record(
             ));
         }
     }
-    if let (Some(address_band_id), Some(record_band_id)) = (address.band_id(), header.band_id)
+    if let (Some(address_slab_id), Some(record_slab_id)) = (address.band_id(), header.band_id)
     {
-        if address_band_id != record_band_id {
+        if address_slab_id != record_slab_id {
             return Err(corrupt_page_envelope(
                 address,
                 format!(
-                    "band id mismatch: address {address_band_id}, record {record_band_id}"
+                    "band id mismatch: address {address_slab_id}, record {record_slab_id}"
                 ),
             ));
         }

--- a/crates/temporalstore-rust/src/block_store/slab_ids.rs
+++ b/crates/temporalstore-rust/src/block_store/slab_ids.rs
@@ -92,15 +92,15 @@ pub(crate) fn band_id_for_slab(block_slab_id: u64) -> u64 {
 
 pub(crate) fn compact_slab_address_from_parts(block_slab_id: u64, offset: u64) -> Option<u64> {
     let band_id = u32::try_from(block_slab_id).ok()?;
-    let band_offset = u32::try_from(offset).ok()?;
-    Some(((band_id as u64) << 32) | band_offset as u64)
+    let slab_offset = u32::try_from(offset).ok()?;
+    Some(((band_id as u64) << 32) | slab_offset as u64)
 }
 
-pub(crate) fn compact_extract_band_id(address: u64) -> u32 {
+pub(crate) fn compact_extract_slab_id(address: u64) -> u32 {
     (address >> 32) as u32
 }
 
-pub(crate) fn compact_extract_band_offset(address: u64) -> u32 {
+pub(crate) fn compact_extract_slab_offset(address: u64) -> u32 {
     (address & 0xFFFF_FFFF) as u32
 }
 

--- a/crates/temporalstore-rust/src/control.rs
+++ b/crates/temporalstore-rust/src/control.rs
@@ -264,7 +264,7 @@ pub struct ShardCanonicalStorageStats {
     #[serde(default)]
     pub bucket_index_resident_entries: u64,
     #[serde(rename = "storage_zone_count")]
-    pub storage_band_count: u64,
+    pub storage_slab_count: u64,
     #[serde(rename = "active_storage_zones")]
     pub active_storage_slabs: u64,
     #[serde(rename = "sealed_storage_zones")]
@@ -314,7 +314,8 @@ pub struct ShardStats {
     pub block_store: BlockStoreStats,
     #[serde(default)]
     #[serde(alias = "block_store_zones")]
-    pub block_store_bands: BlockStoreSlabSummary,
+    #[serde(rename = "block_store_bands")]
+    pub block_store_slabs: BlockStoreSlabSummary,
     pub write_ahead_log: WriteAheadLogStats,
 }
 

--- a/crates/temporalstore-rust/src/data_node.rs
+++ b/crates/temporalstore-rust/src/data_node.rs
@@ -482,7 +482,7 @@ fn apply_shard_storage_metrics(
             "compaction_watermark",
             storage.compaction_watermark,
         );
-        add(metrics, "storage_zone_count", storage.storage_band_count);
+        add(metrics, "storage_zone_count", storage.storage_slab_count);
         add(
             metrics,
             "active_storage_zones",

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -672,7 +672,7 @@ impl TemporalEngine {
                 // long-running node permanently rejected all writes once it tripped.
                 // compares live resident size and evicts; this at least lets
                 // reclamation re-admit writes.
-                .map(|limit| self.page_store.band_summary().total_known_physical_bytes >= limit)
+                .map(|limit| self.page_store.slab_summary().total_known_physical_bytes >= limit)
                 .unwrap_or(false)
         {
             return ExecuteResponse {
@@ -1780,13 +1780,13 @@ impl TemporalEngine {
                     && (!checksums_recorded || entry.checksum.is_some())
             })
         });
-        let band_report = self.page_store.stream_backed_band_runtime_report().ok();
-        let stream_backed_band_api_ready = band_report
+        let band_report = self.page_store.stream_backed_slab_runtime_report().ok();
+        let stream_backed_slab_api_ready = band_report
             .as_ref()
             .map(|report| {
-                report.band_manifest_ready
-                    && report.band_manifest_disk_consistent
-                    && report.band_stats_ready
+                report.slab_manifest_ready
+                    && report.slab_manifest_disk_consistent
+                    && report.slab_stats_ready
                     && report.stream_record_count > 0
                     && report.blockers.iter().all(|blocker| {
                         blocker.contains("append/roll") || blocker.contains("purge lifecycle")
@@ -1855,7 +1855,7 @@ impl TemporalEngine {
         if block_index_count == 0 {
             blockers.push("block_store_segment_index_missing".to_string());
         }
-        if !stream_backed_band_api_ready {
+        if !stream_backed_slab_api_ready {
             blockers.push("stream_backed_band_api_not_ready".to_string());
         }
         if !storage_manager_phase_api_ready {
@@ -1878,7 +1878,7 @@ impl TemporalEngine {
             object_manager_runtime_api_ready: object_manager.runtime_ready,
             block_address_api_ready,
             block_store_slab_api_ready: block_index_count > 0,
-            stream_backed_band_api_ready,
+            stream_backed_slab_api_ready,
             legacy_page_zone_aliases_ready,
             storage_manager_phase_api_ready,
             storage_manager_pressure_api_ready,

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -391,8 +391,8 @@ impl TemporalEngine {
         // physical bytes below the slab's real size, so it cannot lose durable state -- it is a
         // metadata refinement over the lossless disk-derived catalog, making the per-write
         // band-manifest file unnecessary as the catalog's source of truth.
-        if let Ok(Some(meta)) = self.index_log_store.latest_band_catalog(request.shard_id) {
-            let _ = self.page_store.install_band_catalog(&meta.bands);
+        if let Ok(Some(meta)) = self.index_log_store.latest_slab_catalog(request.shard_id) {
+            let _ = self.page_store.install_slab_catalog(&meta.bands);
         }
         let mut state = loaded.unwrap_or_default();
         promote_model_maps_to_bucket_index_authority(

--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -483,7 +483,7 @@ impl TemporalEngine {
         //    after it, the band catalog is recoverable from the durable log, so the per-write
         //    band-manifest file stops being the source of truth.
         let slab_version = anchor;
-        let bands = self.page_store.band_catalog(slab_version);
+        let bands = self.page_store.slab_catalog(slab_version);
         let meta = crate::index_log::MetaItem {
             version: 1,
             start_wal_sequence: anchor,
@@ -735,7 +735,7 @@ impl TemporalEngine {
             .cloned();
         shards.get(&shard_id).map(|state| {
             let page_store = self.page_store.stats();
-            let page_store_bands = self.page_store.band_summary();
+            let page_store_slabs = self.page_store.slab_summary();
             let string_records = state.strings.len();
             let hash_records = state.hashes.len();
             let set_records = state.sets.len();
@@ -810,21 +810,21 @@ impl TemporalEngine {
                 bucket_index_resident_bytes_floor: (state.bucket_index.bucket_map.len() as u64)
                     .saturating_mul(std::mem::size_of::<super::state::BucketNode>() as u64),
                 bucket_index_resident_entries: state.bucket_index.bucket_map.len() as u64,
-                storage_band_count: page_store_bands
+                storage_slab_count: page_store_slabs
                     .active_slabs
-                    .saturating_add(page_store_bands.sealed_slabs)
-                    .saturating_add(page_store_bands.delayed_destroy_slabs)
-                    .saturating_add(page_store_bands.purged_slabs),
-                active_storage_slabs: page_store_bands.active_slabs,
-                sealed_storage_slabs: page_store_bands.sealed_slabs,
-                stream_slab_count: page_store_bands
+                    .saturating_add(page_store_slabs.sealed_slabs)
+                    .saturating_add(page_store_slabs.delayed_destroy_slabs)
+                    .saturating_add(page_store_slabs.purged_slabs),
+                active_storage_slabs: page_store_slabs.active_slabs,
+                sealed_storage_slabs: page_store_slabs.sealed_slabs,
+                stream_slab_count: page_store_slabs
                     .active_slabs
-                    .saturating_add(page_store_bands.sealed_slabs)
-                    .saturating_add(page_store_bands.delayed_destroy_slabs)
-                    .saturating_add(page_store_bands.purged_slabs),
-                storage_slab_total_bytes: page_store_bands.total_known_physical_bytes,
-                storage_slab_used_bytes: page_store_bands.live_physical_bytes,
-                storage_slab_stale_bytes: page_store_bands.reclaimable_physical_bytes,
+                    .saturating_add(page_store_slabs.sealed_slabs)
+                    .saturating_add(page_store_slabs.delayed_destroy_slabs)
+                    .saturating_add(page_store_slabs.purged_slabs),
+                storage_slab_total_bytes: page_store_slabs.total_known_physical_bytes,
+                storage_slab_used_bytes: page_store_slabs.live_physical_bytes,
+                storage_slab_stale_bytes: page_store_slabs.reclaimable_physical_bytes,
                 page_reads: page_store.reads,
                 page_writes: page_store.writes,
                 block_reads: page_store.reads,
@@ -832,7 +832,7 @@ impl TemporalEngine {
                 bytes_read: page_store.bytes_read,
                 bytes_written: page_store.bytes_written,
                 append_watermark: page_store.writes,
-                compaction_watermark: page_store_bands.reclaimable_physical_bytes,
+                compaction_watermark: page_store_slabs.reclaimable_physical_bytes,
             };
             ShardStats {
                 shard_id,
@@ -852,9 +852,9 @@ impl TemporalEngine {
                 storage,
                 cache: self.cache.stats(),
                 page_store: page_store.clone(),
-                page_store_zones: page_store_bands.clone(),
+                page_store_zones: page_store_slabs.clone(),
                 block_store: page_store,
-                block_store_bands: page_store_bands,
+                block_store_slabs: page_store_slabs,
                 write_ahead_log: self.wal_store.stats(shard_id),
             }
         })

--- a/crates/temporalstore-rust/src/engine/prometheus_metrics.rs
+++ b/crates/temporalstore-rust/src/engine/prometheus_metrics.rs
@@ -384,10 +384,10 @@ impl TemporalEngine {
             }
             for (scope, value) in [
                 ("known", stats.page_store_zones.oldest_known_slab_unix_ms),
-                ("live", stats.page_store_zones.oldest_live_band_unix_ms),
+                ("live", stats.page_store_zones.oldest_live_slab_unix_ms),
                 (
                     "reclaimable",
-                    stats.page_store_zones.oldest_reclaimable_band_unix_ms,
+                    stats.page_store_zones.oldest_reclaimable_slab_unix_ms,
                 ),
             ] {
                 if let Some(value) = value {
@@ -413,10 +413,10 @@ impl TemporalEngine {
             }
             for (scope, value) in [
                 ("known", stats.page_store_zones.oldest_known_slab_age_ms),
-                ("live", stats.page_store_zones.oldest_live_band_age_ms),
+                ("live", stats.page_store_zones.oldest_live_slab_age_ms),
                 (
                     "reclaimable",
-                    stats.page_store_zones.oldest_reclaimable_band_age_ms,
+                    stats.page_store_zones.oldest_reclaimable_slab_age_ms,
                 ),
             ] {
                 if let Some(value) = value {

--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -276,8 +276,8 @@ impl TemporalEngine {
         let wal_records = self.wal_store.record_count(shard_id).unwrap_or_default();
         let index_log_records = self.index_log_store.record_count(shard_id).unwrap_or_default();
         let active_block_slab_ids = self.page_store.slab_ids().unwrap_or_default();
-        let band_descriptors = self.page_store.band_descriptors();
-        let band_summary = self.page_store.band_summary();
+        let slab_descriptors = self.page_store.slab_descriptors();
+        let slab_summary = self.page_store.slab_summary();
         let block_slab_reports = self.page_store.slab_reports().unwrap_or_default();
         let shards = self.shards.read().expect("engine lock poisoned");
         let addresses = shards
@@ -401,8 +401,8 @@ impl TemporalEngine {
             index_log_records,
             active_block_slab_ids,
             live_block_slab_ids,
-            band_descriptors,
-            band_summary,
+            slab_descriptors,
+            slab_summary,
             block_slab_reports,
             block_slab_live_reports,
             total_page_refs,

--- a/crates/temporalstore-rust/src/engine/reports.rs
+++ b/crates/temporalstore-rust/src/engine/reports.rs
@@ -266,9 +266,9 @@ pub struct StorageRecoveryReport {
     #[serde(rename = "live_page_slab_ids")]
     pub live_block_slab_ids: Vec<u64>,
     #[serde(rename = "zone_descriptors")]
-    pub band_descriptors: Vec<BlockStoreSlabDescriptor>,
+    pub slab_descriptors: Vec<BlockStoreSlabDescriptor>,
     #[serde(rename = "zone_summary", default)]
-    pub band_summary: BlockStoreSlabSummary,
+    pub slab_summary: BlockStoreSlabSummary,
     #[serde(default)]
     #[serde(alias = "page_segment_reports")]
     #[serde(rename = "page_slab_reports")]
@@ -2133,7 +2133,7 @@ pub struct StorageSlabSample {
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct StorageSlabBandSample {
+pub struct StorageSlabSlabSample {
     pub band: u64,
     pub block_range: Vec<u64>,
     pub reclaim_state: String,
@@ -2155,7 +2155,7 @@ pub struct StorageBucketSample {
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StorageTopologySnapshot {
     #[serde(rename = "storage_zone_count")]
-    pub storage_band_count: u64,
+    pub storage_slab_count: u64,
     #[serde(rename = "active_storage_zones")]
     pub active_storage_slabs: u64,
     #[serde(rename = "sealed_storage_zones")]
@@ -2177,14 +2177,14 @@ pub struct StorageTopologySnapshot {
     pub append_log_reclaimed_records: u64,
     #[serde(default)]
     #[serde(rename = "storage_zone_samples")]
-    pub storage_band_usage_samples: Vec<StorageSlabUsageSample>,
+    pub storage_slab_usage_samples: Vec<StorageSlabUsageSample>,
     #[serde(default)]
     pub stream_samples: Vec<StorageStreamSample>,
     #[serde(default)]
     #[serde(alias = "segment_samples")]
     pub slab_samples: Vec<StorageSlabSample>,
     #[serde(default)]
-    pub band_samples: Vec<StorageSlabBandSample>,
+    pub band_samples: Vec<StorageSlabSlabSample>,
     #[serde(default)]
     #[serde(rename = "slot_samples")]
     pub bucket_samples: Vec<StorageBucketSample>,
@@ -2194,7 +2194,7 @@ pub fn storage_topology_snapshot_from_metrics(
     metrics: &BTreeMap<String, u64>,
 ) -> StorageTopologySnapshot {
     StorageTopologySnapshot {
-        storage_band_count: metric(metrics, "storage_zone_count"),
+        storage_slab_count: metric(metrics, "storage_zone_count"),
         active_storage_slabs: metric(metrics, "active_storage_zones"),
         sealed_storage_slabs: metric(metrics, "sealed_storage_zones"),
         stream_slab_count: metric(metrics, "stream_segment_count"),
@@ -2206,7 +2206,7 @@ pub fn storage_topology_snapshot_from_metrics(
         storage_slab_stale_bytes: metric(metrics, "storage_zone_stale_bytes"),
         append_log_replay_records: metric(metrics, "append_log_replay_records"),
         append_log_reclaimed_records: metric(metrics, "append_log_reclaimed_records"),
-        storage_band_usage_samples: Vec::new(),
+        storage_slab_usage_samples: Vec::new(),
         stream_samples: Vec::new(),
         slab_samples: Vec::new(),
         band_samples: Vec::new(),
@@ -3234,7 +3234,8 @@ pub struct StorageManagerCycleRequest {
     /// (garbage = 10_000 - band live-fraction). 0 reclaims every eligible band
     /// (today's behavior). The garbage-ratio GC gate, expressed against bands.
     #[serde(default)]
-    pub page_gc_min_band_garbage_basis_points: u64,
+    #[serde(rename = "page_gc_min_band_garbage_basis_points")]
+    pub page_gc_min_slab_garbage_basis_points: u64,
 }
 
 /// Per-round bounds for the background storage cycle.
@@ -3319,7 +3320,7 @@ impl Default for StorageManagerCycleRequest {
                 DEFAULT_INDEX_GC_USAGE_RATIO_TRIGGER_BASIS_POINTS,
             index_gc_max_entries_per_round: DEFAULT_INDEX_GC_MAX_ENTRIES_PER_ROUND,
             index_gc_commit_dirty_buckets_before_truncation: true,
-            page_gc_min_band_garbage_basis_points:
+            page_gc_min_slab_garbage_basis_points:
                 DEFAULT_PAGE_GC_MIN_BAND_GARBAGE_BASIS_POINTS,
         }
     }
@@ -3527,7 +3528,8 @@ pub struct StorageDataStructureApiParityReport {
     pub block_address_api_ready: bool,
     #[serde(alias = "block_store_segment_api_ready")]
     pub block_store_slab_api_ready: bool,
-    pub stream_backed_band_api_ready: bool,
+    #[serde(rename = "stream_backed_band_api_ready")]
+    pub stream_backed_slab_api_ready: bool,
     pub legacy_page_zone_aliases_ready: bool,
     pub storage_manager_phase_api_ready: bool,
     pub storage_manager_pressure_api_ready: bool,
@@ -3838,13 +3840,13 @@ mod manifest_field_name_tests {
             block_slab_ids: vec![1, 2, 3],
             last_compacted_slab: Some(5),
         };
-        let mut no_band = full.clone();
-        no_band.last_compacted_slab = None;
+        let mut no_slab = full.clone();
+        no_slab.last_compacted_slab = None;
         let mut empty_slabs = full.clone();
         empty_slabs.block_slab_ids = Vec::new();
         vec![
             ("fully populated", full),
-            ("no compacted band", no_band),
+            ("no compacted band", no_slab),
             ("no slab ids", empty_slabs),
             ("all defaults", BucketStorageSummary::default()),
         ]

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -580,7 +580,7 @@ pub(super) fn storage_topology_snapshot_with_samples(
         delete_markers: BTreeSet<String>,
     }
 
-    let mut bands_usage = BTreeMap::<u64, SlabUsageAcc>::new();
+    let mut slabs_usage = BTreeMap::<u64, SlabUsageAcc>::new();
     let mut slabs = BTreeMap::<u64, SlabAcc>::new();
     let mut bands = BTreeMap::<u64, SlabAccumulator>::new();
     let mut buckets = BTreeMap::<u32, BucketAcc>::new();
@@ -592,7 +592,7 @@ pub(super) fn storage_topology_snapshot_with_samples(
             .unwrap_or(entry.address.block_slab_id);
         let slab_id = entry.address.block_slab_id;
         let generation = entry.address.object_id().unwrap_or(0);
-        let usage = bands_usage.entry(band_id).or_default();
+        let usage = slabs_usage.entry(band_id).or_default();
         usage.slabs.insert(slab_id);
         usage.generation = usage.generation.max(generation);
         if entry.deleted {
@@ -664,7 +664,7 @@ pub(super) fn storage_topology_snapshot_with_samples(
         }
     }
 
-    snapshot.storage_band_usage_samples = bands_usage
+    snapshot.storage_slab_usage_samples = slabs_usage
         .into_iter()
         .take(MAX_STORAGE_TOPOLOGY_SAMPLES)
         .map(|(band_id, usage)| StorageSlabUsageSample {
@@ -703,7 +703,7 @@ pub(super) fn storage_topology_snapshot_with_samples(
     snapshot.band_samples = bands
         .into_iter()
         .take(MAX_STORAGE_TOPOLOGY_SAMPLES)
-        .map(|(band_id, band)| StorageSlabBandSample {
+        .map(|(band_id, band)| StorageSlabSlabSample {
             band: band_id,
             block_range: vec![band.min_offset, band.max_offset],
             reclaim_state: if band.deleted_refs > 0 && band.live_refs == 0 {

--- a/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
+++ b/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
@@ -347,8 +347,8 @@ impl TemporalEngine {
                 // garbage-ratio GC victim selection (specification): reclaim the
                 // highest-garbage bands first, keeping bands below the garbage floor.
                 // Floor 0 (the default) reclaims every eligible band as before.
-                BlockStoreGcPolicy::with_band_garbage_floor(
-                    request.page_gc_min_band_garbage_basis_points,
+                BlockStoreGcPolicy::with_slab_garbage_floor(
+                    request.page_gc_min_slab_garbage_basis_points,
                     None,
                 ),
                 true,

--- a/crates/temporalstore-rust/src/engine/storage_reports.rs
+++ b/crates/temporalstore-rust/src/engine/storage_reports.rs
@@ -392,7 +392,7 @@ impl TemporalEngine {
         shard_id: ShardId,
     ) -> StoragePageFormatCompatibilityReport {
         let stats = self.page_store.stats();
-        let summary = self.page_store.band_summary();
+        let summary = self.page_store.slab_summary();
         StoragePageFormatCompatibilityReport {
             shard_id,
             page_format: "rust-page-envelope-v6".to_string(),

--- a/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
+++ b/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
@@ -292,7 +292,7 @@ impl TemporalEngine {
                     .maxmemory_bytes
                     // Current on-disk footprint (GC-decremented), not cumulative-ever
                     // bytes_written -- see the single-command execute path.
-                    .map(|limit| self.page_store.band_summary().total_known_physical_bytes >= limit)
+                    .map(|limit| self.page_store.slab_summary().total_known_physical_bytes >= limit)
                     .unwrap_or(false)
             {
                 responses.push(ExecuteResponse {

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -2030,7 +2030,7 @@ fn storage_data_structure_api_parity_report_covers_stream_block_and_manager_surf
     assert!(report.object_manager_runtime_api_ready);
     assert!(report.block_address_api_ready);
     assert!(report.block_store_slab_api_ready);
-    assert!(report.stream_backed_band_api_ready);
+    assert!(report.stream_backed_slab_api_ready);
     assert!(report.legacy_page_zone_aliases_ready);
     assert!(report.storage_manager_phase_api_ready);
     assert!(report.storage_manager_pressure_api_ready);
@@ -2267,7 +2267,7 @@ fn recovery_reports_reused_object_id_conflicts() {
 }
 
 #[test]
-fn crash_recovery_report_covers_wal_index_page_and_band_manifest() {
+fn crash_recovery_report_covers_wal_index_page_and_slab_manifest() {
     let cache_dir = unique_temp_path("recovery-cache");
     let page_dir = unique_temp_path("recovery-pages");
     let index_dir = unique_temp_path("recovery-index");
@@ -2329,29 +2329,29 @@ fn crash_recovery_report_covers_wal_index_page_and_band_manifest() {
     assert_eq!(report.slab_integrity.discovered_block_slab_count, 2);
     assert_eq!(report.slab_integrity.live_block_slab_count, 2);
     assert_eq!(report.slab_integrity.unreadable_page_ref_count, 0);
-    assert_eq!(report.band_descriptors.len(), 2);
+    assert_eq!(report.slab_descriptors.len(), 2);
     assert_eq!(
-        report.band_descriptors[0].state,
+        report.slab_descriptors[0].state,
         BlockStoreSlabState::Sealed
     );
     assert_eq!(
-        report.band_descriptors[1].state,
+        report.slab_descriptors[1].state,
         BlockStoreSlabState::Active
     );
-    assert_eq!(report.band_summary.sealed_slabs, 1);
-    assert_eq!(report.band_summary.active_slabs, 1);
-    assert_eq!(report.band_summary.delayed_destroy_slabs, 0);
+    assert_eq!(report.slab_summary.sealed_slabs, 1);
+    assert_eq!(report.slab_summary.active_slabs, 1);
+    assert_eq!(report.slab_summary.delayed_destroy_slabs, 0);
     assert_eq!(
-        report.band_summary.sealed_physical_bytes,
-        report.band_descriptors[0].physical_bytes
+        report.slab_summary.sealed_physical_bytes,
+        report.slab_descriptors[0].physical_bytes
     );
     assert_eq!(
-        report.band_summary.active_physical_bytes,
-        report.band_descriptors[1].physical_bytes
+        report.slab_summary.active_physical_bytes,
+        report.slab_descriptors[1].physical_bytes
     );
     assert_eq!(
-        report.band_summary.live_physical_bytes,
-        report.band_descriptors[0].physical_bytes + report.band_descriptors[1].physical_bytes
+        report.slab_summary.live_physical_bytes,
+        report.slab_descriptors[0].physical_bytes + report.slab_descriptors[1].physical_bytes
     );
     assert_eq!(report.block_slab_live_reports.len(), 2);
     assert_eq!(report.block_slab_live_reports[0].block_slab_id, 0);
@@ -2588,7 +2588,7 @@ fn cold_index_page_address_reads_from_disk_cache_or_block_store_and_refills_memo
 }
 
 #[test]
-fn crash_recovery_rebuilds_missing_band_manifest_from_page_stream() {
+fn crash_recovery_rebuilds_missing_slab_manifest_from_page_stream() {
     let cache_dir = unique_temp_path("recovery-rebuild-cache");
     let page_dir = unique_temp_path("recovery-rebuild-pages");
     let index_dir = unique_temp_path("recovery-rebuild-index");
@@ -2628,7 +2628,7 @@ fn crash_recovery_rebuilds_missing_band_manifest_from_page_stream() {
 
     assert_eq!(report.wal_records, 2);
     assert!(report.all_live_pages_readable);
-    assert!(report.band_summary.live_physical_bytes > 0);
+    assert!(report.slab_summary.live_physical_bytes > 0);
     // The band manifest was rebuilt (from the page stream on the default path; from WAL-replayed
     // pages under the single barrier). Recovery of both acked writes is asserted by the reads below.
     assert!(page_dir.join("page_extent_manifest.json").exists());
@@ -2642,17 +2642,17 @@ fn crash_recovery_rebuilds_missing_band_manifest_from_page_stream() {
         assert_eq!(report.active_block_slab_ids, vec![0, 1]);
         assert_eq!(report.live_block_slab_ids, vec![0, 1]);
         assert_eq!(report.total_page_refs, 2);
-        assert_eq!(report.band_descriptors.len(), 2);
+        assert_eq!(report.slab_descriptors.len(), 2);
         assert_eq!(
-            report.band_descriptors[0].state,
+            report.slab_descriptors[0].state,
             BlockStoreSlabState::Sealed
         );
         assert_eq!(
-            report.band_descriptors[1].state,
+            report.slab_descriptors[1].state,
             BlockStoreSlabState::Active
         );
-        assert_eq!(report.band_summary.sealed_slabs, 1);
-        assert_eq!(report.band_summary.active_slabs, 1);
+        assert_eq!(report.slab_summary.sealed_slabs, 1);
+        assert_eq!(report.slab_summary.active_slabs, 1);
     }
     assert_eq!(
         recovered
@@ -7328,7 +7328,7 @@ fn what_grows_outside_the_shard_index() {
             });
             assert!(response.status.ok, "write {index}: {:?}", response.status);
         }
-        let bands = engine.page_store.band_descriptors().len();
+        let bands = engine.page_store.slab_descriptors().len();
         let slabs = engine.page_store.slab_ids().map(|v| v.len()).unwrap_or(0);
         let strings = {
             let shards = engine.shards.read().expect("engine lock poisoned");
@@ -7350,14 +7350,14 @@ fn what_grows_outside_the_shard_index() {
                  if per > 0.01 { "yes" } else { "no" });
         per
     };
-    let band_per = row("page bands", small_bands, large_bands);
+    let slab_per = row("page bands", small_bands, large_bands);
     row("page slabs", small_slabs, large_slabs);
     row("index entries", small_strings, large_strings);
 
     println!();
-    println!("  A band descriptor is on the order of 100 bytes, so at {band_per:.4} bands per");
-    println!("  record it accounts for roughly {:.1} bytes of the ~842 unattributed.", band_per * 100.0);
-    if band_per * 100.0 < 100.0 {
+    println!("  A band descriptor is on the order of 100 bytes, so at {slab_per:.4} bands per");
+    println!("  record it accounts for roughly {:.1} bytes of the ~842 unattributed.", slab_per * 100.0);
+    if slab_per * 100.0 < 100.0 {
         println!("  That is nowhere near enough: the page store is NOT where the memory goes, and");
         println!("  the remaining structure is somewhere these counts do not reach.");
     }

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -3086,7 +3086,7 @@ fn manifest_fold_threshold_dump_fires_only_past_the_gap_and_folds_the_catalog() 
         "no dump below the threshold"
     );
     assert!(
-        engine.index_log_store().latest_band_catalog(1).unwrap().is_none(),
+        engine.index_log_store().latest_slab_catalog(1).unwrap().is_none(),
         "no folded catalog before any dump"
     );
     // A gap of 1 byte crosses immediately: exactly one dump fires and folds the catalog.
@@ -3097,7 +3097,7 @@ fn manifest_fold_threshold_dump_fires_only_past_the_gap_and_folds_the_catalog() 
         engine.maybe_dump_index_catalog_with_gap_for_test(1, 1, 0),
         "dump fires once the undumped gap crosses the threshold"
     );
-    let catalog = engine.index_log_store().latest_band_catalog(1).unwrap();
+    let catalog = engine.index_log_store().latest_slab_catalog(1).unwrap();
     let catalog = catalog.expect("a folded band catalog must be durable after the dump");
     assert!(
         !catalog.bands.is_empty(),
@@ -3258,7 +3258,7 @@ fn catalog_dump_reclaim_shrinks_both_logs_and_reload_stays_exact() {
     assert!(
         engine
             .index_log_store()
-            .latest_band_catalog(1)
+            .latest_slab_catalog(1)
             .unwrap()
             .is_some(),
         "the folded catalog anchor must survive the index-log sweep"
@@ -3346,7 +3346,7 @@ fn catalog_dump_reclaim_pins_wal_records_holding_block_in_wal_pages() {
 }
 
 #[test]
-fn manifest_fold_reload_reconstructs_catalog_with_band_manifest_deleted() {
+fn manifest_fold_reload_reconstructs_catalog_with_slab_manifest_deleted() {
     // MANIFEST-CONFORMANCE FOLD round-trip: write, dump (folds the catalog), delete the band-manifest
     // file, reload -- every acked key must survive AND the band lifecycle must reconstruct from
     // the folded index-log MetaItem, proving the fold is a lossless catalog source.
@@ -3362,7 +3362,7 @@ fn manifest_fold_reload_reconstructs_catalog_with_band_manifest_deleted() {
     assert!(engine.dump_index_catalog(1), "explicit dump must complete");
     let folded = engine
         .index_log_store()
-        .latest_band_catalog(1)
+        .latest_slab_catalog(1)
         .unwrap()
         .expect("catalog folded");
     drop(engine);
@@ -3387,7 +3387,7 @@ fn manifest_fold_reload_reconstructs_catalog_with_band_manifest_deleted() {
         );
     }
     // The folded lifecycle states are present in the reconstructed catalog.
-    let recovered = restarted.block_store().band_catalog(0);
+    let recovered = restarted.block_store().slab_catalog(0);
     for entry in &folded.bands {
         assert!(
             recovered.iter().any(|z| z.block_slab_id == entry.block_slab_id),

--- a/crates/temporalstore-rust/src/engine/tests/part3.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part3.rs
@@ -1837,12 +1837,12 @@ fn stats_include_style_partition_and_object_manager_accounting() {
     assert_eq!(stats.shard_stat_info.start_routing_bucket, 10);
     assert_eq!(stats.shard_stat_info.end_routing_bucket, 20);
     assert_eq!(stats.shard_stat_info.object_manager, stats.object_manager);
-    assert!(stats.block_store_bands.active_slabs >= 1);
-    assert!(stats.block_store_bands.active_physical_bytes > 0);
+    assert!(stats.block_store_slabs.active_slabs >= 1);
+    assert!(stats.block_store_slabs.active_physical_bytes > 0);
     assert_eq!(
-        stats.block_store_bands.live_physical_bytes,
-        stats.block_store_bands.active_physical_bytes
-            + stats.block_store_bands.sealed_physical_bytes
+        stats.block_store_slabs.live_physical_bytes,
+        stats.block_store_slabs.active_physical_bytes
+            + stats.block_store_slabs.sealed_physical_bytes
     );
 }
 

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -9472,7 +9472,7 @@ fn every_maintenance_round_is_bounded_by_default() {
     assert_eq!(request.max_expire_hot_buckets_per_round, 128);
     assert_eq!(request.max_expire_cold_buckets_per_round, 8);
     assert_eq!(request.eviction_batch_limit, 16);
-    assert_eq!(request.page_gc_min_band_garbage_basis_points, 4_000);
+    assert_eq!(request.page_gc_min_slab_garbage_basis_points, 4_000);
 
     for (name, bound) in [
         ("index_gc_max_entries_per_round", request.index_gc_max_entries_per_round as u64),
@@ -9486,7 +9486,7 @@ fn every_maintenance_round_is_bounded_by_default() {
         ("eviction_batch_limit", request.eviction_batch_limit as u64),
         (
             "page_gc_min_band_garbage_basis_points",
-            request.page_gc_min_band_garbage_basis_points,
+            request.page_gc_min_slab_garbage_basis_points,
         ),
     ] {
         assert!(bound > 0, "{name} is zero, which is not a bound at all");
@@ -17785,7 +17785,7 @@ fn a_compaction_round_stops_at_the_page_ref_budget() {
 }
 
 #[test]
-fn the_band_usage_sample_still_serializes_under_its_zone_wire_names() {
+fn the_slab_usage_sample_still_serializes_under_its_zone_wire_names() {
     // `zone` was the older name for a band, and `zones` is keyed by `band_id`
     // (storage_bucket_internals.rs) -- so the aggregate is the BAND level reported under an old
     // name, not a separate level. The Rust identifiers moved to band; the WIRE must not, because
@@ -17813,7 +17813,7 @@ fn the_band_usage_sample_still_serializes_under_its_zone_wire_names() {
 
     // And the collection it sits in keeps its own wire name.
     let mut snapshot = crate::engine::reports::StorageTopologySnapshot::default();
-    snapshot.storage_band_usage_samples = vec![sample];
+    snapshot.storage_slab_usage_samples = vec![sample];
     let encoded = serde_json::to_value(&snapshot).expect("serialize");
     assert!(
         encoded.get("storage_zone_samples").is_some(),

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -1228,7 +1228,7 @@ impl LocalIndexLogStore {
     /// The most recent `MetaItem` anchor carrying a folded band catalog, or `None` if no
     /// anchor with a non-empty `bands` list has been written. Used on load (gate on) to seed the
     /// block-store band catalog from the folded anchor when the band-manifest file is absent.
-    pub fn latest_band_catalog(&self, shard_id: ShardId) -> Result<Option<MetaItem>, IndexLogError> {
+    pub fn latest_slab_catalog(&self, shard_id: ShardId) -> Result<Option<MetaItem>, IndexLogError> {
         // The LAST matching record wins, so this cannot stop early -- but it never needed to
         // hold the records it walks past. It kept every record in the log, with every item each
         // one carries, to take one field out of one of them.
@@ -2437,7 +2437,7 @@ mod tests {
     /// catalog-less record after the catalogs let a fold that kept "the last meta, bands or not"
     /// pass -- the record had no meta at all, so the wrong rule never fired.
     #[test]
-    fn the_band_catalog_is_the_last_record_that_carries_one() {
+    fn the_slab_catalog_is_the_last_record_that_carries_one() {
         let dir = tempfile::tempdir().unwrap();
         let store = LocalIndexLogStore::new(dir.path());
 
@@ -2459,7 +2459,7 @@ mod tests {
             }],
         };
         // A meta that carries no bands. An anchor looks like this whenever the fold is off.
-        let bandless = MetaItem {
+        let slabless = MetaItem {
             version: 2,
             start_wal_sequence: 2,
             timestamp_ms: 2,
@@ -2475,14 +2475,14 @@ mod tests {
             .unwrap();
         // A meta AFTER the catalogs that carries none of its own.
         store
-            .append_delta(4, Vec::new(), Vec::new(), None, Some(bandless.clone()), false, true)
+            .append_delta(4, Vec::new(), Vec::new(), None, Some(slabless.clone()), false, true)
             .unwrap();
         // And a record with no meta at all.
         store
             .append_delta(4, vec![page_item(1, "later", false)], Vec::new(), None, None, false, true)
             .unwrap();
 
-        let found = store.latest_band_catalog(4).unwrap().expect("a catalog");
+        let found = store.latest_slab_catalog(4).unwrap().expect("a catalog");
         assert_eq!(
             found.bands.first().map(|band| band.block_slab_id),
             Some(22),
@@ -2493,10 +2493,10 @@ mod tests {
         // a fold that kept the last meta whether or not it held bands passes the assertion
         // above and fails here.
         store
-            .append_delta(5, Vec::new(), Vec::new(), None, Some(bandless), false, true)
+            .append_delta(5, Vec::new(), Vec::new(), None, Some(slabless), false, true)
             .unwrap();
         assert!(
-            store.latest_band_catalog(5).unwrap().is_none(),
+            store.latest_slab_catalog(5).unwrap().is_none(),
             "a meta carrying no bands is not a catalog"
         );
     }
@@ -2863,7 +2863,7 @@ mod tests {
     }
 
     #[test]
-    fn meta_item_band_catalog_round_trips_through_the_delta_log() {
+    fn meta_item_slab_catalog_round_trips_through_the_delta_log() {
         let dir = tempfile::tempdir().unwrap();
         let store = LocalIndexLogStore::new(dir.path());
         let meta = MetaItem {
@@ -2901,7 +2901,7 @@ mod tests {
             .unwrap();
         // A reopen reads the folded catalog back exactly, and latest_band_catalog finds it.
         let reopened = LocalIndexLogStore::new(dir.path());
-        let recovered = reopened.latest_band_catalog(4).unwrap().unwrap();
+        let recovered = reopened.latest_slab_catalog(4).unwrap().unwrap();
         assert_eq!(recovered, meta);
         assert_eq!(recovered.bands.len(), 2);
         assert_eq!(recovered.bands[0].state, SlabCatalogState::Sealed);
@@ -2909,7 +2909,7 @@ mod tests {
     }
 
     #[test]
-    fn latest_band_catalog_prefers_the_newest_anchor_and_ignores_empty_ones() {
+    fn latest_slab_catalog_prefers_the_newest_anchor_and_ignores_empty_ones() {
         let dir = tempfile::tempdir().unwrap();
         let store = LocalIndexLogStore::new(dir.path());
         let older = MetaItem {
@@ -2956,7 +2956,7 @@ mod tests {
         store
             .append_delta(6, Vec::new(), Vec::new(), Some(9), Some(newer.clone()), false, true)
             .unwrap();
-        assert_eq!(store.latest_band_catalog(6).unwrap().unwrap(), newer);
+        assert_eq!(store.latest_slab_catalog(6).unwrap().unwrap(), newer);
     }
 
     /// The interval holds a second dump off, and a shard that has never dumped is not held.

--- a/crates/temporalstore-rust/src/index_log_record.rs
+++ b/crates/temporalstore-rust/src/index_log_record.rs
@@ -176,7 +176,7 @@ mod tests {
     }
 
     #[test]
-    fn band_states_keep_their_on_disk_numbering() {
+    fn slab_states_keep_their_on_disk_numbering() {
         // RECYCLED is 4, not 3 -- the gap is real and a renumber would silently reinterpret
         // existing records.
         assert_eq!(SlabState::Init as i32, 0);
@@ -228,7 +228,7 @@ mod tests {
     }
 
     #[test]
-    fn the_dump_watermark_round_trips_with_the_band_catalogue() {
+    fn the_dump_watermark_round_trips_with_the_slab_catalogue() {
         // start_wal_id is what replay resumes from and what truncation must not pass, so it has
         // to survive a round trip alongside the bands it describes.
         let mut bands = std::collections::HashMap::new();

--- a/crates/temporalstore-rust/src/readiness.rs
+++ b/crates/temporalstore-rust/src/readiness.rs
@@ -185,11 +185,14 @@ pub struct StorageProductionPostureReport {
     #[serde(default)]
     #[serde(rename = "native_slot_store_layout_transition_evidence")]
     pub native_bucket_store_layout_transition_evidence: Vec<String>,
-    pub stream_backed_band_runtime_ready: bool,
+    #[serde(rename = "stream_backed_band_runtime_ready")]
+    pub stream_backed_slab_runtime_ready: bool,
     #[serde(default)]
-    pub stream_backed_band_runtime_evidence: Vec<String>,
+    #[serde(rename = "stream_backed_band_runtime_evidence")]
+    pub stream_backed_slab_runtime_evidence: Vec<String>,
     #[serde(default)]
-    pub stream_backed_band_runtime_blockers: Vec<String>,
+    #[serde(rename = "stream_backed_band_runtime_blockers")]
+    pub stream_backed_slab_runtime_blockers: Vec<String>,
     pub model_layout_compaction_ready: bool,
     #[serde(default)]
     pub model_layout_compaction_evidence: Vec<String>,
@@ -1337,13 +1340,13 @@ mod tests {
             .native_bucket_store_layout_transition_evidence
             .iter()
             .any(|item| item.contains("slot objects track layout state transitions")));
-        assert!(report.stream_backed_band_runtime_ready);
+        assert!(report.stream_backed_slab_runtime_ready);
         assert!(report
-            .stream_backed_band_runtime_evidence
+            .stream_backed_slab_runtime_evidence
             .iter()
             .any(|item| item.contains("logical stream reads span page records")));
         assert!(report
-            .stream_backed_band_runtime_blockers
+            .stream_backed_slab_runtime_blockers
             .iter()
             .any(|item| item.contains("byte-for-byte stream backend layout")));
         assert!(report.model_layout_compaction_ready);

--- a/crates/temporalstore-rust/src/readiness/storage_reports.rs
+++ b/crates/temporalstore-rust/src/readiness/storage_reports.rs
@@ -289,8 +289,8 @@ pub fn storage_production_posture_report() -> StorageProductionPostureReport {
         "slot dump/load validates restored slot summaries against the first-class ownership index"
             .to_string(),
     ];
-    let stream_backed_band_runtime_ready = true;
-    let stream_backed_band_runtime_evidence = vec![
+    let stream_backed_slab_runtime_ready = true;
+    let stream_backed_slab_runtime_evidence = vec![
         "LocalBlockStore exposes stream-backed band runtime reports".to_string(),
         "logical stream reads span page records while skipping envelopes and decompression"
             .to_string(),
@@ -299,7 +299,7 @@ pub fn storage_production_posture_report() -> StorageProductionPostureReport {
         "stream envelopes carry checksum, page id, object id, routing slot, band id, and compression metadata"
             .to_string(),
     ];
-    let stream_backed_band_runtime_blockers = vec![
+    let stream_backed_slab_runtime_blockers = vec![
         "byte-for-byte stream backend layout remains out of scope".to_string(),
         "distributed/control-plane compression policy remains separate evidence".to_string(),
     ];
@@ -397,7 +397,7 @@ pub fn storage_production_posture_report() -> StorageProductionPostureReport {
     if !native_bucket_store_layout_transition_ready {
         missing.push("native SlotStore slot layout transitions".to_string());
     }
-    if !stream_backed_band_runtime_ready {
+    if !stream_backed_slab_runtime_ready {
         missing.push("stream-backed band runtime".to_string());
     }
     if !model_layout_compaction_ready {
@@ -431,9 +431,9 @@ pub fn storage_production_posture_report() -> StorageProductionPostureReport {
         native_object_manager_runtime_blockers,
         native_bucket_store_layout_transition_ready,
         native_bucket_store_layout_transition_evidence,
-        stream_backed_band_runtime_ready,
-        stream_backed_band_runtime_evidence,
-        stream_backed_band_runtime_blockers,
+        stream_backed_slab_runtime_ready,
+        stream_backed_slab_runtime_evidence,
+        stream_backed_slab_runtime_blockers,
         model_layout_compaction_ready,
         model_layout_compaction_evidence,
         model_layout_compaction_blockers,

--- a/crates/temporalstore-rust/src/shared_store.rs
+++ b/crates/temporalstore-rust/src/shared_store.rs
@@ -996,8 +996,8 @@ where
 
         // Snapshot the local band descriptors so each uploaded slab carries its sealed-band
         // metadata (logical bytes + page-id range) into the manifest for S3 restore-time install.
-        let band_by_slab: BTreeMap<u64, _> = block_store
-            .band_descriptors()
+        let slab_by_slab: BTreeMap<u64, _> = block_store
+            .slab_descriptors()
             .into_iter()
             .map(|band| (band.block_slab_id, band))
             .collect();
@@ -1010,7 +1010,7 @@ where
                 .put(&key, Bytes::from(bytes.clone()))
                 .await?;
             uploaded_slab_ids.insert(block_slab_id);
-            let band = band_by_slab.get(&block_slab_id);
+            let band = slab_by_slab.get(&block_slab_id);
             block_slabs.push(SharedStoreBlockSlab {
                 block_slab_id,
                 key,
@@ -2065,7 +2065,7 @@ where
             // GC/compaction accounting is complete immediately after restore, before the first
             // on-demand fetch materializes any slab locally. Runs AFTER the reserve so the freshly
             // reserved slab stays the active band and every checkpoint slab is sealed.
-            let lazy_bands: Vec<LazyCheckpointSlab> = manifest
+            let lazy_slabs: Vec<LazyCheckpointSlab> = manifest
                 .block_slabs
                 .iter()
                 .map(|slab| LazyCheckpointSlab {
@@ -2078,7 +2078,7 @@ where
                     updated_unix_ms: slab.updated_unix_ms,
                 })
                 .collect();
-            block_store.install_lazy_checkpoint_bands(&lazy_bands)?;
+            block_store.install_lazy_checkpoint_slabs(&lazy_slabs)?;
         }
         Ok(manifest)
     }
@@ -3817,13 +3817,13 @@ mod tests {
                 value: b"snapshot-value".to_vec(),
             },
         });
-        let primary_band = primary
+        let primary_slab = primary
             .block_store()
-            .band_descriptors()
+            .slab_descriptors()
             .into_iter()
             .find(|b| b.block_slab_id == 0)
             .expect("primary must have a band for slab 0");
-        assert!(primary_band.logical_bytes > 0);
+        assert!(primary_slab.logical_bytes > 0);
 
         let (_store, replicator) = test_shared_store(dir.path());
         let manifest = replicator
@@ -3836,7 +3836,7 @@ mod tests {
             .iter()
             .find(|s| s.block_slab_id == 0)
             .expect("manifest must record slab 0");
-        assert_eq!(slab0.logical_bytes, primary_band.logical_bytes);
+        assert_eq!(slab0.logical_bytes, primary_slab.logical_bytes);
 
         let follower = test_engine(dir.path(), "follower");
         replicator
@@ -3851,18 +3851,18 @@ mod tests {
             "checkpoint slab 0 must not be materialized locally yet"
         );
         // ...but the sealed band descriptor for slab 0 is already present and complete.
-        let follower_band = follower
+        let follower_slab = follower
             .block_store()
-            .band_descriptors()
+            .slab_descriptors()
             .into_iter()
             .find(|b| b.block_slab_id == 0)
             .expect("restore must install a band descriptor for the lazily-backed slab 0");
-        assert_eq!(follower_band.state, crate::block_store::BlockStoreSlabState::Sealed);
-        assert_eq!(follower_band.logical_bytes, primary_band.logical_bytes);
-        assert_eq!(follower_band.physical_bytes, slab0.byte_size);
+        assert_eq!(follower_slab.state, crate::block_store::BlockStoreSlabState::Sealed);
+        assert_eq!(follower_slab.logical_bytes, primary_slab.logical_bytes);
+        assert_eq!(follower_slab.physical_bytes, slab0.byte_size);
         // The band summary counts the sealed shared band immediately (accounting is complete).
         assert!(
-            follower.block_store().band_summary().sealed_slabs >= 1,
+            follower.block_store().slab_summary().sealed_slabs >= 1,
             "sealed shared band must be counted before any lazy fetch"
         );
         assert_eq!(follower.block_store().stats().shared_slab_fetches, 0);

--- a/crates/temporalstore-rust/tests/storage_crash_harness.rs
+++ b/crates/temporalstore-rust/tests/storage_crash_harness.rs
@@ -54,7 +54,7 @@ fn storage_crash_harness_recovers_after_abrupt_process_abort() {
     assert_eq!(summary.recovery.total_page_refs, 2);
     assert_eq!(summary.recovery.readable_page_refs, 2);
     assert!(summary.recovery.all_live_pages_readable);
-    assert_eq!(summary.recovery.band_descriptors.len(), 2);
+    assert_eq!(summary.recovery.slab_descriptors.len(), 2);
     assert_eq!(summary.recovery.block_slab_reports.len(), 2);
     assert!(summary
         .recovery

--- a/crates/temporalstore-rust/tests/unified_temporalstore_corpus.rs
+++ b/crates/temporalstore-rust/tests/unified_temporalstore_corpus.rs
@@ -3452,12 +3452,12 @@ fn maybe_run_storage_parity_command(case: &UnifiedCase, step: &UnifiedStep) -> b
             let storage_case = load_storage_migration_case(&command.required_migration_case());
             verify_storage_recovery_reconciles_bucket_index_to_model_views(&storage_case);
         }
-        "storage_stream_backed_band_runtime" => verify_storage_stream_backed_band_runtime(),
-        "storage_stream_partial_band_rebuild" => verify_storage_stream_backed_band_runtime(),
+        "storage_stream_backed_band_runtime" => verify_storage_stream_backed_slab_runtime(),
+        "storage_stream_partial_band_rebuild" => verify_storage_stream_backed_slab_runtime(),
         "storage_stream_manifest_disk_reconciliation" => {
-            verify_storage_stream_backed_band_runtime()
+            verify_storage_stream_backed_slab_runtime()
         }
-        "storage_stream_segment_manifest_rebuild" => verify_storage_stream_backed_band_runtime(),
+        "storage_stream_segment_manifest_rebuild" => verify_storage_stream_backed_slab_runtime(),
         "storage_stream_reopen_scan" => verify_storage_stream_reopen_scan(&command),
         other => panic!(
             "case={} step={} unsupported storage command {other}",
@@ -4382,7 +4382,7 @@ fn verify_storage_stream_reopen_scan(command: &StorageUnifiedCommand) {
     }
 }
 
-fn verify_storage_stream_backed_band_runtime() {
+fn verify_storage_stream_backed_slab_runtime() {
     verify_random_size_reopen_scan();
     verify_cross_block_large_values();
 }


### PR DESCRIPTION
band becomes slab everywhere else it can

The last mechanical slice: 448 occurrences across 33 files -- functions, locals
and the remaining fields -- with 21 #[serde(rename = "<old>")] pins so the wire
does not move.

The rename list is built FROM THE TREE rather than by hand: take every identifier
containing `band`, propose the slab spelling, and drop the pair if the target
already exists. Nine were dropped that way (stream_band_count, storage_band_id,
band_samples, band_report, large_bands, small_bands, band_fields, band_count,
BandInfo) -- each is a merge rather than a rename, because both names already
exist and carry the same value for a reason someone has to decide about.

Two hazards cost an attempt each, and neither would have been caught by reading.

RUST INLINE FORMAT ARGS LIVE INSIDE STRING LITERALS. format!("{band_usage}")
references a binding from within a string, so a rule of "never touch strings"
renames the binding and orphans the reference -- cannot find value
address_band_id. There were five. The substitution now reaches into {ident} and
leaves the rest of every literal alone, which matters because
temporalstore_block_store_band_* are exported Prometheus metric names; still 13
of them after, unchanged.

THE SHELL ATE A REGEX BACKREFERENCE. Writing the substitution through a shell
turned \1 into a literal 0x01 byte, so the replacement would have dropped the
captured : or } and mangled every format string it touched. `cat -A` showed it as
^A. It is a lambda now, so there is no backreference to mangle. That one compiles
and corrupts output at runtime rather than failing the build.

Not renamed, each deliberately:

  band_id, band          the duplicates of block_slab_id / slab_id. Deletable
                         only, which is a wire break -- documented in place by
                         #1483 and pinned by #1481.
  band_id_for_slab       identity today, and the single point of change if bands
                         ever stop being 1:1 with slabs.
  band_manifest,         module names: renaming needs the FILE renamed too, and
  band_reports           slab_reports already exists.

What the layering looks like where three vocabularies meet:

    #[serde(rename = "zone_usage", default)]
    pub slab_usage: Vec<BlockStoreSlabUsage>,

The Rust name moved band -> slab; the pin still writes the ZONE-era wire name.
Three generations of vocabulary, one unchanged byte stream.

Full suite: 1764 passed, 1 failed -- the known baseline failure.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
