### PR TITLE
The reclaim_page stage quarantines what it collects

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -525,6 +525,18 @@ impl BlockStoreGcPolicy {
     /// Reclaim eligible bands whose garbage ratio is at least
     /// `min_band_garbage_basis_points`, highest-garbage first, optionally bounded by a
     /// minimum band age. Mirrors selecting the maximum-garbage-rate zone under GC.
+    /// A garbage floor that CANNOT currently exclude anything. Measured, not assumed.
+    ///
+    /// The floor is compared against a BAND's live fraction, and a band's used bytes sum only the
+    /// slabs in it that are not collectable. `band_id_for_slab` is the identity function, so every
+    /// band holds exactly one slab -- and a candidate is by definition below the retention floor,
+    /// not current and not live, so its band's used bytes are zero. Utility is therefore 0, garbage
+    /// is 10,000 basis points, and every candidate clears every possible floor.
+    ///
+    /// `can_the_page_gc_garbage_floor_bind` prints this: the floor excluded 0 of 2 candidates, both
+    /// at 10,000 bp garbage with 0 used bytes. Setting this to a larger number changes nothing
+    /// today, and it will start to bite the moment a band holds more than one slab -- which is what
+    /// the knob was built for. It is left in place and documented rather than removed.
     pub fn with_slab_garbage_floor(
         min_slab_garbage_basis_points: u64,
         min_age_ms: Option<u64>,

--- a/crates/temporalstore-rust/src/data_node.rs
+++ b/crates/temporalstore-rust/src/data_node.rs
@@ -768,6 +768,13 @@ pub struct GcRequest {
     #[serde(alias = "retain_page_segments_from_id")]
     #[serde(rename = "retain_page_slabs_from_id")]
     pub retain_block_slabs_from_id: Option<u64>,
+    /// Move reclaimed slabs into quarantine instead of unlinking them there and then.
+    ///
+    /// Defaults to false, which is what this RPC has always done. The storage-manager cycle
+    /// quarantines, and the periodic loop now asks for the same thing; an operator collecting by
+    /// hand keeps the immediate unlink, because the space is usually why they called.
+    #[serde(default)]
+    pub page_gc_delayed_destroy: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/temporalstore-rust/src/data_node/runtime_storage.rs
+++ b/crates/temporalstore-rust/src/data_node/runtime_storage.rs
@@ -433,6 +433,12 @@ impl DataNodeRuntime {
                         .and_then(|report| report.dump_manifest.as_ref())
                         .map(|manifest| manifest.index_log_sequence),
                     retain_block_slabs_from_id,
+                    // Quarantine rather than unlink, as the cycle has always done. This stage
+                    // deleted a slab outright, so if the retain floor above was ever computed too
+                    // generously there was nothing left to recover from. The prepare stage passes
+                    // `purge_delayed_destroy` whenever page GC is on, so quarantined slabs are
+                    // still collected -- an hour later, not never.
+                    page_gc_delayed_destroy: true,
                 },
             );
             if !response.status.ok {

--- a/crates/temporalstore-rust/src/data_node/task_execution.rs
+++ b/crates/temporalstore-rust/src/data_node/task_execution.rs
@@ -185,13 +185,24 @@ pub(super) fn run_gc_inner(inner: &DataNodeRuntimeInner, request: GcRequest) -> 
             for manifest in inner.engine.list_bucket_dump_manifests(request.shard_id) {
                 live_block_slab_ids.extend(manifest.block_slab_ids.iter().copied());
             }
-            match inner
-                .engine
-                .block_store()
-                .gc_slabs_before_with_live_refs(
-                    retain_from_block_slab_id,
-                    live_block_slab_ids,
-                ) {
+            // Quarantine or unlink, nothing else: both entries take the same path and differ
+            // only in what they do with a slab once it has been selected, so a request that does
+            // not ask for quarantine runs exactly the code it ran before.
+            let gc_result = if request.page_gc_delayed_destroy {
+                inner
+                    .engine
+                    .block_store()
+                    .gc_slabs_before_with_live_refs_delayed_destroy(
+                        retain_from_block_slab_id,
+                        live_block_slab_ids,
+                    )
+            } else {
+                inner
+                    .engine
+                    .block_store()
+                    .gc_slabs_before_with_live_refs(retain_from_block_slab_id, live_block_slab_ids)
+            };
+            match gc_result {
                 Ok(report) => {
                     block_slabs_removed = report.removed_block_slab_ids.len();
                     block_slabs_removed_physical_bytes = report.removed_physical_bytes;

--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -1139,6 +1139,7 @@ fn gc_does_not_clear_the_dirty_scheduling_tracker() {
             retain_wal_from_sequence: None,
             retain_index_log_from_sequence: None,
             retain_block_slabs_from_id: None,
+            page_gc_delayed_destroy: false,
         },
         RequestController { timeout_ms: 1000 },
     );
@@ -2145,6 +2146,7 @@ fn runtime_gc_reclaims_log_tails_and_reports_counts() {
             retain_wal_from_sequence: Some(3),
             retain_index_log_from_sequence: Some(2),
             retain_block_slabs_from_id: Some(2),
+            page_gc_delayed_destroy: false,
         },
         RequestController { timeout_ms: 1000 },
     );
@@ -2226,6 +2228,7 @@ fn operator_gc_retains_slabs_referenced_by_dump_manifest() {
             retain_wal_from_sequence: None,
             retain_index_log_from_sequence: None,
             retain_block_slabs_from_id: Some(u64::MAX),
+            page_gc_delayed_destroy: false,
         },
         RequestController { timeout_ms: 1000 },
     );
@@ -2397,6 +2400,7 @@ fn runtime_honors_inflight_cancellation_before_gc_side_effects() {
             retain_wal_from_sequence: Some(2),
             retain_index_log_from_sequence: Some(2),
             retain_block_slabs_from_id: None,
+            page_gc_delayed_destroy: false,
         }),
     };
     runtime
@@ -2508,6 +2512,7 @@ fn runtime_rejects_background_work_when_background_queue_is_full() {
             retain_wal_from_sequence: None,
             retain_index_log_from_sequence: None,
             retain_block_slabs_from_id: None,
+            page_gc_delayed_destroy: false,
         },
         RequestController { timeout_ms: 1000 },
     );
