### PR TITLE
Eviction reads a cache that still exists

### DIFF
--- a/crates/temporalstore-rust/src/data_node/runtime_storage.rs
+++ b/crates/temporalstore-rust/src/data_node/runtime_storage.rs
@@ -311,77 +311,6 @@ impl DataNodeRuntime {
             ),
         ));
 
-        if options.enable_memory_reclaim && cache_pressure {
-            let response = self.apply_storage_lifecycle(StorageLifecycleRequest {
-                shard_id,
-                selected_dump_buckets: Vec::new(),
-                // The cap, not 0. This stage dumps before it invalidates, and an unbounded dump
-                // here made the cap `reclaim_wal` respects meaningless: measured, one round with
-                // every stage on dumped 1,280 of 1,280 dirty buckets, while `reclaim_wal` alone
-                // dumped exactly 64. Bounding is safe -- invalidation drops CACHED pages, and the
-                // data is in the write-ahead log whether or not its bucket was dumped this round.
-                max_dump_buckets_per_round: options.max_dump_buckets_per_round,
-                min_undumped_wal_records: 0,
-                min_undumped_wal_bytes: 0,
-                purge_delayed_destroy: false,
-                prune_bucket_dump_manifests: false,
-                roll_forward_bucket_dump_installs: false,
-                follower_replay_cursors: Vec::new(),
-                page_gc_shared_store_cursors: Vec::new(),
-                page_gc_raft_snapshot_refs: Vec::new(),
-                page_gc_checkpoint_floor_slab_id: None,
-                page_gc_raft_install_floor_slab_id: None,
-                page_gc_delayed_destroy_grace_ms: 0,
-                invalidate_cache: true,
-                warm_cache: false,
-            });
-            let mut stats = self
-                .inner
-                .stats
-                .lock()
-                .expect("runtime stats lock poisoned");
-            stats.storage_manager_reclaim_memory_runs += 1;
-            lifecycle_report = Some(response.report);
-            executed_stages.push("reclaim_memory".to_string());
-        } else if !options.enable_memory_reclaim {
-            skipped_stages.push("reclaim_memory_disabled".to_string());
-        } else {
-            skipped_stages.push("reclaim_memory_no_pressure".to_string());
-        }
-        pressure_decisions.push(storage_manager_pressure_decision(
-            "reclaim_memory",
-            options.enable_memory_reclaim,
-            cache_pressure,
-            options.enable_memory_reclaim && cache_pressure,
-            vec![
-                storage_manager_pressure_signal(
-                    "cache_memory_bytes",
-                    pressure.cache_memory_bytes,
-                    options.cache_memory_bytes_pressure.max(1),
-                ),
-                storage_manager_pressure_signal(
-                    "cache_disk_bytes",
-                    pressure.cache_disk_bytes,
-                    options.cache_disk_bytes_pressure.max(1),
-                ),
-            ],
-            storage_manager_trigger_reasons(&[
-                (
-                    pressure.cache_memory_bytes >= options.cache_memory_bytes_pressure.max(1),
-                    "cache_memory_pressure",
-                ),
-                (
-                    pressure.cache_disk_bytes >= options.cache_disk_bytes_pressure.max(1),
-                    "cache_disk_pressure",
-                ),
-            ]),
-            storage_manager_skip_reason(
-                options.enable_memory_reclaim,
-                cache_pressure,
-                "reclaim_memory",
-            ),
-        ));
-
         if options.enable_expire {
             expired_records_removed = self.sweep_expired_records_bounded(
                 options.max_expire_hot_buckets_per_round,
@@ -460,6 +389,94 @@ impl DataNodeRuntime {
             vec!["operator_enabled_eviction".to_string()],
             (!options.enable_evict).then(|| "evict_disabled".to_string()),
         ));
+
+        // Expire and evict run BEFORE the cache invalidation below, not after it.
+        //
+        // `reclaim_memory` is a blanket whole-shard cache invalidation. Eviction's gate
+        // compares its threshold against exactly that cache, so running it afterwards handed
+        // it a zero: measured over ten rounds, the gate never opened once and every round
+        // skipped with `memory_pressure_below_threshold`, whatever the threshold was set to.
+        // Eviction had therefore never evicted anything on a default server, and
+        // `executed_stages` said "evict" either way, which is why it went unnoticed.
+        //
+        // The name collision is what makes this confusing. The `ReclaimMemory` this stage is
+        // named after CONTAINS expire and evict and invalidates nothing -- there, those two
+        // ARE the memory relief. Our blanket invalidation is a separate mechanism with no
+        // counterpart, so there is no ordering to match, only an input not to destroy.
+        //
+        // `enable_evict` ships false, so no default server changes behaviour here. What
+        // changes is that the knob now means something when an operator turns it on.
+        if options.enable_memory_reclaim && cache_pressure {
+            let response = self.apply_storage_lifecycle(StorageLifecycleRequest {
+                shard_id,
+                selected_dump_buckets: Vec::new(),
+                // The cap, not 0. This stage dumps before it invalidates, and an unbounded dump
+                // here made the cap `reclaim_wal` respects meaningless: measured, one round with
+                // every stage on dumped 1,280 of 1,280 dirty buckets, while `reclaim_wal` alone
+                // dumped exactly 64. Bounding is safe -- invalidation drops CACHED pages, and the
+                // data is in the write-ahead log whether or not its bucket was dumped this round.
+                max_dump_buckets_per_round: options.max_dump_buckets_per_round,
+                min_undumped_wal_records: 0,
+                min_undumped_wal_bytes: 0,
+                purge_delayed_destroy: false,
+                prune_bucket_dump_manifests: false,
+                roll_forward_bucket_dump_installs: false,
+                follower_replay_cursors: Vec::new(),
+                page_gc_shared_store_cursors: Vec::new(),
+                page_gc_raft_snapshot_refs: Vec::new(),
+                page_gc_checkpoint_floor_slab_id: None,
+                page_gc_raft_install_floor_slab_id: None,
+                page_gc_delayed_destroy_grace_ms: 0,
+                invalidate_cache: true,
+                warm_cache: false,
+            });
+            let mut stats = self
+                .inner
+                .stats
+                .lock()
+                .expect("runtime stats lock poisoned");
+            stats.storage_manager_reclaim_memory_runs += 1;
+            lifecycle_report = Some(response.report);
+            executed_stages.push("reclaim_memory".to_string());
+        } else if !options.enable_memory_reclaim {
+            skipped_stages.push("reclaim_memory_disabled".to_string());
+        } else {
+            skipped_stages.push("reclaim_memory_no_pressure".to_string());
+        }
+        pressure_decisions.push(storage_manager_pressure_decision(
+            "reclaim_memory",
+            options.enable_memory_reclaim,
+            cache_pressure,
+            options.enable_memory_reclaim && cache_pressure,
+            vec![
+                storage_manager_pressure_signal(
+                    "cache_memory_bytes",
+                    pressure.cache_memory_bytes,
+                    options.cache_memory_bytes_pressure.max(1),
+                ),
+                storage_manager_pressure_signal(
+                    "cache_disk_bytes",
+                    pressure.cache_disk_bytes,
+                    options.cache_disk_bytes_pressure.max(1),
+                ),
+            ],
+            storage_manager_trigger_reasons(&[
+                (
+                    pressure.cache_memory_bytes >= options.cache_memory_bytes_pressure.max(1),
+                    "cache_memory_pressure",
+                ),
+                (
+                    pressure.cache_disk_bytes >= options.cache_disk_bytes_pressure.max(1),
+                    "cache_disk_pressure",
+                ),
+            ]),
+            storage_manager_skip_reason(
+                options.enable_memory_reclaim,
+                cache_pressure,
+                "reclaim_memory",
+            ),
+        ));
+
 
         if options.enable_page_gc && stale_page_pressure {
             let retain_block_slabs_from_id = lifecycle_plan

--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -4649,9 +4649,13 @@ fn the_maintenance_round_runs_its_stages_in_order() {
     let expected = [
         "prepare",
         "reclaim_wal",
-        "reclaim_memory",
+        // Expire and evict come BEFORE the blanket cache invalidation, not after it: the
+        // invalidation zeroes the very number eviction's gate reads, so running it first meant
+        // eviction never opened its gate at all. See
+        // `eviction_opens_its_gate_when_the_cache_is_still_there`.
         "expire",
         "evict",
+        "reclaim_memory",
         "reclaim_page",
         "reclaim_index",
         "compact_pages",
@@ -5495,5 +5499,85 @@ fn a_bucket_that_went_quiet_does_not_pin_the_reclaim_floor() {
         index_records < written,
         "the index log holds {index_records} records against {written} written -- a bucket that \
          went quiet is pinning the reclaim floor"
+    );
+}
+
+/// Eviction opens its gate, because the cache it measures still exists when it looks.
+///
+/// `apply_storage_eviction` compares `eviction_memory_pressure_threshold` against the shard's
+/// cache bytes. The `reclaim_memory` stage is a blanket whole-shard cache invalidation, and it
+/// used to run FIRST -- so eviction read 0 and skipped with `memory_pressure_below_threshold`
+/// every round, whatever the threshold was. Measured over ten rounds in #1536: the gate never
+/// opened once. Eviction had never evicted anything on a default server, and `executed_stages`
+/// said "evict" either way.
+///
+/// The confusing part is the name. The `ReclaimMemory` our stage is named after CONTAINS expire
+/// and evict and invalidates no cache at all -- there, those two ARE the memory relief. Our
+/// blanket invalidation is a separate mechanism with no counterpart, so there was never an
+/// ordering to match, only an input not to destroy.
+#[test]
+fn eviction_opens_its_gate_when_the_cache_is_still_there() {
+    const KEYS: usize = 1_000;
+
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+    let runtime = DataNodeRuntime::new_without_workers_with_options(
+        engine,
+        DataNodeRuntimeOptions {
+            worker_threads: 0,
+            max_queue_depth: 4,
+            max_background_queue_depth: 2,
+        },
+    );
+    {
+        let engine = runtime.engine();
+        for index in 0..KEYS {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("evictgate-{:06}", index),
+                    value: vec![b'v'; 128],
+                },
+            });
+        }
+        // Read everything back, so there is a populated cache for the gate to measure.
+        for index in 0..KEYS {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringGet {
+                    key: format!("evictgate-{:06}", index),
+                },
+            });
+        }
+    }
+
+    let warm = runtime.engine().cache().stats().memory_bytes;
+    // The denominator. With an empty cache the gate is correct to stay shut and this proves
+    // nothing about ordering.
+    assert!(
+        warm > 0,
+        "the cache held nothing after reading every key back, so the gate has nothing to measure"
+    );
+
+    // A threshold below what the fixture actually built, so a gate reading the real cache must
+    // open and a gate reading a zeroed one cannot.
+    let options = StorageManagerOptions {
+        enable_evict: true,
+        eviction_memory_pressure_threshold: warm / 4,
+        ..StorageManagerOptions::default()
+    };
+    let report = runtime.run_storage_manager_once(1, options);
+    let eviction = report
+        .eviction
+        .as_ref()
+        .expect("the round ran the evict stage but carried no eviction report");
+
+    assert!(
+        eviction.pressure_gate_open,
+        "eviction did not open its gate: it measured {} against a threshold of {} on a cache \
+         holding {warm} bytes, and skipped with {:?} -- an earlier stage has zeroed what it reads",
+        eviction.pressure_before,
+        eviction.memory_pressure_threshold,
+        eviction.skipped_reason,
     );
 }


