### PR TITLE
A page-GC round invalidates what it reclaimed, not the whole shard

### DIFF
--- a/crates/temporalstore-rust/src/data_node.rs
+++ b/crates/temporalstore-rust/src/data_node.rs
@@ -775,6 +775,14 @@ pub struct GcRequest {
     /// hand keeps the immediate unlink, because the space is usually why they called.
     #[serde(default)]
     pub page_gc_delayed_destroy: bool,
+    /// Invalidate only the cache entries for slabs this round actually reclaimed.
+    ///
+    /// Defaults to false, which drops the WHOLE shard's cache -- every memory, pmem and disk
+    /// entry the shard holds, across all three tiers. That is defensible for an operator who
+    /// asked for a collection by hand and wants the caches clean afterwards, so the RPC keeps
+    /// it. It is harder to defend on a loop that runs every thirty seconds.
+    #[serde(default)]
+    pub page_gc_invalidate_removed_slabs_only: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/temporalstore-rust/src/data_node/runtime_storage.rs
+++ b/crates/temporalstore-rust/src/data_node/runtime_storage.rs
@@ -486,6 +486,10 @@ impl DataNodeRuntime {
                     // `purge_delayed_destroy` whenever page GC is on, so quarantined slabs are
                     // still collected -- an hour later, not never.
                     page_gc_delayed_destroy: true,
+                    // This stage ran every round page pressure held, and each run emptied the
+                    // shard's cache outright -- memory, pmem and disk tiers alike -- however few
+                    // slabs it went on to reclaim. Invalidate what was reclaimed instead.
+                    page_gc_invalidate_removed_slabs_only: true,
                 },
             );
             if !response.status.ok {

--- a/crates/temporalstore-rust/src/data_node/task_execution.rs
+++ b/crates/temporalstore-rust/src/data_node/task_execution.rs
@@ -91,13 +91,19 @@ pub(super) fn run_gc_inner(inner: &DataNodeRuntimeInner, request: GcRequest) -> 
     let mut block_slabs_retained_physical_bytes = 0;
     let mut block_slabs_retained_live = 0;
     let mut block_slabs_retained_live_physical_bytes = 0;
-    match inner.engine.cache().invalidate_shard(request.shard_id) {
-        Ok(report) => {
-            cache_entries_removed = report.memory_entries_removed;
-            cache_disk_bytes_removed = report.disk_bytes_removed;
-        }
-        Err(err) => {
-            status = Status::error("cache_gc_failed", &err.to_string());
+    // Dropping the whole shard's cache has to happen BEFORE the collection when it happens at
+    // all: it cannot know what will be reclaimed, so it takes everything. Scoping it to what was
+    // actually reclaimed means doing it after, which is why this is a branch here and a second
+    // block below rather than a narrower call in the same place.
+    if !request.page_gc_invalidate_removed_slabs_only {
+        match inner.engine.cache().invalidate_shard(request.shard_id) {
+            Ok(report) => {
+                cache_entries_removed = report.memory_entries_removed;
+                cache_disk_bytes_removed = report.disk_bytes_removed;
+            }
+            Err(err) => {
+                status = Status::error("cache_gc_failed", &err.to_string());
+            }
         }
     }
     // Both reclaims below delete durable log records on an operator's say-so, and until now
@@ -204,6 +210,33 @@ pub(super) fn run_gc_inner(inner: &DataNodeRuntimeInner, request: GcRequest) -> 
             };
             match gc_result {
                 Ok(report) => {
+                    if request.page_gc_invalidate_removed_slabs_only {
+                        // The entries that went stale are the ones whose slab went away, and
+                        // nothing else in the shard did.
+                        //
+                        // `removed_block_slab_ids` alone, NOT chained with the delayed-destroy
+                        // list: a quarantined slab is pushed onto BOTH, so chaining them -- as the
+                        // cycle does -- visits it twice. Harmless for the invalidation itself,
+                        // which is idempotent, but it would double-count the totals reported here.
+                        for block_slab_id in report.removed_block_slab_ids.iter() {
+                            match inner
+                                .engine
+                                .cache()
+                                .invalidate_page_segment(request.shard_id, *block_slab_id)
+                            {
+                                Ok(cache_report) => {
+                                    cache_entries_removed = cache_entries_removed
+                                        .saturating_add(cache_report.memory_entries_removed);
+                                    cache_disk_bytes_removed = cache_disk_bytes_removed
+                                        .saturating_add(cache_report.disk_bytes_removed);
+                                }
+                                Err(err) => {
+                                    status =
+                                        Status::error("cache_gc_failed", &err.to_string());
+                                }
+                            }
+                        }
+                    }
                     block_slabs_removed = report.removed_block_slab_ids.len();
                     block_slabs_removed_physical_bytes = report.removed_physical_bytes;
                     block_slabs_retained_physical_bytes = report.retained_physical_bytes;

--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -1140,6 +1140,7 @@ fn gc_does_not_clear_the_dirty_scheduling_tracker() {
             retain_index_log_from_sequence: None,
             retain_block_slabs_from_id: None,
             page_gc_delayed_destroy: false,
+            page_gc_invalidate_removed_slabs_only: false,
         },
         RequestController { timeout_ms: 1000 },
     );
@@ -2147,6 +2148,7 @@ fn runtime_gc_reclaims_log_tails_and_reports_counts() {
             retain_index_log_from_sequence: Some(2),
             retain_block_slabs_from_id: Some(2),
             page_gc_delayed_destroy: false,
+            page_gc_invalidate_removed_slabs_only: false,
         },
         RequestController { timeout_ms: 1000 },
     );
@@ -2229,6 +2231,7 @@ fn operator_gc_retains_slabs_referenced_by_dump_manifest() {
             retain_index_log_from_sequence: None,
             retain_block_slabs_from_id: Some(u64::MAX),
             page_gc_delayed_destroy: false,
+            page_gc_invalidate_removed_slabs_only: false,
         },
         RequestController { timeout_ms: 1000 },
     );
@@ -2401,6 +2404,7 @@ fn runtime_honors_inflight_cancellation_before_gc_side_effects() {
             retain_index_log_from_sequence: Some(2),
             retain_block_slabs_from_id: None,
             page_gc_delayed_destroy: false,
+            page_gc_invalidate_removed_slabs_only: false,
         }),
     };
     runtime
