### PR TITLE
Seven more of the recorded definitions go

### DIFF
--- a/tools/matrixark_codex_hook.py
+++ b/tools/matrixark_codex_hook.py
@@ -1564,54 +1564,11 @@ def _format_memory_layer_pressure_bits(memory_layer_pressure: Json) -> list[str]
     return pressure_bits
 
 
-def _format_count_map_bits(counts: Json, *, limit: int = 6) -> str:
-    if not isinstance(counts, dict) or not counts:
-        return ""
-    bits = []
-    for key in sorted(counts):
-        try:
-            count = int(counts[key] or 0)
-        except (TypeError, ValueError):
-            continue
-        if count > 0:
-            bits.append(f"{key}={count}")
-    return ",".join(bits[:limit])
-
-
-def _format_memory_lineage_summary(lineage: Json) -> str:
-    if not isinstance(lineage, dict) or not lineage:
-        return ""
-    bits = []
-    for label, field in [
-        ("roles", "source_role_counts"),
-        ("hooks", "source_hook_type_counts"),
-        ("codex_events", "source_codex_event_counts"),
-    ]:
-        formatted = _format_count_map_bits(lineage.get(field))
-        if formatted:
-            bits.append(f"{label}[{formatted}]")
-    flag_bits = []
-    for label, field in [
-        ("user_prompt", "user_prompt_captured"),
-        ("assistant_response", "assistant_response_captured"),
-        ("tool_evidence", "tool_evidence_captured"),
-    ]:
-        if bool(lineage.get(field)):
-            flag_bits.append(label)
-    if flag_bits:
-        bits.append("captured[" + ",".join(flag_bits) + "]")
-    try:
-        promotion_count = int(lineage.get("profile_promotion_count") or 0)
-    except (TypeError, ValueError):
-        promotion_count = 0
-    if promotion_count > 0:
-        bits.append(f"profile_promotions={promotion_count}")
-    session_ids = lineage.get("promoted_source_session_ids")
-    if isinstance(session_ids, list) and session_ids:
-        bits.append("promoted_sessions=" + ",".join(str(value) for value in session_ids[:4]))
-    if not bits:
-        return ""
-    return "Retrieved memory lineage: " + "; ".join(bits) + "."
+# The "Retrieved memory lineage:" line and its count formatter used to live here. They are gone
+# rather than kept warm: the line was taken out of additionalContext with eight other diagnostics,
+# and test_codex_hook_output_part2 asserts each of them is ABSENT -- so the renderer could not come
+# back without that test failing first. The hook's context budget is what this is about; a
+# diagnostic in additionalContext is paid for out of the agent's own window.
 
 
 def normalized_event_name(event: str) -> str:

