### PR TITLE
Remove the raw-ingestion extraction nothing adopted

### DIFF
--- a/tools/matrixark_mcp_raw_ingestion.py
+++ b/tools/matrixark_mcp_raw_ingestion.py
@@ -1,23 +1,26 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 MatrixArkAI
-"""Raw ingestion helper functions for MatrixArk TemporalStore adapters."""
+"""The two raw-ingestion normalisers the adapters call.
+
+This module once held an extraction of the whole raw-ingestion path -- an append function, a
+`RawIngestionAdapterMixin` carrying thirteen methods, and a raw session index. Nothing ever
+mixed the class in and nothing ever called the function: the live adapters take their
+`_append_raw_ingestion_records` from `_TemporalDirectBackendMixin`, and the only names imported
+from here are the two below. The copy here had drifted into the weaker one -- no backend metric
+fields, no write-debug stamping, no append-options wrapper -- so adopting it later would have
+cost those silently. Removed rather than repaired, because a second implementation nothing runs
+cannot be trusted to still match the one that does.
+"""
 
 from __future__ import annotations
 
-import json
-import os
-import time
 from typing import Any
 
 try:
     from tools.matrixark_mcp_errors import MatrixArkError
-    from tools.matrixark_mcp_identity import stable_hash
-    from tools.matrixark_mcp_temporal_append import slim_persisted_record
 except ModuleNotFoundError:  # Direct script execution from tools/.
     from matrixark_mcp_errors import MatrixArkError
-    from matrixark_mcp_identity import stable_hash
-    from matrixark_mcp_temporal_append import slim_persisted_record
 
 
 Json = dict[str, Any]
@@ -50,122 +53,6 @@ def normalize_raw_storage_backend(value: Any) -> str:
     return backend
 
 
-def raw_ingestion_append_path_for_backend(backend: Any) -> str:
-    normalized = normalize_raw_storage_backend(backend)
-    if normalized == "temporalstore":
-        return "matrixark_raw_ingestion_temporalstore_log"
-    if normalized == "matrixkv":
-        return "matrixark_raw_ingestion_matrixkv_log"
-    if normalized == "s3":
-        return "matrixark_raw_ingestion_s3_object_ref"
-    return "matrixark_raw_ingestion_matrixobject_ref"
-
-
-def raw_ingestion_append_options(backend: Any) -> Json:
-    normalized = normalize_raw_storage_backend(backend)
-    return {
-        "append_path": raw_ingestion_append_path_for_backend(normalized),
-        "raw_storage_backend": normalized,
-        "raw_message_store": normalized,
-        "coalesce_writes": True,
-        "route_by": "raw_ingestion_prefix",
-        "persist_from_storage_options": True,
-        "hset_lowering": "forbidden_for_parity",
-        "count_update": "same_batch",
-        "source": "matrixark_live_ingestion_dual_write",
-    }
-
-
-def ensure_raw_ingestion_fields(target: Any) -> None:
-    if not hasattr(target, "_raw_storage_backend"):
-        target._raw_storage_backend = normalize_raw_storage_backend(
-            (os.environ.get("MATRIXARK_RAW_INGESTION_BACKEND", "").strip() or "temporalstore")
-        )
-    else:
-        target._raw_storage_backend = normalize_raw_storage_backend(target._raw_storage_backend)
-    if not hasattr(target, "_raw_ingestion_prefix"):
-        storage_prefix = str(getattr(target, "_storage_prefix", "matrixark:mcp")).rstrip(":")
-        configured_raw_prefix = os.environ.get("MATRIXARK_DIRECT_RAW_STORAGE_PREFIX", "").strip().rstrip(":")
-        target._raw_ingestion_prefix = configured_raw_prefix or f"{storage_prefix}:raw_ingestion"
-    if not hasattr(target, "_raw_record_hash_key"):
-        target._raw_record_hash_key = f"{target._raw_ingestion_prefix}:records"
-    if not hasattr(target, "_raw_count_key"):
-        target._raw_count_key = f"{target._raw_ingestion_prefix}:record_count"
-    if not hasattr(target, "_raw_entry_count_cache"):
-        target._raw_entry_count_cache = None
-
-
-def raw_record_location(raw_record_hash_key: str, shard_size: int, sequence: int) -> tuple[str, str]:
-    shard = sequence // shard_size
-    offset = sequence % shard_size
-    return f"{raw_record_hash_key}:{shard:06d}", f"{offset:020d}"
-
-
-def raw_session_index_key(raw_ingestion_prefix: str, session_id: str) -> str:
-    return f"{raw_ingestion_prefix}:session_index:{stable_hash(str(session_id))}"
-
-
-def raw_record_scope_value(record: Json, name: str) -> str:
-    scope = record.get("scope") if isinstance(record.get("scope"), dict) else {}
-    envelope = record.get("envelope") if isinstance(record.get("envelope"), dict) else {}
-    envelope_scope = envelope.get("scope") if isinstance(envelope.get("scope"), dict) else {}
-    for key in (name, name.replace("_id", "")):
-        for container in (record, scope, envelope_scope, envelope):
-            if not isinstance(container, dict):
-                continue
-            value = container.get(key)
-            if value not in (None, ""):
-                return str(value)
-    return ""
-
-
-def raw_record_session_ids(record: Json) -> set[str]:
-    candidates = {
-        raw_record_scope_value(record, "session_id"),
-        raw_record_scope_value(record, "conversation_id"),
-    }
-    scope = record.get("scope") if isinstance(record.get("scope"), dict) else {}
-    envelope = record.get("envelope") if isinstance(record.get("envelope"), dict) else {}
-    envelope_scope = envelope.get("scope") if isinstance(envelope.get("scope"), dict) else {}
-    metadata = record.get("metadata") if isinstance(record.get("metadata"), dict) else {}
-    for container in (scope, envelope_scope, metadata, envelope, record):
-        if not isinstance(container, dict):
-            continue
-        for key in ("session_id", "session", "conversation_id", "conversation"):
-            value = container.get(key)
-            if value not in (None, ""):
-                candidates.add(str(value))
-    return {item for item in candidates if item}
-
-
-def raw_session_index_entries(
-    *,
-    raw_ingestion_prefix: str,
-    shard_size: int,
-    sequence: int,
-    record: Json,
-) -> list[Json]:
-    shard = sequence // shard_size
-    offset = sequence % shard_size
-    ref = json.dumps(
-        {
-            "sequence": sequence,
-            "shard": shard,
-            "field": f"{offset:020d}",
-        },
-        sort_keys=True,
-        separators=(",", ":"),
-    )
-    return [
-        {
-            "key": raw_session_index_key(raw_ingestion_prefix, session_id),
-            "field": f"{sequence:020d}",
-            "value": ref,
-        }
-        for session_id in sorted(raw_record_session_ids(record))
-    ]
-
-
 def normalize_raw_ingestion_record(record: Json) -> Json:
     normalized = dict(record)
     if normalized.get("record_type") == "agent_message":
