### PR TITLE
Four of the twenty-five go, and the rest say where they came from

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -1589,9 +1589,9 @@ def round_vector_to_f32(record: Json) -> Json:
     answered -0.40824800729751587. Same store, two answers, decided by which path served it.
 
     Called from `_sanitize_jsonl_record`, which is the one thing BOTH append paths run per record.
-    The list form below is a wrapper over this; putting the rounding in the list comprehensions
-    instead reached only one of the two, because the other spells the same loop with a different
-    variable name.
+    Putting the rounding in the list comprehensions instead reached only one of the two, because
+    the other spells the same loop with a different variable name -- which is why the list form
+    that used to sit below this was removed rather than called.
     """
     if not LOCAL_BINARY_VECTORS or not isinstance(record, dict):
         return record
@@ -1600,22 +1600,6 @@ def round_vector_to_f32(record: Json) -> Json:
     record = dict(record)
     record["vector"] = decode_vector_f32(encode_vector_f32(record["vector"]))
     return record
-
-
-def round_vectors_to_f32(records: list[Json]) -> list[Json]:
-    """Hold the value that will be stored.
-
-    Packing only on the way to the log left the cache and the snapshot holding the original
-    float64s, so a warm read answered -0.408248 where a cold read that re-derived from the log
-    answered -0.40824800729751587. Same store, two answers, decided by which path served it --
-    exactly the warm-and-cold disagreement that is worth refusing to ship.
-
-    Applied where the record is made, so the cache, the snapshot and the log all carry the same
-    float32 value and packing is left with nothing to change but the bytes.
-    """
-    if not LOCAL_BINARY_VECTORS:
-        return records
-    return [round_vector_to_f32(record) for record in records]
 
 
 def pack_record_vectors(records: list[Json]) -> list[Json]:
@@ -3842,22 +3826,6 @@ def _record_derivative_identity_ids(record: Json) -> set[str]:
         if value not in (None, ""):
             ids.add(str(value))
     return ids
-
-
-def _record_own_identity_id(record: Json) -> str | None:
-    """The single addressable id `record` is a *member* under, for the event-membership index:
-    an event's ``event_id_hash`` or a derivative's identity hash. Embeddings / index postings are
-    members *by reference* (their ref target is one of these ids), so they carry no own member id."""
-    event_hash = record.get("event_id_hash")
-    record_type = str(record.get("record_type") or "")
-    if record_type == "context_event" and event_hash not in (None, ""):
-        return str(event_hash)
-    if record_type in _MEMORY_DERIVATIVE_RECORD_TYPES:
-        for field in _MEMORY_DERIVATIVE_IDENTITY_FIELDS:
-            value = record.get(field)
-            if value not in (None, ""):
-                return str(value)
-    return None
 
 
 def build_event_member_index(records: list[Json]) -> dict[str, set[str]]:

--- a/tools/matrixark_mcp_storage_options.py
+++ b/tools/matrixark_mcp_storage_options.py
@@ -127,10 +127,6 @@ def storage_record_kind(record: Json) -> str:
     return record_type or "context_event"
 
 
-def storage_part_for_record(record: Json) -> str:
-    return storage_record_kind(record)
-
-
 def canonical_storage_route(storage_options: Json | None) -> Json:
     options = storage_options if isinstance(storage_options, dict) else {}
     storage_mode = str(options.get("storage_mode") or "default")
@@ -369,10 +365,6 @@ def normalize_record_storage_options(args: Json, metadata: Json | None = None, b
         normalized["storage_part"] = record_kind
         normalized_parts[record_kind] = normalized
     return normalized_parts
-
-
-def normalize_part_storage_options(args: Json, metadata: Json | None = None, base_options: Json | None = None) -> Json:
-    return normalize_record_storage_options(args, metadata, base_options)
 
 
 def default_async_ingest_storage_options() -> Json:

--- a/tools/test_a_definition_nothing_reaches.py
+++ b/tools/test_a_definition_nothing_reaches.py
@@ -84,20 +84,22 @@ UNREACHED = {
     # one-line alias of `storage_record_kind`. The ENVELOPE path for the same idea does work --
     # `storage_options_for_record` reads `envelope["record_storage_options"]` -- so this is a
     # half-wired feature rather than a dead one, and which half should go is a product call.
-    "matrixark_mcp_storage_options.py": (
-        "normalize_part_storage_options",
-        "normalize_record_storage_options",
-        "storage_part_for_record",
-    ),
+    "matrixark_mcp_storage_options.py": ("normalize_record_storage_options",),
     # Two spellings of "the commonest memory layer among these refs", in two modules that both
     # also define `serving_ref_for_pack`. Neither is called.
     "matrixark_mcp_core_packing.py": ("default_memory_layer_for_pack",),
     "matrixark_mcp_context_pack.py": ("_default_memory_layer_for_pack",),
-    # Formatters for hook output lines that are no longer emitted.
+    # These are not decayed code. `git log -S` on each name shows almost every one arriving in a
+    # SINGLE commit and never being touched again -- bulk publish and port commits (4379a739d
+    # "publish the tooling behind index growth, task slimming and tenant policy", 1886b7056,
+    # 06a46d19f, d422a7e21 "OSS sync PR 4/4"), module-split refactors (efd36f9ef, 667b9e17a,
+    # 7c80869cc), or a feature PR whose caller never followed. Import residue, so "left behind by
+    # the path that used to call it" is the wrong story: nothing ever called them here.
     "matrixark_codex_hook.py": ("_format_count_map_bits", "_format_memory_lineage_summary"),
-    # Ingest-side helpers left behind by the paths that used to call them.
+    # Two whose docstrings say where they are applied, and neither is applied anywhere:
+    # `clip_messages_for_ingest` says "Applied ONCE at the ingest boundary", and
+    # `joined_summary_source_text` is the sentence-level summary dedup, measurement included.
     "matrixark_index_growth_bound.py": ("clip_messages_for_ingest", "joined_summary_source_text"),
-    "matrixark_mcp_local_adapter.py": ("_record_own_identity_id", "round_vectors_to_f32"),
     "matrixark_mcp_core_compact.py": ("context_index_data_model",),
     "matrixark_context_backfill.py": ("read_checkpoint_sequence",),
     "matrixark_load_config.py": ("apply_from_file",),
@@ -240,10 +242,11 @@ class ADefinitionNothingReachesTest(unittest.TestCase):
         """A positive control: the method must still be able to report a definition.
 
         Named rather than counted, so a scan that started reporting a different set does not pass
