### PR TITLE
Two citations that point at nothing

### DIFF
--- a/tools/matrixark_tenant_policy.py
+++ b/tools/matrixark_tenant_policy.py
@@ -399,7 +399,14 @@ def _validated(policy: Any, *, source: str, tenant: str) -> Json:
 
 
 def _load_file_policies() -> tuple[Json, dict[str, Json]]:
-    """File defaults and per-tenant overrides. `_load_file_users` reads the same file's users."""
+    """File defaults, per-tenant overrides and the per-user overrides in the same file.
+
+    This used to say `_load_file_users` reads the users half. There is no such function --
+    the users live under `users` in this same file and are read below, into the same cache
+    entry, off the same stat. A reader who went looking for that name would find nothing and
+    could reasonably write a second reader of the same file, which is the one thing the
+    single stat and single cache here exist to avoid.
+    """
     path = os.environ.get("MATRIXARK_TENANT_POLICY_PATH", "").strip()
     if not path:
         return {}, {}

--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -1447,8 +1447,10 @@
      The strip is the one element on every page, and it said "live" whenever the socket was open --
      so a gateway that stopped producing frames left every page green. The page-side client learned
      this in mx#1189; the strip runs its own client, because five of the seven pages never load the
-     other one, so it has to learn it too. `test_both_stream_clients_agree_when_a_stream_is_quiet`
-     is what stops the two rules drifting apart. */
+     other one, so it has to learn it too. `TheTwoClientsAgreeTest` in
+     test_matrixark_the_strip_notices_a_quiet_stream_too is what stops the two rules drifting
+     apart: both must read tick_s off the frame, both must stamp on every block rather than on
+     frames, and neither may write the interval down. */
   var blockAt = 0, tickMs = 0, quietTimer = null;
   /* Set when the gateway says it is closing on purpose, cleared by the reopen it
      causes. A planned recycle and a gateway that stopped answering look identical

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -1158,8 +1158,10 @@
      The strip is the one element on every page, and it said "live" whenever the socket was open --
      so a gateway that stopped producing frames left every page green. The page-side client learned
      this in mx#1189; the strip runs its own client, because five of the seven pages never load the
-     other one, so it has to learn it too. `test_both_stream_clients_agree_when_a_stream_is_quiet`
-     is what stops the two rules drifting apart. */
+     other one, so it has to learn it too. `TheTwoClientsAgreeTest` in
+     test_matrixark_the_strip_notices_a_quiet_stream_too is what stops the two rules drifting
+     apart: both must read tick_s off the frame, both must stamp on every block rather than on
+     frames, and neither may write the interval down. */
   var blockAt = 0, tickMs = 0, quietTimer = null;
   /* Set when the gateway says it is closing on purpose, cleared by the reopen it
      causes. A planned recycle and a gateway that stopped answering look identical

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -686,8 +686,10 @@ NAV_JS = r'''<script>
      The strip is the one element on every page, and it said "live" whenever the socket was open --
      so a gateway that stopped producing frames left every page green. The page-side client learned
      this in mx#1189; the strip runs its own client, because five of the seven pages never load the
-     other one, so it has to learn it too. `test_both_stream_clients_agree_when_a_stream_is_quiet`
-     is what stops the two rules drifting apart. */
+     other one, so it has to learn it too. `TheTwoClientsAgreeTest` in
+     test_matrixark_the_strip_notices_a_quiet_stream_too is what stops the two rules drifting
+     apart: both must read tick_s off the frame, both must stamp on every block rather than on
+     frames, and neither may write the interval down. */
   var blockAt = 0, tickMs = 0, quietTimer = null;
   /* Set when the gateway says it is closing on purpose, cleared by the reopen it
      causes. A planned recycle and a gateway that stopped answering look identical

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -1299,8 +1299,10 @@
      The strip is the one element on every page, and it said "live" whenever the socket was open --
      so a gateway that stopped producing frames left every page green. The page-side client learned
      this in mx#1189; the strip runs its own client, because five of the seven pages never load the
-     other one, so it has to learn it too. `test_both_stream_clients_agree_when_a_stream_is_quiet`
-     is what stops the two rules drifting apart. */
+     other one, so it has to learn it too. `TheTwoClientsAgreeTest` in
+     test_matrixark_the_strip_notices_a_quiet_stream_too is what stops the two rules drifting
+     apart: both must read tick_s off the frame, both must stamp on every block rather than on
+     frames, and neither may write the interval down. */
   var blockAt = 0, tickMs = 0, quietTimer = null;
   /* Set when the gateway says it is closing on purpose, cleared by the reopen it
      causes. A planned recycle and a gateway that stopped answering look identical

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -1714,8 +1714,10 @@
      The strip is the one element on every page, and it said "live" whenever the socket was open --
      so a gateway that stopped producing frames left every page green. The page-side client learned
      this in mx#1189; the strip runs its own client, because five of the seven pages never load the
-     other one, so it has to learn it too. `test_both_stream_clients_agree_when_a_stream_is_quiet`
-     is what stops the two rules drifting apart. */
+     other one, so it has to learn it too. `TheTwoClientsAgreeTest` in
+     test_matrixark_the_strip_notices_a_quiet_stream_too is what stops the two rules drifting
+     apart: both must read tick_s off the frame, both must stamp on every block rather than on
+     frames, and neither may write the interval down. */
   var blockAt = 0, tickMs = 0, quietTimer = null;
   /* Set when the gateway says it is closing on purpose, cleared by the reopen it
      causes. A planned recycle and a gateway that stopped answering look identical

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -1171,8 +1171,10 @@
      The strip is the one element on every page, and it said "live" whenever the socket was open --
      so a gateway that stopped producing frames left every page green. The page-side client learned
      this in mx#1189; the strip runs its own client, because five of the seven pages never load the
-     other one, so it has to learn it too. `test_both_stream_clients_agree_when_a_stream_is_quiet`
-     is what stops the two rules drifting apart. */
+     other one, so it has to learn it too. `TheTwoClientsAgreeTest` in
+     test_matrixark_the_strip_notices_a_quiet_stream_too is what stops the two rules drifting
+     apart: both must read tick_s off the frame, both must stamp on every block rather than on
+     frames, and neither may write the interval down. */
   var blockAt = 0, tickMs = 0, quietTimer = null;
   /* Set when the gateway says it is closing on purpose, cleared by the reopen it
      causes. A planned recycle and a gateway that stopped answering look identical

--- a/tools/portal/mem0_portal.html
+++ b/tools/portal/mem0_portal.html
@@ -1529,8 +1529,10 @@
      The strip is the one element on every page, and it said "live" whenever the socket was open --
      so a gateway that stopped producing frames left every page green. The page-side client learned
      this in mx#1189; the strip runs its own client, because five of the seven pages never load the
-     other one, so it has to learn it too. `test_both_stream_clients_agree_when_a_stream_is_quiet`
-     is what stops the two rules drifting apart. */
+     other one, so it has to learn it too. `TheTwoClientsAgreeTest` in
+     test_matrixark_the_strip_notices_a_quiet_stream_too is what stops the two rules drifting
+     apart: both must read tick_s off the frame, both must stamp on every block rather than on
+     frames, and neither may write the interval down. */
   var blockAt = 0, tickMs = 0, quietTimer = null;
   /* Set when the gateway says it is closing on purpose, cleared by the reopen it
      causes. A planned recycle and a gateway that stopped answering look identical

--- a/tools/portal/onebox_portal.html
+++ b/tools/portal/onebox_portal.html
@@ -1027,8 +1027,10 @@
      The strip is the one element on every page, and it said "live" whenever the socket was open --
      so a gateway that stopped producing frames left every page green. The page-side client learned
      this in mx#1189; the strip runs its own client, because five of the seven pages never load the
-     other one, so it has to learn it too. `test_both_stream_clients_agree_when_a_stream_is_quiet`
-     is what stops the two rules drifting apart. */
+     other one, so it has to learn it too. `TheTwoClientsAgreeTest` in
+     test_matrixark_the_strip_notices_a_quiet_stream_too is what stops the two rules drifting
+     apart: both must read tick_s off the frame, both must stamp on every block rather than on
+     frames, and neither may write the interval down. */
   var blockAt = 0, tickMs = 0, quietTimer = null;
   /* Set when the gateway says it is closing on purpose, cleared by the reopen it
      causes. A planned recycle and a gateway that stopped answering look identical

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -1466,8 +1466,10 @@ function liveStream(options) {
      The strip is the one element on every page, and it said "live" whenever the socket was open --
      so a gateway that stopped producing frames left every page green. The page-side client learned
      this in mx#1189; the strip runs its own client, because five of the seven pages never load the
-     other one, so it has to learn it too. `test_both_stream_clients_agree_when_a_stream_is_quiet`
-     is what stops the two rules drifting apart. */
+     other one, so it has to learn it too. `TheTwoClientsAgreeTest` in
+     test_matrixark_the_strip_notices_a_quiet_stream_too is what stops the two rules drifting
+     apart: both must read tick_s off the frame, both must stamp on every block rather than on
+     frames, and neither may write the interval down. */
   var blockAt = 0, tickMs = 0, quietTimer = null;
   /* Set when the gateway says it is closing on purpose, cleared by the reopen it
      causes. A planned recycle and a gateway that stopped answering look identical

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -3423,8 +3423,10 @@ function liveStream(options) {
      The strip is the one element on every page, and it said "live" whenever the socket was open --
      so a gateway that stopped producing frames left every page green. The page-side client learned
      this in mx#1189; the strip runs its own client, because five of the seven pages never load the
-     other one, so it has to learn it too. `test_both_stream_clients_agree_when_a_stream_is_quiet`
-     is what stops the two rules drifting apart. */
+     other one, so it has to learn it too. `TheTwoClientsAgreeTest` in
+     test_matrixark_the_strip_notices_a_quiet_stream_too is what stops the two rules drifting
+     apart: both must read tick_s off the frame, both must stamp on every block rather than on
+     frames, and neither may write the interval down. */
   var blockAt = 0, tickMs = 0, quietTimer = null;
   /* Set when the gateway says it is closing on purpose, cleared by the reopen it
      causes. A planned recycle and a gateway that stopped answering look identical


### PR DESCRIPTION
This tree cites its guards in prose constantly — *"X is what stops these drifting apart"* — which is
worth more than most comments and is also a thing that can rot. **A citation naming nothing tells a
reader the property is already guarded, so they stop looking.**

### The portal, and the nine pages it generates

`build_portal_pages.py` carried: *"`test_both_stream_clients_agree_when_a_stream_is_quiet` is what
stops the two rules drifting apart."* **No such test exists.** The guard it means is real —
`TheTwoClientsAgreeTest` in `test_matrixark_the_strip_notices_a_quiet_stream_too` — so this is a
wrong name rather than a missing guard. The comment now names it and says what it holds: both
clients read `tick_s` off the frame, both stamp on every block rather than on frames, and neither
writes the interval down. The pages are regenerated and their only diff is that comment.

### The tenant policy

`_load_file_policies` said *"`_load_file_users` reads the same file's users."* **There is no such
function.** The users live under `users` in the same file and are read by `_load_file_policies`
itself, into the same cache entry, off the same stat. A reader who went looking for that name would
find nothing and could reasonably write a second reader of the same file — the one thing a single
stat and a single cache exist to avoid.

### How they were found, and what the narrowing cost

| scan | returns | real |
|---|---|---|
| prose naming an identifier nothing defines | **224 files** — env vars, record types and Rust symbols all read as missing to a Python scan | — |
| …narrowed: lowercase, in no string literal, no Rust `fn`, present-tense verb, no past-tense marker | **13** | **2** |
| prose citing a `test_` function that does not exist | **66 names across 43 files** — nearly all Rust helpers (`test_engine`, `test_insert`), string prefixes, or docs HTML | **1** (the portal one, ×9 pages) |

The narrowing is the work; the fix is two comments.

### Verified

The 96 suites naming the portal, the tenant policy, the quiet stream or the strip: **2,640 tests, 68
failures against 67 on pristine main.** The one name that differs,
`test_rollup_prunes_event_postings_without_losing_recall`, passes **3 of 3 in isolation on this
branch and 2 of 2 on main**, is on the ratchet's own fixed-since-baseline list, and reads nothing
this diff touches — the diff is one docstring and a JavaScript comment.