### PR DESCRIPTION
#1536 measured that eviction has **never evicted anything on a default server**. Its gate compares
`eviction_memory_pressure_threshold` against the shard's cache bytes, and `reclaim_memory` — a
blanket whole-shard cache invalidation — ran earlier in the same round and emptied exactly that
cache. Ten rounds, 4,000 keys read back before each: the gate opened zero times and every round
skipped with `memory_pressure_below_threshold`, whatever the threshold was set to.

`executed_stages` said `"evict"` either way, which is why it went unnoticed. The stage ran; it
always declined.

#1536 recorded this and deliberately shipped no fix, on the grounds that the repair was a design
decision — the gate needed a signal that is not the thing an earlier stage clears. **That framing
was wrong**, and reading the intended structure is what corrected it.

## The name collision is the whole problem

The `ReclaimMemory` our stage is named after contains exactly two things:

```cpp
if (opts_.enable_expire) expirer_->TryExpire();
if (opts_.enable_evict)  evicter_->TryEvict();
```

It invalidates no cache at all. There, expire and evict **are** the memory relief. Our
`reclaim_memory` is a blanket invalidation — a separate mechanism with no counterpart — that
happens to carry the same name and sits in front of the stage whose input it destroys.

So there was never an ordering to match, only an input not to destroy. Expire and evict now run
ahead of it, keeping the pair together:

