### PR TITLE
Where the index-GC stage time goes, and an optimization that did not work

### DIFF
--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -3808,3 +3808,77 @@ fn what_the_index_gc_gate_says() {
         );
     }
 }
+
+/// What does the index-GC GATE cost when it cannot possibly fire? Prints.
+///
+///   cargo test --release -p temporalstore-rust --lib what_the_index_gc_gate_costs -- --ignored --nocapture
+///
+/// The gate needs BOTH triggers, ANDed: at least 768 KiB of index log AND at least 40% removable.
+/// It establishes the second by scanning the WHOLE log and decoding every record -- and only then
+/// checks the first, which is a file length. So every round below the byte threshold pays a full
+/// scan to learn it was never eligible.
+#[test]
+#[ignore]
+fn what_the_index_gc_gate_costs() {
+    for records in [4_000usize, 8_000, 16_000] {
+        let engine = TemporalEngine::default();
+        engine.load_shard(1);
+        for index in 0..records {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("gate-cost-{index:06}"),
+                    value: vec![b'v'; 64],
+                },
+            });
+        }
+        let runtime = DataNodeRuntime::new_without_workers_with_options(
+            engine,
+            DataNodeRuntimeOptions {
+                worker_threads: 0,
+                max_queue_depth: 4,
+                max_background_queue_depth: 2,
+            },
+        );
+        runtime.run_storage_manager_once(1, StorageManagerOptions::default());
+        let engine = runtime.engine();
+        let log_bytes = engine.index_log_store().log_len_bytes(1);
+
+        let lifecycle_request = || crate::engine::reports::StorageLifecycleRequest {
+            shard_id: 1,
+            purge_delayed_destroy: true,
+            prune_bucket_dump_manifests: true,
+            roll_forward_bucket_dump_installs: true,
+            ..crate::engine::reports::StorageLifecycleRequest::default()
+        };
+
+        // Attribute the three pieces separately. Timing only the enclosing call cannot say which
+        // of them costs, and the first guess -- the index-log scan -- turned out to be wrong.
+        let started = std::time::Instant::now();
+        for _ in 0..5 {
+            let _ = engine.storage_lifecycle_plan(lifecycle_request());
+        }
+        let plan_ms = started.elapsed().as_micros() as f64 / 5.0 / 1000.0;
+
+        let started = std::time::Instant::now();
+        for _ in 0..5 {
+            let _ = engine.storage_wal_reclaim_plan(1, Vec::new(), Vec::new());
+        }
+        let wal_plan_ms = started.elapsed().as_micros() as f64 / 5.0 / 1000.0;
+
+        let started = std::time::Instant::now();
+        let mut applied_any = false;
+        for _ in 0..5 {
+            let report = engine.apply_periodic_index_gc(lifecycle_request(), None);
+            applied_any |= report.applied;
+        }
+        let per_call = started.elapsed().as_micros() as f64 / 5.0 / 1000.0;
+
+        eprintln!(
+            "  [gate] {records:>6} records, log {log_bytes:>8} B -> whole {per_call:>7.1} ms = \
+             plan {plan_ms:>7.1} + wal_plan {wal_plan_ms:>6.1} + rest \
+             {:>6.1}, applied={applied_any}",
+            per_call - plan_ms - wal_plan_ms
+        );
+    }
+}


### PR DESCRIPTION
Where the index-GC stage's time actually goes, and an optimization that did not work

#1490 wired index-log reclaim into the periodic loop. This measures what that
stage costs and attributes it, because the obvious answer is wrong.

    records    whole    lifecycle plan    wal reclaim plan    index GC itself
      4,000   71.2 ms           22.5              43.8                   4.9
      8,000  152.5 ms           53.1             101.0                  -1.6
     16,000  365.1 ms          160.2             202.3                   2.7

The index-log work -- the full scan, the per-record decode, the truncation -- is
1 to 7% of its own stage. 95% is rebuilding two O(shard) plans. That is the same
conclusion #1458 reached about apply_storage_lifecycle, now confirmed for the
path #1490 added.

AN OPTIMIZATION THAT MEASURED ZERO, recorded so nobody builds it twice.

The gate scans and decodes the whole index log to establish a removable ratio,
and only then checks a byte threshold that is a file length -- and the two are
ANDed, so a log under the threshold can never reclaim whatever the scan finds.
Declining on log_len_bytes first is correct and provably safe: the on-disk length
includes framing, so it is never smaller than the payload bytes the scan sums.

It bought nothing: 89.1 / 154.1 / 382.7 ms against 72.5 / 158.7 / 376.6 before.
Two reasons, both visible only after attributing:

  the scan is ~5 ms of a 71 ms call, so removing it is inside the noise;
  the early-out only fires BELOW the threshold, so a large index log -- the case
  where a full scan would genuinely cost -- always scans anyway.

Reverted. A 5 ms saving did not justify a new public report field. I had priced
the ENCLOSING call and inferred the cause, which is the mistake this probe now
makes hard to repeat.

The lead it does expose: apply_periodic_index_gc rebuilds a lifecycle plan and a
WAL reclaim plan that the loop already computed earlier in the same round.
Reusing them would cut most of that 365 ms. Not done here, and not a quick edit:
#1490 recomputes AFTER the dump on purpose so the safety check reads post-dump
state, and a stale retain_from_index_log_sequence would truncate against the
wrong frontier.

Probe only, #[ignore]d. No production code changes.

Full suite: 1765 passed, 1 failed -- the known baseline failure.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
