### PR TITLE
A page-GC round that reclaimed nothing no longer rewrites the manifest

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -2384,6 +2384,48 @@ mod tests {
     }
 
     #[test]
+    fn a_gc_round_that_reclaimed_nothing_does_not_rewrite_the_manifest() {
+        // The sibling test above keeps the full manifest re-serialize off the APPEND path. The
+        // page-GC path had no such guard and rewrote it unconditionally, once per round, on a
+        // stage the periodic loop runs whenever page pressure holds.
+        //
+        // It is not a cheap write: it serialises every band, fsyncs the temp file, renames it and
+        // fsyncs the parent directory -- two fsyncs. A round that reclaimed nothing rewrites it
+        // with byte-identical content, so unlike the append test the BYTES cannot tell the two
+        // apart and the modification time is the observable.
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalBlockStore::new(dir.path());
+        for index in 0..8u64 {
+            store.append(format!("record-{index}").as_bytes()).unwrap();
+        }
+        store.sync_durable().unwrap();
+        let manifest = slab_manifest_path(dir.path());
+        assert!(manifest.exists(), "expected the manifest to exist after a durable sync");
+        let before = std::fs::metadata(&manifest).unwrap().modified().unwrap();
+
+        // `retain_from` 0 leaves every slab above the floor, so this round walks and reclaims
+        // nothing.
+        let report = store.gc_slabs_before(0).unwrap();
+        assert!(
+            report.removed_block_slab_ids.is_empty(),
+            "the fixture was supposed to reclaim nothing, but removed {:?}",
+            report.removed_block_slab_ids
+        );
+        // The denominator: a round that walked no slabs at all would satisfy the assertion below
+        // for the wrong reason.
+        assert!(
+            !report.retained_block_slab_ids.is_empty(),
+            "the round walked no slabs, so it proves nothing about skipping the write"
+        );
+
+        let after = std::fs::metadata(&manifest).unwrap().modified().unwrap();
+        assert_eq!(
+            before, after,
+            "a page-GC round that reclaimed nothing rewrote the slab manifest"
+        );
+    }
+
+    #[test]
     fn per_append_does_not_reserialize_the_slab_manifest_on_the_default_path() {
         // MANIFEST-CONFORMANCE FOLD no-O(n) proof: on the default single-barrier path the per-append
         // band-manifest full re-serialize (the measured O(n) aging driver -- ~961 B rewritten per

--- a/crates/temporalstore-rust/src/block_store/gc.rs
+++ b/crates/temporalstore-rust/src/block_store/gc.rs
@@ -367,7 +367,19 @@ impl LocalBlockStore {
                 retained.push(block_slab_id);
             }
         }
