### PR TITLE
One ranking blend, and the weights pinned where they are written four times

### DIFF
--- a/tools/matrixark_mcp_core_scoring.py
+++ b/tools/matrixark_mcp_core_scoring.py
@@ -194,16 +194,27 @@ except ImportError:  # Direct script execution from tools/.
 
 
 def final_recall_score(origin_score: float, time_score: float, business_score: float, weights: Json) -> float:
-    time_weight = clamp01(weights.get("time", DEFAULT_TIME_WEIGHT), DEFAULT_TIME_WEIGHT)
-    business_weight = clamp01(weights.get("business", DEFAULT_BUSINESS_WEIGHT), DEFAULT_BUSINESS_WEIGHT)
-    if time_weight + business_weight > 1.0:
-        scale = 1.0 / (time_weight + business_weight)
-        time_weight *= scale
-        business_weight *= scale
-    origin_weight = 1.0 - time_weight - business_weight
-    return round(
-        origin_weight * origin_score + time_weight * time_score + business_weight * business_score,
-        6,
+    """This build's ranking blend, with the weights this module's constants carry.
+
+    The arithmetic used to be written out here as well as in `matrixark_mcp_scoring`, and the two
+    copies differed only in where the defaults came from: this one read
+    `DEFAULT_TIME_WEIGHT`/`DEFAULT_BUSINESS_WEIGHT`, the other had 0.18 and 0.22 in its signature.
+    They answered identically for every caller, because the one caller of the other copy passes the
+    constants in -- which is the same shape the two `cosine` implementations had before one of them
+    was fixed and the other was not. `test_there_is_one_cosine` states the rule this follows: not
+    "the two must agree" but "there must not be two".
+    """
+    try:  # package path (tools.matrixark_mcp_scoring)
+        from .matrixark_mcp_scoring import final_recall_score as _blend
+    except ImportError:  # Direct script execution from tools/.
+        from matrixark_mcp_scoring import final_recall_score as _blend
+    return _blend(
+        origin_score,
+        time_score,
+        business_score,
+        weights,
+        default_time_weight=DEFAULT_TIME_WEIGHT,
+        default_business_weight=DEFAULT_BUSINESS_WEIGHT,
     )
 
 

--- a/tools/test_numeric_defaults_agree.py
+++ b/tools/test_numeric_defaults_agree.py
@@ -55,6 +55,7 @@ started outside every shipped path, and the resolver now agrees at 60000.
 from __future__ import annotations
 
 import ast
+import io
 import collections
 import os
 import re
@@ -244,3 +245,105 @@ class NumericDefaultsAgreeTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TheRankingWeightsAreWrittenOnceTest(unittest.TestCase):
+    """`DEFAULT_TIME_WEIGHT` and `DEFAULT_BUSINESS_WEIGHT` are written in four places.
+
+    Two are module constants -- `matrixark_mcp_core` and `matrixark_mcp_runtime_config` -- which
+    core's own comment says are deliberately defined in both. The other two are the keyword
+    defaults in `matrixark_mcp_scoring.final_recall_score`, spelled 0.18 and 0.22.
+
+    `test_no_new_variable_disagrees_about_its_default` above cannot see the last two: it compares
+    the fallback of an ENVIRONMENT READ, and a signature default is not one. So four numbers that
+    have to move together had a check over two of them.
+
+    They agree today, and only because the single caller of that function passes the constants in
+    explicitly. A new caller that omits them gets 0.18 and 0.22 whatever the constants say, for
+    every deployment that configures no weights -- which is most of them, and the one nobody tests.
+    That is the failure this file's own docstring describes for numbers, one layer further in.
+    """
+
+    NAMES = ("DEFAULT_TIME_WEIGHT", "DEFAULT_BUSINESS_WEIGHT")
+
+    @staticmethod
+    def _module_constants(stem):
+        with io.open(os.path.join(TOOLS, stem + ".py"), encoding="utf-8") as handle:
+            tree = ast.parse(handle.read())
+        found = {}
+        for node in tree.body:
+            if isinstance(node, ast.Assign) and len(node.targets) == 1 \
+                    and isinstance(node.targets[0], ast.Name) \
+                    and isinstance(node.value, ast.Constant):
+                found[node.targets[0].id] = node.value.value
+        return found
+
+    @staticmethod
+    def _signature_defaults(stem, function):
+        with io.open(os.path.join(TOOLS, stem + ".py"), encoding="utf-8") as handle:
+            tree = ast.parse(handle.read())
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function:
+                names = [a.arg for a in node.args.kwonlyargs]
+                values = [d.value if isinstance(d, ast.Constant) else None
+                          for d in node.args.kw_defaults]
+                return dict(zip(names, values))
+        return {}
+
+    def test_the_two_modules_agree_about_the_weights(self) -> None:
+        core = self._module_constants("matrixark_mcp_core")
+        runtime = self._module_constants("matrixark_mcp_runtime_config")
+        for name in self.NAMES:
+            with self.subTest(constant=name):
+                self.assertIn(name, core, "%s is no longer a plain constant in core" % name)
+                self.assertIn(name, runtime, "%s is no longer a plain constant in runtime" % name)
+                self.assertEqual(
+                    core[name], runtime[name],
+                    "%s is %r in matrixark_mcp_core and %r in matrixark_mcp_runtime_config. Both "
+                    "are read as the default weight for a deployment that sets none, so which one "
+                    "a request gets depends on which module served it."
+                    % (name, core[name], runtime[name]))
+
+    def test_the_signature_defaults_are_the_constants(self) -> None:
+        core = self._module_constants("matrixark_mcp_core")
+        signature = self._signature_defaults("matrixark_mcp_scoring", "final_recall_score")
+        for name, keyword in zip(self.NAMES, ("default_time_weight", "default_business_weight")):
+            with self.subTest(keyword=keyword):
+                self.assertIn(keyword, signature,
+                              "final_recall_score no longer takes %s" % keyword)
+                self.assertEqual(
+                    core[name], signature[keyword],
+                    "final_recall_score defaults %s to %r while %s is %r. Every caller passes the "
+                    "constant in today, so the two agree by habit rather than by construction -- "
+                    "and a caller that omits it silently ranks on the older number."
+                    % (keyword, signature[keyword], name, core[name]))
+
+    def test_there_is_one_blend(self) -> None:
+        """A delegation is an import and a return; a second implementation is not.
+
+        matrixark_mcp_core_scoring held its own copy of the arithmetic until this was written.
+        """
+        implementations = []
+        for entry in sorted(os.listdir(TOOLS)):
+            if not entry.startswith("matrixark_") or not entry.endswith(".py"):
+                continue
+            try:
+                with io.open(os.path.join(TOOLS, entry), encoding="utf-8",
+                             errors="replace") as handle:
+                    tree = ast.parse(handle.read())
+            except (SyntaxError, OSError):
+                continue
+            for node in tree.body:
+                if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                if node.name != "final_recall_score":
+                    continue
+                body = [s for s in node.body
+                        if not (isinstance(s, ast.Expr) and isinstance(s.value, ast.Constant))]
+                if len(body) > 3:
+                    implementations.append(entry[:-3])
+        self.assertEqual(
+            ["matrixark_mcp_scoring"], sorted(implementations),
+            "the ranking blend has more than one implementation: %r. The rule is the strong form "
+            "test_there_is_one_cosine states -- not that the copies must agree, but that there "
+            "must not be two." % (sorted(implementations),))


### PR DESCRIPTION
`final_recall_score` was implemented **twice**, in the same pair of modules that produced the two
`cosine` implementations. The arithmetic was identical; the copies differed in where the defaults
came from:

| | defaults from |
|---|---|
| `matrixark_mcp_core_scoring` | `DEFAULT_TIME_WEIGHT` / `DEFAULT_BUSINESS_WEIGHT` |
| `matrixark_mcp_scoring` | `0.18` and `0.22`, in its signature |

They answer identically today, and **only because the one caller of the second copy passes the
constants in explicitly.** That is the shape the two cosines had: *"vectors stored today are unit
length, so the two answered the same and nothing had gone wrong. That is what let one copy be fixed
while the other was not."*

`test_there_is_one_cosine` states the rule this follows — not *the two must agree* but **there must
not be two**. `matrixark_mcp_core_scoring` now delegates: an import and a return, which
`test_a_delegate_accepts_only_what_it_forwards` recognises as a delegation rather than a second
implementation, and which adds **no import edge** because that module already imports
`business_score_for_candidate` from the same place.

### The numbers were guarded by nothing

`DEFAULT_TIME_WEIGHT` and `DEFAULT_BUSINESS_WEIGHT` are written in **four** places: constants in
`matrixark_mcp_core` and `matrixark_mcp_runtime_config` (core's own comment says both are
deliberate), plus the two signature defaults. `grep DEFAULT_TIME_WEIGHT test_*.py` returned
**nothing**.

`test_no_new_variable_disagrees_about_its_default` next door cannot see the signature pair: it
compares the fallback of an **environment read**, and a keyword default is not one. Four numbers
that have to move together had a check over none of them.

Three assertions added to that file, where the rule for numbers already lives: the two modules agree
about the weights; the signature defaults equal the constants; and there is exactly one
implementation of the blend.

### Verified by value, not only by the suite

The delegation against the removed arithmetic over **2,160 combinations** — six origin scores by six
time by six business by ten weight sets, including negative, string, `None` and over-1.0 weights —
**zero differences**. The 24 suites naming the blend, either scoring module, the numeric defaults or
the candidate policy: **168 tests, zero failures**, and 161 with the same result on pristine main.
