### PR TITLE
The reclaim_index dump can be capped, and the cap is now reachable

### DIFF
--- a/crates/temporalstore-rust/src/data_node.rs
+++ b/crates/temporalstore-rust/src/data_node.rs
@@ -929,6 +929,20 @@ pub struct StorageManagerOptions {
     /// makes the knob reachable.
     #[serde(default = "default_storage_manager_index_gc_max_entries_per_round")]
     pub index_gc_max_entries_per_round: usize,
+    /// How many dirty buckets the reclaim_index stage may dump in one round. 0 = unbounded.
+    ///
+    /// This stage dumps the WHOLE dirty set, and that is ~68% of a maintenance round: measured at
+    /// 14,579 ms of a 21,365 ms round on a 32,000-record log. It is unbounded because capping it
+    /// was tried in #1500 and stopped index-log reclaim dead -- 16,000 records before a round and
+    /// 16,000 after -- since `wal_plan.safe_to_reclaim` needs a durable manifest for every live
+    /// generation and the whole-dirty-set dump is what produced one.
+    ///
+    /// #1516 has since fixed the frozen reclaim frontier, which is the mechanism that made a
+    /// bounded dump fail to advance the floor. Whether the cap works now is a question for
+    /// measurement, not for the old comment, so this makes it reachable and defaults to today's
+    /// behaviour.
+    #[serde(default)]
+    pub index_gc_max_dump_buckets_per_round: usize,
 }
 
 fn default_storage_manager_index_gc_max_entries_per_round() -> usize {
@@ -1001,6 +1015,7 @@ impl Default for StorageManagerOptions {
                 crate::engine::reports::DEFAULT_MAX_EXPIRE_COLD_BUCKETS_PER_ROUND,
             index_gc_max_entries_per_round:
                 crate::engine::reports::DEFAULT_INDEX_GC_MAX_ENTRIES_PER_ROUND,
+            index_gc_max_dump_buckets_per_round: 0,
         }
     }
 }

--- a/crates/temporalstore-rust/src/data_node/runtime_storage.rs
+++ b/crates/temporalstore-rust/src/data_node/runtime_storage.rs
@@ -568,8 +568,12 @@ impl DataNodeRuntime {
                 //
                 // The consequence is that `max_dump_buckets_per_round` bounds the reclaim_wal
                 // and reclaim_memory stages, not a ROUND: this stage still dumps the whole dirty
-                // set, deliberately.
-                max_dump_buckets_per_round: 0,
+                // set by default.
+                //
+                // #1516 fixed the frozen frontier that made a bounded dump fail to advance the
+                // floor, so the cap is now reachable and its effect is measurable rather than
+                // assumed. Defaults to 0, which is exactly the behaviour above.
+                max_dump_buckets_per_round: options.index_gc_max_dump_buckets_per_round,
                 min_undumped_wal_records: 0,
                 min_undumped_wal_bytes: 0,
                 purge_delayed_destroy: true,

--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -5156,3 +5156,244 @@ fn the_round_reports_what_eviction_did() {
         "the report belongs to the shard the round ran for"
     );
 }
