### PR TITLE
One scope key, and the guard learns to see a copy that never leaves its module

### DIFF
--- a/tools/matrixark_pipeline_task_slim.py
+++ b/tools/matrixark_pipeline_task_slim.py
@@ -175,7 +175,19 @@ def collapse_pipeline_task_rows(records: list[Json]) -> list[Json]:
     return output
 
 
-def _task_scope_key(record: Json) -> str:
+def _scope_key(record: Json) -> str:
+    """The scope a row is grouped under, however the row spells it.
+
+    Both levers in this module group by scope before ageing anything out -- pipeline tasks in
+    `slim_terminal_pipeline_tasks`, audit rows in `slim_audit_payloads` -- and each had its own
+    copy of this under its own name, `_task_scope_key` and `_audit_scope_key`, byte for byte the
+    same five statements. Nothing read that: the duplicate-body guards next door both need the
+    copies to be in two different MODULES, and `test_a_nested_helper_has_one_copy_too` says so in
+    as many words -- "two defs in ONE module is a different fault".
+
+    If the two kinds of row ever should be grouped differently, that is now an edit somebody makes
+    on purpose rather than a change to whichever copy they happened to open.
+    """
     scope_key = record.get("scope_key")
     if scope_key:
         return str(scope_key)
@@ -209,7 +221,7 @@ def slim_terminal_pipeline_tasks(records: list[Json]) -> list[Json]:
         return records
     by_scope: dict[str, list[tuple[int, Json]]] = {}
     for entry in finished:
-        by_scope.setdefault(_task_scope_key(entry[1]), []).append(entry)
+        by_scope.setdefault(_scope_key(entry[1]), []).append(entry)
     slim_positions: set[int] = set()
     for entries in by_scope.values():
         if retain <= 0:
@@ -254,15 +266,6 @@ AUDIT_PAYLOAD_FIELDS = (
 )
 
 
-def _audit_scope_key(record: Json) -> str:
-    scope_key = record.get("scope_key")
-    if scope_key:
-        return str(scope_key)
-    scope = record.get("scope")
-    if isinstance(scope, dict):
-        return str(scope.get("scope_key") or f"{scope.get('tenant_id')}/{scope.get('user_id')}")
-    return ""
-
 
 def slim_audit_payloads(records: list[Json]) -> list[Json]:
     """Strip diagnostic payloads from audit/commit rows beyond the newest N per scope.
@@ -292,7 +295,7 @@ def slim_audit_payloads(records: list[Json]) -> list[Json]:
 
     by_scope: dict[str, list[tuple[int, Json]]] = {}
     for entry in candidates:
-        by_scope.setdefault(_audit_scope_key(entry[1]), []).append(entry)
+        by_scope.setdefault(_scope_key(entry[1]), []).append(entry)
 
     slim_positions: set[int] = set()
     for scope_key, entries in by_scope.items():

--- a/tools/test_a_nested_helper_has_one_copy_too.py
+++ b/tools/test_a_nested_helper_has_one_copy_too.py
@@ -94,6 +94,13 @@ def same_module_duplicates():
     `matrixark_pipeline_task_slim` held `_task_scope_key` and `_audit_scope_key`: one function
     under two names, five statements each, byte for byte the same, one caller apiece thirty lines
     apart.
+
+    The corpus is `_production_sources()`, which leaves out `test_`, `run_` and `validate_`, and
+    that exclusion is measured rather than assumed: run the same scan over those buckets and the
+    gate scripts return NOTHING -- zero within-module duplicates across 39 `validate_`, 36 `run_`
+    and 3 `generate_` files. The only hits anywhere are repeated `__init__` and `setUp` bodies in
+    four test modules, which both guards exclude on purpose because a fixture spelled out where it
+    is used reads better than one imported from three files away.
     """
     found = {}
     for stem, tree in _production_sources().items():

--- a/tools/test_a_nested_helper_has_one_copy_too.py
+++ b/tools/test_a_nested_helper_has_one_copy_too.py
@@ -83,6 +83,34 @@ def _production_sources():
     return sources
 
 
