### PR TITLE
Due keys are a prefix, so expiry stops scaling with the keyspace

### DIFF
--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -3412,18 +3412,27 @@ fn the_periodic_loop_can_evict_when_the_operator_asks() {
 }
 
 #[test]
-fn the_periodic_expire_stage_takes_a_bounded_window_and_resumes_past_it() {
+fn the_periodic_expire_stage_takes_a_bounded_window_each_round() {
     // The periodic loop passed `ShardExpirySweepRequest::default()`, whose limits are 0 -- and the
     // window code says plainly that "zero limits mean no limit". So every tick walked the WHOLE
     // deadline map, hot and cold, for every loaded shard, while the on-demand cycle passed 128 and
     // carried a cursor. Measured by ablation, that stage was 201.5 ms at 20k objects.
     //
-    // The fixture is built to make the CURSOR the thing under test. A first attempt used only
-    // expired keys and passed with resuming disabled -- removing a key deletes it, so the next
-    // round finds the next one whether or not it resumed. The cursor only earns its keep when a
-    // round EXAMINES keys it does not remove: here a long-lived prefix that the window selects
-    // (they exist) but the sweep never deletes (they are not due). Without resuming, every round
-    // re-examines that same prefix and never reaches anything expired.
+    // This test was originally built around a CURSOR, and that mechanism is gone.
+    //
+    // The sweep used to walk the deadlines in KEY order, so a window from the start landed on
+    // whatever sorted first -- live or not -- and only a resuming cursor let later rounds reach
+    // the expired tail. The fixture below still carries a live prefix sorted ahead of the expired
+    // keys because of that.
+    //
+    // Since the deadlines gained a deadline-ordered view, the due keys ARE the front: the live
+    // prefix is never examined, the walk stops at the first deadline in the future, and progress
+    // needs no cursor because removing a due key shrinks the prefix. The live prefix is kept as a
+    // control -- it must still be there afterwards, untouched -- rather than as the obstacle it
+    // used to be.
+    //
+    // What remains worth asserting is the BOUND: one round must take at most its window, and
+    // successive rounds must finish the job.
     const LIVE_PREFIX: usize = 20;
     const EXPIRED: usize = 20;
     const WINDOW: usize = 4;
@@ -3507,29 +3516,45 @@ fn the_periodic_expire_stage_takes_a_bounded_window_and_resumes_past_it() {
         "the shipped default must clear a store smaller than its own per-round bound"
     );
 
-    // Bounded: each round takes a window of live-but-not-due keys and RESUMES past them, so it
-    // eventually reaches the expired tail. Without resuming this stays at 0 for ever.
+    // Bounded, ONE round: the window is what limits it.
+    //
+    // The old form of this assertion ran many rounds and required that they had NOT finished,
+    // which only held because each round wasted its window on live keys it could not remove.
+    // Now a round spends its whole window on due keys, so "not finished yet" is no longer a
+    // statement about the bound -- the bound is what ONE round takes.
     let bounded = runtime_with_a_live_prefix();
     let options = StorageManagerOptions {
         max_expire_hot_buckets_per_round: WINDOW,
         max_expire_cold_buckets_per_round: WINDOW,
         ..StorageManagerOptions::default()
     };
-    let rounds = LIVE_PREFIX / WINDOW + 3;
+    bounded.run_storage_manager_once(1, options.clone());
+    let after_one = bounded.stats().expired_records_removed;
+    assert!(
+        after_one > 0,
+        "a bounded round removed nothing, so the window is not reaching the expired keys at all"
+    );
+    assert!(
+        after_one <= WINDOW as u64,
+        "one bounded round removed {after_one} with a window of {WINDOW} -- the bound is not \
+         binding"
+    );
+
+    // And successive rounds finish the job, so the bound paces the work without stalling it.
+    let rounds = EXPIRED / WINDOW + 3;
     for _ in 0..rounds {
         bounded.run_storage_manager_once(1, options.clone());
     }
     let removed = bounded.stats().expired_records_removed;
-    assert!(
-        removed > 0,
-        "after {rounds} bounded rounds the sweep must have resumed past the {LIVE_PREFIX} \
-         live keys and reached the expired tail, but removed {removed}"
+    assert_eq!(
+        removed, EXPIRED as u64,
+        "after {rounds} further bounded rounds the sweep should have cleared all {EXPIRED} \
+         expired keys, but removed {removed}"
     );
-    assert!(
-        removed < EXPIRED as u64,
-        "a bounded sweep must not clear the whole tail at once -- that would mean the bound \
-         is not binding: removed {removed} of {EXPIRED}"
-    );
+
+    // That equality is also the control on the live prefix: those {LIVE_PREFIX} keys carry no
+    // deadline at all, so removing one would be counted here and push the total ABOVE
+    // {EXPIRED}. Exactly {EXPIRED} means the sweep took the due keys and nothing else.
 }
 
 /// Does the PERIODIC loop -- the one `bin/server.rs` starts -- actually reclaim the logs?
@@ -5677,4 +5702,91 @@ fn how_long_an_expired_key_survives() {
             ),
         }
     }