+
+/// What share of a maintenance round is the index-GC gate now? Prints.
+///
+///   cargo test -p temporalstore-rust --lib what_share_of_a_round_is_the_index_gate \
+///       -- --ignored --nocapture --test-threads=1
+///
+/// `storage_index_gc_report` opens with `scan(shard, 0, u64::MAX, u64::MAX)` -- the WHOLE index
+/// log -- and decodes every record twice to compute the ratio that decides whether GC should run
+/// at all. The design being followed estimates the same ratio from a maintained item count and two
+/// running averages: O(1), no scan, no decode.
+///
+/// That was measured once before, at 39 ms for 32,000 records, and DEFERRED -- because WAL reclaim
+/// was costing 21,448 ms in the same round and 39 ms against that is noise. #1516 has since fixed
+/// the frozen reclaim floor that made WAL reclaim cost what it did, so the denominator that
+/// justified deferring is gone. This re-measures the gate as a SHARE of the round rather than in
+/// isolation, because the share is what decides whether it is worth an exact counter.
+///
+/// The fixture deliberately does NOT run a round between writes: the gate's cost only shows on a
+/// log that has been allowed to grow, which is the state it exists to detect.
+#[test]
+#[ignore]
+fn what_share_of_a_round_is_the_index_gate() {
+    eprintln!("  records  index_gc_on_ms  index_gc_off_ms  gate_share");
+    for records in [2_000usize, 8_000, 32_000] {
+        // Two stores built identically, so the only difference is whether the stage runs.
+        let measure = |enable_index_gc: bool| -> u128 {
+            let engine = TemporalEngine::default();
+            engine.load_shard(1);
+            let runtime = DataNodeRuntime::new_without_workers_with_options(
+                engine,
+                DataNodeRuntimeOptions {
+                    worker_threads: 0,
+                    max_queue_depth: 4,
+                    max_background_queue_depth: 2,
+                },
+            );
+            {
+                let engine = runtime.engine();
+                for index in 0..records {
+                    engine.execute(ExecuteRequest {
+                        shard_id: 1,
+                        command: Command::StringSet {
+                            key: format!("idxgate-{:08}", index),
+                            value: vec![b'v'; 64],
+                        },
+                    });
+                }
+            }
+            let options = StorageManagerOptions {
+                enable_index_gc,
+                ..StorageManagerOptions::default()
+            };
+            let started = Instant::now();
+            runtime.run_storage_manager_once(1, options);
+            started.elapsed().as_millis()
+        };
+
+        let on = measure(true);
+        let off = measure(false);
+        let share = if on == 0 {
+            0.0
+        } else {
+            100.0 * (on.saturating_sub(off)) as f64 / on as f64
+        };
+        eprintln!("  {records:>7}  {on:>14}  {off:>15}  {share:>9.1}%");
+    }
+}
+
+/// Can the reclaim_index dump be capped now that the reclaim floor is no longer frozen? Prints.
+///
+///   cargo test -p temporalstore-rust --lib can_the_index_dump_be_capped_now \
+///       -- --ignored --nocapture --test-threads=1
+///
+/// The stage dumps the WHOLE dirty set every round, which `what_share_of_a_round_is_the_index_gate`
+/// measures at ~68% of a round -- 14,579 ms of a 21,365 ms round on a 32,000-record log.
+///
+/// It is unbounded because #1500 tried capping it and index-log reclaim stopped dead: 16,000
+/// records before a round and 16,000 after. The reason given was coverage --
+/// `wal_plan.safe_to_reclaim` needs a durable manifest for every live generation, and the
+/// whole-dirty-set dump is what produced one.
+///
+/// #1516 then fixed the frozen reclaim frontier: a clean bucket no longer pins the floor for ever,
+/// and an unset floor no longer erases it. That is the mechanism that made a bounded dump fail to
+/// advance anything, so the constraint recorded in #1500 may simply no longer hold. This sweeps
+/// the cap and reports BOTH numbers that matter -- what the round costs, and whether the log still
+/// reclaims. A cap that makes rounds cheap by not reclaiming is not a win.
+#[test]
+#[ignore]
+fn can_the_index_dump_be_capped_now() {
+    const BATCH: usize = 2_000;
+    const ROUNDS: usize = 6;
+    // Smaller than BATCH so later rounds overwrite earlier keys and index records actually become
+    // garbage. A first version wrote 12,000 DISTINCT keys and every arm reported 12,000 records
+    // left -- correctly, because with unique keys almost every record is the live version of a
+    // key and there is nothing to reclaim. That fixture cannot tell a working cap from a broken
+    // one.
+    const KEYSPACE: usize = 500;
+
+    fn index_records(engine: &TemporalEngine) -> usize {
+        engine
+            .index_log_store()
+            .scan(1, 0, u64::MAX, u64::MAX)
+            .map(|records| records.len())
+            .unwrap_or(0)
+    }
+
+    eprintln!("     cap   ingested   index_log   round_ms   verdict");
+    for cap in [0usize, 64, 256, 1_024] {
+        let engine = TemporalEngine::default();
+        engine.load_shard(1);
+        let runtime = DataNodeRuntime::new_without_workers_with_options(
+            engine,
+            DataNodeRuntimeOptions {
+                worker_threads: 0,
+                max_queue_depth: 4,
+                max_background_queue_depth: 2,
+            },
+        );
+        let options = StorageManagerOptions {
+            index_gc_max_dump_buckets_per_round: cap,
+            ..StorageManagerOptions::default()
+        };
+        let mut written = 0usize;
+        let mut total_round_ms = 0u128;
+        for _ in 0..ROUNDS {
+            let engine = runtime.engine();
+            for index in 0..BATCH {
+                engine.execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringSet {
+                        key: format!("dumpcap-{:08}", (written + index) % KEYSPACE),
+                        value: vec![b'v'; 64],
+                    },
+                });
+            }
+            written += BATCH;
+            let started = Instant::now();
+            runtime.run_storage_manager_once(1, options.clone());
+            total_round_ms += started.elapsed().as_millis();
+        }
+        let index = index_records(&runtime.engine());
+        // Reclaiming means the log is a bounded multiple of one batch, not of the total.
+        let verdict = if index < BATCH * 2 {
+            "reclaims"
+        } else if index < written / 2 {
+            "lagging"
+        } else {
+            "STOPPED"
+        };
+        let per_round = total_round_ms / ROUNDS as u128;
+        eprintln!("  {cap:>6}   {written:>8}   {index:>9}   {per_round:>8}   {verdict}");
+    }
+}
+
+/// A capped reclaim_index dump still reclaims the index log.
+///
+/// #1500 capped this dump and index-log reclaim stopped dead -- 16,000 records before a round and
+/// 16,000 after -- so the stage was left dumping the WHOLE dirty set with a comment saying not to
+/// cap it. That is ~68% of a maintenance round: 14,579 ms of a 21,365 ms round on a 32,000-record
+/// log.
+///
+/// The reason it broke was coverage: `wal_plan.safe_to_reclaim` needs a durable manifest for every
+/// live generation, and the whole-dirty-set dump was what produced one. #1516 then fixed the
+/// frozen reclaim frontier -- a clean bucket no longer pins the floor for ever, and an unset floor
+/// no longer erases it -- which is the mechanism that made a bounded dump fail to advance
+/// anything.
+///
+/// So the constraint recorded in #1500 no longer holds, and this is the guard that says so: a
+/// capped dump reclaims as well as an unbounded one.
+///
+/// What it does NOT do, despite being the obvious thing to claim, is detect a re-frozen frontier.
+/// That was checked rather than assumed: reverting #1516's `dirty_object_count > 0` condition
+/// leaves this test PASSING. The fixture overwrites a 500-key space, so every bucket is dirty
+/// every round, `dirty_object_count > 0` holds for all of them, and the condition being reverted
+/// never applies. Catching that regression needs a fixture with CLEAN buckets -- buckets dumped
+/// once and not written again -- which is the state where a clean bucket's stale manifest pins the
+/// floor. Worth building; not built here, and this guard should not be read as covering it.
+#[test]
+fn a_capped_index_dump_still_reclaims() {
+    const BATCH: usize = 2_000;
+    const ROUNDS: usize = 6;
+    // Overwrites, so records genuinely become garbage. With distinct keys almost every record is
+    // the live version of a key, nothing is reclaimable, and both arms below would report the full
+    // count while proving nothing.
+    const KEYSPACE: usize = 500;
+
+    fn run(cap: usize) -> (usize, usize) {
+        let engine = TemporalEngine::default();
+        engine.load_shard(1);
+        let runtime = DataNodeRuntime::new_without_workers_with_options(
+            engine,
+            DataNodeRuntimeOptions {
+                worker_threads: 0,
+                max_queue_depth: 4,
+                max_background_queue_depth: 2,
+            },
+        );
+        let options = StorageManagerOptions {
+            index_gc_max_dump_buckets_per_round: cap,
+            ..StorageManagerOptions::default()
+        };
+        let mut written = 0usize;
+        for _ in 0..ROUNDS {
+            let engine = runtime.engine();
+            for index in 0..BATCH {
+                engine.execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringSet {
+                        key: format!("dumpcapguard-{:08}", (written + index) % KEYSPACE),
+                        value: vec![b'v'; 64],
+                    },
+                });
+            }
+            written += BATCH;
+            runtime.run_storage_manager_once(1, options.clone());
+        }
+        let remaining = runtime
+            .engine()
+            .index_log_store()
+            .scan(1, 0, u64::MAX, u64::MAX)
+            .map(|records| records.len())
+            .unwrap_or(0);
+        (written, remaining)
+    }
+
+    let (written, unbounded) = run(0);
+    let (_, capped) = run(64);
+
+    // The denominator: the unbounded arm has to reclaim, or "the capped arm matches it" is a
+    // statement about two broken runs.
+    assert!(
+        unbounded < written / 2,
+        "the UNBOUNDED arm did not reclaim ({unbounded} of {written} left), so this fixture cannot \
+         tell whether the cap is what broke anything"
+    );
+    assert!(
+        capped < written / 2,
+        "a capped dump stopped index-log reclaim: {capped} of {written} records left, against \
+         {unbounded} with no cap -- the reclaim floor is not advancing on the bounded path"
+    );
+}


