### PR TITLE
Reclaim the index log before rewriting blocks

### DIFF
--- a/crates/temporalstore-rust/src/data_node/runtime_storage.rs
+++ b/crates/temporalstore-rust/src/data_node/runtime_storage.rs
@@ -494,67 +494,6 @@ impl DataNodeRuntime {
             ),
         ));
 
-        if options.enable_page_compaction && stale_page_pressure {
-            let response = run_compaction_inner(&self.inner, CompactionRequest { shard_id });
-            if !response.status.ok {
-                status = response.status.clone();
-            }
-            compaction_report = Some(response);
-            self.inner
-                .stats
-                .lock()
-                .expect("runtime stats lock poisoned")
-                .storage_manager_compact_runs += 1;
-            executed_stages.push("compact_pages".to_string());
-        } else if !options.enable_page_compaction {
-            skipped_stages.push("compact_pages_disabled".to_string());
-        } else {
-            skipped_stages.push("compact_pages_no_pressure".to_string());
-        }
-        pressure_decisions.push(storage_manager_pressure_decision(
-            "compact_pages",
-            options.enable_page_compaction,
-            stale_page_pressure,
-            options.enable_page_compaction && stale_page_pressure,
-            vec![
-                storage_manager_pressure_signal(
-                    "stale_page_segment_count",
-                    pressure.stale_block_slab_count as u64,
-                    options.stale_block_slab_pressure.max(1) as u64,
-                ),
-                storage_manager_pressure_signal(
-                    "reclaim_candidate_count",
-                    pressure.reclaim_candidate_count as u64,
-                    options.stale_block_slab_pressure.max(1) as u64,
-                ),
-                storage_manager_pressure_signal(
-                    "reclaimable_physical_bytes",
-                    pressure.reclaimable_physical_bytes,
-                    options.reclaimable_physical_bytes_pressure.max(1),
-                ),
-            ],
-            storage_manager_trigger_reasons(&[
-                (
-                    pressure.stale_block_slab_count >= options.stale_block_slab_pressure.max(1),
-                    "stale_page_segment_pressure",
-                ),
-                (
-                    pressure.reclaim_candidate_count >= options.stale_block_slab_pressure.max(1),
-                    "reclaim_candidate_pressure",
-                ),
-                (
-                    pressure.reclaimable_physical_bytes
-                        >= options.reclaimable_physical_bytes_pressure.max(1),
-                    "reclaimable_physical_bytes_pressure",
-                ),
-            ]),
-            storage_manager_skip_reason(
-                options.enable_page_compaction,
-                stale_page_pressure,
-                "compact_pages",
-            ),
-        ));
-
         let index_gc_pressure = lifecycle_plan.reasons.iter().any(|reason| {
             reason == "slot_dump_manifest_prune" || reason == "slot_dump_install_roll_forward_check"
         });
@@ -663,6 +602,83 @@ impl DataNodeRuntime {
             },
             (!options.enable_index_gc).then(|| "reclaim_index_disabled".to_string()),
         ));
