### PR TITLE
A quiet bucket does not pin the reclaim floor — now with a test

### DIFF
--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -5397,3 +5397,103 @@ fn a_capped_index_dump_still_reclaims() {
          {unbounded} with no cap -- the reclaim floor is not advancing on the bounded path"
     );
 }
+
+/// A bucket that stopped being written does not pin the reclaim floor for ever.
+///
+/// #1514 measured both logs growing linearly under continuous ingestion while the plan reported
+/// safe=true, full coverage, no blockers -- and a frontier frozen at 2001 for twelve rounds.
+/// #1516 fixed it: the floor is a minimum over DIRTY buckets only, and an unset floor means "no
+/// constraint" rather than zero. It shipped as 14 lines in one file with NO test, which is why
+/// this exists.
+///
+/// The bug needs CLEAN buckets to show itself -- buckets dumped once and never written again. A
+/// dirty-everything fixture cannot reproduce it: every bucket constrains the floor legitimately,
+/// so including clean ones changes nothing. That is not hypothetical; the guard beside this one
+/// (`a_capped_index_dump_still_reclaims`) overwrites a small key space, and reverting #1516 leaves
+/// it passing.
+///
+/// So: write widely, dump everything, then keep writing to a SMALL subset. The buckets left behind
+/// are clean, and their manifests hold sequence numbers from the first phase. Before #1516 those
+/// stale manifests pinned the floor and neither log could ever be reclaimed past them.
+#[test]
+fn a_bucket_that_went_quiet_does_not_pin_the_reclaim_floor() {
+    const WIDE_KEYS: usize = 2_000;
+    const HOT_KEYS: usize = 20;
+    const ROUNDS: usize = 8;
+    const BATCH: usize = 1_000;
+
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+    let runtime = DataNodeRuntime::new_without_workers_with_options(
+        engine,
+        DataNodeRuntimeOptions {
+            worker_threads: 0,
+            max_queue_depth: 4,
+            max_background_queue_depth: 2,
+        },
+    );
+
+    // Phase one: write widely, so many buckets carry a sequence, then dump them all.
+    {
+        let engine = runtime.engine();
+        for index in 0..WIDE_KEYS {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("quiet-wide-{:08}", index),
+                    value: vec![b'v'; 64],
+                },
+            });
+        }
+    }
+    runtime.run_storage_manager_once(1, StorageManagerOptions::default());
+
+    // Phase two: keep writing, but only to a handful of keys. Every bucket the wide phase touched
+    // and this one does not is now CLEAN, holding a manifest from phase one.
+    let mut written = 0usize;
+    for _ in 0..ROUNDS {
+        let engine = runtime.engine();
+        for index in 0..BATCH {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("quiet-hot-{:04}", (written + index) % HOT_KEYS),
+                    value: vec![b'v'; 64],
+                },
+            });
+        }
+        written += BATCH;
+        runtime.run_storage_manager_once(1, StorageManagerOptions::default());
+    }
+
+    let engine = runtime.engine();
+    let wal_records = engine
+        .write_ahead_log_store()
+        .scan(1, 0, u64::MAX, u64::MAX)
+        .map(|records| records.len())
+        .unwrap_or(0);
+    let index_records = engine
+        .index_log_store()
+        .scan(1, 0, u64::MAX, u64::MAX)
+        .map(|records| records.len())
+        .unwrap_or(0);
+
+    // The denominator: phase two has to have written enough that a frozen floor is visible as
+    // growth rather than lost in the noise of phase one.
+    assert!(
+        written >= BATCH * ROUNDS,
+        "phase two wrote {written} records, too few to tell a frozen floor from a moving one"
+    );
+    // Neither log may hold everything phase two wrote. A floor pinned by the quiet buckets from
+    // phase one cannot advance, and both logs then grow with the total.
+    assert!(
+        wal_records < written,
+        "the write-ahead log holds {wal_records} records against {written} written -- a bucket \
+         that went quiet is pinning the reclaim floor"
+    );
+    assert!(
+        index_records < written,
+        "the index log holds {index_records} records against {written} written -- a bucket that \
+         went quiet is pinning the reclaim floor"
+    );
+}


### PR DESCRIPTION
#1516 is the fix that stopped both logs growing without bound under continuous ingestion. #1514 had
measured a frontier frozen at 2001 for twelve rounds while the plan reported `safe=true`, full
coverage and no blockers — nothing refused, there was simply no mechanism to advance it.

It shipped as **14 lines in one file with no test**. This adds one.

## Why the obvious fixture cannot catch it

The bug needs **clean** buckets to appear: buckets dumped once and never written again, whose stale
manifests pinned a floor computed as a minimum over *all* buckets. A fixture that keeps writing
everywhere cannot reproduce it, because every bucket then constrains the floor legitimately and
including the clean ones changes nothing.

That is not hypothetical. I first intended to claim the guard in #1537
(`a_capped_index_dump_still_reclaims`) covered this regression. It does not — that fixture
overwrites a 500-key space, so every bucket is dirty every round, and reverting #1516 leaves it
**passing**. The claim was checked before it was written down, and this test is what came out of the
check.

## What this one does

Writes widely so many buckets carry a sequence, dumps them all, then keeps writing to twenty keys
for eight rounds. Every bucket the wide phase touched and the hot phase does not is left clean,
holding a manifest from phase one. If those manifests pin the floor, neither log can be reclaimed
past them and both grow with the total rather than with the working set.

Verified by reverting the fix — with `dirty_object_count > 0` removed, so clean buckets constrain
the frontier again:

```
the write-ahead log holds 8869 records against 8000 written
  -- a bucket that went quiet is pinning the reclaim floor
```

8,869 against 8,000 written, because phase one's 2,000 records are pinned too. That is the frozen
frontier, reproduced. With the fix in place both logs stay below what phase two wrote.

A denominator assertion comes first, so a fixture that wrote too little to tell a frozen floor from
a moving one fails loudly instead of passing.

## Verification

`cargo test -p temporalstore-rust --lib -- --test-threads=1` → **1772 passed, 1 failed**. The one
failure is `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the standing `--lib`
baseline failure on main. No new failure name.