@@ -2513,6 +2517,7 @@ fn runtime_rejects_background_work_when_background_queue_is_full() {
             retain_index_log_from_sequence: None,
             retain_block_slabs_from_id: None,
             page_gc_delayed_destroy: false,
+            page_gc_invalidate_removed_slabs_only: false,
         },
         RequestController { timeout_ms: 1000 },
     );
@@ -4675,4 +4680,236 @@ fn the_maintenance_round_runs_its_stages_in_order() {
             "{required} did not run, so the order assertion above proved nothing: {stages:?}"
         );
     }
+}
+
+
+/// Who actually drops the shard cache during a maintenance round? Prints.
+///
+///   cargo test -p temporalstore-rust --lib what_drops_the_shard_cache \
+///       -- --ignored --nocapture --test-threads=1
+///
+/// `run_gc_inner` opens by calling `invalidate_shard`, which empties the whole shard. But
+/// `reclaim_memory` ALSO passes `invalidate_cache: true` and runs earlier in the round, so on any
+/// round where that stage fires the cache is already gone by the time page GC looks at it. This
+/// prints, per round, which stages ran, how warm the cache was, and what each invalidation
+/// actually removed -- so the size of the page-GC drop is measured rather than assumed.
+#[test]
+#[ignore]
+fn what_drops_the_shard_cache() {
+    const BATCH: usize = 300;
+    const ROUNDS: usize = 8;
+    const KEYSPACE: usize = 100;
+
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+    let runtime = DataNodeRuntime::new_without_workers_with_options(
+        engine,
+        DataNodeRuntimeOptions {
+            worker_threads: 0,
+            max_queue_depth: 4,
+            max_background_queue_depth: 2,
+        },
+    );
+    let options = StorageManagerOptions::default();
+
+    eprintln!("  round  warm_bytes  mem_ran  gc_ran  gc_cache_removed  slabs_removed");
+    let mut written = 0usize;
+    for round in 0..ROUNDS {
+        let engine = runtime.engine();
+        for index in 0..BATCH {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("whodrops-{:06}", (written + index) % KEYSPACE),
+                    value: vec![b'v'; 96],
+                },
+            });
+        }
+        written += BATCH;
+        for key_index in 0..KEYSPACE {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringGet {
+                    key: format!("whodrops-{:06}", key_index),
+                },
+            });
+        }
+        let warm = engine.cache().stats().memory_bytes;
+        let report = runtime.run_storage_manager_once(1, options.clone());
+        let mem_ran = report
+            .executed_stages
+            .iter()
+            .any(|stage| stage == "reclaim_memory");
+        let gc_ran = report
+            .executed_stages
+            .iter()
+            .any(|stage| stage == "reclaim_page");
+        let gc_removed = report
+            .gc_report
+            .as_ref()
+            .map(|gc| gc.cache_entries_removed)
+            .unwrap_or(0);
+        let slabs = report
+            .gc_report
+            .as_ref()
+            .map(|gc| gc.block_slabs_removed)
+            .unwrap_or(0);
+        eprintln!(
+            "  {round:>5}  {warm:>10}  {mem_ran:>7}  {gc_ran:>6}  {gc_removed:>16}  {slabs:>13}"
+        );
+    }
+
+    // Scenario two: reclaim_memory SKIPPED.
+    //
+    // That stage is pressure-gated. When it fires it invalidates the whole shard itself, which is
+    // why page GC's own drop removes nothing above. The question this scenario answers is what
+    // page GC does on a round where the earlier stage did NOT run and the cache is still warm.
+    eprintln!("  -- with reclaim_memory disabled --");
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+    let runtime = DataNodeRuntime::new_without_workers_with_options(
+        engine,
+        DataNodeRuntimeOptions {
+            worker_threads: 0,
+            max_queue_depth: 4,
+            max_background_queue_depth: 2,
+        },
+    );
+    let options = StorageManagerOptions {
+        enable_memory_reclaim: false,
+        ..StorageManagerOptions::default()
+    };
+    let mut written = 0usize;
+    for round in 0..ROUNDS {
+        let engine = runtime.engine();
+        for index in 0..BATCH {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("whodrops2-{:06}", (written + index) % KEYSPACE),
+                    value: vec![b'v'; 96],
+                },
+            });
+        }
+        written += BATCH;
+        for key_index in 0..KEYSPACE {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringGet {
+                    key: format!("whodrops2-{:06}", key_index),
+                },
+            });
+        }
+        let warm = engine.cache().stats().memory_bytes;
+        let report = runtime.run_storage_manager_once(1, options.clone());
+        let mem_ran = report
+            .executed_stages
+            .iter()
+            .any(|stage| stage == "reclaim_memory");
+        let gc_ran = report
+            .executed_stages
+            .iter()
+            .any(|stage| stage == "reclaim_page");
+        let gc_removed = report
+            .gc_report
+            .as_ref()
+            .map(|gc| gc.cache_entries_removed)
+            .unwrap_or(0);
+        let slabs = report
+            .gc_report
+            .as_ref()
+            .map(|gc| gc.block_slabs_removed)
+            .unwrap_or(0);
+        eprintln!(
+            "  {round:>5}  {warm:>10}  {mem_ran:>7}  {gc_ran:>6}  {gc_removed:>16}  {slabs:>13}"
+        );
+    }
+}
+
+/// A page-GC round invalidates the slabs it reclaimed, not the whole shard's cache.
+///
+/// `run_gc_inner` opened by calling `invalidate_shard`, which empties every memory, pmem and disk
+/// entry the shard holds. It runs BEFORE the collection, because at that point nothing knows what
+/// will be reclaimed -- so it takes everything, including on a round that goes on to reclaim
+/// nothing at all. The storage-manager cycle has always invalidated per reclaimed slab instead.
+///
+/// `enable_memory_reclaim: false` is load-bearing, not incidental. `reclaim_memory` passes
+/// `invalidate_cache: true` and runs earlier in the round, so when it fires it empties the shard
+/// itself and page GC's drop removes nothing -- measured, zero entries on every round. Two earlier
+/// versions of this guard passed under mutation for exactly that reason: they were watching a
+/// cache that an earlier stage had already emptied. Disabling that stage is what isolates the
+/// behaviour under test. `what_drops_the_shard_cache` prints both arrangements.
+///
+/// The assertion is the invariant that separates them: a round that reclaimed NOTHING must
+/// invalidate nothing. Measured, whole-shard drops 200-400 entries on such a round.
+#[test]
+fn a_page_gc_round_invalidates_only_what_it_reclaimed() {
+    const BATCH: usize = 300;
+    const ROUNDS: usize = 6;
+    const KEYSPACE: usize = 100;
+
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+    let runtime = DataNodeRuntime::new_without_workers_with_options(
+        engine,
+        DataNodeRuntimeOptions {
+            worker_threads: 0,
+            max_queue_depth: 4,
+            max_background_queue_depth: 2,
+        },
+    );
+    let options = StorageManagerOptions {
+        enable_memory_reclaim: false,
+        ..StorageManagerOptions::default()
+    };
+
+    let mut written = 0usize;
+    let mut checked_rounds = 0usize;
+    for _ in 0..ROUNDS {
+        let engine = runtime.engine();
+        for index in 0..BATCH {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("cachescope-{:06}", (written + index) % KEYSPACE),
+                    value: vec![b'v'; 96],
+                },
+            });
+        }
+        written += BATCH;
+        // Warm the cache before each round, so a whole-shard drop always has something to take.
+        for key_index in 0..KEYSPACE {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringGet {
+                    key: format!("cachescope-{:06}", key_index),
+                },
+            });
+        }
+        assert!(
+            engine.cache().stats().memory_bytes > 0,
+            "the cache held nothing after reading every key, so this round proves nothing"
+        );
+
+        let report = runtime.run_storage_manager_once(1, options.clone());
+        let Some(gc) = report.gc_report.as_ref() else {
+            continue;
+        };
+        if gc.block_slabs_removed == 0 {
+            checked_rounds += 1;
+            assert_eq!(
+                gc.cache_entries_removed, 0,
+                "a round that reclaimed no slabs invalidated {} cache entries -- that is the \
+                 whole shard being dropped, not what this round collected",
+                gc.cache_entries_removed
+            );
+        }
+    }
+
+    // The denominator. The assertion only fires on rounds that reclaimed nothing, so without one
+    // of those it checked nothing at all.
+    assert!(
+        checked_rounds > 0,
+        "no round reclaimed zero slabs, so the invariant was never exercised"
+    );
 }


