### PR TITLE
Stop offering six engine knobs the portal never had a reason to

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -1710,10 +1710,6 @@ SETTINGS.extend([
             "fold the owner always carries its vector, which is the condition the prefilter's "
             "owner branch is gated on, so that branch now reaches every chunk and the posting "
             "is a restatement. Set it off to write them again."),
-    Setting("storage_engine.max_secondary_index_records_per_operation", "storage_engine", "MATRIXARK_MAX_SECONDARY_INDEX_RECORDS_PER_OPERATION",
-            "Max secondary index records per operation", "int", "128", "restart",
-            "Maximum secondary index records per operation. Defaults to 128. Frozen when the process "
-            "starts. Read by matrixark_mcp_core, matrixark_mcp_indexing."),
     Setting("storage_engine.max_secondary_index_refs_per_posting", "storage_engine", "MATRIXARK_MAX_SECONDARY_INDEX_REFS_PER_POSTING",
             "Max secondary index refs per posting", "int", "512", "restart",
             "Maximum secondary index refs per posting. Defaults to 512. Frozen when the process starts. "
@@ -1722,32 +1718,6 @@ SETTINGS.extend([
             "Max secondary index terms per record", "int", "10", "restart",
             "Maximum secondary index terms per record. Defaults to 10. Frozen when the process starts. "
             "Read by matrixark_mcp_core, matrixark_mcp_indexing."),
-    Setting("storage_engine.native_side_index_assume_fresh", "storage_engine", "MATRIXARK_NATIVE_SIDE_INDEX_ASSUME_FRESH",
-            "Native side index assume fresh", "bool", "0", "live",
-            "Writes side-index entries from the new records alone, skipping the read of what is "
-            "already stored there. It saves a read per entry on ingest, and it is safe only "
-            "where nothing else writes those entries: the merge that preserves existing "
-            "references is handed an empty answer, so references already on an entry are "
-            "overwritten rather than kept."),
-    Setting("storage_engine.rust_proxy_startup_warmup_full_scan", "storage_engine", "MATRIXARK_RUST_PROXY_STARTUP_WARMUP_FULL_SCAN",
-            "Rust proxy startup warmup full scan", "bool", "1", "live",
-            "Chooses which retrieve the proxy daemon issues to warm itself: the full-scan "
-            "variant, or the ordinary one that consults the index. It only matters where the "
-            "warmup runs at all -- MATRIXARK_RUST_PROXY_STARTUP_WARMUP defaults to auto, which "
-            "warms on local and single-node deployments and declines on distributed, "
-            "replicated, raft, cluster or production ones."),
-    Setting("storage_engine.secondary_index_posting_bucket_ms", "storage_engine", "MATRIXARK_SECONDARY_INDEX_POSTING_BUCKET_MS",
-            "Secondary index posting bucket ms", "int", "60000", "restart",
-            "Secondary index posting bucket milliseconds. Defaults to 60000. Frozen when the process "
-            "starts. Read by matrixark_mcp_core, matrixark_mcp_indexing."),
-    Setting("storage_engine.secondary_index_time_bucket_ms", "storage_engine", "MATRIXARK_SECONDARY_INDEX_TIME_BUCKET_MS",
-            "Secondary index time bucket ms", "int", "60000", "restart",
-            "Secondary index time bucket milliseconds. Defaults to 60000. Frozen when the process starts. "
-            "Read by matrixark_mcp_core, matrixark_mcp_indexing."),
-    Setting("storage_engine.stream_materialize_max_scopes", "storage_engine", "MATRIXARK_STREAM_MATERIALIZE_MAX_SCOPES",
-            "Stream materialize max scopes", "int", "20000", "restart",
-            "Stream materialize maximum scopes. Defaults to 20000. Frozen when the process starts. Read "
-            "by matrixark_mcp_server."),
 ])
 
 SETTINGS.extend(_knob_settings())


### PR DESCRIPTION
First of a series aimed at a much smaller Setup page. **The variables keep working** — every
reader is untouched. What goes is the portal *offering*.

```
MATRIXARK_MAX_SECONDARY_INDEX_RECORDS_PER_OPERATION
MATRIXARK_NATIVE_SIDE_INDEX_ASSUME_FRESH
MATRIXARK_RUST_PROXY_STARTUP_WARMUP_FULL_SCAN
MATRIXARK_SECONDARY_INDEX_POSTING_BUCKET_MS
MATRIXARK_SECONDARY_INDEX_TIME_BUCKET_MS
MATRIXARK_STREAM_MATERIALIZE_MAX_SCOPES
```

This is the rule `test_an_addressed_flag_is_offered` already states from the other direction —
*"the property is not 'every flag is on the portal'; most flags are internal and should stay that
way"*. These six are held by nothing that would make them operator-facing:

- the shipped config file does not name them
- no document names them
- **no reader writes a sentence addressed to an operator** within 900 characters of any read
- no test names the key
- this deployment has no value stored for any of them

### Why that last check is not a formality

Removing a setting is not free. `apply_boot` stops seeding a stored value, so a deployment that
*had* set one quietly reverts to the default — which is exactly what
`test_matrixark_a_stored_setting_this_build_forgot` is about, and why the page names stale keys
rather than deleting them.

Checked against this box's `runtime_config.json`: **115 stored values, 83 declared by this build,
32 already stale — and none of these six.**

**233 → 227.** 878 tests across the 69 suites that read the settings module pass, with no change to
any guard: the knob-read-by-something check, the config-file mirror, the default-matches-code check
and the unoffered-override map all still agree.