-        this by arithmetic.
+        this by arithmetic. `normalize_record_storage_options` is the one checked by hand -- its
+        only occurrence in the tree is its own `def` line.
         """
-        self.assertIn("round_vectors_to_f32",
-                      self.found.get("matrixark_mcp_local_adapter.py", ()),
+        self.assertIn("normalize_record_storage_options",
+                      self.found.get("matrixark_mcp_storage_options.py", ()),
                       "the scan no longer finds a definition verified by hand to have no caller")
 
     def test_the_guard_does_not_feed_on_its_own_list(self):


### PR DESCRIPTION
The guard that landed in #1502 recorded 25 definitions nothing reaches. Four are safe to remove
today, because for each one the thing that replaced it is named and running.

| removed | what is doing the job instead |
|---|---|
| `round_vectors_to_f32` | the **singular** `round_vector_to_f32`, called from `_sanitize_jsonl_record` — "the one thing BOTH append paths run per record" |
| `_record_own_identity_id` | `_record_derivative_identity_ids`, used by `build_event_member_index` directly below it |
| `storage_part_for_record` | `storage_record_kind`, which it aliased in one line |
| `normalize_part_storage_options` | nothing — it aliased `normalize_record_storage_options`, which is itself unreached |

**I nearly filed the first one as a live bug.** Its docstring describes a real defect — a warm read
answering `-0.408248` where a cold read answered `-0.40824800729751587`, "same store, two answers,
decided by which path served it" — and the function is called by nobody. But the singular form
*is* called, at the place the singular's own docstring says is the right one. No defect; an unused
wrapper. The singular's docstring pointed at it ("the list form below"), so that sentence changes
with it.

`normalize_record_storage_options` **stays on the list**: 46 lines validating a request field no
caller passes, while the envelope path for the same idea does work. Half-wired, and which half
should go is a product call.

Neither edited module has `__all__` and neither is star-imported, so nothing is re-exported out
from under a caller.

### Also corrected: where these actually came from

The guard's group comment said they were "left behind by the paths that used to call them."
`git log -S` on each name says otherwise — almost every one arrives in a **single** commit and is
never touched again: a bulk publish (`4379a739d`, `1886b7056`, `06a46d19f`, `d422a7e21`), a module
split (`efd36f9ef`, `667b9e17a`, `7c80869cc`), or a feature PR whose caller never followed. Import
residue, not decay. Nothing ever called them here.

### On the baseline

Name-diffed against main in a **real worktree**: 164 red on both sides, both directions empty.

An earlier `git archive` baseline said these four deletions *fixed 14 tests*. Four of the
tree-scanning guards shell out to `git ls-files`, and an archive directory has no `.git`, so they
fall back to a wider file set and report duplicates that are not there. A baseline that flatters
the change is still a broken baseline.