--- a/tools/matrixark_context_backfill.py
+++ b/tools/matrixark_context_backfill.py
@@ -1057,27 +1057,6 @@ def checkpoint_key(
     return f'matrixark:backfill:{job_id}:checkpoint:{fingerprint}'
 
 
-def read_checkpoint_sequence(kv: Any, key: str) -> int | None:
-    raw_checkpoint = kv.get_string(key)
-    if not raw_checkpoint:
-        return None
-    try:
-        return int(raw_checkpoint)
-    except ValueError:
-        pass
-    try:
-        checkpoint = json.loads(raw_checkpoint)
-    except json.JSONDecodeError:
-        return None
-    if not isinstance(checkpoint, dict):
-        return None
-    value = checkpoint.get('last_sequence')
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
-
-
 def read_checkpoint_state(kv: Any, key: str) -> Json:
     raw_checkpoint = kv.get_string(key)
     state: Json = {

--- a/tools/matrixark_mcp_core_compact.py
+++ b/tools/matrixark_mcp_core_compact.py
@@ -44,7 +44,7 @@ except ImportError:  # top-level path
     from matrixark_mcp_models import embedding_model_ref_for_name
     from matrixark_mcp_runtime_config import ENABLE_CONTEXT_DEBUG_RECORDS
 
-__all__ = ['HOT_SERVING_RECORD_TYPES', 'COMPACT_SCOPE_RECORD_TYPES', 'COMPACT_TIMESTAMP_RECORD_TYPES', 'TOPOLOGY_DERIVED_PATH_RECORD_TYPES', 'NODE_PATH_HEAVY_RECORD_TYPES', 'EVENT_DEBUG_FIELDS', 'ENTITY_DEBUG_FIELDS', 'EMBEDDING_LINEAGE_DEBUG_FIELDS', 'HOT_EMBEDDING_COMPACT_TYPES', 'HOT_SESSION_SUMMARY_EMBEDDING_COMPACT_TYPES', 'HOT_EMBEDDING_LINEAGE_FIELDS', 'compact_hot_context_embedding_record', 'legacy_hook_type_from_codex_event', 'CONTEXT_TIMELINE_FANOUT', 'COMPACT_DERIVED_SCOPE_FIELDS', 'COMPACT_TOPOLOGY_SCOPE_STRING_RECORD_TYPES', 'COMPACT_TOPOLOGY_SCOPE_STRING_FIELDS', 'compact_record_scope', '_record_debug_ref', 'context_event_timestamp_ms', 'context_event_time_key', 'attach_context_event_time_key', 'attach_storage_route', 'context_placement_key', 'attach_context_placement', 'compact_record_lifecycle_fields', 'compact_storage_record', 'materialize_serving_records', 'context_index_timestamp_key', 'context_index_posting_bucket', 'context_index_data_model', 'context_index_ref_hashes', 'materialize_serving_record_batch', 'latest_context_state_key', 'compact_latest_context_state_records']
+__all__ = ['HOT_SERVING_RECORD_TYPES', 'COMPACT_SCOPE_RECORD_TYPES', 'COMPACT_TIMESTAMP_RECORD_TYPES', 'TOPOLOGY_DERIVED_PATH_RECORD_TYPES', 'NODE_PATH_HEAVY_RECORD_TYPES', 'EVENT_DEBUG_FIELDS', 'ENTITY_DEBUG_FIELDS', 'EMBEDDING_LINEAGE_DEBUG_FIELDS', 'HOT_EMBEDDING_COMPACT_TYPES', 'HOT_SESSION_SUMMARY_EMBEDDING_COMPACT_TYPES', 'HOT_EMBEDDING_LINEAGE_FIELDS', 'compact_hot_context_embedding_record', 'legacy_hook_type_from_codex_event', 'CONTEXT_TIMELINE_FANOUT', 'COMPACT_DERIVED_SCOPE_FIELDS', 'COMPACT_TOPOLOGY_SCOPE_STRING_RECORD_TYPES', 'COMPACT_TOPOLOGY_SCOPE_STRING_FIELDS', 'compact_record_scope', '_record_debug_ref', 'context_event_timestamp_ms', 'context_event_time_key', 'attach_context_event_time_key', 'attach_storage_route', 'context_placement_key', 'attach_context_placement', 'compact_record_lifecycle_fields', 'compact_storage_record', 'materialize_serving_records', 'context_index_timestamp_key', 'context_index_posting_bucket', 'context_index_ref_hashes', 'materialize_serving_record_batch', 'latest_context_state_key', 'compact_latest_context_state_records']
 
 # These record-shape constants live in matrixark_mcp_serving_records, and did so here as a second
 # copy: which record types are hot, which fields are debug-only, which carry a heavy node path,
@@ -355,22 +355,9 @@ def context_index_posting_bucket(timestamp_ms: int) -> int:
     return int(timestamp_ms) - (int(timestamp_ms) % bucket_ms)
 
 
-def context_index_data_model(record: Json) -> str:
-    explicit = str(record.get("data_model") or "").strip()
-    if explicit:
-        return explicit
-    ref_type = str(record.get("ref_type") or "").strip()
-    if ref_type:
-        return ref_type
-    if record.get("batch_id_hash") is not None:
-        return "context_batch_commit"
-    if record.get("summary_hash") is not None:
-        return "context_summary"
-    if record.get("chunk_hash") is not None:
-        return "resource_chunk"
-    if record.get("skill_hash") is not None or record.get("section_hash") is not None:
-        return "skill"
-    return "context"
+# A fallback that derived `data_model` from a record's other hashes used to sit here. It was
+# never called: matrixark_mcp_indexing writes the field explicitly when it builds the record, so
+# the fallback existed for a record shape this tree does not produce.
 
 
 # Not defined here: the implementation lives in matrixark_mcp_indexing and this module carried an

--- a/tools/matrixark_tenant_policy.py
+++ b/tools/matrixark_tenant_policy.py
@@ -913,19 +913,10 @@ def clear_user_policy_cache() -> None:
         _USER_POLICIES.clear()
 
 
-def tenant_scope_from_node_path(node_path: Any) -> Json:
-    """Recover a tenant identity from a context node path (``["tenant:acme", "user:u1", ...]``).
-
-    A background summary refresh can run with no scope argument, against a dirty marker whose own
-    scope was stripped by serving materialization -- but the node path always names the tenant, so
-    per-tenant policy has a last-resort identity instead of failing open."""
-    if not isinstance(node_path, (list, tuple)):
-        return {}
-    for part in node_path:
-        text = str(part or "")
-        if text.startswith("tenant:") and len(text) > 7:
-            return {"tenant_id": text[7:]}
-    return {}
+# Recovering a tenant from a node path is not done here. `candidate_access_scope` in
+# matrixark_mcp_core is the live one and recovers tenant AND user AND session, after trying the
+# record's own access_scope, its metadata and the serving scope first -- so the copy that used to
+# sit here answered a strictly narrower question, and was called by nothing.
 
 
 def explicit_int(name: str, scope: Any, fallback: int) -> int:

--- a/tools/test_a_definition_nothing_reaches.py
+++ b/tools/test_a_definition_nothing_reaches.py
@@ -95,15 +95,15 @@ UNREACHED = {
     # 06a46d19f, d422a7e21 "OSS sync PR 4/4"), module-split refactors (efd36f9ef, 667b9e17a,
     # 7c80869cc), or a feature PR whose caller never followed. Import residue, so "left behind by
     # the path that used to call it" is the wrong story: nothing ever called them here.
-    "matrixark_codex_hook.py": ("_format_count_map_bits", "_format_memory_lineage_summary"),
     # Two whose docstrings say where they are applied, and neither is applied anywhere:
     # `clip_messages_for_ingest` says "Applied ONCE at the ingest boundary", and
     # `joined_summary_source_text` is the sentence-level summary dedup, measurement included.
     "matrixark_index_growth_bound.py": ("clip_messages_for_ingest", "joined_summary_source_text"),
-    "matrixark_mcp_core_compact.py": ("context_index_data_model",),
-    "matrixark_context_backfill.py": ("read_checkpoint_sequence",),
     "matrixark_load_config.py": ("apply_from_file",),
-    "matrixark_tenant_policy.py": ("clear_user_policy_cache", "tenant_scope_from_node_path"),
+    # `clear_user_policy_cache` stays: it is the twin of `clear_tenant_policy_cache`, which is
+    # itself called only from tests. Deleting one half of a symmetric test affordance makes the
+    # module worse rather than smaller.
+    "matrixark_tenant_policy.py": ("clear_user_policy_cache",),
     "matrixark_temporalstore_blob.py": ("BlobPutResult", "engine_blob_sweep"),
     # Reporting scripts: these are the rows and lookups their own main stopped printing.
     "run_matrixark_message_pdf_debug_trace.py": (
@@ -112,9 +112,9 @@ UNREACHED = {
         "latest_records_by_key",
         "model_registry_map",
     ),
+    # `require_int_between` stays for the same reason as the cache clearer above: its neighbour
+    # `require_string_set` is used, and half a validation vocabulary is worse than all of it.
     "validate_context_resource_skill_scale.py": ("require_int_between",),
-    "validate_grafana_metrics_conformance.py": ("check_scan_extent_placeholder_removed",),
-    "validate_storage_tuning_conformance.py": ("extract_runtime_defaults",),
 }
 
 

--- a/tools/validate_grafana_metrics_conformance.py
+++ b/tools/validate_grafana_metrics_conformance.py
@@ -486,10 +486,6 @@ def check_no_bare_histogram_targets(kinds: dict) -> list:
     return failures
 
 
-def check_scan_extent_placeholder_removed() -> list:
-    return []
-
-
 def check_dashboard_extent() -> list:
     """Every dashboard listed must exist, or its panels stop being checked silently."""
     return ["dashboard_missing:%s" % path.name for path in DASHBOARDS if not path.exists()]

--- a/tools/validate_storage_tuning_conformance.py
+++ b/tools/validate_storage_tuning_conformance.py
@@ -45,21 +45,6 @@ def _eval_numeric_expr(expr: str) -> int:
     return int(eval(expr, {"__builtins__": {}}, {}))
 
 
-def extract_runtime_defaults(path: pathlib.Path) -> dict[str, object]:
-    text = path.read_text(encoding="utf-8")
-    values: dict[str, object] = {}
-    for name in EXPECTED_KNOBS:
-        match = re.search(rf'{name}="\$\{{{name}:-([^}}]+)\}}"', text)
-        if not match:
-            continue
-        raw = match.group(1)
-        if raw.lower() in {"true", "false"}:
-            values[name] = raw.lower() == "true"
-        else:
-            values[name] = int(raw)
-    return values
-
-
 def extract_rust_defaults(path: pathlib.Path) -> dict[str, object]:
     text = path.read_text(encoding="utf-8")
     constant_map = {


### PR DESCRIPTION
Each one has its replacement named, or a test that already pins its absence.

| removed | why it is safe |
|---|---|
| `_format_memory_lineage_summary` + `_format_count_map_bits` | the `"Retrieved memory lineage:"` line was taken out of `additionalContext` with eight other diagnostics, and `test_codex_hook_output_part2` asserts each of them is **absent** — the renderer could not come back without that test failing first |
| `tenant_scope_from_node_path` | recovered only the tenant, only from `node_path`. `candidate_access_scope` in `matrixark_mcp_core` recovers tenant **and** user **and** session, after trying the record's own `access_scope`, its metadata and the serving scope first |
| `context_index_data_model` | derived a `data_model` label from a record's other hashes; `matrixark_mcp_indexing` writes that field explicitly when it builds the record. Leaves `__all__` with it — hand-written there, and no test pins its contents |
| `read_checkpoint_sequence` | the narrower twin of `read_checkpoint_state`, which is used |
| `check_scan_extent_placeholder_removed` | `return []`, unconditionally, and called by nothing — a check that cannot fail and does not run, sitting in a list of checks that do |
| `extract_runtime_defaults` | parsed a launcher script that no longer exists. The comment beside its former call site already says so: reading a missing key raised `KeyError` on every run, so that validator reported nothing until the entry was removed. The parser stayed |

The hook pair is the one worth a second look. That module's diagnostics are paid for out of the
agent's own context window, which is why they were stripped — keeping a renderer warm for a line
nine tests assert must not appear is the opposite of cheap.

### Two stay, and the guard now says why

`clear_user_policy_cache` is the twin of `clear_tenant_policy_cache`, which is itself called only
from tests; `require_int_between`'s neighbour `require_string_set` is used. Deleting one half of a
symmetric affordance makes a module worse rather than smaller.

Name-diffed against main in a **real worktree** (not a `git archive` — four tree-scanning guards
shell out to `git ls-files` and an archive has no `.git`): 70 red on both sides, both directions
empty. Both validators still exit 0.