@@ -4430,5 +4435,158 @@ fn what_the_stage_order_buys() {
     assert!(
         compacted_rounds > 0,
         "compaction never ran, so this measures nothing about the stage order"
+    );
+}
+
+/// Can the page-GC garbage floor ever exclude a slab? Prints.
+///
+///   cargo test -p temporalstore-rust --lib can_the_page_gc_garbage_floor_bind \
+///       -- --ignored --nocapture --test-threads=1
+///
+/// The floor keeps a slab whose band is less than `min_slab_garbage_basis_points` garbage, and the
+/// band's live fraction is summed over the slabs in that band which are NOT collectable. So the
+/// floor can only bind where a band holds a MIX -- some collectable slabs, some not. This prints
+/// each candidate's band id against its own id, and the utility the floor is compared against.
+#[test]
+#[ignore]
+fn can_the_page_gc_garbage_floor_bind() {
+    const BATCH: usize = 400;
+    const ROUNDS: usize = 6;
+    const KEYSPACE: usize = 100;
+
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+    let runtime = DataNodeRuntime::new_without_workers_with_options(
+        engine,
+        DataNodeRuntimeOptions {
+            worker_threads: 0,
+            max_queue_depth: 4,
+            max_background_queue_depth: 2,
+        },
+    );
+    let options = StorageManagerOptions::default();
+    let mut written = 0usize;
+    for _ in 0..ROUNDS {
+        let engine = runtime.engine();
+        for index in 0..BATCH {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("floor-{:06}", (written + index) % KEYSPACE),
+                    value: vec![b'v'; 96],
+                },
+            });
+        }
+        written += BATCH;
+        runtime.run_storage_manager_once(1, options.clone());
+    }
+
+    let engine = runtime.engine();
+    let live = engine.live_block_slab_ids_all_shards();
+    let plan = engine
+        .block_store()
+        .gc_policy_plan(
+            u64::MAX,
+            live.iter().copied(),
+            &crate::block_store::BlockStoreGcPolicy::with_slab_garbage_floor(
+                crate::engine::reports::DEFAULT_PAGE_GC_MIN_BAND_GARBAGE_BASIS_POINTS,
+                None,
+            ),
+        )
+        .expect("plan");
+
+    eprintln!(
+        "  candidates={} selected={} skipped_by_policy={}",
+        plan.candidate_count,
+        plan.selected_block_slab_ids.len(),
+        plan.skipped_by_policy_count
+    );
+    eprintln!("     slab   total_b    used_b   utility_bp   garbage_bp   floor_keeps_it");
+    for candidate in plan.candidates.iter() {
+        let garbage = 10_000u64.saturating_sub(candidate.utility_basis_points);
+        let kept = garbage < crate::engine::reports::DEFAULT_PAGE_GC_MIN_BAND_GARBAGE_BASIS_POINTS;
+        eprintln!(
+            "  {:>7}  {:>8}  {:>8}   {:>10}   {:>10}   {}",
+            candidate.block_slab_id,
+            candidate.total_bytes,
+            candidate.used_bytes,
+            candidate.utility_basis_points,
+            garbage,
+            kept
+        );
+    }
+    eprintln!(
+        "  VERDICT: the floor excluded {} of {} candidates",
+        plan.skipped_by_policy_count, plan.candidate_count
+    );
+}
+
+/// The reclaim_page stage quarantines the slabs it reclaims instead of unlinking them.
+///
+/// The stage reached `gc_slabs_before_with_live_refs`, which destroys immediately. The
+/// storage-manager cycle has always reached the delayed-destroy entry, so a slab it reclaimed
+/// stayed on disk until a later purge and could be recovered if the retain floor turned out to
+/// have been computed too generously. The periodic loop had no such second chance.
+///
+/// Quarantined slabs are still collected -- `DELAYED_DESTROY_MIN_AGE_MS` is an hour, and the
+/// prepare stage passes `purge_delayed_destroy` whenever page GC is on -- so this trades prompt
+/// space for recoverability, it does not leak.
+#[test]
+fn the_periodic_reclaim_quarantines_what_it_collects() {
+    const BATCH: usize = 400;
+    const ROUNDS: usize = 6;
+    // Smaller than BATCH so later rounds overwrite earlier keys and whole slabs fall out of use.
+    // With insert-only traffic every slab stays live, nothing is reclaimed at all, and the
+    // assertions below would be measuring an empty run.
+    const KEYSPACE: usize = 100;
+
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+    let runtime = DataNodeRuntime::new_without_workers_with_options(
+        engine,
+        DataNodeRuntimeOptions {
+            worker_threads: 0,
+            max_queue_depth: 4,
+            max_background_queue_depth: 2,
+        },
+    );
+    let options = StorageManagerOptions::default();
+    let mut written = 0usize;
+    let mut removed = 0usize;
+    for _ in 0..ROUNDS {
+        let engine = runtime.engine();
+        for index in 0..BATCH {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("quarantine-{:06}", (written + index) % KEYSPACE),
+                    value: vec![b'v'; 96],
+                },
+            });
+        }
+        written += BATCH;
+        let report = runtime.run_storage_manager_once(1, options.clone());
+        if let Some(gc) = report.gc_report.as_ref() {
+            removed = removed.saturating_add(gc.block_slabs_removed);
+        }
+    }
+
+    // The denominator. Nothing below means anything if the stage reclaimed nothing.
+    assert!(
+        removed > 0,
+        "the stage reclaimed no slabs, so this measures nothing about how it disposes of them"
+    );
+
+    // Purging with a zero minimum age reports exactly what the stage left in quarantine. The
+    // loop's own purge cannot have taken them: it uses the one-hour minimum.
+    let quarantined = runtime
+        .engine()
+        .block_store()
+        .purge_delayed_destroy_slabs_older_than(0)
+        .map(|report| report.purged_block_slab_ids.len())
+        .unwrap_or(0);
+    assert!(
+        quarantined > 0,
+        "reclaimed {removed} slabs and quarantined none of them -- the stage unlinked them outright"
     );
 }