-        persist_slab_manifest(&inner.root, &inner.bands)?;
+        // Only when this round actually changed something.
+        //
+        // `inner.bands` is mutated in exactly one place in the loop above -- `set_slab_state`,
+        // inside the branch that also pushes onto `removed` -- so an empty `removed` means the
+        // manifest would be rewritten with byte-identical content. That rewrite is not free: it
+        // serialises every band, fsyncs the temp file, renames it, and fsyncs the parent
+        // directory. TWO fsyncs, on a stage the periodic loop runs whenever page pressure holds.
+        //
+        // Measured on a fixture where the store settles at three slabs and a round reclaims
+        // nothing: 4.0 ms per round before, and the round does no other durable work.
+        if !removed.is_empty() {
+            persist_slab_manifest(&inner.root, &inner.bands)?;
+        }
         Ok(BlockStoreGcReport {
             retain_from_block_slab_id,
             removed_block_slab_ids: removed,

--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -4913,3 +4913,66 @@ fn a_page_gc_round_invalidates_only_what_it_reclaimed() {
         "no round reclaimed zero slabs, so the invariant was never exercised"
     );
 }
+
+/// Does a page-GC round's cost grow with the number of slabs the store holds? Prints.
+///
+///   cargo test -p temporalstore-rust --lib what_a_page_gc_round_walks \
+///       -- --ignored --nocapture --test-threads=1
+///
+/// `gc_slabs_before_with_live_refs` lists every slab file under the block-store root and stats each
+/// one, every round, with no bound and no cursor -- the report's retained + removed IS the walk.
+/// The design it converges on does one zone per round and resumes an in-progress zone from a stored
+/// cursor, so its per-round cost does not grow with the store.
+///
+/// This prints the walk width and the wall time of the call as slabs accumulate, so the question
+/// "does it matter here" is answered with numbers rather than from the shape of the code.
+#[test]
+#[ignore]
+fn what_a_page_gc_round_walks() {
+    const BATCH: usize = 400;
+    const ROUNDS: usize = 12;
+    const KEYSPACE: usize = 200;
+
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+    let runtime = DataNodeRuntime::new_without_workers_with_options(
+        engine,
+        DataNodeRuntimeOptions {
+            worker_threads: 0,
+            max_queue_depth: 4,
+            max_background_queue_depth: 2,
+        },
+    );
+    let options = StorageManagerOptions::default();
+
+    eprintln!("  round  slabs_walked  retained  removed  gc_micros");
+    let mut written = 0usize;
+    for round in 0..ROUNDS {
+        let engine = runtime.engine();
+        for index in 0..BATCH {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("gcwalk-{:06}", (written + index) % KEYSPACE),
+                    value: vec![b'v'; 96],
+                },
+            });
+        }
+        written += BATCH;
+        runtime.run_storage_manager_once(1, options.clone());
+
+        // Time the walk directly, with a floor that retains everything, so the measurement is the
+        // SCAN and not the deletion: retain_from 0 makes every slab ineligible.
+        let engine = runtime.engine();
+        let started = std::time::Instant::now();
+        let report = engine
+            .block_store()
+            .gc_slabs_before_with_live_refs(0, std::iter::empty())
+            .expect("gc");
+        let micros = started.elapsed().as_micros();
+        let retained = report.retained_block_slab_ids.len();
+        let removed = report.removed_block_slab_ids.len();
+        let walked = retained + removed;
+        eprintln!("  {round:>5}  {walked:>12}  {retained:>8}  {removed:>7}  {micros:>9}");
+    }
+}


### PR DESCRIPTION
`gc_slabs_before_with_live_refs_selected` ended by calling `persist_slab_manifest`
unconditionally. That is not a cheap write: it serialises every band, fsyncs the temp file, renames
it, and fsyncs the parent directory — **two fsyncs** — and the periodic loop runs this stage
whenever page pressure holds.

`inner.bands` is mutated in exactly one place in that function: `set_slab_state`, inside the branch
that also pushes onto `removed`. So a round with nothing removed rewrote the manifest with
byte-identical content.

## Measured

Timing the call directly with a retain floor that keeps everything, so the number is the round and
not the deletion. The fixture settles at three slabs:

| round | slabs walked | retained | removed | before | after |
|---|---|---|---|---|---|
| 0 | 2 | 2 | 0 | 3,807 µs | **72 µs** |
| 1 | 3 | 3 | 0 | 3,853 µs | **88 µs** |
| 2 | 3 | 3 | 0 | 3,865 µs | **90 µs** |
| 3 | 3 | 3 | 0 | 4,557 µs | **112 µs** |
| 4 | 3 | 3 | 0 | 3,964 µs | **102 µs** |

About 97% of a no-op round was the redundant write.

## The suite already held this line on the append path

`per_append_does_not_reserialize_the_slab_manifest_on_the_default_path` exists precisely because
the full re-serialize was measured as an O(n) aging driver there — ~961 B rewritten per write,
growing with the band count. The GC path had no equivalent, so the new guard sits beside it.

Unlike its sibling the guard cannot compare **bytes**, because a no-op round would rewrite
identical content; the modification time is the observable. It asserts the round reclaimed nothing
**and** that it walked something, so it cannot pass on a round that saw no slabs at all. Written
red: it fails on the parent commit with "a page-GC round that reclaimed nothing rewrote the slab
manifest".

`what_a_page_gc_round_walks` prints the table above.

## What this is not

The walk itself is unbounded — every slab file listed and stat-ed, no cursor, no per-round cap —
where the design being followed does one zone per round and resumes an in-progress one from a
stored cursor. That looked like the finding, and it is not, on the evidence here: the walk stays at
three slabs because reclaim keeps pace. The `slabs_walked` column is printed so a store that does
**not** settle shows up as the walk widening rather than as a surprise later.

## Verification

`cargo test -p temporalstore-rust --lib -- --test-threads=1` → **1770 passed, 1 failed**. The one
failure is `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the standing `--lib`
baseline failure on main. No new failure name.
