### PR TITLE
The round reports what eviction did, and eviction never gets to do it

### DIFF
--- a/crates/temporalstore-rust/src/data_node.rs
+++ b/crates/temporalstore-rust/src/data_node.rs
@@ -1193,6 +1193,16 @@ pub struct StorageManagerLoopReport {
     pub compaction_report: Option<CompactionResponse>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gc_report: Option<GcResponse>,
+    /// What the evict stage did, when it ran.
+    ///
+    /// Every other stage reports itself here. This one computed a full report -- the victims it
+    /// picked, the pressure before and after, whether the round relieved anything at all -- and
+    /// the loop dropped it on the floor, keeping only "did it run" for `executed_stages`. So the
+    /// one stage whose whole purpose is relieving memory was also the one stage an operator could
+    /// not see the result of, and `cooldown` (pressure_after >= pressure_before, i.e. the round
+    /// freed nothing) reached nobody.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub eviction: Option<crate::engine::reports::StorageEvictionReport>,
     pub status: Status,
 }
 

--- a/crates/temporalstore-rust/src/data_node/runtime_storage.rs
+++ b/crates/temporalstore-rust/src/data_node/runtime_storage.rs
@@ -800,6 +800,7 @@ impl DataNodeRuntime {
             metrics_reap,
             compaction_report,
             gc_report,
+            eviction,
             status,
         }
     }

--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -4976,3 +4976,183 @@ fn what_a_page_gc_round_walks() {
         eprintln!("  {round:>5}  {walked:>12}  {retained:>8}  {removed:>7}  {micros:>9}");
     }
 }
+
+/// How many rounds does eviction need to get back under its memory limit? Prints.
+///
+///   cargo test -p temporalstore-rust --lib how_long_eviction_takes_to_converge \
+///       -- --ignored --nocapture --test-threads=1
+///
+/// `apply_storage_eviction` selects up to `eviction_batch_limit` victims, evicts them once, and
+/// returns -- even when the pressure it just measured is still far above the threshold. It reports
+/// `cooldown: pressure_after >= pressure_before`, so it knows when a round freed nothing, and
+/// nothing acts on that. The design being followed loops instead, taking batches until usage is
+/// back under the limit and stopping on a per-call count budget rather than on the first batch.
+///
+/// Each arm builds its OWN store. A first version shared one runtime across both arms, so the
+/// second arm inherited a cache the first had already drained and reported zeros that meant
+/// nothing.
+#[test]
+#[ignore]
+fn how_long_eviction_takes_to_converge() {
+    const KEYS: usize = 4_000;
+    const ROUNDS: usize = 10;
+
+    fn arm(memory_reclaim: bool) {
+        let engine = TemporalEngine::default();
+        engine.load_shard(1);
+        let runtime = DataNodeRuntime::new_without_workers_with_options(
+            engine,
+            DataNodeRuntimeOptions {
+                worker_threads: 0,
+                max_queue_depth: 4,
+                max_background_queue_depth: 2,
+            },
+        );
+        {
+            let engine = runtime.engine();
+            for index in 0..KEYS {
+                engine.execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringSet {
+                        key: format!("evictconv-{:08}", index),
+                        value: vec![b'v'; 256],
+                    },
+                });
+            }
+            for index in 0..KEYS {
+                engine.execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringGet {
+                        key: format!("evictconv-{:08}", index),
+                    },
+                });
+            }
+        }
+        let start = runtime.engine().cache().stats().memory_bytes;
+        let threshold = (start / 4).max(1);
+        eprintln!(
+            "  -- enable_memory_reclaim={memory_reclaim}  start={start}  threshold={threshold} --"
+        );
+        eprintln!("  round  gate_open  before  after  victims  cooldown  skipped");
+
+        let options = StorageManagerOptions {
+            enable_evict: true,
+            enable_memory_reclaim: memory_reclaim,
+            eviction_memory_pressure_threshold: threshold,
+            ..StorageManagerOptions::default()
+        };
+        let mut converged: Option<usize> = None;
+        for round in 0..ROUNDS {
+            // Re-warm before each round, so the question is what EVICTION does with a warm cache
+            // rather than what an earlier stage left behind.
+            let engine = runtime.engine();
+            for index in 0..KEYS {
+                engine.execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringGet {
+                        key: format!("evictconv-{:08}", index),
+                    },
+                });
+            }
+            let report = runtime.run_storage_manager_once(1, options.clone());
+            let Some(eviction) = report.eviction.as_ref() else {
+                eprintln!("  {round:>5}  (evict stage did not run)");
+                continue;
+            };
+            eprintln!(
+                "  {round:>5}  {:>9}  {:>6}  {:>5}  {:>7}  {:>8}  {}",
+                eviction.pressure_gate_open,
+                eviction.pressure_before,
+                eviction.pressure_after,
+                eviction.selected_victims.len(),
+                eviction.cooldown,
+                if eviction.skipped_reason.is_empty() {
+                    "-"
+                } else {
+                    eviction.skipped_reason.as_str()
+                },
+            );
+            if eviction.pressure_after < threshold && converged.is_none() {
+                converged = Some(round + 1);
+            }
+        }
+        match converged {
+            Some(n) => eprintln!("  VERDICT: under the limit after {n} round(s)"),
+            None => eprintln!("  VERDICT: still OVER after {ROUNDS} rounds"),
+        }
+    }
+
+    arm(true);
+    arm(false);
+}
+
+/// The round reports what eviction did, including when it declined to do anything.
+///
+/// Every other stage puts its report on `StorageManagerLoopReport`. The evict stage built a full
+/// one -- victims, pressure before and after, `cooldown` for a round that freed nothing, and
+/// `skipped_reason` for a round that never started -- and the loop dropped it, keeping only "did
+/// it run" for `executed_stages`. So the one stage whose purpose is relieving memory was the one
+/// stage whose outcome nobody could see.
+///
+/// That is not cosmetic. On the shipped configuration this stage NEVER opens its gate:
+/// `reclaim_memory` runs earlier in the round and invalidates the whole shard cache, and
+/// eviction's threshold is compared against exactly that cache, so it reads 0 and skips with
+/// `memory_pressure_below_threshold` every time. Measured over ten rounds in
+/// `how_long_eviction_takes_to_converge`. With the report discarded there was no way to learn this
+/// from a running server -- `executed_stages` says "evict" either way.
+#[test]
+fn the_round_reports_what_eviction_did() {
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+    let runtime = DataNodeRuntime::new_without_workers_with_options(
+        engine,
+        DataNodeRuntimeOptions {
+            worker_threads: 0,
+            max_queue_depth: 4,
+            max_background_queue_depth: 2,
+        },
+    );
+    for index in 0..400usize {
+        let engine = runtime.engine();
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("evictreport-{:06}", index % 100),
+                value: vec![b'v'; 96],
+            },
+        });
+    }
+
+    // Eviction ships disabled, so without this the stage would not run and the assertion would
+    // be about a round that never reached it.
+    let options = StorageManagerOptions {
+        enable_evict: true,
+        ..StorageManagerOptions::default()
+    };
+    let report = runtime.run_storage_manager_once(1, options);
+
+    assert!(
+        report
+            .executed_stages
+            .iter()
+            .any(|stage| stage == "evict"),
+        "the evict stage did not run, so there is no report to carry: {:?}",
+        report.executed_stages
+    );
+    let eviction = report
+        .eviction
+        .as_ref()
+        .expect("the round ran the evict stage but carried no eviction report");
+
+    // A skipped round must say why. `pressure_gate_open` and `skipped_reason` are the two fields
+    // that distinguish "evicted nothing because there was nothing to evict" from "never looked",
+    // and on the shipped configuration it is always the latter.
+    assert!(
+        eviction.pressure_gate_open || !eviction.skipped_reason.is_empty(),
+        "eviction neither opened its gate nor said why it skipped -- the report cannot be acted on"
+    );
+    assert_eq!(
+        eviction.shard_id, 1,
+        "the report belongs to the shard the round ran for"
+    );
+}