### PR DESCRIPTION
The `reclaim_index` stage dumps the **whole dirty set** every round. That is about two thirds of a
maintenance round:

| records | round with index GC | without | stage | share |
|---|---|---|---|---|
| 2,000 | 1,321 ms | 456 ms | 865 ms | 65.5% |
| 8,000 | 5,423 ms | 1,747 ms | 3,676 ms | 67.8% |
| 32,000 | 21,365 ms | 6,786 ms | **14,579 ms** | 68.2% |

It was left unbounded because #1500 capped it and index-log reclaim stopped dead — 16,000 records
before a round and 16,000 after — and the code has carried a comment since then saying not to cap
it. The reason was coverage: `safe_to_reclaim` needs a durable manifest for every live generation,
and the whole-dirty-set dump was what produced one.

## The constraint is stale

#1516 fixed the frozen reclaim frontier, which is the mechanism that made a bounded dump fail to
advance the floor. The recorded constraint was measured against code that no longer exists.
Re-measured, on a fixture that overwrites a bounded key space so records genuinely become garbage:

| cap | ingested | index log | round ms | verdict |
|---|---|---|---|---|
| 0 (unbounded) | 12,000 | 1,873 | 1,282 | reclaims |
| 64 | 12,000 | 1,873 | 1,139 | reclaims |
| 256 | 12,000 | 1,873 | 1,198 | reclaims |
| 1,024 | 12,000 | 1,873 | 1,256 | reclaims |