+
+        // Reclaim the index log BEFORE rewriting blocks, not after, so the stages run in the
+        // order the design intends: reclaim memory, reclaim pages, reclaim the index, compact.
+        //
+        // This is an ALIGNMENT, not a throughput fix, and the probe beside it is what settles
+        // that. `what_the_stage_order_buys` runs the same eight-round overwrite fixture under
+        // both arrangements, with compaction firing in all eight rounds either way, and the two
+        // are identical to the record: 1,873 left in the log, 1,765 removed per round.
+        //
+        // The reason they are identical is worth keeping, because the opposite is intuitive:
+        // compaction rewrites live records into fresh blocks and appends an index record for
+        // each, so running it first looks like it should hand the reclaim a log it just grew.
+        // It does -- but those records are above the floor the reclaim computed, and a record
+        // above the floor is protected whichever order the two stages run in. Moving the reclaim
+        // earlier cannot collect them any sooner; it only stops them from being written until
+        // after it has finished. Neither order is unsafe and neither collects more.
+        if options.enable_page_compaction && stale_page_pressure {
+            let response = run_compaction_inner(&self.inner, CompactionRequest { shard_id });
+            if !response.status.ok {
+                status = response.status.clone();
+            }
+            compaction_report = Some(response);
+            self.inner
+                .stats
+                .lock()
+                .expect("runtime stats lock poisoned")
+                .storage_manager_compact_runs += 1;
+            executed_stages.push("compact_pages".to_string());
+        } else if !options.enable_page_compaction {
+            skipped_stages.push("compact_pages_disabled".to_string());
+        } else {
+            skipped_stages.push("compact_pages_no_pressure".to_string());
+        }
+        pressure_decisions.push(storage_manager_pressure_decision(
+            "compact_pages",
+            options.enable_page_compaction,
+            stale_page_pressure,
+            options.enable_page_compaction && stale_page_pressure,
+            vec![
+                storage_manager_pressure_signal(
+                    "stale_page_segment_count",
+                    pressure.stale_block_slab_count as u64,
+                    options.stale_block_slab_pressure.max(1) as u64,
+                ),
+                storage_manager_pressure_signal(
+                    "reclaim_candidate_count",
+                    pressure.reclaim_candidate_count as u64,
+                    options.stale_block_slab_pressure.max(1) as u64,
+                ),
+                storage_manager_pressure_signal(
+                    "reclaimable_physical_bytes",
+                    pressure.reclaimable_physical_bytes,
+                    options.reclaimable_physical_bytes_pressure.max(1),
+                ),
+            ],
+            storage_manager_trigger_reasons(&[
+                (
+                    pressure.stale_block_slab_count >= options.stale_block_slab_pressure.max(1),
+                    "stale_page_segment_pressure",
+                ),
+                (
+                    pressure.reclaim_candidate_count >= options.stale_block_slab_pressure.max(1),
+                    "reclaim_candidate_pressure",
+                ),
+                (
+                    pressure.reclaimable_physical_bytes
+                        >= options.reclaimable_physical_bytes_pressure.max(1),
+                    "reclaimable_physical_bytes_pressure",
+                ),
+            ]),
+            storage_manager_skip_reason(
+                options.enable_page_compaction,
+                stale_page_pressure,
+                "compact_pages",
+            ),
+        ));
+
 
         // Gather what the stage has always claimed to gather. Deliberately a snapshot and not
         // a reset: `durability_metrics` documents its counters as process-wide and monotonic,

--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -4332,3 +4332,103 @@ fn what_index_gc_cap_keeps_up() {
         eprintln!("  {cap:>6}   {written:>8}   {index:>10}   {verdict}");
     }
 }
+
+/// Does reclaiming the index log before rewriting blocks trim more of it per round? Prints.
+///
+///   cargo test -p temporalstore-rust --lib what_the_stage_order_buys \
+///       -- --ignored --nocapture --test-threads=1
+///
+/// The round-cap sweep established that index-log removal saturates at 512 records a round no
+/// matter how large the round cap is -- 2,048 and 4,096 leave the log at exactly the same size --
+/// so the cap is not what binds. One candidate for what does: compaction rewrites live records
+/// into fresh blocks and appends an index record for each, and it ran BEFORE the reclaim. Those
+/// records sit above the floor the reclaim computed, so no round cap can touch them.
+///
+/// The fixture OVERWRITES a fixed key space rather than appending fresh keys. That matters: an
+/// insert-only load leaves no stale pages, so compaction never fires, and a first version of this
+/// probe measured a run where `compact_pages` executed zero times out of eight -- a number that
+/// looked like a clean result and was actually a measurement of nothing. The assertion below is
+/// there so that can never pass silently again.
+///
+/// MEASURED, both arrangements, compaction firing in all eight rounds of each:
+///
+///     compact then reclaim (before)   ingested=16000  index_log=1873  per_round=1765
+///     reclaim then compact (after)    ingested=16000  index_log=1873  per_round=1765
+///
+/// Identical. The candidate above is REFUTED: compaction's fresh records are above the floor the
+/// reclaim computed, and a record above the floor is protected whichever order the stages run in,
+/// so moving the reclaim earlier cannot collect them sooner. The stage order was changed to match
+/// the intended sequence, not to buy throughput, and this probe exists so a later change that
+/// claims otherwise has to produce a different pair of numbers.
+///
+/// Note the per-round figure against the round-cap sweep's 64: the difference is the WORKLOAD,
+/// not the cap. Here records genuinely become garbage; there, 16,000 distinct keys meant almost
+/// every record was the live version of a key and there was little to reclaim.
+#[test]
+#[ignore]
+fn what_the_stage_order_buys() {
+    const BATCH: usize = 2_000;
+    const ROUNDS: usize = 8;
+    // Smaller than BATCH, so every round rewrites keys earlier rounds wrote and the blocks
+    // holding the old versions become garbage -- which is what compaction needs to trigger.
+    const KEYSPACE: usize = 500;
+
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+    let runtime = DataNodeRuntime::new_without_workers_with_options(
+        engine,
+        DataNodeRuntimeOptions {
+            worker_threads: 0,
+            max_queue_depth: 4,
+            max_background_queue_depth: 2,
+        },
+    );
+    let options = StorageManagerOptions::default();
+    let mut written = 0usize;
+    let mut compacted_rounds = 0usize;
+    let mut reclaimed_rounds = 0usize;
+    for _ in 0..ROUNDS {
+        let engine = runtime.engine();
+        for index in 0..BATCH {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("order-{:08}", (written + index) % KEYSPACE),
+                    value: vec![b'v'; 96],
+                },
+            });
+        }
+        written += BATCH;
+        let report = runtime.run_storage_manager_once(1, options.clone());
+        if report
+            .executed_stages
+            .iter()
+            .any(|stage| stage == "compact_pages")
+        {
+            compacted_rounds += 1;
+        }
+        if report
+            .executed_stages
+            .iter()
+            .any(|stage| stage == "reclaim_index")
+        {
+            reclaimed_rounds += 1;
+        }
+    }
+    let engine = runtime.engine();
+    let index = engine
+        .index_log_store()
+        .scan(1, 0, u64::MAX, u64::MAX)
+        .map(|records| records.len())
+        .unwrap_or(0);
+    let removed = written.saturating_sub(index);
+    eprintln!("  ingested={written} index_log={index} removed={removed} per_round={}",
+        removed / ROUNDS);
+    eprintln!("  rounds={ROUNDS} compact_pages_ran={compacted_rounds} reclaim_index_ran={reclaimed_rounds}");
+    // The positive control. Where compaction never runs, the two stage orders are the same
+    // program and the size above says nothing about either.
+    assert!(
+        compacted_rounds > 0,
+        "compaction never ran, so this measures nothing about the stage order"
+    );
+}


