### PR TITLE
The dump cap bounds a stage, not a round

### DIFF
--- a/crates/temporalstore-rust/src/data_node/runtime_storage.rs
+++ b/crates/temporalstore-rust/src/data_node/runtime_storage.rs
@@ -315,7 +315,12 @@ impl DataNodeRuntime {
             let response = self.apply_storage_lifecycle(StorageLifecycleRequest {
                 shard_id,
                 selected_dump_buckets: Vec::new(),
-                max_dump_buckets_per_round: 0,
+                // The cap, not 0. This stage dumps before it invalidates, and an unbounded dump
+                // here made the cap `reclaim_wal` respects meaningless: measured, one round with
+                // every stage on dumped 1,280 of 1,280 dirty buckets, while `reclaim_wal` alone
+                // dumped exactly 64. Bounding is safe -- invalidation drops CACHED pages, and the
+                // data is in the write-ahead log whether or not its bucket was dumped this round.
+                max_dump_buckets_per_round: options.max_dump_buckets_per_round,
                 min_undumped_wal_records: 0,
                 min_undumped_wal_bytes: 0,
                 purge_delayed_destroy: false,
@@ -557,6 +562,17 @@ impl DataNodeRuntime {
             let index_gc_request = StorageLifecycleRequest {
                 shard_id,
                 selected_dump_buckets: Vec::new(),
+                // UNBOUNDED, and load-bearing -- do not cap this.
+                //
+                // Capping it was tried and it stopped index-log reclaim dead: 16,000 records
+                // before a round, 16,000 after. The reason is COVERAGE, not the commit check:
+                // `wal_plan.safe_to_reclaim` needs a durable manifest for every live generation,
+                // and this whole-dirty-set dump is what produces one. Bound it and the frontier
+                // never advances -- the #1439 finding seen from the other side.
+                //
+                // The consequence is that `max_dump_buckets_per_round` bounds the reclaim_wal
+                // and reclaim_memory stages, not a ROUND: this stage still dumps the whole dirty
+                // set, deliberately.
                 max_dump_buckets_per_round: 0,
                 min_undumped_wal_records: 0,
                 min_undumped_wal_bytes: 0,

--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -3882,3 +3882,71 @@ fn what_the_index_gc_gate_costs() {
         );
     }
 }
+
+#[test]
+fn the_dump_cap_bounds_a_stage_but_not_a_round() {
+    // Two facts, and the second is the surprising one.
+    //
+    // `reclaim_wal` honours `max_dump_buckets_per_round` (64). `reclaim_index` does NOT, and that
+    // is deliberate: `wal_plan.safe_to_reclaim` needs a durable manifest for every live
+    // generation, and its whole-dirty-set dump is what produces one. Capping it was tried and
+    // stopped index-log reclaim dead -- 16,000 records before a round, 16,000 after.
+    //
+    // So the option bounds a STAGE, not a round, and a default round still dumps everything. If
+    // you came here because you capped that stage and this test failed, that is the reason, and
+    // `the_periodic_loop_actually_reclaims_the_index_log` is what breaks next.
+    let cap = StorageManagerOptions::default().max_dump_buckets_per_round;
+    assert!(cap > 0, "this test is about a non-zero cap");
+    let keys = cap * 20;
+
+    fn dirty_after_one_round(keys: usize, options: StorageManagerOptions) -> (usize, usize) {
+        let engine = TemporalEngine::default();
+        engine.load_shard(1);
+        for index in 0..keys {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("cap-{index:06}"),
+                    value: vec![b'v'; 64],
+                },
+            });
+        }
+        let runtime = DataNodeRuntime::new_without_workers_with_options(
+            engine,
+            DataNodeRuntimeOptions {
+                worker_threads: 0,
+                max_queue_depth: 4,
+                max_background_queue_depth: 2,
+            },
+        );
+        let first = runtime.run_storage_manager_once(1, options.clone());
+        let second = runtime.run_storage_manager_once(1, options);
+        (
+            first.pressure.dirty_bucket_count,
+            second.pressure.dirty_bucket_count,
+        )
+    }
+
+    // The stage that honours the cap dumps exactly the cap.
+    let (before, after) = dirty_after_one_round(
+        keys,
+        StorageManagerOptions {
+            enable_memory_reclaim: false,
+            enable_index_gc: false,
+            ..StorageManagerOptions::default()
+        },
+    );
+    assert_eq!(
+        before.saturating_sub(after),
+        cap,
+        "reclaim_wal alone must dump exactly its cap: {before} -> {after}"
+    );
+
+    // A whole round does not, because reclaim_index dumps the rest on purpose.
+    let (before, after) = dirty_after_one_round(keys, StorageManagerOptions::default());
+    assert_eq!(
+        after, 0,
+        "a default round dumps the whole dirty set, because index GC needs the coverage: \
+         {before} -> {after}"
+    );
+}


### PR DESCRIPTION
The dump cap bounds a stage, not a round

Two stages of the periodic loop dump before doing their own work, and both passed
max_dump_buckets_per_round: 0 -- unbounded. One of those was a mistake and the
other is load-bearing, which is only visible by trying to change both.

reclaim_memory now passes the cap. It dumps before it invalidates, and passing 0
made the cap reclaim_wal respects meaningless: measured, one round with every
stage on dumped 1,280 of 1,280 dirty buckets while reclaim_wal alone dumped
exactly 64. Bounding it is safe -- invalidation drops CACHED pages, and the data
is in the write-ahead log whether or not its bucket was dumped this round.

reclaim_index stays unbounded, deliberately, and the comment now says so in the
imperative. Capping it stopped index-log reclaim dead: 16,000 records before a
round, 16,000 after. The reason is COVERAGE rather than the commit check --
wal_plan.safe_to_reclaim needs a durable manifest for every live generation, and
that whole-dirty-set dump is what produces one. Bound it and the frontier never
advances. That is the #1439 finding seen from the other side: there, a cap left
undumped buckets pinning the floor at 0; here, a cap would leave generations
uncovered and do the same.

So the option bounds a STAGE, not a round. A default round still dumps the whole
dirty set, because the last stage to run needs it to.

the_dump_cap_bounds_a_stage_but_not_a_round pins both halves: the stage that
honours the cap dumps exactly the cap, and a whole round does not. It carries the
reason in its body, including which test breaks next if someone caps the index
stage -- the_periodic_loop_actually_reclaims_the_index_log, from #1490.

Full suite: 1766 passed, 1 failed -- the known baseline failure.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
