### PR TITLE
An expired key survives for keyspace/scan_budget rounds

### DIFF
--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -5581,3 +5581,100 @@ fn eviction_opens_its_gate_when_the_cache_is_still_there() {
         eviction.skipped_reason,
     );
 }
+
+/// How long does an expired key survive when the keyspace is large? Prints.
+///
+///   cargo test -p temporalstore-rust --lib how_long_an_expired_key_survives \
+///       -- --ignored --nocapture --test-threads=1
+///
+/// `expires_at_ms` is a `BTreeMap<String, u64>` -- keyed by KEY, with the deadline as the value --
+/// and `expiry_window` walks it in KEY order from a cursor, bounded by a scan budget. The caller
+/// then tests `expires_at <= now` on what came back. So a key whose deadline has passed is found
+/// only when the cursor happens to reach it, and every key that is NOT due is walked and charged
+/// against the same budget on the way.
+///
+/// That makes time-to-expire a function of how many keys carry deadlines, not of how many are
+/// actually due. The design being followed stores TTLs per bucket and keeps a per-bucket MINIMUM,
+/// so a whole bucket that cannot contain anything due is skipped in one comparison and never
+/// loaded.
+///
+/// This measures the consequence directly: a handful of already-expired keys hidden in a large
+/// keyspace of live ones, and how many maintenance rounds pass before they are actually removed.
+/// At 30 s a round, a round count IS a latency.
+#[test]
+#[ignore]
+fn how_long_an_expired_key_survives() {
+    const DUE_KEYS: usize = 10;
+    const MAX_ROUNDS: usize = 60;
+
+    for live_keys in [1_000usize, 10_000, 40_000] {
+        let engine = TemporalEngine::default();
+        engine.load_shard(1);
+        let runtime = DataNodeRuntime::new_without_workers_with_options(
+            engine,
+            DataNodeRuntimeOptions {
+                worker_threads: 0,
+                max_queue_depth: 4,
+                max_background_queue_depth: 2,
+            },
+        );
+        {
+            let engine = runtime.engine();
+            // Live keys with a long TTL: never due, but every one of them carries a deadline and
+            // so sits in the map the sweep walks.
+            for index in 0..live_keys {
+                engine.execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringSetEx {
+                        key: format!("live-{:08}", index),
+                        value: vec![b'v'; 32],
+                        ttl_ms: 3_600_000,
+                    },
+                });
+            }
+            // The keys under test, with a TTL that has already passed by the time the first round
+            // runs. "zzz" so they sort AFTER the live ones -- the cursor has to walk the whole
+            // live set to reach them, which is the cost being measured.
+            for index in 0..DUE_KEYS {
+                engine.execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringSetEx {
+                        key: format!("zzz-due-{:04}", index),
+                        value: vec![b'v'; 32],
+                        ttl_ms: 1,
+                    },
+                });
+            }
+        }
+
+        let options = StorageManagerOptions::default();
+        // Count what the SWEEP removed, never a read.
+        //
+        // A `StringGet` on an expired key triggers lazy expiry (`remove_if_expired`), so probing
+        // for presence would delete the very keys under measurement and make the sweep look as
+        // though it had found them. The stat counts only what the sweep itself removed.
+        let before = runtime.stats().expired_records_removed;
+        let mut rounds_until_gone: Option<usize> = None;
+        for round in 0..MAX_ROUNDS {
+            runtime.run_storage_manager_once(1, options.clone());
+            let removed = runtime
+                .stats()
+                .expired_records_removed
+                .saturating_sub(before);
+            if removed >= DUE_KEYS as u64 {
+                rounds_until_gone = Some(round + 1);
+                break;
+            }
+        }
+        match rounds_until_gone {
+            Some(rounds) => eprintln!(
+                "  live_keys={live_keys:>6}  expired after {rounds:>3} round(s)  (~{}s at 30s/round)",
+                rounds * 30
+            ),
+            None => eprintln!(
+                "  live_keys={live_keys:>6}  STILL PRESENT after {MAX_ROUNDS} rounds (~{}s)",
+                MAX_ROUNDS * 30
+            ),
+        }
+    }
+}


### PR DESCRIPTION
TTL expiry is effectively unenforced at scale for any key nobody reads. This records the
measurement that shows it.

`expires_at_ms` is a `BTreeMap<String, u64>` — keyed by **key**, with the deadline as the *value* —
and `expiry_window` walks it in key order from a cursor, bounded by a scan budget. The caller then
tests `expires_at <= now` on whatever came back. So a key whose deadline has passed is found only
when the cursor reaches it, and every key that is **not** due is walked and charged against the same
budget on the way.

Ten already-expired keys hidden behind a keyspace of live ones, counting rounds until the **sweep**
removes them:

| live keys with TTLs | rounds for the sweep to remove them |
|---|---|
| 1,000 | 8 (~240 s at 30 s a round) |
| 10,000 | **>60 — still present after ~30 min** |
| 40,000 | **>60 — still present after ~30 min** |

The 1,000-key row is what pins the mechanism: 8 rounds is exactly `keyspace / scan_budget`, so
latency scales linearly with the keyspace. At 40,000 keys that is ~2.6 hours; at a million, days.

## Why this has not been noticed

A read expires lazily — `remove_if_expired` runs on the way into `ttl_ms` and the read paths — so
any key someone actually asks for is expired on demand and looks correct. What lingers is the **cold
set**: keys nobody reads, which is precisely the set that costs memory and index space, and
precisely the set an operator sets a TTL to be rid of. It compounds the recorded finding that the
bucket index is never evicted from memory.

## The probe counts sweep removals, never a read

Worth stating because the obvious probe is wrong: checking presence with a `StringGet` would trigger
that same lazy expiry and delete the keys under measurement, making the sweep look as though it had
found them. This reads `stats().expired_records_removed`, which counts only what the sweep removed.
The due keys also sort **after** the live ones on purpose, so the cursor has to traverse the live set
to reach them — that traversal is the cost being measured.

## The fix shape, not done here

Due keys should be a **prefix**, not a scattered subset. A deadline-ordered index
(`BTreeSet<(u64, String)>` beside the existing map, which is still needed for the point lookup in
`ttl_ms`) makes finding them O(due) instead of O(keyspace) — and removes the need for a cursor over
the due set at all, since the cursor exists only because the scan is key-ordered.

The design being followed reaches the same end differently: TTLs live per bucket and each bucket
keeps a **minimum**, so a bucket that cannot contain anything due is skipped in one comparison and
never loaded.

Not attempted here because it is a data-structure change with 11 mutation sites to keep in sync, and
it changes the cursor semantics #1469's guard was written against. That deserves its own gate rather
than being folded into a measurement.

## Verification

`cargo test -p temporalstore-rust --lib -- --test-threads=1` → **1774 passed, 1 failed**. The one
failure is `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the standing `--lib`
baseline failure on main. No new failure name.
