### PR TITLE
The periodic loop now reclaims the index log too

### DIFF
--- a/crates/temporalstore-rust/src/data_node/runtime_storage.rs
+++ b/crates/temporalstore-rust/src/data_node/runtime_storage.rs
@@ -554,7 +554,7 @@ impl DataNodeRuntime {
             reason == "slot_dump_manifest_prune" || reason == "slot_dump_install_roll_forward_check"
         });
         if options.enable_index_gc {
-            let response = self.apply_storage_lifecycle(StorageLifecycleRequest {
+            let index_gc_request = StorageLifecycleRequest {
                 shard_id,
                 selected_dump_buckets: Vec::new(),
                 max_dump_buckets_per_round: 0,
@@ -571,7 +571,28 @@ impl DataNodeRuntime {
                 page_gc_delayed_destroy_grace_ms: 0,
                 invalidate_cache: false,
                 warm_cache: false,
-            });
+            };
+            let response = self.apply_storage_lifecycle(index_gc_request.clone());
+            // Pruning manifests and rolling forward installs make the index log RECLAIMABLE.
+            // Neither frees a byte of it: `storage_index_gc_report` is what truncates, and until
+            // now nothing on this loop reached it -- so a server started as shipped grew its index
+            // log for ever, exactly as it grew its write-ahead log before #1470.
+            //
+            // The same request this stage just applied, so the plan the safety check reads is the
+            // one this stage's dump produced; and this stage's OWN report, so a dump that
+            // committed dirty buckets is visible to
+            // `index_gc_commit_dirty_buckets_before_truncation`.
+            let index_gc = self
+                .inner
+                .engine
+                .apply_periodic_index_gc(index_gc_request, Some(&response.report));
+            if index_gc.applied {
+                tracing::debug!(
+                    shard_id,
+                    index_log_records_removed = index_gc.records_removed,
+                    "storage manager reclaimed index-log records"
+                );
+            }
             lifecycle_report = Some(response.report);
             self.inner
                 .stats

--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -3665,3 +3665,146 @@ fn the_periodic_loop_actually_reclaims_the_write_ahead_log() {
         "with reclaim_wal disabled nothing may shrink the log: {control_before} -> {control_after}"
     );
 }
+
+#[test]
+fn the_periodic_loop_actually_reclaims_the_index_log() {
+    // #1470 gave this loop its write-ahead log reclaim and left the index log open, because
+    // `storage_index_gc_report` is engine-internal and takes a cycle request for its thresholds.
+    // Until this, the index log was truncated only by the cycle endpoint, an explicit /gc request,
+    // or the embedded proxy's own thread -- so a server started as shipped grew it for ever, the
+    // same way it grew the write-ahead log.
+    //
+    // The fixture is large on purpose. The shipped gate needs BOTH triggers, ANDed: at least
+    // `DEFAULT_INDEX_GC_INDEX_LOG_BYTES_THRESHOLD` (768 KiB) of index log AND at least 40%
+    // removable. Measured, an index-log record is about 59 B, so 8,000 records is 477 KB and the
+    // byte gate declines -- correctly. 16,000 reaches 943 KB and it fires. Testing at a tuned-down
+    // threshold would exercise a gate no deployment runs.
+    fn index_log_records(engine: &TemporalEngine, shard_id: crate::types::ShardId) -> usize {
+        engine
+            .index_log_store()
+            .scan(shard_id, 0, u64::MAX, u64::MAX)
+            .map(|records| records.len())
+            .unwrap_or(0)
+    }
+
+    fn runtime_with_records(records: usize) -> (DataNodeRuntime, usize) {
+        let engine = TemporalEngine::default();
+        engine.load_shard(1);
+        for index in 0..records {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("index-gc-{index:06}"),
+                    value: vec![b'v'; 64],
+                },
+            });
+        }
+        let before = index_log_records(&engine, 1);
+        let runtime = DataNodeRuntime::new_without_workers_with_options(
+            engine,
+            DataNodeRuntimeOptions {
+                worker_threads: 0,
+                max_queue_depth: 4,
+                max_background_queue_depth: 2,
+            },
+        );
+        (runtime, before)
+    }
+
+    const RECORDS: usize = 16_000;
+
+    let (runtime, before) = runtime_with_records(RECORDS);
+    assert!(before > 0, "the fixture must write index-log records, got {before}");
+    for _ in 0..3 {
+        runtime.run_storage_manager_once(1, StorageManagerOptions::default());
+    }
+    let runtime_engine = runtime.engine();
+    let after = index_log_records(&runtime_engine, 1);
+    assert!(
+        after < before,
+        "the periodic loop must reclaim index-log records: {before} before, {after} after"
+    );
+
+    // CONTROL: the same rounds with the stage switched off must reclaim NOTHING. Without it,
+    // "the log shrank" could be the dump, the prune or the roll-forward, and the assertion above
+    // would pass while proving nothing about index GC.
+    let (control, control_before) = runtime_with_records(RECORDS);
+    for _ in 0..3 {
+        control.run_storage_manager_once(
+            1,
+            StorageManagerOptions {
+                enable_index_gc: false,
+                ..StorageManagerOptions::default()
+            },
+        );
+    }
+    let control_engine = control.engine();
+    let control_after = index_log_records(&control_engine, 1);
+    assert_eq!(
+        control_after, control_before,
+        "with index GC off nothing may truncate the index log: {control_before} before, \
+         {control_after} after -- if this moved, the stage under test is not the one responsible"
+    );
+}
+
+
+/// Why does the index-log reclaim decline? Prints the gate.
+///
+///   cargo test -p temporalstore-rust --lib what_the_index_gc_gate_says -- --ignored --nocapture
+#[test]
+#[ignore]
+fn what_the_index_gc_gate_says() {
+    for records in [8_000usize, 16_000, 32_000] {
+        let engine = TemporalEngine::default();
+        engine.load_shard(1);
+        for index in 0..records {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("gate-{index:06}"),
+                    value: vec![b'v'; 64],
+                },
+            });
+        }
+        let runtime = DataNodeRuntime::new_without_workers_with_options(
+            engine,
+            DataNodeRuntimeOptions {
+                worker_threads: 0,
+                max_queue_depth: 4,
+                max_background_queue_depth: 2,
+            },
+        );
+        // A round first, so the dump has run and the plan reflects it.
+        runtime.run_storage_manager_once(1, StorageManagerOptions::default());
+        let engine = runtime.engine();
+        let wal_plan = engine.storage_wal_reclaim_plan(1, Vec::new(), Vec::new());
+        eprintln!(
+            "  {records:>6} records -> wal_safe={} blockers={:?}",
+            wal_plan.safe_to_reclaim, wal_plan.blocker_reasons
+        );
+        let report = engine.apply_periodic_index_gc(
+            crate::engine::reports::StorageLifecycleRequest {
+                shard_id: 1,
+                purge_delayed_destroy: true,
+                prune_bucket_dump_manifests: true,
+                roll_forward_bucket_dump_installs: true,
+                ..crate::engine::reports::StorageLifecycleRequest::default()
+            },
+            None,
+        );
+        eprintln!(
+            "  {records:>6} records -> enabled={} applied={} safe_dirty={} bytes_before={} \
+             threshold={} usage={}bp trigger={}bp retain_from={} before={} after={}",
+            report.enabled,
+            report.applied,
+            report.dirty_buckets_committed_before_truncate,
+            report.bytes_before,
+            report.bytes_threshold,
+            report.usage_ratio_basis_points,
+            report.usage_ratio_trigger_basis_points,
+            report.retain_from_index_log_sequence,
+            report.records_before,
+            report.records_after,
+        );
+    }
+}

