### PR TITLE
Restore the #[test] the slab rename moved onto the wrong function

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -2839,14 +2839,13 @@ mod tests {
     }
 
     #[test]
-    #[test]
     fn a_slab_descriptor_carries_the_same_number_twice() {
         // `band_id_for_slab` is the identity function, so a descriptor's `band_id` and its
         // `block_slab_id` are ONE value under two names. Every construction site says so:
         // band_id_for_slab(inner.block_slab_id), band_id_for_slab(band.block_slab_id),
         // band_id_for_slab(new_slab_id).
         //
-        // `rolled_slabs_stamp_new_band_ids` above pins that for an ADDRESS. This pins it for the
+        // `rolled_slabs_stamp_new_slab_ids` below pins that for an ADDRESS. This pins it for the
         // DESCRIPTOR, which is the struct that actually stores both, and where a caller picks
         // whichever name is nearer without it mattering today.
         //
@@ -2872,6 +2871,7 @@ mod tests {
         }
     }
 
+    #[test]
     fn rolled_slabs_stamp_new_slab_ids() {
         let dir = tempfile::tempdir().unwrap();
         let store = LocalBlockStore::new(dir.path());


### PR DESCRIPTION
Restore the #[test] the slab rename moved onto the wrong function

ce259fa85 left two #[test] attributes stacked on
a_slab_descriptor_carries_the_same_number_twice and none on
rolled_slabs_stamp_new_slab_ids, which sits directly below it. Rust accepts the
duplicate without complaint, so the second function still compiles, is called by
nobody, and has never run.

test_a_test_shaped_function_without_the_attribute_never_runs caught it on the
next push and has been failing on main since:

    these take no arguments, return nothing, and are called by nobody -- so they
    are tests missing `#[test]` and have never run:
    ['crates/temporalstore-rust/src/block_store.rs:2874 rolled_slabs_stamp_new_slab_ids']

The attribute moves back. The test it belongs to asserts that a rolled slab
stamps new ids and that band_id and block_slab_id stay equal across the roll --
the address-level half of the invariant its neighbour pins for the descriptor.

Also in that neighbour's comment: it named `rolled_slabs_stamp_new_band_ids`,
which exists nowhere after the rename, and called it "above" when it is below.

Found while a docs-only change was blocked by the ratchet. The failure was not
that change's, and the guard was right.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