### PR DESCRIPTION
Every stage puts its report on `StorageManagerLoopReport`. The evict stage built a full one — the
victims it picked, pressure before and after, `cooldown` for a round that freed nothing,
`skipped_reason` for a round that never started — and the loop bound it to a local, tested it for
`is_some()` to push `"evict"` onto `executed_stages`, and **dropped it**. The one stage whose
purpose is relieving memory was the one stage whose outcome nobody could see.

That turned out not to be cosmetic, because of what the report says once you can read it.

## Eviction cannot fire on the shipped configuration

Its gate compares `eviction_memory_pressure_threshold` against the shard's cache bytes.
`reclaim_memory` runs **earlier in the same round** and passes `invalidate_cache: true`, which
empties that cache. So by the time eviction looks, the number it reads is 0 and it skips with
`memory_pressure_below_threshold` — every round, whatever the threshold is set to.

Ten rounds, 4,000 keys of 256 B read back before each round:

```
enable_memory_reclaim=true   start=2,132,000  threshold=533,000
round  gate_open  before  after  victims  skipped
  0-9      false       0      0        0  memory_pressure_below_threshold
```

#1467 made this stage reachable and #1527 moved it beside expire. It is still fed a signal an
earlier stage zeroes, so it has never evicted anything on a default server. `executed_stages` says
`"evict"` either way, which is exactly why this went unnoticed — the stage runs, it just always
declines.

## And when it does fire, it does not converge

Same fixture with `reclaim_memory` off, so the gate opens:

| round | gate_open | before | after | victims | cooldown |
|---|---|---|---|---|---|
| 0 | true | 2,308,000 | 2,303,200 | 16 | false |
| 3 | true | 2,293,600 | 2,288,800 | 16 | false |
| 6 | true | 2,287,000 | 2,287,000 | 16 | **true** |

16 victims a round move ~4,800 bytes, falling to ~900, then to nothing by round 6 — against a
1,775,000-byte overage. It never reaches the threshold. The design being followed loops instead:
it keeps taking batches until usage is back under the limit, bounded by a per-call count budget,
and reports hitting that budget rather than stopping after the first batch.

## What this change does

Surfaces the report, and nothing else. Both findings are measured and recorded rather than fixed
here, because both fixes are design decisions and not mine to make in passing:

- the gate needs a signal that is not the thing an earlier stage clears. Theirs reads total
  allocated size, not a cache counter — which also lines up with the already-recorded finding that
  our memory signal excludes the index, the part that actually grows;
- the convergence loop needs a round budget chosen against a real workload.

`how_long_eviction_takes_to_converge` prints both tables so neither has to be taken on trust. Each
arm builds its **own** store: a first version shared one runtime, and the second arm inherited a
cache the first had already drained, reporting zeros that meant nothing.

## Verification

The guard asserts the stage ran before asserting anything about its report, and that a skipped
round says **why** — `pressure_gate_open` and `skipped_reason` are what separate "nothing to evict"
from "never looked". Verified by mutation: dropping the report from the loop fails it with "the
round ran the evict stage but carried no eviction report".

`cargo test -p temporalstore-rust --lib -- --test-threads=1` → **1771 passed, 1 failed**. The one
failure is `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the standing `--lib`
baseline failure on main. No new failure name.