+}
+
+/// An expired key is removed in a bounded number of rounds, whatever the keyspace.
+///
+/// The sweep used to walk `expires_at_ms` in KEY order from a cursor, testing deadlines as it
+/// went, so a key that was not due was still walked and charged against the round's scan budget.
+/// Time-to-expire was therefore keyspace/scan_budget rounds: ten expired keys behind 10,000 live
+/// ones survived more than sixty rounds, and behind 40,000 they survived just as long.
+///
+/// `expiry_by_deadline` orders the same deadlines by deadline, so the due keys are a PREFIX and
+/// the walk stops at the first one in the future. Measured after the change: one round at 1,000,
+/// 10,000 and 40,000 live keys alike.
+///
+/// This guards the property that matters -- that the bound does not depend on the keyspace -- by
+/// hiding the due keys behind a large live set and sorting them AFTER it, which is exactly the
+/// arrangement the key-ordered scan was worst at.
+#[test]
+fn an_expired_key_is_removed_in_a_bounded_number_of_rounds() {
+    const LIVE_KEYS: usize = 5_000;
+    const DUE_KEYS: usize = 5;
+    // Generous next to the measured 1, so this fails on a return to keyspace-proportional
+    // latency (which would need ~39 rounds at this size) and not on a round of slack.
+    const ROUND_BUDGET: usize = 3;
+
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+    let runtime = DataNodeRuntime::new_without_workers_with_options(
+        engine,
+        DataNodeRuntimeOptions {
+            worker_threads: 0,
+            max_queue_depth: 4,
+            max_background_queue_depth: 2,
+        },
+    );
+    {
+        let engine = runtime.engine();
+        for index in 0..LIVE_KEYS {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSetEx {
+                    key: format!("live-{index:08}"),
+                    value: vec![b'v'; 16],
+                    ttl_ms: 3_600_000,
+                },
+            });
+        }
+        // "zzz" so the due keys sort AFTER every live one: a key-ordered cursor has to traverse
+        // the whole live set to reach them.
+        for index in 0..DUE_KEYS {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSetEx {
+                    key: format!("zzz-due-{index:04}"),
+                    value: vec![b'v'; 16],
+                    ttl_ms: 1,
+                },
+            });
+        }
+    }
+
+    // Count what the SWEEP removed. A `StringGet` would expire the key lazily on the way through
+    // and make the sweep look as though it had found it.
+    let before = runtime.stats().expired_records_removed;
+    let options = StorageManagerOptions::default();
+    let mut rounds_used = 0usize;
+    for round in 0..ROUND_BUDGET {
+        runtime.run_storage_manager_once(1, options.clone());
+        rounds_used = round + 1;
+        if runtime
+            .stats()
+            .expired_records_removed
+            .saturating_sub(before)
+            >= DUE_KEYS as u64
+        {
+            break;
+        }
+    }
+
+    let removed = runtime
+        .stats()
+        .expired_records_removed
+        .saturating_sub(before);
+    assert!(
+        removed >= DUE_KEYS as u64,
+        "the sweep removed {removed} of {DUE_KEYS} expired keys in {rounds_used} round(s) behind \
+         {LIVE_KEYS} live ones -- time-to-expire is scaling with the keyspace again"
+    );
 }

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -3263,6 +3263,100 @@ where
     (selected, next_cursor)
 }
 