### PR DESCRIPTION
The `reclaim_page` stage reached `gc_slabs_before_with_live_refs`, which unlinks a reclaimed slab
there and then. The storage-manager cycle has always reached the delayed-destroy entry instead, so
a slab it reclaimed stayed on disk until a later purge and could be recovered if the retain floor
turned out to have been computed too generously. The periodic loop had no such second chance.

`GcRequest` gains one field, defaulting to today's behaviour, and only the periodic stage opts in.
An operator collecting by hand keeps the immediate unlink — the space is usually why they called.

## What I set out to ship and did not

I expected this to be two changes, the second being the **garbage floor**: the cycle passes
`BlockStoreGcPolicy::with_slab_garbage_floor(4_000, None)` and the periodic path passes no policy
at all, which reads like a clear difference. It is not one, and the probe added here is why.

The floor is compared against a **band's** live fraction, and a band's used bytes sum only the
slabs in it that are not collectable. `band_id_for_slab` is the identity function, so every band
holds exactly one slab — and a candidate is by definition below the retention floor, not current,
and not live, so its band's used bytes are zero:

```
     slab   total_b    used_b   utility_bp   garbage_bp   floor_keeps_it
        4     54000         0            0        10000   false
        5     54000         0            0        10000   false
  VERDICT: the floor excluded 0 of 2 candidates
```

