### PR TITLE
The older latest context-state variant goes, instead of being adopted

### DIFF
--- a/tools/matrixark_mcp_latest_context_state.py
+++ b/tools/matrixark_mcp_latest_context_state.py
@@ -1,24 +1,32 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 MatrixArkAI
-"""Latest context-state storage helpers for MatrixArk TemporalStore adapters."""
+"""Bundle flattening for MatrixArk TemporalStore adapters.
+
+This module once also held a second copy of the latest context-state adapter methods --
+`LatestContextStateAdapterMixin` and the five module-level helpers it delegated to. They were
+the OLDER variant of the seven methods on `_TemporalDirectBackendMixin`, extracted and then
+never adopted: the mixin was named exactly once in the repository, its own class line.
+
+They are gone rather than shared, and the measurement that decided it is worth keeping: of the
+seven method names the two classes had in common, two bodies agreed and on the other five the
+backend carried logic this copy did not. `latest_context_state_payload` serialised the whole
+record where the backend serialises `slim_persisted_record(record)` first, so adopting the mixin
+would have fattened every latest-state write; `_with_latest_context_state_records` and
+`_split_compacted_latest_context_state` both run on the retrieval hot path. So this was not a
+shared home waiting to be used -- it was the variant the backend had grown past, kept alive only
+by a guard describing it.
+
+`expand_record_bundles` is the one export anything reaches, from
+`matrixark_temporal_direct_backend` and `matrixark_mcp_temporal_adapters`.
+"""
 
 from __future__ import annotations
 
-import json
-
 try:
-    from tools.matrixark_mcp_core import Json, candidate_access_scope, scope_matches
-    from tools.matrixark_mcp_serving_records import (
-        compact_latest_context_state_records,
-        latest_context_state_key,
-    )
+    from tools.matrixark_mcp_core import Json
 except ModuleNotFoundError:  # Direct script execution from tools/.
-    from matrixark_mcp_core import Json, candidate_access_scope, scope_matches
-    from matrixark_mcp_serving_records import (
-        compact_latest_context_state_records,
-        latest_context_state_key,
-    )
+    from matrixark_mcp_core import Json
 
 
 def expand_record_bundles(records: list[Json]) -> list[Json]:
@@ -42,120 +50,3 @@ def expand_record_bundles(records: list[Json]) -> list[Json]:
                 continue
         expanded.append(record)
     return expanded
-
-
-def latest_context_state_storage_key(storage_prefix: str) -> str:
-    return f"{storage_prefix}:context_latest_state"
-
-
-def latest_context_state_field(record: Json) -> str | None:
-    key = latest_context_state_key(record)
-    if key is None:
-        return None
-    return ":".join(str(part) for part in key)
-
-
-def latest_context_state_payload(record: Json) -> str:
-    payload_record = dict(record)
-    payload_record.pop("summary_version_hash", None)
-    return json.dumps(payload_record, sort_keys=True, separators=(",", ":"))
-
-
-def latest_context_state_entries(storage_prefix: str, records: list[Json]) -> list[Json]:
-    entries: list[Json] = []
-    latest_state_key = latest_context_state_storage_key(storage_prefix)
-    for record in compact_latest_context_state_records(records):
-        field = latest_context_state_field(record)
-        if not field:
-            continue
-        entries.append(
-            {
-                "key": latest_state_key,
-                "field": field,
-                "value": latest_context_state_payload(record),
-                "storage_route": record.get("storage_route") if isinstance(record.get("storage_route"), dict) else {},
-            }
-        )
-    return entries
-
-
-def append_log_records_without_latest_state(records: list[Json]) -> list[Json]:
-    return [record for record in records if latest_context_state_key(record) is None]
-
-
-class LatestContextStateAdapterMixin:
-    """Adapter methods for latest context-state storage and retrieval."""
-
-    def _latest_context_state_key(self) -> str:
-        return latest_context_state_storage_key(self._storage_prefix)
-
-    def _latest_context_state_field(self, record: Json) -> str | None:
-        return latest_context_state_field(record)
-
-    def _append_log_records(self, records: list[Json]) -> list[Json]:
-        return append_log_records_without_latest_state(records)
-
-    def _split_compacted_latest_context_state(self, records: list[Json]) -> tuple[list[Json], list[Json]]:
-        latest_state_entries: list[Json] = []
-        append_records_for_log: list[Json] = []
-        for record in records:
-            field = self._latest_context_state_field(record)
-            if not field:
-                append_records_for_log.append(record)
-                continue
-            latest_state_entries.extend(latest_context_state_entries(self._storage_prefix, [record]))
-        return latest_state_entries, append_records_for_log
-
-    def _load_latest_context_state_records(self) -> list[Json]:
-        scanner = getattr(getattr(self, "_client", None), "scan_hash", None)
-        if not callable(scanner):
-            return []
-        try:
-            response = scanner(self._latest_context_state_key())
-        except Exception:
-            return []
-        rows = response.get("records") if isinstance(response, dict) else []
-        records: list[Json] = []
-        for row in rows if isinstance(rows, list) else []:
-            if not isinstance(row, dict):
-                continue
-            value = row.get("value")
-            if not isinstance(value, str) or not value:
-                continue
-            try:
-                decoded = json.loads(value)
-            except Exception:
-                continue
-            if isinstance(decoded, dict):
-                records.append(decoded)
-        return records
-
-    def _with_latest_context_state_records(self, records: list[Json]) -> list[Json]:
-        return compact_latest_context_state_records(
-            expand_record_bundles(records) + self._load_latest_context_state_records()
-        )
-
-    def _latest_context_state_records_for_candidate_scan(
-        self,
-        *,
-        scope: Json,
-        record_types: set[str],
-        selected_node_hashes: set[int] | None,
-    ) -> list[Json]:
-        selected = {int(item) for item in (selected_node_hashes or set())}
-        filtered: list[Json] = []
-        for record in self._load_latest_context_state_records():
-            record_type = str(record.get("record_type") or "")
-            if record_type not in record_types:
-                continue
-            if not scope_matches(candidate_access_scope(record), scope):
-                continue
-            if selected:
-                try:
-                    node_hash = int(record.get("node_hash") or 0)
-                except (TypeError, ValueError):
-                    node_hash = 0
-                if node_hash and node_hash not in selected:
-                    continue
-            filtered.append(record)
-        return filtered