### PR DESCRIPTION
`run_gc_inner` opened by calling `invalidate_shard`, which empties every cache entry the shard
holds — memory, pmem and disk tiers alike. It has to run **before** the collection, because at that
point nothing knows what will be reclaimed, so it takes everything, including on a round that goes
on to reclaim nothing at all. The storage-manager cycle has always invalidated per reclaimed slab.

On the operator RPC that is a defensible reading of "collect garbage on this shard", and it keeps
it: the field added here defaults to the old behaviour. Only the periodic stage opts in.

## How much this actually matters, measured

Less than I first claimed, and the scope belongs in the description rather than left to be implied.

`reclaim_memory` also passes `invalidate_cache: true`, and it runs earlier in the round. When it
fires it empties the shard itself, so page GC's drop finds nothing left and removes **zero**
entries — measured, on every round of an eight-round fixture. On those rounds this change is a
no-op.

It bites on rounds where `reclaim_memory` is skipped, which is pressure-gated and does skip. With
it disabled, on the same fixture (300 writes a round over a 100-key space, cache warmed by reading
every key before each round):

| round | slabs reclaimed | whole-shard | scoped |
|---|---|---|---|
| 0 | 0 | 200 | **0** |
| 1 | 0 | 400 | **0** |
| 2–7 | 1 | 400 | 100–200 |
| cache retained | | 40,500 B | **69,300 B** |

