### PR TITLE
Evict runs beside expire, not at the end of the round

### DIFF
--- a/crates/temporalstore-rust/src/data_node/runtime_storage.rs
+++ b/crates/temporalstore-rust/src/data_node/runtime_storage.rs
@@ -414,6 +414,53 @@ impl DataNodeRuntime {
             (!options.enable_expire).then(|| "expire_disabled".to_string()),
         ));
 
+        // Evict, when the operator has asked for it -- beside expire, and before the stages
+        // that rewrite pages.
+        //
+        // Expire drops what has died of old age and evict drops what is merely cold; they are two
+        // halves of relieving memory, and the design runs them together at this point in the
+        // round. This stage ran LAST, after the metrics reap, which put it after every stage that
+        // rewrites pages: it decided what to drop from a state compaction had just churned, and
+        // the memory it frees arrived too late to spare those stages any work. It has no data
+        // dependency on any of them -- it reads options and engine state only -- so the position
+        // was incidental.
+        //
+        // reclaim_memory above relieves memory by invalidating cached pages, which frees the cache
+        // and leaves the index untouched. This is the stage that can actually free a bucket -- and
+        // dump it first, so freeing does not strand the log.
+        let eviction = options.enable_evict.then(|| {
+            self.inner.engine.apply_storage_eviction(
+                shard_id,
+                options.eviction_memory_pressure_threshold,
+                options.eviction_batch_limit,
+                options.eviction_dump_before_evict,
+                options.eviction_delete_drop,
+            )
+        });
+        if eviction.is_some() {
+            executed_stages.push("evict".to_string());
+            self.inner
+                .stats
+                .lock()
+                .expect("data node stats lock poisoned")
+                .storage_manager_evict_runs += 1;
+        } else {
+            skipped_stages.push("evict_disabled".to_string());
+        }
+        pressure_decisions.push(storage_manager_pressure_decision(
+            "evict",
+            options.enable_evict,
+            true,
+            options.enable_evict,
+            vec![storage_manager_pressure_signal(
+                "cache_memory_bytes",
+                options.eviction_memory_pressure_threshold,
+                1,
+            )],
+            vec!["operator_enabled_eviction".to_string()],
+            (!options.enable_evict).then(|| "evict_disabled".to_string()),
+        ));
+
         if options.enable_page_gc && stale_page_pressure {
             let retain_block_slabs_from_id = lifecycle_plan
                 .stale_block_slab_ids
@@ -728,43 +775,6 @@ impl DataNodeRuntime {
             (!options.enable_metrics_reap).then(|| "reap_metrics_disabled".to_string()),
         ));
 
-        // Evict, when the operator has asked for it.
-        //
-        // The stage above this one relieves memory by invalidating cached pages, which frees the
-        // cache and leaves the index untouched. This is the stage that can actually free a bucket
-        // -- and dump it first, so freeing does not strand the log.
-        let eviction = options.enable_evict.then(|| {
-            self.inner.engine.apply_storage_eviction(
-                shard_id,
-                options.eviction_memory_pressure_threshold,
-                options.eviction_batch_limit,
-                options.eviction_dump_before_evict,
-                options.eviction_delete_drop,
-            )
-        });
-        if eviction.is_some() {
-            executed_stages.push("evict".to_string());
-            self.inner
-                .stats
-                .lock()
-                .expect("data node stats lock poisoned")
-                .storage_manager_evict_runs += 1;
-        } else {
-            skipped_stages.push("evict_disabled".to_string());
-        }
-        pressure_decisions.push(storage_manager_pressure_decision(
-            "evict",
-            options.enable_evict,
-            true,
-            options.enable_evict,
-            vec![storage_manager_pressure_signal(
-                "cache_memory_bytes",
-                options.eviction_memory_pressure_threshold,
-                1,
-            )],
-            vec!["operator_enabled_eviction".to_string()],
-            (!options.enable_evict).then(|| "evict_disabled".to_string()),
-        ));
 
         {
             // Recorded beside the round counter, so every caller gets it: the per-shard

--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -4590,3 +4590,89 @@ fn the_periodic_reclaim_quarantines_what_it_collects() {
         "reclaimed {removed} slabs and quarantined none of them -- the stage unlinked them outright"
     );
 }