@@ -176,125 +63,3 @@ def normalize_raw_ingestion_record(record: Json) -> Json:
     normalized.setdefault("serving_visible", False)
     normalized.setdefault("session_binding", "metadata_only_for_backfill_batching")
     return normalized
-
-
-def get_raw_count(target: Any) -> int:
-    ensure_raw_ingestion_fields(target)
-    try:
-        raw = target._client.get_string(target._raw_count_key)
-    except Exception:
-        return 0
-    if not raw:
-        return 0
-    try:
-        value = int(raw)
-    except ValueError:
-        return 0
-    return max(0, value)
-
-
-def append_raw_ingestion_records(target: Any, records: list[Json], *, allow_queue: bool = True) -> None:
-    if not records:
-        return
-    records = [normalize_raw_ingestion_record(record) for record in records]
-    ensure_raw_ingestion_fields(target)
-    if target._raw_ingestion_prefix == target._storage_prefix:
-        raise MatrixArkError("MATRIXARK_DIRECT_RAW_STORAGE_PREFIX must differ from the serving storage prefix")
-    if (
-        allow_queue
-        and bool(getattr(target, "_direct_raw_ingestion_queue_enabled", False))
-        and bool(getattr(target, "_direct_write_queue_enabled", False))
-        and getattr(target, "_direct_write_queue_mode", "memory") == "memory"
-    ):
-        target._enqueue_direct_write_item({"queue_mode": "raw_ingestion", "records": list(records)}, len(records))
-        return
-    started_perf = time.perf_counter()
-    with target._records_lock:
-        count = target._raw_entry_count_cache if target._raw_entry_count_cache is not None else get_raw_count(target)
-        sequence = count
-        entries: list[Json] = []
-        for record in records:
-            record_key, record_id = raw_record_location(target._raw_record_hash_key, target._shard_size, sequence)
-            payload = json.dumps(slim_persisted_record(record),
-                                 sort_keys=True, separators=(",", ":"))
-            route = record.get("storage_route") if isinstance(record.get("storage_route"), dict) else {}
-            entries.append({"key": record_key, "field": record_id, "value": payload, "storage_route": route})
-            entries.extend(
-                raw_session_index_entries(
-                    raw_ingestion_prefix=target._raw_ingestion_prefix,
-                    shard_size=target._shard_size,
-                    sequence=sequence,
-                    record=record,
-                )
-            )
-            sequence += 1
-        append_records = getattr(target._client, "matrixark_batch_append_records", None)
-        if callable(append_records):
-            target._write_with_backoff(
-                lambda: append_records(
-                    entries,
-                    count_key=target._raw_count_key,
-                    count_value=str(sequence),
-                    append_options=raw_ingestion_append_options(target._raw_storage_backend),
-                ),
-                op="matrixark_batch_append_raw_ingestion_records",
-            )
-        else:
-            target._hset_many_with_backoff(entries)
-            target._put_string_with_backoff(target._raw_count_key, str(sequence))
-        if target._raw_ingestion_visibility_required_after_flush():
-            target._note_pending_visibility_keys(
-                [target._raw_count_key] + [str(entry.get("key") or "") for entry in entries]
-            )
-        target._raw_entry_count_cache = sequence
-        elapsed_ms = (time.perf_counter() - started_perf) * 1000.0
-        target._observe_backend_command(elapsed_ms, records_written=len(records))
-
-
-class RawIngestionAdapterMixin:
-    """Adapter methods for raw ingestion storage and indexing."""
-
-    def _normalize_raw_storage_backend(self, value: Any) -> str:
-        return normalize_raw_storage_backend(value)
-
-    def _raw_ingestion_append_path(self) -> str:
-        return raw_ingestion_append_path_for_backend(
-            getattr(self, "_raw_storage_backend", "temporalstore")
-        )
-
-    def _raw_ingestion_append_options(self) -> Json:
-        return raw_ingestion_append_options(
-            getattr(self, "_raw_storage_backend", "temporalstore")
-        )
-
-    def _ensure_raw_ingestion_fields(self) -> None:
-        ensure_raw_ingestion_fields(self)
-
-    def _raw_record_location(self, sequence: int) -> tuple[str, str]:
-        self._ensure_raw_ingestion_fields()
-        return raw_record_location(self._raw_record_hash_key, self._shard_size, sequence)
-
-    def _raw_session_index_key(self, session_id: str) -> str:
-        self._ensure_raw_ingestion_fields()
-        return raw_session_index_key(self._raw_ingestion_prefix, session_id)
-
-    def _raw_record_scope_value(self, record: Json, name: str) -> str:
-        return raw_record_scope_value(record, name)
-
-    def _raw_record_session_ids(self, record: Json) -> set[str]:
-        return raw_record_session_ids(record)
-
-    def _raw_session_index_entries(self, *, sequence: int, record: Json) -> list[Json]:
-        self._ensure_raw_ingestion_fields()
-        return raw_session_index_entries(
-            raw_ingestion_prefix=self._raw_ingestion_prefix,
-            shard_size=self._shard_size,
-            sequence=sequence,
-            record=record,
-        )
-
-    def _get_raw_count(self) -> int:
-        return get_raw_count(self)
-
-    def _append_raw_ingestion_records(self, records: list[Json], *, allow_queue: bool = True) -> None:
-        append_raw_ingestion_records(self, records, allow_queue=allow_queue)

