### PR TITLE
The lane counts say which switch they are waiting on

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -1200,10 +1200,17 @@ SETTINGS.extend([
             "matrixark_mcp_local_adapter, matrixark_mcp_retrieve_pre_refresh."),
     Setting("ingestion.rust_proxy_read_lanes", "ingestion", "MATRIXARK_RUST_PROXY_READ_LANES",
             "Rust proxy read lanes", "int", "4", "live",
-            'Rust proxy read lanes. Defaults to 4. Read by matrixark_mcp_temporal_adapters.'),
+            "How many proxy processes serve reads when each lane group runs its own pool. It "
+            "binds only with MATRIXARK_RUST_PROXY_SHARED_PROCESS off: on -- the default -- "
+            "reads share the single process with writes and control, and this number is read "
+            "and then not used."),
     Setting("ingestion.rust_proxy_write_lanes", "ingestion", "MATRIXARK_RUST_PROXY_WRITE_LANES",
             "Rust proxy write lanes", "int", "4", "live",
-            'Rust proxy write lanes. Defaults to 4. Read by matrixark_mcp_temporal_adapters.'),
+            "How many proxy processes serve writes when each lane group runs its own pool. "
+            "Like the read count, it binds only with MATRIXARK_RUST_PROXY_SHARED_PROCESS off. "
+            "That default is deliberate: with the engine embedded in the proxy process, a "
+            "multi-process write pool can hide writes from reads until a real shared server "
+            "sits behind it."),
     Setting("ingestion.stream_materialize_interval_ms", "ingestion", "MATRIXARK_STREAM_MATERIALIZE_INTERVAL_MS",
             "Stream materialize interval ms", "int", "1500", "restart",
             "Stream materialize interval milliseconds. Defaults to 1500. Frozen when the process starts. "
@@ -1453,7 +1460,10 @@ SETTINGS.extend([
             'Rust proxy dedicated pack lanes. Off by default. Read by matrixark_mcp_temporal_adapters.'),
     Setting("retrieval.rust_proxy_pack_lanes", "retrieval", "MATRIXARK_RUST_PROXY_PACK_LANES",
             "Rust proxy pack lanes", "int", "8", "live",
-            'Rust proxy pack lanes. Defaults to 8. Read by matrixark_mcp_temporal_adapters.'),
+            "How many proxy processes serve retrieve-pack. The only lane count that can bind "
+            "while MATRIXARK_RUST_PROXY_SHARED_PROCESS is on, and only then with "
+            "MATRIXARK_RUST_PROXY_DEDICATED_PACK_LANES also on -- without it, pack shares the "
+            "single process and this number is read and then not used."),
     Setting("retrieval.segment_max_new_tokens", "retrieval", "MATRIXARK_SEGMENT_MAX_NEW_TOKENS",
             "Segment max new tokens", "int", "512", "live",
             'Segment maximum new tokens. Defaults to 512. Read by matrixark_mcp_core.'),


### PR DESCRIPTION
Three int settings whose help was their own label plus "Defaults to N". The portal offered a
number to tune; **none of the three tunes anything in a default deployment.**

The live client reads all four lane counts unconditionally and then takes the shared-process
branch, where write, read and control lanes are `_make_lanes(1)`:

```python
if self._shared_process_mode:                     # env_bool(..., True)
    shared_lanes = self._make_lanes(1)
    pack_lanes = self._make_lanes(self._pack_lane_count) if self._dedicated_pack_lanes_enabled \
                 else shared_lanes
    self._lanes = {"write": shared_lanes, "read": shared_lanes,
                   "pack": pack_lanes, "control": shared_lanes}
```

| setting | binds when |
|---|---|
| `MATRIXARK_RUST_PROXY_READ_LANES` | `..._SHARED_PROCESS` off |
| `MATRIXARK_RUST_PROXY_WRITE_LANES` | `..._SHARED_PROCESS` off |
| `MATRIXARK_RUST_PROXY_PACK_LANES` | shared process **on** is fine, but `..._DEDICATED_PACK_LANES` must also be on |

Each now says which switch it is waiting on, and the write count carries the reason the default is
what it is: with the engine embedded in the proxy process, a multi-process write pool can hide
writes from reads until a real shared server sits behind it.

Help text only, no behaviour change. 873 tests across the 68 suites that read the settings module
pass.

**Noticed, not changed here:** `MATRIXARK_RUST_PROXY_CONTROL_LANES` is read by the same block and
has no `Setting` at all, so the portal does not offer it.