### PR TITLE
Three folds onto an import edge that had to be added

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -499,36 +499,21 @@ def embedding_model_conflicts(stored_model: str, active_model: str) -> bool:
     return not same_embedding_model(stored, active)
 
 
-def context_model_registry_record(model_name: str, *, model_kind: str = "embedding", updated_at_ms: int | None = None) -> Json:
-    model_name = str(model_name or "").strip()
-    model_hash = stable_hash(f"{model_kind}_model:{model_name}")
-    return {
-        "record_type": "context_model_registry",
-        "model_kind": model_kind,
-        "model_ref": embedding_model_ref_for_name(model_name) if model_kind == "embedding" else f"{model_kind}:{compact_model_slug(model_name)}:{model_hash % 10000:04d}",
-        "model_name": model_name,
-        "model_hash": model_hash,
-        "provider": (os.environ.get("MATRIXARK_EMBEDDING_PROVIDER", "").strip() or "deterministic") if model_kind == "embedding" else "",
-        "execution_mode": embedding_execution_mode_name() if model_kind == "embedding" else "",
-        "updated_at_ms": int(updated_at_ms or now_ms()),
-    }
-
-
-def context_model_registry_records(records: list[Json]) -> list[Json]:
-    models: dict[str, int] = {}
-    for record in records:
-        if str(record.get("record_type") or "") != "context_embedding":
-            continue
-        model_name = str(record.get("model") or "").strip()
-        if not model_name:
-            continue
-        updated_at_ms = record.get("updated_at_ms") or record.get("created_at_ms") or now_ms()
-        try:
-            timestamp = int(updated_at_ms)
-        except (TypeError, ValueError):
-            timestamp = now_ms()
-        models[model_name] = max(models.get(model_name, 0), timestamp)
-    return [context_model_registry_record(model_name, updated_at_ms=timestamp) for model_name, timestamp in sorted(models.items())]
+# Not defined here: both implementations live in matrixark_mcp_model_registry and this module
+# carried identical second copies -- same bodies, same docstrings, and the owner binds every free
+# name each reads. The import edge did not exist before, so it was added only after computing the
+# closure over top-level imports in both directions: matrixark_mcp_model_registry does not reach
+# this module by any chain.
+try:  # package path
+    from .matrixark_mcp_model_registry import (
+        context_model_registry_record,
+        context_model_registry_records,
+    )
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_model_registry import (
+        context_model_registry_record,
+        context_model_registry_records,
+    )
 
 
 def entity_patch(search: str, replace: str, *, field: str = "state") -> Json:

--- a/tools/matrixark_mcp_core_candidate_policy.py
+++ b/tools/matrixark_mcp_core_candidate_policy.py
@@ -98,14 +98,14 @@ def is_pending_async_candidate(candidate: Json) -> bool:
     )
 
 
-def bounded_max_children_scored_per_parent(value: int) -> int:
-    hard_cap = max(1, HARD_MAX_CHILDREN_SCORED_PER_PARENT)
-    if value > hard_cap:
-        raise MatrixArkError(
-            "max_children_scored_per_parent must be <= "
-            f"{hard_cap}; split over-wide ContextNode children into deeper node layers"
-        )
-    return value
+# Not defined here: the implementation lives in matrixark_mcp_budget_policies and this module
+# carried an identical second copy. The import edge did not exist before, so it was added only
+# after computing the closure over top-level imports in both directions -- matrixark_mcp_budget
+# _policies does not reach this module by any chain, so the new edge cannot close a cycle.
+try:  # package path
+    from .matrixark_mcp_budget_policies import bounded_max_children_scored_per_parent
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_budget_policies import bounded_max_children_scored_per_parent
 
 
 def score_recall_candidate(candidate: Json, ranking: Json, *, reference_time_ms: int) -> Json:


### PR DESCRIPTION
| function | from | to |
|---|---|---|
| `bounded_max_children_scored_per_parent` | `matrixark_mcp_core_candidate_policy` | `matrixark_mcp_budget_policies` |
| `context_model_registry_record` | `matrixark_mcp_core` | `matrixark_mcp_model_registry` |
| `context_model_registry_records` | `matrixark_mcp_core` | `matrixark_mcp_model_registry` |

#1512, #1515 and #1517 all leaned on an edge that already existed. **These do not**, so the cycle
question is answered first and **transitively**: the closure over top-level imports was computed in
both directions, and neither owner reaches its holder by any chain. A single-hop check would not
have been enough — a cycle two modules long is still a cycle.

Everything else as before: identical free-name sets with the owner binding each name, identical
docstrings, identical results when called.

### Verified by importing, in four orders, each in its own process

```
first=matrixark_mcp_core                    -> identity-ok=True  core-has-both=True  cp-has=True
first=matrixark_mcp_core_candidate_policy   -> ImportError: cannot import name
                                               'candidate_codex_outcome_terms' from partially
                                               initialized module 'matrixark_mcp_core'
first=matrixark_mcp_budget_policies         -> identity-ok=True  core-has-both=True  cp-has=True
first=matrixark_mcp_model_registry          -> identity-ok=True  core-has-both=True  cp-has=True
```

That one failing order **fails identically on `main`**. `matrixark_mcp_core_candidate_policy`
imports core at top level while core star-imports it back at line 4697 — the same shape this tree
already has between `matrixark_mcp_core` and `matrixark_mcp_core_context_pack` (noted in #1517).
Pre-existing, unchanged here.

**−38 lines, +23: three fewer function definitions.**

Name-diffed against main in a real worktree across the 12 suites that read these modules: 1 red on
each side, both diff directions empty.