+
+/// The maintenance round runs its stages in the intended order.
+///
+/// Every other assertion about stages in this suite asks whether one RAN -- `.any(|s| s == ..)` --
+/// and none of them asks what ran before what, so the round could be reshuffled without a single
+/// test noticing. Two stages have already been in the wrong place: the index reclaim ran after
+/// compaction, and evict ran last of all, after the metrics reap.
+///
+/// Evict's position was the more interesting of the two. Expire drops what has died of old age and
+/// evict drops what is merely cold; they are two halves of relieving memory and belong together,
+/// ahead of the stages that rewrite pages. Running evict last meant it chose victims from a state
+/// compaction had just churned, and the memory it freed arrived too late to spare any of those
+/// stages work.
+///
+/// This pins the sequence itself. It asserts relative order and not an exact list, so a new stage
+/// can be added without editing it -- only MOVING one of these breaks it.
+#[test]
+fn the_maintenance_round_runs_its_stages_in_order() {
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+    let runtime = DataNodeRuntime::new_without_workers_with_options(
+        engine,
+        DataNodeRuntimeOptions {
+            worker_threads: 0,
+            max_queue_depth: 4,
+            max_background_queue_depth: 2,
+        },
+    );
+    for index in 0..600usize {
+        let engine = runtime.engine();
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("order-guard-{:06}", index % 100),
+                value: vec![b'v'; 96],
+            },
+        });
+    }
+    // Every stage on, so the round has something to order. Eviction ships DISABLED, so without
+    // this the evict stage would be absent and the assertion about it would be vacuous.
+    let options = StorageManagerOptions {
+        enable_evict: true,
+        ..StorageManagerOptions::default()
+    };
+    let report = runtime.run_storage_manager_once(1, options);
+    let stages = report.executed_stages.clone();
+
+    // The order the design intends. Some of these are pressure-gated and legitimately skip a
+    // round -- `reclaim_memory` does exactly that on this fixture -- so the check is on the
+    // stages that RAN, in the order they ran. Requiring all nine made the guard fail for a
+    // reason that had nothing to do with ordering.
+    let expected = [
+        "prepare",
+        "reclaim_wal",
+        "reclaim_memory",
+        "expire",
+        "evict",
+        "reclaim_page",
+        "reclaim_index",
+        "compact_pages",
+        "reap_metrics",
+    ];
+    let mut previous: Option<(&str, usize)> = None;
+    for name in expected {
+        let Some(position) = stages.iter().position(|stage| stage == name) else {
+            continue;
+        };
+        if let Some((earlier, earlier_position)) = previous {
+            assert!(
+                earlier_position < position,
+                "{earlier} must run before {name}, but the round executed {stages:?}"
+            );
+        }
+        previous = Some((name, position));
+    }
+
+    // The denominator. Skipping absent stages is what makes the loop above robust, and it is
+    // also what would let it pass a round that ran nothing worth ordering -- so require the
+    // three this change is actually about.
+    for required in ["expire", "evict", "reclaim_page"] {
+        assert!(
+            stages.iter().any(|stage| stage == required),
+            "{required} did not run, so the order assertion above proved nothing: {stages:?}"
+        );
+    }
+}


### PR DESCRIPTION
The maintenance round ran `evict` **last**, after the metrics reap, which put it after every stage
that rewrites pages. The intended sequence relieves memory in one place: expire drops what has died
of old age, evict drops what is merely cold, and both run before the page and index stages.

| intended | ours, before | ours, after |
|---|---|---|
| Prepare | prepare | prepare |
| ReclaimOpLog | reclaim_wal | reclaim_wal |
| ReclaimMemory { TryExpire, TryEvict } | reclaim_memory, expire | reclaim_memory, expire, **evict** |
| ReclaimPage | reclaim_page | reclaim_page |
| ReclaimIndex | reclaim_index | reclaim_index |
| CompactPages | compact_pages | compact_pages |
| ReapMetrics | reap_metrics | reap_metrics |
| — | **evict** | — |

Running evict last had two consequences: it chose victims from a state compaction had just churned,
and the memory it freed arrived too late to spare any of the heavy stages work — the round did its
page GC, index reclaim and compaction under the memory pressure evict was about to relieve.

It moves cleanly. The stage reads options and engine state only, with no dependency on
`reclaim_page`, `reclaim_index`, `compact_pages` or `reap_metrics`; the position was incidental,
from #1467 appending it at the end when it made the stage reachable at all. `enable_evict` ships
false, so no default behaviour changes.

## Why nothing caught this

Every stage assertion in the suite asks whether a stage **ran** — `.any(|s| s == ..)` — and none
asks what ran before what, so the round could be reshuffled without a test noticing. Two stages had
drifted: the index reclaim ran after compaction until #1525, and evict ran last until now. Both were
found by reading the intended sequence, not by a failing test.

So this adds the missing kind of assertion. It checks **relative** order, and only among stages that
actually ran — `reclaim_memory` is pressure-gated and legitimately skips a round, and a first version
that demanded all nine failed for a reason that had nothing to do with ordering. Skipping absent
stages is also what would let it pass a round that ran nothing worth ordering, so it then requires
`expire`, `evict` and `reclaim_page` to have run. It turns eviction on explicitly, because eviction
ships disabled and the assertion about it would otherwise be vacuous.

Verified by mutation: run against `main`, where evict is still last, it fails with

```
evict must run before reclaim_page, but the round executed
["prepare", "reclaim_wal", "expire", "reclaim_page", "reclaim_index", "compact_pages", "reap_metrics", "evict"]
```

## Verification

`cargo test -p temporalstore-rust --lib -- --test-threads=1` → **1768 passed, 1 failed**. The one
failure is `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the standing `--lib`
baseline failure on main. No new failure name.