--- a/tools/matrixark_mcp_temporal_append.py
+++ b/tools/matrixark_mcp_temporal_append.py
@@ -337,14 +337,14 @@ def slim_persisted_record_kind(record: Json) -> Json:
 def slim_persisted_record(record: Json) -> Json:
     """Everything a record does not need to carry to disk, removed in one place.
 
-    Four sites serialise a record into a persisted entry -- the bundle path and the legacy index
-    path in `matrixark_temporal_direct_write`, the raw path in `matrixark_temporal_direct_backend`,
-    and `matrixark_mcp_raw_ingestion` -- and the slimmers were applied at ONE of them. Measured on
+    Three sites serialise a record into a persisted entry -- the bundle path and the legacy index
+    path in `matrixark_temporal_direct_write`, and the raw path in
+    `matrixark_temporal_direct_backend` -- and the slimmers were applied at ONE of them. Measured on
     the live log after that landed: of 26,944 records written, **871 still carried the derived
     fields** -- 504 of 1,065 `matrixark_idempotency` rows and 366 of 619 `context_summary` rows,
     because those went out through a path that never saw a slimmer.
 
-    Composing them here means a fifth call site inherits every one, instead of inheriting none.
+    Composing them here means a fourth call site inherits every one, instead of inheriting none.
     Each slimmer is a no-op on a record without the fields it looks for, so this is safe to apply
     to any record on any path.
     """

