### PR TITLE
The blob entry says what it is

### DIFF
--- a/tools/test_a_definition_nothing_reaches.py
+++ b/tools/test_a_definition_nothing_reaches.py
@@ -104,6 +104,15 @@ UNREACHED = {
     # itself called only from tests. Deleting one half of a symmetric test affordance makes the
     # module worse rather than smaller.
     "matrixark_tenant_policy.py": ("clear_user_policy_cache",),
+    # `engine_blob_sweep` is not one more unreached helper. It is the engine attachment tier's
+    # ONLY deletion path -- for unreferenced blobs AND for stale staging files -- and in
+    # engine/resource_blobs.rs it is reachable from exactly one place, the
+    # Command::ContextResourceBlobSweep arm, so nothing collects unless something asks. Nothing
+    # asks: the live adapter exposes resource_blob_sweep, this wrapper is its only caller, and
+    # this wrapper has none. TemporalStoreBlobClient, the other tier, has put/get/exists and no
+    # delete at all. Do not wire a sweep to clear this entry: the caller must enumerate every
+    # manifest still naming a content hash for that tenant, there is no such enumerator, and a
+    # wrong referenced set deletes live attachments.
     "matrixark_temporalstore_blob.py": ("BlobPutResult", "engine_blob_sweep"),
     # Reporting scripts: these are the rows and lookups their own main stopped printing.
     "run_matrixark_message_pdf_debug_trace.py": (


### PR DESCRIPTION
`engine_blob_sweep` reads as one more unreached helper on that list. It is the engine attachment
tier's **only deletion path** — for blobs no manifest still names, *and* for stale staging files
from interrupted uploads — and its own doc says so:

> Delete … blobs for one tenant, plus stale staging files. … only files OLDER than `min_age_ms`
> are eligible, so an upload racing the sweep keeps its blob until its manifest lands.

In `engine/resource_blobs.rs` it is reachable from exactly one place — the
`Command::ContextResourceBlobSweep` arm — so it is on **no engine maintenance cycle**: something
outside has to ask.

**Nothing asks.** The proxy op exists, the live adapter exposes `resource_blob_sweep`, this wrapper
is its only caller, and this wrapper has no caller. `TemporalStoreBlobClient` — the other tier —
has `put`, `get` and `exists` and **no delete method at all**; a grep of the whole Python tree for
a blob deletion returns one line, inside the wrapper nobody uses.

What that does and does not prove: an object store can be collected by bucket lifecycle rules
outside this repository, and an HTTP blob service can collect server-side. What is established is
that **this tree never asks any tier to delete an attachment**, and that for the engine tier —
where the store is a directory this process owns — there is nothing else that could.
`test_engine_blob_tier.py` covers put, get, URI parsing and the engine-only cloud mode; nothing
touches the sweep.

### Deliberately not wired

Choosing when to sweep, with what live set and what `min_age_ms`, is a design decision, and getting
that set wrong **deletes live attachments**. The caller has to enumerate every manifest still naming
a content hash for that tenant, and no such enumerator exists. The entry now carries that warning,
so the next reader does not clear it by writing one.

Comment only, no behaviour change. Both guards pass.