The whole-shard drop discards 200–400 entries on rounds that reclaimed nothing, and the cache never
grows because every round empties it. Scoped, it retains 71% more.

## One detail worth keeping

The loop iterates `removed_block_slab_ids` alone and **not** chained with
`delayed_destroy_block_slab_ids`. A quarantined slab is pushed onto both, so chaining them — as the
cycle does — visits it twice. Harmless for the invalidation, which is idempotent, but it would
double-count the entries and bytes this reports.

## The guard, and two that did not work

`enable_memory_reclaim: false` in the guard is load-bearing, not incidental. Two earlier versions
passed under **mutation** because they were watching a cache an earlier stage had already emptied:

- the first measured `memory_bytes` after the whole round, by which point the dump inside
  `reclaim_page` and then compaction have refilled it — both arrangements left exactly 19,200
  bytes, a number that cannot tell them apart;
- the second used `cache_entries_removed`, the right observable, but still read zero in both arms
  because `reclaim_memory` had already invalidated the shard.

Disabling that stage is what isolates the behaviour under test. The assertion is then the invariant
that separates the two: a round that reclaimed nothing must invalidate nothing. Verified by
mutation — flipping the pass-through fails it with "a round that reclaimed no slabs invalidated 200
cache entries" — and a denominator assertion requires such a round to have happened.

`what_drops_the_shard_cache` prints both arrangements and both scenarios, so the table above is
re-measurable rather than taken on trust.

## Verification

`cargo test -p temporalstore-rust --lib -- --test-threads=1` → **1768 passed, 1 failed**. The one
failure is `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the standing `--lib`
baseline failure on main. No new failure name. The guard was re-checked after rebasing onto #1527,
which reorders the round: it still passes scoped and still fails under mutation.
