### PR TITLE
Record the compaction fix that was tried and reverted

### DIFF
--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -5805,6 +5805,18 @@ fn an_expired_key_is_removed_in_a_bounded_number_of_rounds() {
 /// The design being followed bounds the scan too: it walks `page_compaction_max_slots_per_round`
 /// buckets through a PERSISTENT iterator and resumes where it stopped.
 ///
+/// ONE FIX WAS TRIED AND REVERTED -- do not repeat it. Skipping the slab roll when every live page
+/// already sits on the newest slab makes this probe read 1 round and 0 refs at every size, and it
+/// is WRONG: fourteen tests fail, among them
+/// `page_compaction_rewrites_live_addresses_and_allows_old_slab_gc` and
+/// `a_compaction_round_stops_at_the_page_ref_budget`.
+///
+/// The premise is the mistake. "Every live page is on the active slab" does not mean there is
+/// nothing to compact -- it means no live pages sit on OLDER slabs. The active slab itself can be
+/// mostly dead, and rolling so that its live pages move elsewhere is exactly what lets its dead
+/// space be reclaimed. The question is DEAD SPACE, not slab membership, so any real fix has to
+/// read something like `live_ref_density_basis_points` rather than which slab a page is on.
+///
 /// This measures the difference the only way that separates them -- run compaction until there is
 /// nothing left to move, then time one more round. Whatever that round costs is scan, not work. If
 /// it grows with the shard, the scan is the cost; if it is flat, the budget already bounds


### PR DESCRIPTION
Record the compaction fix that was tried and reverted

#1547 measured that compaction never reaches a fixed point: sixty-four
consecutive rounds, none moving zero, each rewriting up to the 2,048-ref budget
over a store nobody was writing to, because a finished round drops its
continuation state and the next rolls a fresh slab and relocates everything
again.

The obvious fix is to skip the roll when every live page is already on the newest
slab. It looks convincing -- the probe drops from 64 rounds to 1 and from 3,430
ms to 647 ms at 32,000 keys, with zero refs moved -- and it is WRONG. Fourteen
tests fail on it, among them
`page_compaction_rewrites_live_addresses_and_allows_old_slab_gc` and
`a_compaction_round_stops_at_the_page_ref_budget`.

The premise is the mistake, not the implementation. "Every live page is on the
active slab" does not mean there is nothing to compact -- it means no live pages
sit on OLDER slabs. The active slab itself can be mostly dead, and rolling so its
live pages move elsewhere is exactly what lets that dead space be reclaimed. The
question compaction answers is about DEAD SPACE; I wrote a check about slab
membership.

So a real fix has to read something like `live_ref_density_basis_points` rather
than which slab a page happens to be on. Recording that on the probe rather than
leaving the next attempt to rediscover it by breaking the same fourteen tests --
the measurement in #1547 stands and is worth acting on, just not that way.

Doc only; no behaviour changes.

Full suite: unchanged from #1547, which this only adds comments to.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