--- a/tools/test_a_nested_helper_has_one_copy_too.py
+++ b/tools/test_a_nested_helper_has_one_copy_too.py
@@ -46,17 +46,6 @@ RECORDED_PAIRS = {
     frozenset({"matrixark_mcp_async_ingest", "matrixark_mcp_session_runtime"}):
         "add_count, 9 statements. BOTH modules are recorded unreachable, so this is dead-vs-dead: "
         "consolidating it would move nothing and would promote one dead copy over another.",
-    frozenset({"matrixark_mcp_latest_context_state", "matrixark_temporal_direct_backend"}):
-        "_load_latest_context_state_records (22 statements) and "
-        "_latest_context_state_records_for_candidate_scan (17), byte-identical. The first copy of "
-        "each is a method on LatestContextStateAdapterMixin, which is named exactly once in the "
-        "repository -- its own class line -- so nothing inherits it. DO NOT resolve this by "
-        "adopting the mixin: the two classes share all SEVEN method names and only these two "
-        "bodies agree. On the other five the backend is the richer copy, and adopting would "
-        "revert _with_latest_context_state_records and _split_compacted_latest_context_state, "
-        "both of which run on the retrieval hot path. The mixin is the older variant the backend "
-        "has since grown past, not a shared home waiting to be used. See "
-        "test_the_unadopted_mixin_is_still_unadopted.",
 }
 
 
@@ -166,32 +155,31 @@ class ANestedHelperHasOneCopyToo(unittest.TestCase):
             "these are recorded as duplicated but no longer are -- take them out, so the list "
             "cannot carry a name that hides the next one: %s" % "; ".join(stale))
 
-    def test_the_unadopted_mixin_is_still_unadopted(self):
-        """Adopting LatestContextStateAdapterMixin would revert five methods, not share two.
+    def test_the_older_latest_state_variant_does_not_come_back(self):
+        """The seven latest context-state methods have one home, and it is the backend.
 
