### PR TITLE
The gate scripts share one vocabulary, and the duplicate check can finally see them

### DIFF
--- a/tools/matrixark_validation_requirements.py
+++ b/tools/matrixark_validation_requirements.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The shape checks the `validate_*` gates share, with one copy of each.
+
+Two vocabularies live here, and they differ in how they refuse:
+
+* the ``require_*`` report-field checks raise ``ValueError``, which their caller's ``main``
+  catches and turns into that script's own ``fail`` line, so the message keeps naming the gate
+  it came from;
+* ``require_snippets`` reads a FILE rather than a report field and raises ``SystemExit``
+  directly, because its callers count return values and have no error funnel.
+
+They are together because they are one vocabulary for one kind of script, not because the
+contracts match -- and saying which is which here is cheaper than discovering it at a call site.
+
+``ROOT`` is the repository root, computed the way every gate that used to carry its own copy of
+``require_snippets`` computed it. That is not incidental: a body that reads a module-scope
+constant only moves safely when the constant resolves to the same value in its new home, and
+this module sits in ``tools/`` beside the scripts it serves, so ``parents[1]`` is the same
+directory it was.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_report(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            report = json.load(handle)
+    except FileNotFoundError:
+        raise ValueError(f"report not found: {path}")
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"report is not valid JSON: {exc}") from exc
+    if not isinstance(report, dict):
+        raise ValueError("report root must be a JSON object")
+    return report
+
+
+def require_bool(report: dict[str, Any], field: str) -> bool:
+    value = report.get(field)
+    if value is not True:
+        raise ValueError(f"{field} must be true, got {value!r}")
+    return True
+
+
+def require_int_at_least(report: dict[str, Any], field: str, minimum: int) -> int:
+    value = report.get(field)
+    if not isinstance(value, int):
+        raise ValueError(f"{field} must be an integer, got {value!r}")
+    if value < minimum:
+        raise ValueError(f"{field} must be >= {minimum}, got {value}")
+    return value
+
+
+def require_int_between(report: dict[str, Any], field: str, minimum: int, maximum: int) -> int:
+    value = report.get(field)
+    if not isinstance(value, int):
+        raise ValueError(f"{field} must be an integer, got {value!r}")
+    if value < minimum or value > maximum:
+        raise ValueError(f"{field} must be between {minimum} and {maximum}, got {value}")
+    return value
+
+
+def require_int_equal(report: dict[str, Any], field: str, expected: int) -> None:
+    value = report.get(field)
+    if value != expected:
+        raise ValueError(f"{field} must be {expected}, got {value!r}")
+
+
+def require_string_set(report: dict[str, Any], field: str, required: set[str]) -> set[str]:
+    value = report.get(field)
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"{field} must be a string array")
+    observed = set(value)
+    missing = sorted(required - observed)
+    if missing:
+        raise ValueError(f"{field} missing required entries: {missing}")
+    return observed
+
+
+def require_int_map(report: dict[str, Any], field: str) -> dict[str, int]:
+    value = report.get(field)
+    if not isinstance(value, dict):
+        raise ValueError(f"{field} must be an object")
+    bad_items = {
+        key: item
+        for key, item in value.items()
+        if not isinstance(key, str) or not isinstance(item, int)
+    }
+    if bad_items:
+        raise ValueError(f"{field} must map strings to integers, got {bad_items!r}")
+    return value
+
+
+def require_map_keys_at_least(
+    report: dict[str, Any], field: str, required: set[str], minimum: int
+) -> dict[str, Any]:
+    value = report.get(field)
+    if not isinstance(value, dict):
+        raise ValueError(f"{field} must be an object")
+    missing = sorted(required - set(value))
+    if missing:
+        raise ValueError(f"{field} missing required keys: {missing}")
+    too_small = {
+        key: value.get(key)
+        for key in sorted(required)
+        if not isinstance(value.get(key), int) or value.get(key) < minimum
+    }
+    if too_small:
+        raise ValueError(f"{field} entries must be >= {minimum}: {too_small}")
+    return value
+
+
+def require_distribution_count(report: dict[str, Any], field: str, key: str, expected: int) -> None:
+    value = report.get(field)
+    if not isinstance(value, dict):
+        raise ValueError(f"{field} must be an object")
+    observed = value.get(key, 0)
+    if observed != expected:
+        raise ValueError(f"{field}[{key!r}] must be {expected}, got {observed!r}")
+
+
+def require_snippets(path: Path, snippets: tuple[str, ...], label: str) -> int:
+    if not path.exists():
+        raise SystemExit(f"{label}: missing {path.relative_to(ROOT)}")
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    missing = [snippet for snippet in snippets if snippet not in text]
+    if missing:
+        raise SystemExit(
+            f"{label}: {path.relative_to(ROOT)} missing snippets: {', '.join(missing)}"
+        )
+    return len(snippets)

