### PR TITLE
The periodic loop adopts the cycle round bounds

### DIFF
--- a/crates/temporalstore-rust/src/data_node.rs
+++ b/crates/temporalstore-rust/src/data_node.rs
@@ -951,12 +951,24 @@ impl Default for StorageManagerOptions {
             // from the periodic loop; enabling it by default is a separate decision.
             enable_evict: false,
             eviction_memory_pressure_threshold: 0,
-            eviction_batch_limit: 0,
+            // The CYCLE's value, not 0. Both pipelines run the same stages, and where they
+            // disagree on a bound the periodic one -- the loop a server actually starts -- was
+            // the unbounded side. 0 here was mine (#1467) and I justified it as "preserve current
+            // behaviour", which was the weaker reading: the choice was never change-vs-no-change,
+            // it was between a considered value that already existed next door and an accidental
+            // one. Only reachable when `enable_evict` is on, which is still off by default.
+            eviction_batch_limit: crate::engine::reports::DEFAULT_EVICTION_BATCH_LIMIT,
             eviction_dump_before_evict: false,
             eviction_delete_drop: false,
             // 0 = unbounded, the behaviour this loop has always had. See the field docs.
-            max_expire_hot_buckets_per_round: 0,
-            max_expire_cold_buckets_per_round: 0,
+            // Likewise the cycle's values. 0 meant the expire stage walked the WHOLE deadline
+            // map, hot and cold, every tick for every loaded shard, which is what #1469 measured
+            // at 201.5 ms per round at 20k objects. The cursor #1469 added is what makes a bound
+            // usable: a round takes its window and the next resumes past it.
+            max_expire_hot_buckets_per_round:
+                crate::engine::reports::DEFAULT_MAX_EXPIRE_HOT_BUCKETS_PER_ROUND,
+            max_expire_cold_buckets_per_round:
+                crate::engine::reports::DEFAULT_MAX_EXPIRE_COLD_BUCKETS_PER_ROUND,
         }
     }
 }

--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -3467,8 +3467,23 @@ fn the_periodic_expire_stage_takes_a_bounded_window_and_resumes_past_it() {
         )
     }
 
-    // CONTROL: the shipped default is unbounded and must still clear every expired key in one
-    // round. This is what says the change is opt-in, not a silent slowdown of expiry.
+    // CONTROL: the shipped default clears this fixture in one round -- because its bound is
+    // LARGER than the fixture, not because it is unbounded.
+    //
+    // This wording is deliberate. When this test was written the default WAS 0, meaning no bound,
+    // and the assertion below read as "the default is unbounded". It is not any more: the default
+    // is now the cycle's 128 hot / 8 cold. The assertion still passes, but for a different reason
+    // than it used to, and a control that passes for a reason it does not state is worth nothing.
+    //
+    // What it pins now is that the shipped bound comfortably exceeds a small store, so ordinary
+    // expiry is not slowed by it -- which is the property that actually matters to a deployment,
+    // and which a too-small default would break loudly here.
+    let default_bound = StorageManagerOptions::default().max_expire_hot_buckets_per_round;
+    assert!(
+        default_bound > EXPIRED,
+        "this control only means something while the default bound ({default_bound}) exceeds \
+         the fixture ({EXPIRED}); raise the fixture or rewrite the control"
+    );
     let unbounded = runtime_with_a_live_prefix();
     let cleared = unbounded.run_storage_manager_once(1, StorageManagerOptions::default());
     assert!(
@@ -3479,7 +3494,7 @@ fn the_periodic_expire_stage_takes_a_bounded_window_and_resumes_past_it() {
     assert_eq!(
         unbounded.stats().expired_records_removed,
         EXPIRED as u64,
-        "the shipped default must still clear every expired key in one round"
+        "the shipped default must clear a store smaller than its own per-round bound"
     );
 
     // Bounded: each round takes a window of live-but-not-due keys and RESUMES past them, so it


### PR DESCRIPTION
The periodic loop adopts the cycle's round bounds

Both pipelines run the same stages, and where they disagreed on a bound the
periodic one -- the loop a server actually starts -- was the unbounded side:

  max_expire_hot_buckets_per_round    0  ->  128
  max_expire_cold_buckets_per_round   0  ->    8
  eviction_batch_limit                0  ->   16

Those zeros were mine, from #1467 and #1469, and I justified them as "preserve
current behaviour". That framed the choice wrongly. It was never change against
no-change: it was a considered value that already existed in the sibling pipeline
against an accidental one, and I picked the accidental one and called it safe.
The constants are now referenced from one place rather than copied, so the two
cannot drift again.

0 meant the expire stage walked the WHOLE deadline map, hot and cold, every tick
for every loaded shard -- 201.5 ms per round at 20k objects, measured in #1469.
The cursor #1469 added is what makes a bound usable: a round takes its window and
the next resumes past it. The bound without the cursor would have starved later
keys; the cursor without the bound saved nothing.

eviction_batch_limit is only reachable while enable_evict is on, which is still
off by default (#1467).

A TEST THAT KEPT PASSING FOR THE WRONG REASON

#1469's control asserts "the shipped default must still clear every expired key
in one round". It still passed after this change -- the fixture is 20 keys and
the new bound is 128 -- while no longer meaning what it said. A control that
passes for a reason it does not state is worth nothing.

It now asserts the shipped bound EXCEEDS the fixture, and says so, which is the
property that actually matters to a deployment: ordinary expiry is not slowed by
the bound, and a too-small default breaks here loudly. Mutation-verified --
reverting the default to 0 fails it with "this control only means something while
the default bound (0) exceeds the fixture (20)".

Full suite: 1766 passed, 1 failed -- the known baseline failure.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