--- a/tools/test_matrixark_every_persist_site_slims_the_record.py
+++ b/tools/test_matrixark_every_persist_site_slims_the_record.py
@@ -3,18 +3,19 @@
 # Copyright 2026 MatrixArkAI
 """Every site that serialises a record for storage slims it first.
 
-Four sites turn a record into a persisted entry: the bundle path and the legacy index path in
-matrixark_temporal_direct_write, the raw path in matrixark_temporal_direct_backend, and
-matrixark_mcp_raw_ingestion. The slimmers were applied at ONE of them, on the strength of a comment
-reading "This is the ONLY append call site" -- which is true of the append CLIENT, not of record
-serialisation.
+Three sites turn a record into a persisted entry: the bundle path and the legacy index path in
+matrixark_temporal_direct_write, and the raw path in matrixark_temporal_direct_backend. The
+slimmers were applied at ONE of them, on the strength of a comment reading "This is the ONLY append
+call site" -- which is true of the append CLIENT, not of record serialisation. (A fourth sat in
+matrixark_mcp_raw_ingestion, in an extraction nothing had adopted; it was removed rather than
+maintained.)
 
 Measured on the live log afterwards: of 26,944 records written, **871 still carried the derived
 fields** -- 504 of 1,065 matrixark_idempotency rows and 366 of 619 context_summary rows.
 
 test_no_persist_site_serialises_an_unslimmed_record is the point of this file. Applying a slimmer to
 one of several equivalent paths is the defect that keeps recurring here, and a structural check is
-the only kind that catches the FIFTH site before it ships.
+the only kind that catches the NEXT site before it ships.
 """
 import ast
 import os
@@ -33,7 +34,6 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 PERSIST_MODULES = (
     "matrixark_temporal_direct_write.py",
     "matrixark_temporal_direct_backend.py",
-    "matrixark_mcp_raw_ingestion.py",
     "matrixark_mcp_temporal_append.py",
 )
 


### PR DESCRIPTION
`tools/matrixark_mcp_raw_ingestion.py` held an extraction of the raw-ingestion path — an append
function, a `RawIngestionAdapterMixin` of thirteen methods, and a raw session index. **Nothing ever
mixed the class in and nothing ever called the function.**

```
RawIngestionAdapterMixin.__subclasses__()            -> []
the mixin's name outside its own def, 783 .py files  -> 0
every live adapter's _append_raw_ingestion_records   -> _TemporalDirectBackendMixin
```

Eleven of the fourteen top-level names had no use anywhere outside the module. Live code imports
two normalisers from here and nothing else.

### The copy left behind was the weaker one

Against the live implementation in `matrixark_temporal_direct_backend`, this one was missing:

- `_ensure_backend_metric_fields`
- write-debug stamping on both the queue and the direct path — `queue_batch_id`, `queued_at_ms`,
  `queue_depth_before`, `persist_sequence`, `persist_key`, `persist_field`, `queue_wait_ms`
- the `_matrixark_batch_append_records_with_options` wrapper

It had one thing the live path does not: a **raw session index**. Its key builder and entry builder
are called by nothing either, so it was a closed loop — never written, never read.

Removed rather than repaired. A second implementation nothing runs cannot be shown to still match
the one that does, and adopting it later would have cost the metric and debug fields silently.

### Also corrected

Two places named this module as one of four record-persist sites: `slim_persisted_record`'s
docstring and `test_matrixark_every_persist_site_slims_the_record`'s module list. Both now say
three. That suite keeps its `assertGreaterEqual(checked, 3)` floor and still passes, so it has not
gone vacuous.

**300 lines to 62.** 24 suites derived from what reads these modules were run; the two red ones
(`test_matrixark_codex_hook_pipeline`, `test_matrixark_python_module_boundaries`) were name-diffed
against a clean `main` checkout and are red there with the identical test names — 54 and 84
respectively, no new failure and none fixed.