--- a/tools/test_a_definition_nothing_reaches.py
+++ b/tools/test_a_definition_nothing_reaches.py
@@ -137,8 +137,10 @@ UNREACHED = {
         "model_registry_map",
     ),
     # `require_int_between` stays for the same reason as the cache clearer above: its neighbour
-    # `require_string_set` is used, and half a validation vocabulary is worse than all of it.
-    "validate_context_resource_skill_scale.py": ("require_int_between",),
+    # `require_string_set` is used, and half a validation vocabulary is worse than all of it. It
+    # moved here when the gates stopped each carrying their own copy of that vocabulary, and the
+    # reason reads better from the shared home than it did from one of the two scripts.
+    "matrixark_validation_requirements.py": ("require_int_between",),
 }
 
 

--- a/tools/test_there_is_one_copy_of_each_helper.py
+++ b/tools/test_there_is_one_copy_of_each_helper.py
@@ -36,6 +36,19 @@ MIN_BODY_STATEMENTS = 4
 #: helper that exists to bootstrap importing cannot itself be imported from a shared module.
 NON_PRODUCTION_PREFIXES = ("test_", "run_", "validate_")
 
+#: The same list, minus the gate scripts -- used by the FUNCTION-BODY check below and by nothing
+#: else. The distinction is the point of the split: a `run_` or `validate_` script's module-scope
+#: constants are its own configuration, so two gates each naming `REQUIRED_DOC_SNIPPETS` for their
+#: own document is not drift and the constant checks would report it as if it were. A copied
+#: FUNCTION body is a copied helper wherever it sits.
+#:
+#: Leaving the gates out of the body check as well was the exclusion doing more than its reason:
+#: 75 scripts carrying 855 definitions sat outside every duplicate check in the tree. Including
+#: them here takes this one corpus from 217 modules to 292, and it found five copied bodies --
+#: every one a `require_*` shape check that both context gates or both readiness gates had
+#: written out twice. They live once now, in `matrixark_validation_requirements`.
+BODY_CHECK_PREFIXES = ("test_",)
+
 #: Empty, and meant to stay that way. It held thirty-three pairs: every one is now a single
 #: definition that the other module re-exports or delegates to.
 #:
@@ -88,10 +101,19 @@ def _tracked_production_modules() -> list[str]:
     return out
 
 
+def _tracked_modules_with_gates() -> list[str]:
+    """`_tracked_production_modules` plus the `run_` and `validate_` gate scripts."""
+    listed = subprocess.run(
+        ["git", "ls-files", "tools/*.py"], cwd=REPO_ROOT,
+        capture_output=True, text=True, check=False).stdout.split()
+    return [rel for rel in listed
+            if not os.path.basename(rel).startswith(BODY_CHECK_PREFIXES)]
+
+
 def _duplicate_pairs() -> set[tuple[str, tuple[str, ...]]]:
-    """Every function body that appears at module scope in more than one production module."""
+    """Every function body that appears at module scope in more than one non-test module."""
     by_shape: dict[str, list[tuple[str, str]]] = {}
-    for rel in _tracked_production_modules():
+    for rel in _tracked_modules_with_gates():
         try:
             with open(os.path.join(REPO_ROOT, rel), encoding="utf-8", errors="replace") as handle:
                 tree = ast.parse(handle.read())

--- a/tools/validate_context_multi_agent_scan.py
+++ b/tools/validate_context_multi_agent_scan.py
@@ -6,10 +6,30 @@
 from __future__ import annotations
 
 import argparse
-import json
 import sys
 from pathlib import Path
 from typing import Any