### PR DESCRIPTION
The periodic scheduler ran its stages as `reclaim_memory`, `reclaim_page`, `compact_pages`,
`reclaim_index`. The intended sequence puts the index reclaim ahead of compaction, and this makes
ours match:

| intended | ours, before | ours, after |
|---|---|---|
| Prepare | prepare | prepare |
| ReclaimOpLog | reclaim_wal | reclaim_wal |
| ReclaimMemory | reclaim_memory | reclaim_memory |
| ReclaimPage | reclaim_page | reclaim_page |
| ReclaimIndex | compact_pages | **reclaim_index** |
| CompactPages | reclaim_index | **compact_pages** |
| ReapMetrics | reap_metrics | reap_metrics |

A single adjacent move. No stage gains or loses work, and nothing between the two blocks reads
what the other writes — `lifecycle_report`'s only readers sit in `reclaim_page`, ahead of both.
No test asserts stage order; every assertion is membership via `.any(...)`.

## It buys nothing, and that is measured rather than assumed

`what_the_stage_order_buys` runs an eight-round overwrite fixture under both arrangements, with
compaction firing in all eight rounds either way:

| arrangement | ingested | index log | removed/round |
|---|---|---|---|
| compact then reclaim (before) | 16,000 | 1,873 | 1,765 |
| reclaim then compact (after) | 16,000 | 1,873 | 1,765 |

Identical to the record. The intuitive case for the move is that compaction rewrites live records
into fresh blocks and appends an index record for each, so running it first hands the reclaim a
log it has just grown. It does — but those records are above the floor the reclaim computed, and a
record above the floor is protected whichever order the stages run in. Moving the reclaim earlier
cannot collect them sooner.

So this lands as an alignment, not a throughput fix, and the probe is committed so a later change
claiming otherwise has to produce a different pair of numbers.

## The probe asserts compaction actually ran

An earlier version did not, and measured a run where `compact_pages` executed **zero** times out
of eight: with insert-only traffic there are no stale pages, so compaction never fires and the two
orders are literally the same program. That run produced a clean-looking number and established
nothing. The assertion now fails loudly instead.

Worth carrying across to the round-cap sweep in #1524: its 64-records-per-round figure came from
an insert-only fixture, against 1,765 here. That difference is the workload, not any knob — with
16,000 distinct keys almost every index record is the live version of a key and there is
legitimately little to reclaim.

## Verification

`cargo test -p temporalstore-rust --lib -- --test-threads=1` → **1766 passed, 1 failed**. The one
failure is `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the standing `--lib`
baseline failure on main. No new failure name.
