### PR TITLE
Count the O(shard) plans one maintenance round builds

### DIFF
--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -3950,3 +3950,67 @@ fn the_dump_cap_bounds_a_stage_but_not_a_round() {
          {before} -> {after}"
     );
 }
+
+/// How many O(shard) plans does ONE round build? Prints.
+///
+///   cargo test -p temporalstore-rust --lib what_one_round_rebuilds -- --ignored --nocapture
+///
+/// #1496 attributed the index-GC stage: 95% of its 365 ms at 16k records is rebuilding a
+/// lifecycle plan and a WAL reclaim plan, not the index-log work it exists to do. This asks the
+/// wider question -- how many such plans a whole round builds -- because the answer decides
+/// whether reuse is worth the correctness risk.
+///
+/// COUNTED, not timed. A count does not move when another build is running on the box, and the
+/// question is how much duplicated work happens, which is a count. #1496's timings were taken on
+/// a quiet box; these do not need one.
+#[test]
+#[ignore]
+fn what_one_round_rebuilds() {
+    for keys in [2_000usize, 8_000] {
+        let engine = TemporalEngine::default();
+        engine.load_shard(1);
+        for index in 0..keys {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("plan-{index:06}"),
+                    value: vec![b'v'; 64],
+                },
+            });
+        }
+        let runtime = DataNodeRuntime::new_without_workers_with_options(
+            engine,
+            DataNodeRuntimeOptions {
+                worker_threads: 0,
+                max_queue_depth: 4,
+                max_background_queue_depth: 2,
+            },
+        );
+
+        crate::engine::reset_storage_plan_build_counts();
+        runtime.run_storage_manager_once(1, StorageManagerOptions::default());
+        let (lifecycle, wal) = crate::engine::storage_plan_build_counts();
+        eprintln!(
+            "  {keys:>6} keys -> one round built {lifecycle} lifecycle plans and {wal} wal \
+             reclaim plans"
+        );
+
+        // And the same for the stage #1496 measured, on its own.
+        crate::engine::reset_storage_plan_build_counts();
+        let engine = runtime.engine();
+        let _ = engine.apply_periodic_index_gc(
+            crate::engine::reports::StorageLifecycleRequest {
+                shard_id: 1,
+                prune_bucket_dump_manifests: true,
+                roll_forward_bucket_dump_installs: true,
+                ..crate::engine::reports::StorageLifecycleRequest::default()
+            },
+            None,
+        );
+        let (lifecycle, wal) = crate::engine::storage_plan_build_counts();
+        eprintln!(
+            "  {keys:>6} keys -> apply_periodic_index_gc alone built {lifecycle} lifecycle and \
+             {wal} wal reclaim plans"
+        );
+    }
+}

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -27,6 +27,7 @@ mod zset_index_serde;
 mod seen_index_serde;
 mod bucket_dump_manifest_methods;
 mod storage_lifecycle_methods;
+pub use storage_lifecycle_methods::{reset_storage_plan_build_counts, storage_plan_build_counts};
 mod storage_manager_cycle;
 mod storage_reports;
 mod prometheus_metrics;

--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -13,8 +13,36 @@ use super::*;
 pub(crate) static DIRTY_DRAIN_VISITS: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 
+/// How many O(shard) plans one round builds, counted rather than timed.
+///
+/// A round builds these in several stages and each walks the shard. Whether that is duplicated
+/// work is a question about COUNTS, and a count is immune to whatever else is running on the box
+/// -- timing it beside another build would measure the machine, not the loop.
+pub(crate) static LIFECYCLE_PLAN_BUILDS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// The same, for the WAL reclaim plan. Separate because the two have different costs and a
+/// single total would hide which one a change moved.
+pub(crate) static WAL_RECLAIM_PLAN_BUILDS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// Both counters, for a probe measuring one round.
+pub fn storage_plan_build_counts() -> (u64, u64) {
+    (
+        LIFECYCLE_PLAN_BUILDS.load(std::sync::atomic::Ordering::Relaxed),
+        WAL_RECLAIM_PLAN_BUILDS.load(std::sync::atomic::Ordering::Relaxed),
+    )
+}
+
+/// Zero both, so a probe measures a round rather than a process.
+pub fn reset_storage_plan_build_counts() {
+    LIFECYCLE_PLAN_BUILDS.store(0, std::sync::atomic::Ordering::Relaxed);
+    WAL_RECLAIM_PLAN_BUILDS.store(0, std::sync::atomic::Ordering::Relaxed);
+}
+
 impl TemporalEngine {
     pub fn storage_lifecycle_plan(&self, request: StorageLifecycleRequest) -> StorageLifecyclePlan {
+        LIFECYCLE_PLAN_BUILDS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let bucket_summaries = self.bucket_storage_summaries(request.shard_id);
         // Select the least-recently-dumped (most overdue) dirty buckets first, matching the
         // WAL-reclaim routine's oldest-first-dirty ordering (dirty buckets are consumed
@@ -673,6 +701,7 @@ impl TemporalEngine {
         follower_replay_cursors: impl IntoIterator<Item = BucketDumpFollowerReplayCursor>,
         raft_snapshot_refs: impl IntoIterator<Item = BucketDumpRaftSnapshotRef>,
     ) -> StorageWalReclaimPlan {
+        WAL_RECLAIM_PLAN_BUILDS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let follower_replay_cursors = follower_replay_cursors.into_iter().collect::<Vec<_>>();
         let raft_snapshot_refs = raft_snapshot_refs.into_iter().collect::<Vec<_>>();
         let current_wal_sequence = self.write_ahead_log_store().stats(shard_id).last_sequence;


### PR DESCRIPTION
Count the O(shard) plans one maintenance round builds

#1496 attributed the index-GC stage: 95% of its 365 ms at 16k records is
rebuilding a lifecycle plan and a WAL reclaim plan, not the index-log work the
stage exists to do. This asks the wider question -- how many such plans a whole
round builds -- because that decides whether reuse is worth its correctness risk.

Measured, and the count is structural: identical at 2,000 and 8,000 keys.

  one round                          4 lifecycle plans, 2 wal reclaim plans
  apply_periodic_index_gc alone      1 lifecycle plan,  1 wal reclaim plan

Against #1496's per-plan timings at 16k records (160 ms and 202 ms) that is
roughly 1.0 s per round spent building plans before any stage does its own work.

COUNTED rather than timed, deliberately. Another build was running on this box in
a different worktree, so a timing would have measured the machine. A count does
not move under CPU contention, and "how much duplicated work" is a count
question. Multiplying a contention-immune count by #1496's timings, which were
taken on a quiet box, is the honest combination.

What the count does NOT establish is that the work is redundant, and the saving
is smaller than the total suggests. The four plans are built at different points
in the round -- the pressure snapshot before any stage, reclaim_wal's after,
reclaim_index's after that, and apply_periodic_index_gc's deliberately after its
own dump, which #1490 depends on so the safety check reads post-dump state. Each
sees different shard state, so they are not interchangeable. The reusable pair,
if any, is the pressure snapshot and the first mutating stage, since nothing
mutates between them -- one plan, about 160 ms, not four.

So this narrows the #1496 lead from "1.0 s of waste" to "one possibly-redundant
plan", which is a much smaller target than it looked.

Counters only, plus an #[ignore]d probe. The two statics sit beside
DIRTY_DRAIN_VISITS and follow its rationale: count what actually happens, because
that stays true after someone changes the loop.

Full suite: 1766 passed, 1 failed -- the known baseline failure.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
