### PR TITLE
Four more identical bodies become re-exports

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -3420,11 +3420,10 @@ except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_scoring import normalized_dense_score
 
 
-def sparse_lexical_score(query_terms: set[str], text: str) -> float:
-    if not query_terms:
-        return 0.0
-    matched = len(query_terms.intersection(tokens(text)))
-    return clamp01(matched / max(len(query_terms), 1))
+try:  # the implementation lives in matrixark_mcp_scoring; this module re-exports it
+    from .matrixark_mcp_scoring import sparse_lexical_score
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_scoring import sparse_lexical_score
 
 
 def candidate_index_terms(

--- a/tools/matrixark_mcp_core_context_pack.py
+++ b/tools/matrixark_mcp_core_context_pack.py
@@ -41,24 +41,6 @@ except ImportError:  # top-level path (matrixark_mcp_core)
 __all__ = ['selected_context_class_counts', '_positive_count_from_ref', '_attach_compact_profile_source_counts', '_context_memory_source_ref_is_debug_only', 'compact_context_pack_ref', 'compact_context_pack_refs', 'compact_context_pack_for_serving_flat', 'compact_context_pack_for_serving', 'normalized_role_int_map', 'normalized_string_int_map', 'budget_control_policy_summary']
 
 
-def selected_context_class_counts(refs: list[Json]) -> Json:
-    counts: Json = {
-        "event": 0,
-        "entity": 0,
-        "segment": 0,
-        "compression": 0,
-        "resource_fact": 0,
-        "resource_entity_fact": 0,
-        "resource_chunk": 0,
-        "skill_section": 0,
-        "summary": 0,
-    }
-    for ref in refs:
-        context_class = str(ref.get("context_class") or ref.get("ref_type") or "")
-        counts[context_class] = int(counts.get(context_class, 0)) + 1
-    return counts
-
-
 def _positive_count_from_ref(ref: Json, *fields: str, list_fields: tuple[str, ...] = ()) -> int:
     for field in fields:
         value = ref.get(field)
@@ -110,10 +92,12 @@ def _attach_compact_profile_source_counts(item: Json, ref: Json) -> None:
 try:
     from tools.matrixark_mcp_context_pack import (
         _context_memory_source_ref_is_debug_only,
+        selected_context_class_counts,
     )
 except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_context_pack import (
         _context_memory_source_ref_is_debug_only,
+        selected_context_class_counts,
     )
 
 def compact_context_pack_ref(ref: Json, *, include_debug: bool = False) -> Json:

--- a/tools/matrixark_mcp_core_identity.py
+++ b/tools/matrixark_mcp_core_identity.py
@@ -140,13 +140,6 @@ def metaserver_reachable(address: str, timeout_ms: int = BACKEND_READINESS_CONNE
         return {"ok": False, "address": address, "error": str(exc)}
 
 
-def require_string(data: Json, field: str) -> str:
-    value = data.get(field)
-    if not isinstance(value, str) or not value:
-        raise MatrixArkError(f"{field} must be a non-empty string")
-    return value
-
-
 def normalize_message_role(role: Any) -> str:
     role_name = str(role or "").strip().lower()
     role_aliases = {
@@ -208,11 +201,13 @@ try:
     from tools.matrixark_mcp_validation import (
         optional_string,
         optional_string_list,
+        require_string,
     )
 except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_validation import (
         optional_string,
         optional_string_list,
+        require_string,
     )
 
 

--- a/tools/matrixark_mcp_core_packing.py
+++ b/tools/matrixark_mcp_core_packing.py
@@ -448,19 +448,6 @@ def serving_ref_for_pack(ref: Json, *, default_session_continuity: str = "", def
     return item
 
 
-def session_continuity_counts(refs: list[Json]) -> Json:
-    counts: Json = {}
-    for ref in refs:
-        if not isinstance(ref, dict):
-            continue
-        metadata = ref.get("metadata", {}) if isinstance(ref.get("metadata"), dict) else {}
-        value = str(ref.get("session_continuity") or metadata.get("session_continuity") or "")
-        if not value:
-            continue
-        counts[value] = int(counts.get(value, 0)) + 1
-    return counts
-
-
 def default_session_continuity_for_pack(refs: list[Json]) -> str:
     counts = session_continuity_counts(refs)
     if not counts:
@@ -569,10 +556,12 @@ def serving_ref_groups_for_pack(
 try:
     from tools.matrixark_mcp_context_pack import (
         selected_ref_count_from_pack,
+        session_continuity_counts,
     )
 except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_context_pack import (
         selected_ref_count_from_pack,
+        session_continuity_counts,
     )
 
 


### PR DESCRIPTION
Following #1512 and #1515. Each goes into a block the holder already has for exactly this purpose.

| function | from | to |
|---|---|---|
| `selected_context_class_counts` | `matrixark_mcp_core_context_pack` | `matrixark_mcp_context_pack` |
| `session_continuity_counts` | `matrixark_mcp_core_packing` | `matrixark_mcp_context_pack` |
| `sparse_lexical_score` | `matrixark_mcp_core` | `matrixark_mcp_scoring` |
| `require_string` | `matrixark_mcp_core_identity` | `matrixark_mcp_validation` |

Checked for every one: identical free-name sets with the owner binding each name, identical
docstrings, a **top-level** import of the owner already present, the owner not importing the holder
at top level, and identical results when called — **including the error paths**. `require_string`
raises the same `MatrixArkError` text from both copies for a missing field, a non-string and a
blank string, which is the half a happy-path check would have missed.

**Two more candidates were dropped rather than waved through.** `remember_ref_scope` and
`recovered_scope_for_query` read names that `matrixark_local_adapter_retrieval` receives through a
star-import rather than binding itself, so "the owner binds every free name" does not hold and the
re-export would not be the no-op the others are.

### What the identity check turned up — and it is not from this change

Verifying by `is` rather than by reading showed `matrixark_mcp_core.selected_context_class_counts`
**absent under one import order**. The same probe on `main` shows the same thing:

```
[mine] first import matrixark_mcp_core_context_pack -> selected_context_c=False ...
[main] first import matrixark_mcp_core_context_pack -> selected_context_c=False ...
```

`matrixark_mcp_core_context_pack` imports `matrixark_mcp_core` at top level while
`matrixark_mcp_core` star-imports it back at line 4715, so importing the sibling first leaves core
holding a partially initialised copy. Pre-existing, equal on both sides, recorded rather than fixed
here — it is the kind of thing that produces "works from one entry point, `AttributeError` from
another."

**−43 lines, +10: four fewer function definitions.**

Name-diffed against main in a real worktree across the 28 suites that read these families: 65 red
on each side, both diff directions empty.