Every candidate sits at 10,000 basis points of garbage and clears every possible floor. The
control cannot exclude anything today, on the cycle's path as much as the loop's, so wiring it
through would have added a knob that does nothing while claiming a difference had been closed.
It is documented on `with_slab_garbage_floor` and left alone; it starts to bite the moment a band
holds more than one slab, which is what it was built for.

Two smaller corrections in the same area, both from checking rather than reading: `max_destroy_slabs: 0`
means **unbounded**, not "select nothing" — the plan tests `policy.max_destroy_slabs > 0` before
applying a budget — and no caller anywhere sets it non-zero, so the destroy budget is a
declared-and-never-set knob on every path rather than a periodic-only hole.

## The trade-off this accepts

`DELAYED_DESTROY_MIN_AGE_MS` is one hour, so space the stage reclaims now comes back an hour later
rather than at once. `removed_physical_bytes` is incremented before the quarantine branch, so the
stage reports those bytes as removed while the files are still in the trash directory;
`delayed_destroy_physical_bytes` reports the same bytes separately, and the cycle has always had
this property. Quarantined slabs are still collected: the prepare stage passes
`purge_delayed_destroy` whenever page GC is enabled, and `reclaim_index` passes it unconditionally.
This trades prompt space for recoverability — it does not leak.

## Verification

A guard that fails if the wiring is dropped, with a denominator assertion first so it cannot pass
on a run that reclaimed nothing. Its fixture overwrites a small key space on purpose: with
insert-only traffic every slab stays live, nothing is reclaimed, and the disposal assertion would
be measuring an empty run.

`cargo test -p temporalstore-rust --lib -- --test-threads=1` — see below.

 → **1767 passed, 1 failed**. The one
failure is , the standing 
baseline failure on main. No new failure name.

The guard is mutation-verified: flipping the pass-through to  fails it with
"reclaimed 4 slabs and quarantined none of them -- the stage unlinked them outright", and the
denominator assertion ahead of it confirms the fixture did real work rather than passing empty.
