### PR TITLE
One lane deadline, not five

### DIFF
--- a/tools/matrixark_mcp_rust_proxy_cache.py
+++ b/tools/matrixark_mcp_rust_proxy_cache.py
@@ -14,8 +14,10 @@ from typing import Any, Iterable
 
 try:
     from tools.matrixark_mcp_core import Json, MatrixArkError
+    from tools.matrixark_json_lane import lane_response_deadline_s
 except ModuleNotFoundError:  # Direct script execution from tools/.
     from matrixark_mcp_core import Json, MatrixArkError
+    from matrixark_json_lane import lane_response_deadline_s
 
 
 def string_cache_key_allowed(target: Any, key: str) -> bool:
@@ -210,7 +212,7 @@ def context_pack_response_singleflight_wait(target: Any, cache_key: str, infligh
     if not isinstance(event, threading.Event):
         raise MatrixArkError("invalid ContextPack singleflight state")
     started = time.perf_counter()
-    timeout_s = max(target._backpressure_timeout_s, target.request_timeout_ms / 1000.0 + 2.0)
+    timeout_s = max(target._backpressure_timeout_s, lane_response_deadline_s(target.request_timeout_ms))
     if not event.wait(timeout=timeout_s):
         raise MatrixArkError(f"Rust TemporalStore ContextPack singleflight timed out after {timeout_s:.1f}s")
     wait_ms = (time.perf_counter() - started) * 1000.0

--- a/tools/matrixark_mcp_rust_proxy_coalesce.py
+++ b/tools/matrixark_mcp_rust_proxy_coalesce.py
@@ -13,8 +13,10 @@ from typing import Any
 
 try:
     from tools.matrixark_mcp_core import Json, MatrixArkError
+    from tools.matrixark_json_lane import lane_response_deadline_s
 except ModuleNotFoundError:  # Direct script execution from tools/.
     from matrixark_mcp_core import Json, MatrixArkError
+    from matrixark_json_lane import lane_response_deadline_s
 
 
 def coalesced_batch_hset(target: Any, compact_entries: list[list[str]]) -> None:
@@ -34,7 +36,7 @@ def coalesced_batch_hset(target: Any, compact_entries: list[list[str]]) -> None:
     if became_leader:
         drain_batch_hset_coalescer(target)
     else:
-        timeout_s = max(target._backpressure_timeout_s, target.request_timeout_ms / 1000.0 + 2.0)
+        timeout_s = max(target._backpressure_timeout_s, lane_response_deadline_s(target.request_timeout_ms))
         if not event.wait(timeout=timeout_s):
             raise MatrixArkError(f"Rust TemporalStore batch_hset coalescer timed out after {timeout_s:.1f}s")
     wait_ms = (time.perf_counter() - queued_at) * 1000.0
@@ -145,7 +147,7 @@ def coalesced_matrixark_batch_append_records(
     if became_leader:
         drain_append_coalescer(target)
     else:
-        timeout_s = max(target._backpressure_timeout_s, target.request_timeout_ms / 1000.0 + 2.0)
+        timeout_s = max(target._backpressure_timeout_s, lane_response_deadline_s(target.request_timeout_ms))
         if not event.wait(timeout=timeout_s):
             raise MatrixArkError(f"Rust TemporalStore matrixark append coalescer timed out after {timeout_s:.1f}s")
     wait_ms = (time.perf_counter() - queued_at) * 1000.0
@@ -247,7 +249,7 @@ def coalesced_batch_hget(target: Any, compact_entries: list[list[str]]) -> list[
     if became_leader:
         drain_batch_hget_coalescer(target)
     else:
-        timeout_s = max(target._backpressure_timeout_s, target.request_timeout_ms / 1000.0 + 2.0)
+        timeout_s = max(target._backpressure_timeout_s, lane_response_deadline_s(target.request_timeout_ms))
         if not event.wait(timeout=timeout_s):
             raise MatrixArkError(f"Rust TemporalStore batch_hget coalescer timed out after {timeout_s:.1f}s")
     wait_ms = (time.perf_counter() - queued_at) * 1000.0

--- a/tools/matrixark_mcp_rust_proxy_config.py
+++ b/tools/matrixark_mcp_rust_proxy_config.py
@@ -29,18 +29,6 @@ except ImportError:  # pragma: no cover
 _ = LANE_RESPONSE_GRACE_S  # noqa: F401 - re-exported for readers of this module
 
 
-def _unused_lane_response_deadline_s(request_timeout_ms: int) -> float:
-    """How long one call may hold a lane waiting for the proxy to answer.
-
-    This is the ONLY definition. It used to be written out again inside `_read_json_line`, and the
-    backpressure timeout was derived from `request_timeout_ms` alone -- two seconds less. A waiter
-    that gives up before the holder's own deadline can never be granted the lane, so any call that
-    ran to its deadline rejected every caller queued behind it, reporting lane backpressure when
-    the truth was one slow call.
-    """
-    return max(LANE_RESPONSE_GRACE_S, request_timeout_ms / 1000.0 + LANE_RESPONSE_GRACE_S)
-
-
 def initialize_rust_proxy_config(target: Any, *, request_timeout_ms: int) -> None:
     # Defaults to the longest one in-flight call may legitimately take, so backpressure means the
     # lane is saturated rather than merely busy. An operator value still wins, in either spelling;

--- a/tools/test_a_waiter_outlasts_the_call_it_waits_for.py
+++ b/tools/test_a_waiter_outlasts_the_call_it_waits_for.py
@@ -93,16 +93,32 @@ class EveryLaneServerUsesTheSharedDeadlineTest(unittest.TestCase):
             "found %d modules defining _read_json_line, expected at least %d -- this check has "
             "gone blind, or the lane moved and it needs re-aiming" % (len(servers), LANE_SERVER_FLOOR))
 
-    def test_no_lane_server_spells_the_deadline_itself(self) -> None:
-        """A module with its own copy of the formula is a module the next fix will miss."""
-        for stem in lane_servers():
+    def test_no_module_spells_the_deadline_itself(self) -> None:
+        """A module with its own copy of the formula is a module the next fix will miss.
+
+        This asked only `lane_servers()` -- the modules that define `_read_json_line` -- and the
+        three that had drifted were exactly the ones it did not look at. The fix for mx#1073
+        reached the two lane servers and left the formula written out in
+        `matrixark_mcp_rust_proxy_cache` (the ContextPack singleflight wait) and three times in
+        `matrixark_mcp_rust_proxy_coalesce` (the batch_hset, append and batch_hget coalescers),
+        plus a fifth copy in `matrixark_mcp_rust_proxy_config` whose docstring said "This is the ONLY
+        definition".
+
+        Every one of those is a waiter on the same lane as the holder. A scope drawn from who
+        defines `_read_json_line` describes how the modules were split, not who waits, so this
+        reads every production module instead.
+        """
+        for path in sorted(glob.glob(os.path.join(TOOLS, "*.py"))):
+            stem = os.path.basename(path)[:-3]
+            if stem.startswith("test_") or stem == "matrixark_json_lane":
+                continue
             with self.subTest(module=stem):
                 # assertTrue, not assertNotIn: the haystack is a 280 KB module and unittest
                 # prints the whole thing, which buries the one line that matters.
                 self.assertTrue(
                     INLINE_FORMULA not in source_of(stem),
-                    "%s spells the lane deadline out itself (%r). Both copies drifted apart "
-                    "last time; derive it from matrixark_json_lane instead."
+                    "%s spells the lane deadline out itself (%r). Copies of it drifted apart "
+                    "twice; derive it from matrixark_json_lane instead."
                     % (stem, INLINE_FORMULA))
 
     def test_every_lane_server_derives_it_from_the_shared_helper(self) -> None:


### PR DESCRIPTION
mx#1073 was a waiter that gave up **before the holder it was queued behind**, so any call that ran
to its deadline rejected every caller behind it and reported *lane backpressure* when the truth was
one slow call. The fix put the formula in `matrixark_json_lane.lane_response_deadline_s` and added
`test_a_waiter_outlasts_the_call_it_waits_for` to stop a module spelling it out again.

**The guard asked `lane_servers()`** — the modules that define `_read_json_line`. Four copies were
outside that scope and stayed:

| | |
|---|---|
| `matrixark_mcp_rust_proxy_cache.py:213` | the ContextPack singleflight wait |
| `matrixark_mcp_rust_proxy_coalesce.py:37` | the batch_hset coalescer |
| `matrixark_mcp_rust_proxy_coalesce.py:148` | the append coalescer |
| `matrixark_mcp_rust_proxy_coalesce.py:250` | the batch_hget coalescer |

All four write `max(target._backpressure_timeout_s, target.request_timeout_ms / 1000.0 + 2.0)` —
**the exact string the guard refuses** — and every one is a waiter on the same lane as the holder,
which is the thing the fix was about. A scope drawn from who defines `_read_json_line` describes how
the modules were split, not who waits.

### A fifth copy is gone rather than derived

`matrixark_mcp_rust_proxy_config` held `_unused_lane_response_deadline_s`, whose docstring says
*"This is the ONLY definition"*. That stopped being true when the formula moved, and the `_unused_`
prefix says somebody knew. A copy that is both wrong and unreachable is the worst kind: it cannot
fail today, and it is what the next reader reaches for. It would also have satisfied
`test_every_lane_server_derives_it_from_the_shared_helper`, which asks whether the source
**contains** `"lane_response_deadline_s"` — a substring the dead name contains.

### The substitution is value-identical, not equivalent-looking

`lane_response_deadline_s(ms)` is `max(GRACE, ms/1000 + GRACE)` with `GRACE = 2.0`, so for `ms >= 0`
it equals `ms/1000.0 + 2.0` **exactly** — checked over 0..120000 in steps of 97 plus the edges, zero
differences. For a negative timeout it clamps to the grace instead of returning less, which is the
safer direction.

The guard now reads **every production module** rather than the lane servers — which is what would
have caught these four.

### Verified

The 30 suites naming the proxy, the lane, a coalescer, the singleflight or backpressure:
**277 tests, 15 failures, the same 15 by name on pristine main, none new.**