+
+try:
+    from tools.matrixark_validation_requirements import (
+        load_report,
+        require_bool,
+        require_distribution_count,
+        require_int_at_least,
+        require_int_equal,
+        require_int_map,
+        require_string_set,
+    )
+except ModuleNotFoundError:  # Direct script execution from tools/.
+    from matrixark_validation_requirements import (
+        load_report,
+        require_bool,
+        require_distribution_count,
+        require_int_at_least,
+        require_int_equal,
+        require_int_map,
+        require_string_set,
+    )
 
 
 REQUIRED_LAYERS = {"agent", "user", "workspace", "global"}
@@ -20,75 +40,6 @@ REQUIRED_SELECTED_SCOPE_KEYS = {"agent:codex", "user:user", "workspace:context",
 def fail(message: str) -> int:
     print(f"context multi-agent scan validation failed: {message}", file=sys.stderr)
     return 1
-
-
-def load_report(path: Path) -> dict[str, Any]:
-    try:
-        with path.open("r", encoding="utf-8") as handle:
-            report = json.load(handle)
-    except FileNotFoundError:
-        raise ValueError(f"report not found: {path}")
-    except json.JSONDecodeError as exc:
-        raise ValueError(f"report is not valid JSON: {exc}") from exc
-    if not isinstance(report, dict):
-        raise ValueError("report root must be a JSON object")
-    return report
-
-
-def require_bool(report: dict[str, Any], field: str) -> bool:
-    value = report.get(field)
-    if value is not True:
-        raise ValueError(f"{field} must be true, got {value!r}")
-    return True
-
-
-def require_int_at_least(report: dict[str, Any], field: str, minimum: int) -> int:
-    value = report.get(field)
-    if not isinstance(value, int):
-        raise ValueError(f"{field} must be an integer, got {value!r}")
-    if value < minimum:
-        raise ValueError(f"{field} must be >= {minimum}, got {value}")
-    return value
-
-
-def require_string_set(report: dict[str, Any], field: str, required: set[str]) -> set[str]:
-    value = report.get(field)
-    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
-        raise ValueError(f"{field} must be a string array")
-    observed = set(value)
-    missing = sorted(required - observed)
-    if missing:
-        raise ValueError(f"{field} missing required entries: {missing}")
-    return observed
-
-
-def require_int_equal(report: dict[str, Any], field: str, expected: int) -> None:
-    value = report.get(field)
-    if value != expected:
-        raise ValueError(f"{field} must be {expected}, got {value!r}")
-
-
-def require_distribution_count(report: dict[str, Any], field: str, key: str, expected: int) -> None:
-    value = report.get(field)
-    if not isinstance(value, dict):
-        raise ValueError(f"{field} must be an object")
-    observed = value.get(key, 0)
-    if observed != expected:
-        raise ValueError(f"{field}[{key!r}] must be {expected}, got {observed!r}")
-
-
-def require_int_map(report: dict[str, Any], field: str) -> dict[str, int]:
-    value = report.get(field)
-    if not isinstance(value, dict):
-        raise ValueError(f"{field} must be an object")
-    bad_items = {
-        key: item
-        for key, item in value.items()
-        if not isinstance(key, str) or not isinstance(item, int)
-    }
-    if bad_items:
-        raise ValueError(f"{field} must map strings to integers, got {bad_items!r}")
-    return value
 
 
 def validate_report(report: dict[str, Any], min_candidates: int, max_expanded: int) -> None:

--- a/tools/validate_context_resource_skill_scale.py
+++ b/tools/validate_context_resource_skill_scale.py
@@ -6,10 +6,32 @@
 from __future__ import annotations
 
 import argparse
-import json
 import sys
 from pathlib import Path
 from typing import Any
+
+try:
+    from tools.matrixark_validation_requirements import (
+        load_report,
+        require_bool,
+        require_distribution_count,
+        require_int_at_least,
+        require_int_equal,
+        require_int_map,
+        require_map_keys_at_least,
+        require_string_set,
+    )
+except ModuleNotFoundError:  # Direct script execution from tools/.
+    from matrixark_validation_requirements import (
+        load_report,
+        require_bool,
+        require_distribution_count,
+        require_int_at_least,
+        require_int_equal,
+        require_int_map,
+        require_map_keys_at_least,
+        require_string_set,
+    )
 
 REQUIRED_LAYERS = {"agent", "user", "workspace", "global"}
 REQUIRED_GROUPS = {"global", "user:user", "workspace:context"}
@@ -28,100 +50,6 @@ REQUIRED_REQUESTED_SOURCE_CLASSES = {"resource", "skill"}
 def fail(message: str) -> int:
     print(f"context resource/skill scale validation failed: {message}", file=sys.stderr)
     return 1
-
-
-def load_report(path: Path) -> dict[str, Any]:
-    try:
-        report = json.loads(path.read_text(encoding="utf-8"))
-    except FileNotFoundError:
-        raise ValueError(f"report not found: {path}")
-    except json.JSONDecodeError as exc:
-        raise ValueError(f"report is not valid JSON: {exc}") from exc
-    if not isinstance(report, dict):
-        raise ValueError("report root must be a JSON object")
-    return report
-
-
-def require_bool(report: dict[str, Any], field: str) -> None:
-    if report.get(field) is not True:
-        raise ValueError(f"{field} must be true, got {report.get(field)!r}")
-
-
-def require_int_at_least(report: dict[str, Any], field: str, minimum: int) -> int:
-    value = report.get(field)
-    if not isinstance(value, int):
-        raise ValueError(f"{field} must be an integer, got {value!r}")
-    if value < minimum:
-        raise ValueError(f"{field} must be >= {minimum}, got {value}")
-    return value
-
-
-def require_int_equal(report: dict[str, Any], field: str, expected: int) -> None:
-    value = report.get(field)
-    if value != expected:
-        raise ValueError(f"{field} must be {expected}, got {value!r}")
-
-
-def require_int_between(report: dict[str, Any], field: str, minimum: int, maximum: int) -> int:
-    value = report.get(field)
-    if not isinstance(value, int):
-        raise ValueError(f"{field} must be an integer, got {value!r}")
-    if value < minimum or value > maximum:
-        raise ValueError(f"{field} must be between {minimum} and {maximum}, got {value}")
-    return value
-
-
-def require_string_set(report: dict[str, Any], field: str, required: set[str]) -> set[str]:
-    value = report.get(field)
-    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
-        raise ValueError(f"{field} must be a string array")
-    observed = set(value)
-    missing = sorted(required - observed)
-    if missing:
-        raise ValueError(f"{field} missing required entries: {missing}")
-    return observed
-
-
-def require_map_keys_at_least(
-    report: dict[str, Any], field: str, required: set[str], minimum: int
-) -> dict[str, Any]:
-    value = report.get(field)
-    if not isinstance(value, dict):
-        raise ValueError(f"{field} must be an object")
-    missing = sorted(required - set(value))
-    if missing:
-        raise ValueError(f"{field} missing required keys: {missing}")
-    too_small = {
-        key: value.get(key)
-        for key in sorted(required)
-        if not isinstance(value.get(key), int) or value.get(key) < minimum
-    }
-    if too_small:
-        raise ValueError(f"{field} entries must be >= {minimum}: {too_small}")
-    return value
-
-
-def require_int_map(report: dict[str, Any], field: str) -> dict[str, int]:
-    value = report.get(field)
-    if not isinstance(value, dict):
-        raise ValueError(f"{field} must be an object")
-    bad_items = {
-        key: item
-        for key, item in value.items()
-        if not isinstance(key, str) or not isinstance(item, int)
-    }
-    if bad_items:
-        raise ValueError(f"{field} must map strings to integers, got {bad_items!r}")
-    return value
-
-
-def require_distribution_count(report: dict[str, Any], field: str, key: str, expected: int) -> None:
-    value = report.get(field)
-    if not isinstance(value, dict):
-        raise ValueError(f"{field} must be an object")
-    observed = value.get(key, 0)
-    if observed != expected:
-        raise ValueError(f"{field}[{key!r}] must be {expected}, got {observed!r}")
 
 
 def validate_report(report: dict[str, Any], min_sources: int, max_expanded: int) -> None:

--- a/tools/validate_metaserver_production_meta_management.py
+++ b/tools/validate_metaserver_production_meta_management.py
@@ -12,6 +12,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
+try:
+    from tools.matrixark_validation_requirements import (
+        require_snippets,
+    )
+except ModuleNotFoundError:  # Direct script execution from tools/.
+    from matrixark_validation_requirements import (
+        require_snippets,
+    )
+
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -81,18 +90,6 @@ REQUIRED_DOC_SNIPPETS = (
     "Server heartbeat/liveness feeds scheduler repair decisions",
     "No-majority writes fail closed",
 )
-
-
-def require_snippets(path: Path, snippets: tuple[str, ...], label: str) -> int:
-    if not path.exists():
-        raise SystemExit(f"{label}: missing {path.relative_to(ROOT)}")
-    text = path.read_text(encoding="utf-8", errors="ignore")
-    missing = [snippet for snippet in snippets if snippet not in text]
-    if missing:
-        raise SystemExit(
-            f"{label}: {path.relative_to(ROOT)} missing snippets: {', '.join(missing)}"
-        )
-    return len(snippets)
 
 
 def main() -> None:

--- a/tools/validate_storage_raft_production_plan.py
+++ b/tools/validate_storage_raft_production_plan.py
@@ -7,6 +7,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
+try:
+    from tools.matrixark_validation_requirements import (
+        require_snippets,
+    )
+except ModuleNotFoundError:  # Direct script execution from tools/.
+    from matrixark_validation_requirements import (
+        require_snippets,
+    )
+
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -92,18 +101,6 @@ REQUIRED_SCALE_SLO_SNIPPETS = (
     "p99_write_us",
     "error_budget_remaining_percent",
 )
-
-
-def require_snippets(path: Path, snippets: tuple[str, ...], label: str) -> int:
-    if not path.exists():
-        raise SystemExit(f"{label}: missing {path.relative_to(ROOT)}")
-    text = path.read_text(encoding="utf-8", errors="ignore")
-    missing = [snippet for snippet in snippets if snippet not in text]
-    if missing:
-        raise SystemExit(
-            f"{label}: {path.relative_to(ROOT)} missing snippets: {', '.join(missing)}"
-        )
-    return len(snippets)
 
 
 def main() -> None:


### PR DESCRIPTION
`test_there_is_one_copy_of_each_helper` excluded `test_`, `run_` and `validate_` under one
sentence: *test modules repeat fixtures on purpose.* That reason covers test modules. It does not
cover a gate script, which is not a fixture and imports like any other module -- and **75 of them
carrying 855 definitions sat outside every duplicate check in the tree.**

### The exclusion is split, not dropped

Widening the whole file reported seven constants and three compiled patterns as duplicated. Most
were not duplication at all: a gate script module-scope constant **is** its own configuration, and
two readiness gates each naming `REQUIRED_DOC_SNIPPETS` for their own document is not drift. A
copied FUNCTION body is a copied helper wherever it sits.

So `BODY_CHECK_PREFIXES` excludes only `test_`, and the **body check alone** reads the gates:
**217 modules to 292.** The constant and pattern checks keep the corpus they had.

### What it found

Five copied bodies, every one a `require_*` shape check written out twice:

| body | copies |
|---|---|
| `require_string_set`, `require_int_map`, `require_int_at_least`, `require_distribution_count` | both context gates |
| `require_snippets` | both readiness gates |

They live once now, in `tools/matrixark_validation_requirements`, with the rest of the vocabulary
those four scripts had each spelled out: `load_report`, `require_bool`, `require_int_equal`,
`require_int_between`, `require_map_keys_at_least`. **Eighteen definitions become nine.** `fail`,
`validate_report` and `main` stay put -- each says something different per gate.

### Two bodies were not identical, and the differences are recorded rather than smoothed over

`require_bool` returned `True` in one gate and `None` in the other, raising the same message from
the same condition, and every call is in statement position. `load_report` opened a handle in one
and read the text in the other. The shared copy takes the returning and the handle-opening forms.

`require_snippets` reads a module-scope `ROOT`. The shared module computes it the same way, from
`tools/`, so `parents[1]` is the same directory it was -- which is the check this file own history
says to make before moving a body that reads a constant.

### Verified behaviourally, not just structurally

Both context gates against a ladder of six synthetic reports that walks the vocabulary -- a
non-object root, an empty object, a wrong type, a failed cross-field sum, a short string set, a bad
int map -- and both readiness gates against the repository. **Twelve runs, byte-identical stdout,
stderr and exit code before and after.** Plus the 50 tree-scanning suites: **385 tests, zero
failures.**