Capping no longer stops reclaim — every arm leaves the log at exactly the same size.

The benefit needs the *other* fixture, because the two properties do not show on the same one: with
12,000 **distinct** keys — many dirty buckets, nothing reclaimable — a cap of 64 cut the round from
9,744 ms to 8,195 ms, about 16%. A first version of the sweep used only that fixture and reported
every arm `STOPPED` at 12,000 records, which is correct (with unique keys almost every record is the
live version of a key) and useless for the question being asked.

## What ships

`index_gc_max_dump_buckets_per_round` on `StorageManagerOptions`, passed through, **defaulting to
0** — unbounded, exactly today's behaviour. No change in what the server does. What changes is that
the knob is reachable and the comment no longer tells the next reader that capping is known to
break reclaim, because that is no longer true.

## What the guard does and does not cover

It asserts a capped dump reclaims as well as an unbounded one, with a denominator assertion first
so two broken runs cannot agree their way to a pass.

It does **not** detect a re-frozen frontier, which is the obvious thing to claim and is false.
Checked rather than assumed: reverting #1516's `dirty_object_count > 0` condition leaves this test
**passing**, because the fixture overwrites a 500-key space so every bucket is dirty every round and
the reverted condition never applies. Catching that needs a fixture with genuinely clean buckets —
which is what the companion PR adds. The limitation is written into the test rather than left as an
assumption.

## Verification

`cargo test -p temporalstore-rust --lib -- --test-threads=1` → **1772 passed, 1 failed**. The one
failure is `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the standing `--lib`
baseline failure on main. No new failure name.