-        The obvious reading of the pair above is "the backend should inherit the mixin". It should
-        not. Measured: the two classes share all seven method names, two bodies are identical, and
-        on the other five the backend carries logic the mixin does not -- including the two that
-        run on the retrieval hot path. So this fails the moment anything inherits the mixin,
-        because at that point those five must be reconciled first.
+        `LatestContextStateAdapterMixin` used to carry a second copy of all seven, extracted and
+        never adopted -- named exactly once in the repository, its own class line. This entry
+        used to read "do not resolve this by adopting the mixin", because two of the seven bodies
+        agreed and on the other five the backend carried logic the mixin did not: the mixin's
+        `latest_context_state_payload` serialised the whole record where the backend serialises
+        `slim_persisted_record(record)` first, and `_with_latest_context_state_records` and
+        `_split_compacted_latest_context_state` both run on the retrieval hot path.
+
+        So the copy went instead of being shared, and this is what keeps it gone. A guard that
+        only DESCRIBES dead code also keeps it reachable to a word scan, which is how twelve
+        definitions stayed off the reachability list next door.
         """
         sources = _production_sources()
-        mixin_name = "LatestContextStateAdapterMixin"
-        inheritors = []
-        for stem, tree in sources.items():
-            for node in ast.walk(tree):
-                if not isinstance(node, ast.ClassDef):
-                    continue
-                for base in node.bases:
-                    if ast.unparse(base).split(".")[-1] == mixin_name:
-                        inheritors.append("%s.%s" % (stem, node.name))
+        carrying = sorted(
+            stem for stem, tree in sources.items()
+            if any(isinstance(node, ast.ClassDef) and node.name == "LatestContextStateAdapterMixin"
+                   for node in ast.walk(tree)))
         self.assertEqual(
-            [], sorted(inheritors),
-            "%s is now inherited by %s. Five of its seven methods are the OLDER variant of the "
-            "backend's -- reconcile _append_log_records, _latest_context_state_field, "
-            "_latest_context_state_key, _split_compacted_latest_context_state and "
-            "_with_latest_context_state_records before this lands, or the hot-path versions are "
-            "reverted." % (mixin_name, ", ".join(sorted(inheritors))))
+            [], carrying,
+            "%s is defined again in %s. The backend's seven methods are the variant that ships; "
+            "a second copy of them is not a shared home, it is the older one."
+            % ("LatestContextStateAdapterMixin", ", ".join(carrying)))
 
     def test_every_recorded_pair_says_why(self):
         thin = sorted(" + ".join(sorted(modules)) for modules, reason in RECORDED_PAIRS.items()

--- a/tools/test_latest_state_key_agreement.py
+++ b/tools/test_latest_state_key_agreement.py
@@ -24,7 +24,11 @@ MODULES = (
     # application's own import order to resolve a cycle, and fail the same way on pristine main.
     "matrixark_mcp_serving_records",
     "matrixark_mcp_core_compact",
-    "matrixark_mcp_latest_context_state",
+    # `matrixark_mcp_latest_context_state` was a third name here. It never implemented the
+    # function -- it imported it for a mixin that nothing inherited, and both went together with
+    # that mixin. A module that does not resolve the name cannot be the one the write path picks
+    # up, so dropping it costs no coverage; the two that CAN disagree are both still here, and
+    # `_resolved_all` below fails if either stops resolving it.
 )
 
 # One per record type that carries an identity, plus one that must not.


### PR DESCRIPTION
`LatestContextStateAdapterMixin` and the five module-level helpers it delegated to were a second
copy of the seven latest context-state methods on `_TemporalDirectBackendMixin`. The mixin was
named **exactly once in the repository -- its own class line** -- so nothing inherited it, and the
five helpers were reached only from inside it. **Twelve definitions, 161 lines down to 52.**

### The guard was right, and that is why the copy goes

`test_a_nested_helper_has_one_copy_too` recorded this pair with "DO NOT resolve this by adopting
the mixin". It was correct: two of the seven bodies agreed and on the other five the backend
carries logic this copy does not.

| method | what the copy lacked |
|---|---|
| `latest_context_state_payload` | serialises the whole record; the backend serialises `slim_persisted_record(record)` first, so adopting would fatten every latest-state write |
| `_with_latest_context_state_records` | runs on the retrieval hot path, and carries the measurement that corrected the proxy-wedge attribution |
| `_split_compacted_latest_context_state` | also hot path |

The third option the entry did not take is the one here: **delete the older variant.** The
measurement moves into the module docstring and into the test that replaces the do-not-adopt
guard, so nothing that was known is lost.

### Why it stayed invisible

`test_a_definition_nothing_reaches` never listed these twelve. Its corpus is a word scan over
every tracked file, and the do-not-adopt guard's own prose names the mixin -- so a guard
*describing* dead code kept it reachable. Worth knowing about that scan; deleting the code
settles this instance of it either way.

### One test participant narrowed

`test_latest_state_key_agreement` listed this module third. It never implemented
`latest_context_state_key` -- it imported it for the mixin. A module that does not resolve the
name cannot be the one the write path picks up, so **both modules that can actually disagree are
still checked**, and `_resolved_all` still fails if either stops resolving it.

### Verified

The 42 suites naming `latest_context_state`, `expand_record_bundles`, `record_bundle`,
`_TemporalDirectBackendMixin` or the temporal adapters: **343 tests, 11 failures, the same 11 by
name on pristine main, none new.**