```
prepare, reclaim_wal, expire, evict, reclaim_memory,
reclaim_page, reclaim_index, compact_pages, reap_metrics
```

This also corrects #1527, which put `reclaim_memory` ahead of the pair on the strength of the
shared name. That change's stage-order guard is updated with the reason in place, so the next
reader does not re-derive it.

## No default server changes behaviour

`enable_evict` ships false. What changes is that the knob means something when an operator turns it
on, instead of silently declining every round.

## Verified by mutation

Moving expire and evict back behind the invalidation fails the new guard with the numbers that make
the bug unambiguous:

```
eviction did not open its gate: it measured 0 against a threshold of 69250
on a cache holding 277000 bytes, and skipped with
"memory_pressure_below_threshold" -- an earlier stage has zeroed what it reads
```

A denominator assertion comes first, so a fixture whose cache is empty — where a shut gate is
correct and proves nothing about ordering — fails loudly instead of passing.

## Still open, and not fixed here

Even with the gate open, eviction takes one batch per round and does not converge: 16 victims
moving ~4,800 bytes, falling to ~900, then to nothing by round 6 against a 1,775,000-byte overage
(#1536). That needs a convergence loop with a round budget chosen against a real workload.

## Verification

`cargo test -p temporalstore-rust --lib -- --test-threads=1` → **1774 passed, 1 failed**. The one
failure is `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the standing `--lib`
baseline failure on main. No new failure name.