+/// How many deadlines disagree between the two expiry indexes. Zero is the invariant.
+///
+/// Exposed so a guard can assert it after a real workload: the two maps are kept in step by
+/// `set_expiry`/`clear_expiry`, and a mutation site that bypassed them would show up here rather
+/// than as keys that silently never expire.
+pub(in crate::engine) fn expiry_index_disagreements(shard: &ShardState) -> usize {
+    let mut disagreements = 0usize;
+    for (key, expires_at) in shard.expires_at_ms.iter() {
+        if !shard
+            .expiry_by_deadline
+            .contains_key(&(*expires_at, key.clone()))
+        {
+            disagreements = disagreements.saturating_add(1);
+        }
+    }
+    for ((expires_at, key), ()) in shard.expiry_by_deadline.iter() {
+        if shard.expires_at_ms.get(key) != Some(expires_at) {
+            disagreements = disagreements.saturating_add(1);
+        }
+    }
+    disagreements
+}
+
+/// Record a deadline for `key`, keeping both expiry indexes in step.
+pub(in crate::engine) fn set_expiry(shard: &mut ShardState, key: String, expires_at: u64) {
+    ensure_expiry_order(shard);
+    if let Some(previous) = shard.expires_at_ms.insert(key.clone(), expires_at) {
+        shard.expiry_by_deadline.remove(&(previous, key.clone()));
+    }
+    shard.expiry_by_deadline.insert((expires_at, key), ());
+}
+
+/// Drop any deadline for `key`. Returns whether there was one.
+pub(in crate::engine) fn clear_expiry(shard: &mut ShardState, key: &str) -> bool {
+    ensure_expiry_order(shard);
+    match shard.expires_at_ms.remove(key) {
+        Some(previous) => {
+            shard.expiry_by_deadline.remove(&(previous, key.to_string()));
+            true
+        }
+        None => false,
+    }
+}
+
+/// Rebuild the deadline-ordered view if a load left it empty.
+///
+/// It carries `#[serde(skip)]`, so a shard restored from a snapshot has the key-ordered map and
+/// not this one. Rebuilding on first use keeps the persisted format unchanged and costs one pass
+/// per load rather than a migration.
+pub(in crate::engine) fn ensure_expiry_order(shard: &mut ShardState) {
+    if shard.expiry_by_deadline.is_empty() && !shard.expires_at_ms.is_empty() {
+        for (key, expires_at) in shard.expires_at_ms.iter() {
+            shard
+                .expiry_by_deadline
+                .insert((*expires_at, key.clone()), ());
+        }
+    }
+}
+
+/// The keys whose deadline has passed, cheapest first, up to `limit` that `keep` accepts.
+///
+/// Due keys are a PREFIX of the deadline-ordered view, so this stops at the first deadline in the
+/// future instead of walking the keyspace. `scan_budget` still bounds the walk, because `keep`
+/// can reject a long run of due keys belonging to the other class.
+pub(in crate::engine) fn due_window<F>(
+    shard: &ShardState,
+    now: u64,
+    limit: usize,
+    scan_budget: usize,
+    keep: F,
+) -> Vec<(String, u64)>
+where
+    F: Fn(&str) -> bool,
+{
+    let mut selected = Vec::new();
+    let mut walked = 0usize;
+    for ((expires_at, key), ()) in shard.expiry_by_deadline.iter() {
+        if *expires_at > now {
+            break;
+        }
+        if limit > 0 && selected.len() >= limit {
+            break;
+        }
+        if scan_budget > 0 && walked >= scan_budget {
+            break;
+        }
+        walked = walked.saturating_add(1);
+        if keep(key.as_str()) {
+            selected.push((key.clone(), *expires_at));
+        }
+    }
+    selected
+}
+
 fn remove_if_expired(shard: &mut ShardState, key: &str) -> bool {
     // Use the replay-aware clock: during WAL replay this resolves to the per-record leader
     // timestamp so lazy expiry reproduces the leader's original branch. Using the real
@@ -3326,7 +3420,7 @@ fn delete_record(shard: &mut ShardState, key: &str) -> bool {
 fn delete_record_exact(shard: &mut ShardState, key: &str) -> bool {
     let mut removed = false;
     removed |= mark_bucket_index_object_deleted(shard, key);
-    removed |= shard.expires_at_ms.remove(key).is_some();
+    removed |= clear_expiry(shard, key);
     removed |= shard.strings.remove(key).is_some();
     removed |= shard.hashes.remove(key).is_some();
     removed |= shard.sets.remove(key).is_some();

--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -193,7 +193,7 @@ pub(crate) fn execute_on_shard(
             let expires_at = resolve_now_ms().saturating_add(ttl_ms);
             for record_key in associated_record_keys(&key) {
                 if record_exists_exact(shard, &record_key) {
-                    shard.expires_at_ms.insert(record_key, expires_at);
+                    crate::engine::set_expiry(shard, record_key, expires_at);
                 }
             }
             mutated = true;
@@ -223,7 +223,7 @@ pub(crate) fn execute_on_shard(
             } else {
                 let mut removed = false;
                 for record_key in associated_record_keys(&key) {
-                    if shard.expires_at_ms.remove(&record_key).is_some()
+                    if crate::engine::clear_expiry(shard, &record_key)
                         && record_exists_exact(shard, &record_key)
                     {
                         removed = true;
@@ -325,7 +325,7 @@ pub(crate) fn execute_on_shard(
                 );
                 shard.strings.insert(key.clone(), address);
                 let expires_at = resolve_now_ms().saturating_add(ttl_ms);
-                shard.expires_at_ms.insert(key.clone(), expires_at);
+                crate::engine::set_expiry(shard, key.clone(), expires_at);
                 // This write sets a value AND a deadline. Recording only the page passes a probe
                 // that asks whether the record said anything, and produces a recovered key that
                 // never expires -- so the deadline is recorded too, already resolved, exactly as
@@ -388,7 +388,7 @@ pub(crate) fn execute_on_shard(
                     shard.strings.insert(key.clone(), address);
                     if let Some(ttl_ms) = ttl_ms {
                         let expires_at = resolve_now_ms().saturating_add(ttl_ms);
-                        shard.expires_at_ms.insert(key.clone(), expires_at);
+                        crate::engine::set_expiry(shard, key.clone(), expires_at);
                         // A conditional write that refreshes a deadline records the refreshed
                         // one. Recording only the page leaves a replay installing the value over
                         // a LAPSED deadline from an earlier record, and the key reads as expired
@@ -404,7 +404,7 @@ pub(crate) fn execute_on_shard(
                             false,
                         );
                     } else {
-                        shard.expires_at_ms.remove(&key);
+                        crate::engine::clear_expiry(shard, &key);
                         // No deadline is equally a result. An object outcome carrying neither a
                         // deadline nor a deletion says exactly that.
                         stage_meta_outcome(
@@ -1926,7 +1926,7 @@ pub(crate) fn execute_on_shard(
             hll::record_change(shard, &key, bucket_ms, value);
             if let Some(ttl_ms) = ttl_ms {
                 let expires_at = resolve_now_ms().saturating_add(ttl_ms);
-                shard.expires_at_ms.insert(key.clone(), expires_at);
+                crate::engine::set_expiry(shard, key.clone(), expires_at);
                 stage_meta_outcome(
                     shard_id,
                     "object",
@@ -2266,7 +2266,7 @@ pub(crate) fn execute_on_shard(
             }
             if ttl_ms > 0 {
                 let expires_at = resolve_now_ms().saturating_add(ttl_ms);
-                shard.expires_at_ms.insert(key.clone(), expires_at);
+                crate::engine::set_expiry(shard, key.clone(), expires_at);
                 stage_meta_outcome(
                     shard_id,
                     "object",

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -916,13 +916,13 @@ impl TemporalEngine {
                 // a lapsed deadline from an earlier record outlives the write that removed it.
                 let Some(expires_at) = item.ttl else {
                     for record_key in super::associated_record_keys(&item.object_key) {
-                        shard.expires_at_ms.remove(&record_key);
+                        crate::engine::clear_expiry(shard, &record_key);
                     }
                     return true;
                 };
                 for record_key in super::associated_record_keys(&item.object_key) {
                     if super::record_exists_exact(shard, &record_key) {
-                        shard.expires_at_ms.insert(record_key, expires_at);
+                        crate::engine::set_expiry(shard, record_key, expires_at);
                     }
                 }
                 true

--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -493,20 +493,29 @@ fn expiry_scan_budget(limit: usize) -> usize {
         let hot_limit = request.max_hot_buckets_per_round;
         let cold_limit = request.max_cold_buckets_per_round;
         let scan_budget = Self::expiry_scan_budget(hot_limit.max(cold_limit));
-        let (hot_selected, next_hot_cursor) = crate::engine::expiry_window(
-            &shard.expires_at_ms,
-            request.hot_cursor.as_deref(),
-            hot_limit,
-            scan_budget,
-            |key| record_exists(shard, key),
-        );
-        let (cold_selected, next_cold_cursor) = crate::engine::expiry_window(
-            &shard.expires_at_ms,
-            request.cold_cursor.as_deref(),
-            cold_limit,
-            scan_budget,
-            |key| !record_exists(shard, key),
-        );
+        // Read the DUE keys, not a window of the keyspace that might contain some.
+        //
+        // These windows used to walk `expires_at_ms` in KEY order from a cursor, testing each
+        // deadline as they went, so a key that was not due was still walked and charged against
+        // the budget. That made time-to-expire a function of the keyspace: measured at
+        // keyspace/scan_budget rounds, with ten expired keys behind 10,000 live ones surviving
+        // more than sixty rounds.
+        //
+        // `expiry_by_deadline` orders the same deadlines by deadline, so the due keys are a
+        // PREFIX and the walk stops at the first one in the future. The cursors are no longer
+        // needed for correctness -- a due key is at the front, not somewhere ahead of a cursor --
+        // and the request/report fields are kept so the wire format does not change.
+        crate::engine::ensure_expiry_order(shard);
+        let hot_selected =
+            crate::engine::due_window(shard, now, hot_limit, scan_budget, |key| {
+                record_exists(shard, key)
+            });
+        let cold_selected =
+            crate::engine::due_window(shard, now, cold_limit, scan_budget, |key| {
+                !record_exists(shard, key)
+            });
+        let next_hot_cursor: Option<String> = None;
+        let next_cold_cursor: Option<String> = None;
         let mut expired_records_removed = 0;
         let mut skipped_records = 0usize;
         let mut loaded_for_expire = 0usize;
@@ -531,7 +540,7 @@ fn expiry_scan_budget(limit: usize) -> usize {
                         expired_records_removed += 1;
                         expired_keys.push(key.clone());
                     } else {
-                        shard.expires_at_ms.remove(key);
+                        crate::engine::clear_expiry(shard, key);
                     }
                 } else {
                     skipped_records = skipped_records.saturating_add(1);

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -87,9 +87,25 @@ pub(super) struct ShardState {
     /// full sweep, so a fresh process starts from fully recomputed flags.
     #[serde(skip)]
     pub(super) buckets_pending_flag_refresh: BTreeSet<u32>,
-    /// Deadlines, kept in key order so a sweep can resume from its cursor and look at the
-    /// window rather than at everything.
+    /// Deadlines, kept in key order for the point lookup `ttl_ms` needs.
+    ///
+    /// MUTATE THIS THROUGH `set_expiry` / `clear_expiry`, never directly: `expiry_by_deadline`
+    /// below mirrors it and the two must agree. `the_two_expiry_indexes_agree` fails if they
+    /// drift.
     pub(super) expires_at_ms: BTreeMap<String, u64>,
+    /// The same deadlines, DEADLINE-ordered, so the keys that are due are a PREFIX.
+    ///
+    /// Walking `expires_at_ms` in key order to find due keys made time-to-expire a function of
+    /// the keyspace rather than of how many keys were actually due: measured at
+    /// keyspace/scan_budget rounds, so ten expired keys behind 10,000 live ones survived more
+    /// than sixty rounds. Ordered by deadline, finding them costs the number that are due.
+    ///
+    /// The same pair as `SeenSet`'s `by_member`/`by_time`, for the same reason.
+    ///
+    /// Derived, never persisted: it is rebuilt from `expires_at_ms` on first use after a load,
+    /// so no snapshot or wire format changes and an older snapshot needs no migration.
+    #[serde(skip)]
+    pub(super) expiry_by_deadline: BTreeMap<(u64, String), ()>,
     pub(super) strings: HashMap<String, BlockAddress>,
     // Rebuildable from the durable bucket/page index on load; do not duplicate in checkpoints.
     #[serde(default, skip_serializing)]

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -8595,3 +8595,78 @@ fn emptied_buckets_are_dropped_without_walking_the_map() {
         "per-write cost grew {growth:.2}x from a 2k to a 20k corpus. This asserts a RATIO and \n         cannot say what caused it: the by-name drop this test was written for is intact \n         (storage_bucket_internals.rs, `Drop buckets this call emptied -- BY NAME`), and \n         the growth reproduces at load 5 and at load 15 alike, so it is neither that walk \n         nor machine noise. Look for other per-write work that scales with the corpus."
     );
 }
+
+/// The two expiry indexes agree after a workload that touches every path that writes one.
+///
+/// `expires_at_ms` (key-ordered, for the point lookup `ttl_ms` needs) and `expiry_by_deadline`
+/// (deadline-ordered, so the due keys are a prefix) hold the same facts twice. They are kept in
+/// step by `set_expiry`/`clear_expiry`, and a mutation site that bypassed those would leave keys
+/// that silently never expire -- the failure mode is invisible from outside, which is why this
+/// asserts the invariant directly rather than asserting on behaviour that happens to depend on it.
+///
+/// The workload is chosen to hit each kind of write: a fresh deadline, a deadline REPLACED by a
+/// second set (the case where the old entry must be removed from the ordered view, not just
+/// overwritten in the map), a deadline removed by a persist without one, and a key deleted
+/// outright.
+#[test]
+fn the_two_expiry_indexes_agree() {
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+
+    for index in 0..200usize {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSetEx {
+                key: format!("agree-{index:04}"),
+                value: b"v".to_vec(),
+                ttl_ms: 60_000,
+            },
+        });
+    }
+    // Replace the deadline on half of them: the old (deadline, key) entry has to go.
+    for index in 0..100usize {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSetEx {
+                key: format!("agree-{index:04}"),
+                value: b"v2".to_vec(),
+                ttl_ms: 120_000,
+            },
+        });
+    }
+    // Drop the deadline entirely by writing without one.
+    for index in 100..150usize {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("agree-{index:04}"),
+                value: b"v3".to_vec(),
+            },
+        });
+    }
+    // And delete some outright.
+    for index in 150..200usize {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::CommonDelete {
+                key: format!("agree-{index:04}"),
+            },
+        });
+    }
+
+    let shards = engine.shards.read().expect("engine lock poisoned");
+    let shard = shards.get(&1).expect("shard 1 is loaded");
+    // The denominator: an empty index agrees with an empty index, and proves nothing.
+    assert!(
+        !shard.expires_at_ms.is_empty(),
+        "no deadlines survived the workload, so agreement here is vacuous"
+    );
+    assert_eq!(
+        crate::engine::expiry_index_disagreements(shard),
+        0,
+        "the key-ordered and deadline-ordered expiry indexes disagree: {} deadlines vs {} ordered \
+         entries -- a write path is bypassing set_expiry/clear_expiry",
+        shard.expires_at_ms.len(),
+        shard.expiry_by_deadline.len(),
+    );
+}


### PR DESCRIPTION
#1541 measured that TTL expiry is effectively unenforced at scale for any key nobody reads: ten
expired keys behind 10,000 live ones survived more than sixty rounds, and the 1,000-key case landed
at exactly `keyspace / scan_budget` rounds.

The cause is the ordering. `expires_at_ms` is keyed by **key** with the deadline as the value, and
the sweep walked it in key order from a cursor, testing each deadline as it went — so a key that was
**not** due was still walked and charged against the round's scan budget, and a due key was found
only when the cursor reached it.

| live keys with TTLs | before | after |
|---|---|---|
| 1,000 | 8 rounds | **1** |
| 10,000 | >60 | **1** |
| 40,000 | >60 | **1** |

Constant, because the due keys are now a **prefix** and the walk stops at the first deadline in the
future. The probe's own runtime fell from 1,998 s to 103 s for the same reason.

## The pattern is already in this tree

`SeenSet` carries `by_member` and `by_time` — the same facts twice, one ordered for lookup and one
ordered for expiry — for exactly this reason. Expiry now has the same pair: `expires_at_ms` stays
for the point lookup `ttl_ms` needs, and `expiry_by_deadline` is the deadline-ordered view.

## No format change

`expiry_by_deadline` is `#[serde(skip)]` and rebuilt from `expires_at_ms` on first use after a load.
No snapshot or wire format changes, and an older snapshot needs no migration — it costs one pass per
load instead.

## Keeping two indexes honest

All eleven mutation sites now go through `set_expiry` / `clear_expiry`, which update both.
`the_two_expiry_indexes_agree` asserts they hold the same facts after a workload that hits each
write path — a fresh deadline, a deadline **replaced** by a second set (where the old ordered entry
must be removed and not merely overwritten), a deadline dropped by a write without one, and an
outright delete. A site that bypassed the helpers would leave keys that silently never expire, which
is invisible from outside, so the invariant is asserted directly.

The cursors are no longer needed for correctness — a due key is at the front, not somewhere ahead of
a cursor — but the request and report fields are kept so the wire format is unchanged.

Verified by mutation: putting the sweep back on the key-ordered walk fails the new bounded-latency
guard with "the sweep removed 0 of 5 expired keys in 3 round(s) behind 5000 live ones — time-to-
expire is scaling with the keyspace again".

## A test that was measuring the old inefficiency

`the_periodic_expire_stage_takes_a_bounded_window_and_resumes_past_it` (#1469) failed on this
change, and it was right to. It ran eight bounded rounds with a window of 4 over 20 expired keys and
asserted the sweep had **not** finished — *"a bounded sweep must not clear the whole tail at once"*.
That only held because each round spent its window on live keys sorted ahead of the expired ones and
could not remove them. With the due keys at the front, every round spends its whole window on work,
so eight rounds of 4 clear all 20 and the assertion trips.

"Not finished yet" was therefore a statement about wasted rounds, not about the bound. Rewritten to
assert what the bound actually is: **one** round removes at most its window, and successive rounds
finish the job. Renamed to `..._takes_a_bounded_window_each_round`, since the cursor it was named for
is gone.

The live prefix stays as a **control** rather than an obstacle: those keys carry no deadline, so
removing one would be counted and push the total above 20. Exactly 20 means the sweep took the due
keys and nothing else.

## Verification

`cargo test -p temporalstore-rust --lib -- --test-threads=1` → **1776 passed, 1 failed**. The one
failure is `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the standing `--lib`
baseline failure on main. No new failure name.