+def same_module_duplicates():
+    """{module stem: [(name, name, ...)]} for identical bodies that never leave one file.
+
+    The two duplicate-body guards in this tree both require the copies to sit in two different
+    modules -- this file groups by `frozenset(module stems)` and refuses a group of one, and
+    `test_there_is_one_copy_of_each_helper` does the same. The comment there calls a pair inside
+    one module "a different fault", and it is, but nothing was reading it.
+
+    `matrixark_pipeline_task_slim` held `_task_scope_key` and `_audit_scope_key`: one function
+    under two names, five statements each, byte for byte the same, one caller apiece thirty lines
+    apart.
+    """
+    found = {}
+    for stem, tree in _production_sources().items():
+        groups = collections.defaultdict(list)
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            body = _body_statements(node)
+            if len(body) < MIN_BODY_STATEMENTS:
+                continue
+            groups["\n".join(ast.unparse(s) for s in body)].append(node.name)
+        pairs = sorted(tuple(sorted(set(names))) for names in groups.values() if len(names) > 1)
+        if pairs:
+            found[stem] = pairs
+    return found
+
+
 def nested_duplicate_pairs():
     """{frozenset(module stems): [names]} for duplicates with at least one NESTED copy.
 
@@ -180,6 +208,27 @@ class ANestedHelperHasOneCopyToo(unittest.TestCase):
             "%s is defined again in %s. The backend's seven methods are the variant that ships; "
             "a second copy of them is not a shared home, it is the older one."
             % ("LatestContextStateAdapterMixin", ", ".join(carrying)))
+
+    def test_no_module_holds_the_same_body_twice(self):
+        """A copy that never leaves its file is still a copy, and was the one nobody looked for.
+
+        Asserted EMPTY rather than ratcheted: the class had exactly one member when this was
+        written and it was consolidated in the same change, so there is nothing to record and a
+        new one should fail rather than be listed.
+        """
+        found = same_module_duplicates()
+        self.assertEqual(
+            {}, found,
+            "these modules define one body under more than one name. Neither duplicate-body guard "
+            "sees this -- both need the copies in two different modules -- so it is worth fixing "
+            "at the first instance rather than recording: %r" % (found,))
+
+    def test_the_same_module_scan_can_find_something(self):
+        """A positive control. Empty is also what a scan that stopped parsing reports."""
+        sources = _production_sources()
+        self.assertGreater(len(sources), 100,
+                           "the production corpus came back nearly empty, so the check above "
+                           "passes over nothing")
 
     def test_every_recorded_pair_says_why(self):
         thin = sorted(" + ".join(sorted(modules)) for modules, reason in RECORDED_PAIRS.items()


### PR DESCRIPTION
`matrixark_pipeline_task_slim` held `_task_scope_key` and `_audit_scope_key`: **one function under
two names**, five statements each, byte for byte the same, with one caller apiece thirty lines
apart. Both levers in that module group rows by scope before ageing anything out —
`slim_terminal_pipeline_tasks` for pipeline tasks, `slim_audit_payloads` for audit rows — and each
had brought its own.

### Nothing was reading that class

**Both duplicate-body guards need the copies in two different modules.**
`test_a_nested_helper_has_one_copy_too` groups by `frozenset(module stems)` and refuses a group of
one; `test_there_is_one_copy_of_each_helper` does the same. The comment in the first calls a pair
inside one module *"a different fault"* — which it is, and it was a fault nobody looked for.

`same_module_duplicates()` now reads it, **asserted empty rather than ratcheted**: the class had
exactly one member and it is consolidated here, so there is nothing to record and a new one should
fail rather than join a list.

### The check is proved, not just run

With main's copy of the module put back for one call it reports
`{'matrixark_pipeline_task_slim': [('_audit_scope_key', '_task_scope_key')]}`; with the fix it
reports `{}`. A positive control on the corpus size sits beside it, because empty is also what a
scan that stopped parsing prints.

If the two kinds of row ever should be grouped differently, that is now an edit somebody makes on
purpose rather than a change to whichever copy they happened to open.

### Verified

The suites naming the slim levers or either duplicate guard: **26 tests on this branch against 24
on pristine main, zero failures on both** — the two extra are the check and its control.
