### PR TITLE
Three more identical bodies become re-exports

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -137,6 +137,7 @@ try:
         MATRIXARK_ALLOW_LOCAL_BACKEND,
         live_float,
         live_int,
+        python_hot_cache_allowed,
         DEFAULT_MAX_CONTEXT_TOKENS as _RUNTIME_DEFAULT_MAX_CONTEXT_TOKENS,
     )
 except ModuleNotFoundError:  # Direct script execution from tools/.
@@ -151,6 +152,7 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
         MATRIXARK_ALLOW_LOCAL_BACKEND,
         live_float,
         live_int,
+        python_hot_cache_allowed,
         DEFAULT_MAX_CONTEXT_TOKENS as _RUNTIME_DEFAULT_MAX_CONTEXT_TOKENS,
     )
 DEFAULT_MAX_CONTEXT_TOKENS = _RUNTIME_DEFAULT_MAX_CONTEXT_TOKENS
@@ -375,26 +377,11 @@ def matrixark_production_profile_enabled() -> bool:
     return MATRIXARK_MCP_PROFILE in {"prod", "production", "benchmark", "bench", "parity"}
 
 
-def python_hot_cache_allowed(*, backend_label: str = "") -> bool:
-    """Whether the record cache may serve a read. Native backends are excluded BY POLICY.
-
-    The cache itself is safe on any backend: it is validated by the record COUNT read fresh from
-    the store on every call, and the record log is append-only -- a delete is a tombstone append --
-    so any write anywhere moves the count and the entry misses. The mutable half, the
-    latest-context-state store, is never cached; it is re-read and re-folded even on a hit.
-
-    It is nonetheless off for the native backends on purpose, matching
-    `native_candidate_prefilter_required`: TemporalStore serving is meant to read through native
-    pushdown rather than a Python-side cache. `test_python_hot_cache_default_policy` pins that.
-
-    Turning it on is a measured, one-variable win if a deployment wants it --
-    MATRIXARK_ALLOW_PYTHON_HOT_CACHE=1. Over the mem0 surface, 4 users x a 10-turn conversation:
-    get_all 1491->326 ms, get 1677->402 ms, update 5050->1218 ms, users 1512->475 ms,
-    batch_update 7782->3144 ms, search 710->510 ms, with all 15 APIs still correct on both arms.
-    """
-    if MATRIXARK_ALLOW_PYTHON_HOT_CACHE:
-        return MATRIXARK_ALLOW_PYTHON_HOT_CACHE in {"1", "true", "yes"}
-    return backend_label == "local"
+# `python_hot_cache_allowed` is not defined here: it is imported from
+# matrixark_mcp_runtime_config with the constants above, and this module carried an identical
+# second copy -- the same body and the same docstring, including the mem0 measurement table. The
+# note above is about exactly this hazard: the two modules read the same variable, and a second
+# literal here is what lets the answers drift apart.
 
 
 def native_candidate_prefilter_required(*, backend_label: str = "") -> bool:

--- a/tools/matrixark_mcp_core_identity.py
+++ b/tools/matrixark_mcp_core_identity.py
@@ -46,14 +46,20 @@ except ImportError:  # Direct script execution from tools/.
 
 
 # Not defined here: the implementation lives in matrixark_mcp_identity and this module carried an
-# identical second copy of each.
+# identical second copy of each -- same body, same docstring, and the free names each body reads
+# are bound the same way in both modules, which is what makes re-exporting a no-op rather than a
+# swap.
 try:
     from tools.matrixark_mcp_identity import (
+        json_text,
         role_allows_scopes,
+        session_scope_mode,
     )
 except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_identity import (
+        json_text,
         role_allows_scopes,
+        session_scope_mode,
     )
 
 
@@ -72,17 +78,6 @@ def make_api_key(prefix: str = "mk_test") -> str:
 
 def now_ms() -> int:
     return int(time.time() * 1000)
-
-
-def json_text(value: Json) -> Json:
-    return {
-        "content": [
-            {
-                "type": "text",
-                "text": json.dumps(value, sort_keys=True),
-            }
-        ]
-    }
 
 
 # One class, not two. This was written out here as well as in matrixark_mcp_errors, and two
@@ -280,18 +275,6 @@ try:  # the implementation lives in matrixark_mcp_identity; this module re-expor
     from .matrixark_mcp_identity import parse_scope_key
 except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_identity import parse_scope_key
-
-
-def session_scope_mode(query_scope: Json) -> str:
-    mode = str(
-        query_scope.get("_session_scope")
-        or query_scope.get("session_scope")
-        or query_scope.get("_session_filter_mode")
-        or "only"
-    ).strip().lower()
-    if mode in {"prefer", "preferred", "soft", "continuity"}:
-        return "prefer"
-    return "only"
 
 
 def scope_key_matches_query(record_scope_key: str, query_scope: Json, explicit_keys: set[str]) -> bool:


### PR DESCRIPTION
Following #1512, three more — each into an import block that already exists for this purpose, so
no new dependency and no cycle (the edges are one-directional, checked both ways).

| function | from | to |
|---|---|---|
| `python_hot_cache_allowed` | `matrixark_mcp_core` | `matrixark_mcp_runtime_config` |
| `session_scope_mode` | `matrixark_mcp_core_identity` | `matrixark_mcp_identity` |
| `json_text` | `matrixark_mcp_core_identity` | `matrixark_mcp_identity` |

### One check more than last time

Identical free-name sets with the owner binding every one, and identical results when called — and
**identical docstrings**, because the copy that survives must not be the poorer one.
`python_hot_cache_allowed`'s docstring carries the mem0 measurement table (`get_all 1491→326 ms`,
`update 5050→1218 ms`, and the rest); losing that to a consolidation would be a worse outcome than
the duplication.

The core one lands exactly where that module already warns about this class of drift. The note
above that import block records `DEFAULT_MAX_CONTEXT_TOKENS` being read from the same variable in
both modules with different fallbacks, so an operator who set nothing got a 128k ceiling through
core paths and 500k through runtime-config paths. A second literal is what lets the answers drift
apart — and so is a second body.

Verified by identity rather than by reading:

```
core.python_hot_cache_allowed IS runtime_config's: True
core_identity.json_text IS identity's            : True
core_identity.session_scope_mode IS identity's   : True
```

**−44 lines, +14: three fewer function definitions.**

Name-diffed against main in a real worktree across the 28 suites that read these four modules:
1 red on each side, both diff directions empty.