--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -1028,6 +1028,41 @@ impl TemporalEngine {
         }
     }
 
+    /// Reclaim the index log on the same terms the background cycle uses.
+    ///
+    /// [`Self::storage_index_gc_report`] is engine-internal and takes a cycle request for its
+    /// thresholds, which is why the periodic scheduler could not reach it: the index log was
+    /// truncated only by the cycle endpoint, an explicit `/gc` request, or the embedded proxy's
+    /// own reclaim thread. This is the entry that closes that, and it takes the CYCLE's defaults
+    /// rather than inventing a second policy -- including
+    /// `index_gc_commit_dirty_buckets_before_truncation`, which defaults TRUE and is the safe
+    /// order: an index-log record names where a block's bytes live, so dropping one the durable
+    /// state does not yet reflect loses the LOCATION of data that is still on disk, which reads
+    /// as missing rather than as corruption.
+    ///
+    /// The plan is recomputed from `request` AFTER the caller's dump has run, which is the order
+    /// that makes the safety check meaningful: if that dump cleared the dirty set, the plan now
+    /// selects nothing and truncation is safe on its own terms. A stale plan would ask about
+    /// buckets that have already been committed.
+    pub fn apply_periodic_index_gc(
+        &self,
+        request: StorageLifecycleRequest,
+        lifecycle_report: Option<&StorageLifecycleReport>,
+    ) -> StorageIndexGcReport {
+        let shard_id = request.shard_id;
+        let plan = self.storage_lifecycle_plan(request);
+        let wal_plan = self.storage_wal_reclaim_plan(shard_id, Vec::new(), Vec::new());
+        self.storage_index_gc_report(
+            &plan,
+            &wal_plan,
+            lifecycle_report,
+            &StorageManagerCycleRequest {
+                shard_id,
+                ..StorageManagerCycleRequest::default()
+            },
+        )
+    }
+
     pub(super) fn storage_index_gc_report(
         &self,
         plan: &StorageLifecyclePlan,


### PR DESCRIPTION
The periodic loop now reclaims the index log too

#1470 gave this loop its write-ahead log reclaim and deliberately left the index
log open, because storage_index_gc_report is engine-internal and takes a cycle
request for its thresholds. So the index log was still truncated only by the
cycle endpoint, an explicit /gc request, or the embedded proxy's own reclaim
thread -- and a server started as shipped grew it for ever, exactly as it grew
the write-ahead log before #1470.

apply_periodic_index_gc is the entry that closes it. It takes the CYCLE's
defaults rather than inventing a second policy, including
index_gc_commit_dirty_buckets_before_truncation, which defaults true and is the
safe order: an index-log record names where a block's bytes live, so dropping one
the durable state does not yet reflect loses the LOCATION of data still on disk,
which reads as missing rather than as corruption.

The plan is recomputed from the stage's own request AFTER its dump has run. That
ordering is what makes the safety check meaningful: if the dump cleared the dirty
set, the plan now selects nothing and truncation is safe on its own terms.

My first test asserted 1,512 records and failed with "1512 before, 1512 after",
which looks exactly like broken wiring. It was not. Probing the gate showed every
safety term satisfied -- wal_safe=true, no blockers, dirty buckets committed,
100% of records removable against a 40% trigger -- and applied=false anyway. The
reason was in the line I had not read: the two triggers are ANDed, not ORed, and
the byte threshold is 768 KiB.

  8,000 records   477 KB index log   declines, correctly
 16,000 records   943 KB             applies
 32,000 records   1.9 MB             applies

So the test runs at 16,000 records and crosses the SHIPPED gate. Testing at a
tuned-down threshold would exercise a gate no deployment runs.

Mutation results, both stated because one of them is a limit of the test:
removing the reclaim call fails it with "16000 before, 16000 after". Replacing
the lifecycle report with None SURVIVES -- the recomputed plan selects nothing,
so the commit-before-truncate check passes either way. Passing the report is
defensive on this path, not load-bearing, and the test does not cover it.

The control runs the same rounds with enable_index_gc off and asserts the log
does NOT shrink, so the dump, the prune and the roll-forward cannot be what
moved it.

Measured and not addressed here: each call removes exactly
max_entries_per_round, 256. Draining 31,744 removable records takes about 124
rounds, an hour at a 30 s tick, while writes continue. That is the cycle's own
default so this matches it; whether it keeps pace under sustained write load is a
separate question.

Full suite: 1765 passed, 1 failed -- the known baseline failure.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
