### PR TITLE
A clean bucket no longer pins the reclaim floor for ever

### DIFF
--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -859,9 +859,13 @@ impl TemporalEngine {
             };
             retained_manifest_ids.insert(manifest.manifest_id.clone());
             covered_bucket_count = covered_bucket_count.saturating_add(1);
-            durable_wal_frontier = durable_wal_frontier.min(manifest.wal_sequence);
-            durable_index_log_frontier =
-                durable_index_log_frontier.min(manifest.index_log_sequence);
+            // EXPERIMENT: a bucket that is CLEAN has no undumped write, so it needs nothing
+            // retained on its behalf and must not hold the floor.
+            if summary.dirty_object_count > 0 {
+                durable_wal_frontier = durable_wal_frontier.min(manifest.wal_sequence);
+                durable_index_log_frontier =
+                    durable_index_log_frontier.min(manifest.index_log_sequence);
+            }
         }
 
         let mut blocker_reasons = Vec::new();
@@ -875,10 +879,15 @@ impl TemporalEngine {
         }
 
         if durable_wal_frontier == u64::MAX {
-            durable_wal_frontier = 0;
+            // EXPERIMENT 2: no bucket held the floor, which means every bucket is dumped and
+            // nothing needs the log retained -- so the floor is the CURRENT position, not zero.
+            // Zero here reads as "retain everything" and is what took the plan unsafe in the
+            // first experiment.
+            durable_wal_frontier = current_wal_sequence;
         }
         if durable_index_log_frontier == u64::MAX {
-            durable_index_log_frontier = 0;
+            // EXPERIMENT 2, the index-log half, same reasoning.
+            durable_index_log_frontier = current_index_log_sequence;
         }
         let mut follower_cursor_block_count = 0usize;
         for cursor in follower_replay_cursors


### PR DESCRIPTION
A clean bucket no longer pins the reclaim floor for ever

#1514 measured both logs growing linearly under continuous ingestion while the
plan reported safe=true, full coverage, no blockers, and a frontier frozen at
2001 for twelve rounds. Nothing refused. There was no mechanism to advance it.

Two changes, and the first alone is worse than neither.

1. A CLEAN bucket does not hold the floor. The frontier was a min over EVERY
   bucket's manifest, and bucket_storage_summaries returns every bucket. A bucket
   dumped in round 1 at sequence ~2000 then goes clean and is never dumped again,
   so it contributed 2000 to that min for ever. A clean bucket has no undumped
   write, so nothing needs the log retained on its behalf.

2. An UNSET frontier means NO CONSTRAINT, not zero. With (1) alone the frontier
   has no contributor, stays u64::MAX, and the existing code maps that to 0 --
   which reads as "retain everything" and takes the plan UNSAFE. When nothing
   holds the floor, every bucket is dumped and the floor is the CURRENT position.

Measured on the #1514 soak -- 2,000 writes then one maintenance round, twelve
times:

                     before              after
  wal at 24k         22,340 growing      2,490, oscillating 2,000-3,421
  index log          24,000, never        22,464, reclaiming from round 7
  frontier           2001, frozen        2001 -> 4001 -> ... -> 24001
  plan               safe=true           safe=true

The WAL reaches a steady state. The index log now reclaims but still lags: 256 a
round against 2,000 arriving, which is index_gc_max_entries_per_round and a known
separate knob (#1490), not this.

WHY THE FIRST EXPERIMENT WAS NOT SHIPPED. With (1) alone the WAL also looked
bounded -- and the plan read safe=false, retain_wal=0. The floor had been erased
rather than advanced, and the boundedness was coming from another mechanism
entirely. Shipping that would have disabled the reclaim path #1470 added while
appearing to fix the symptom. Only the pair gives an advancing frontier with a
safe plan.

The shape comes from the comparison design rather than from guessing: its floor
is the oldest STILL-DIRTY slot's first-dirty log id, set as a single scalar with
"all log entries before have been dumped", and a dumped slot leaves the dirty
queue. We already carry the equivalent per-bucket fields from #1440 and #1444 and
were using them only as a fallback.

SAFETY. The new branch is reached only when every bucket is covered by a durable
manifest AND none is dirty -- that is, when every write is captured in a dump and
the log is genuinely not needed. It is the same question
index_gc_commit_dirty_buckets_before_truncation exists to answer, so the gate for
this change is the durability suite rather than the soak.

Full suite: 1766 passed, 1 failed -- the known baseline failure. The durability set passes.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
