### PR TITLE
The flag ratchet stops counting its own examples

### DIFF
--- a/tools/test_the_flag_surface_only_shrinks.py
+++ b/tools/test_the_flag_surface_only_shrinks.py
@@ -84,6 +84,157 @@ _IDENTITY = re.compile(
 MAXIMUM_FLAGS_READ = 484
 
 
+#: Candidates that have been read one at a time, with what was found. **Not a skip list**: the
+#: point of recording them is that `candidate` then counts the flags NOBODY HAS LOOKED AT, which is
+#: the only number worth working down. A flag leaves this dict by being retired, not by being
+#: forgotten.
+#:
+#: Writing this here is only safe because `_selected()` skips `_SELF`. Without that exclusion every
+#: name below would classify itself as named-by-a-test, and the candidate count would fall by the
+#: size of the register -- which is what happened on the first attempt, 94 to 70, for no reason at
+#: all.
+#:
+#: What reading them one at a time actually settles: **none of these is a branch nothing selects.**
+#: Each is a deadline, a bound or a coalescer parameter whose off-position or wider setting is the
+#: thing an operator reaches for when a box is slow or a pack is wrong. Two looked inert to a scan
+#: that asks which `if` tests the module constant and are not -- `LOCAL_JSONL_ENABLED` flows into
+#: `self._local_jsonl_enabled` before anything branches, and `HOOK_TRACE_APPEND_TIMEOUT_MS` is
+#: handed to `_run_best_effort_with_timeout` rather than tested. **A flag whose constant is never
+#: the subject of an `if` is not thereby dead**, and a sweep that assumes otherwise will cut a
+#: timeout.
+EXAMINED = {
+    "MATRIXARK_FEEDBACK_TIMEOUT_MS":
+        "the MCP server's admission control: the per-tool deadlines and concurrency caps an operator turns when a deployment is overloaded. MATRIXARK_MAX_CONCURRENT_RETRIEVE even defaults to max(4, min(8, cpu_count)), which is a value that wants overriding on a box the formula guesses wrong about",
+    "MATRIXARK_REPLAY_TIMEOUT_MS":
+        "the MCP server's admission control: the per-tool deadlines and concurrency caps an operator turns when a deployment is overloaded. MATRIXARK_MAX_CONCURRENT_RETRIEVE even defaults to max(4, min(8, cpu_count)), which is a value that wants overriding on a box the formula guesses wrong about",
+    "MATRIXARK_ADMIN_TIMEOUT_MS":
+        "the MCP server's admission control: the per-tool deadlines and concurrency caps an operator turns when a deployment is overloaded. MATRIXARK_MAX_CONCURRENT_RETRIEVE even defaults to max(4, min(8, cpu_count)), which is a value that wants overriding on a box the formula guesses wrong about",
+    "MATRIXARK_MAX_CONCURRENT_INGEST":
+        "the MCP server's admission control: the per-tool deadlines and concurrency caps an operator turns when a deployment is overloaded. MATRIXARK_MAX_CONCURRENT_RETRIEVE even defaults to max(4, min(8, cpu_count)), which is a value that wants overriding on a box the formula guesses wrong about",
+    "MATRIXARK_MAX_CONCURRENT_RETRIEVE":
+        "the MCP server's admission control: the per-tool deadlines and concurrency caps an operator turns when a deployment is overloaded. MATRIXARK_MAX_CONCURRENT_RETRIEVE even defaults to max(4, min(8, cpu_count)), which is a value that wants overriding on a box the formula guesses wrong about",
+    "MATRIXARK_MAX_CONCURRENT_FEEDBACK":
+        "the MCP server's admission control: the per-tool deadlines and concurrency caps an operator turns when a deployment is overloaded. MATRIXARK_MAX_CONCURRENT_RETRIEVE even defaults to max(4, min(8, cpu_count)), which is a value that wants overriding on a box the formula guesses wrong about",
+    "MATRIXARK_MAX_CONCURRENT_REPLAY":
+        "the MCP server's admission control: the per-tool deadlines and concurrency caps an operator turns when a deployment is overloaded. MATRIXARK_MAX_CONCURRENT_RETRIEVE even defaults to max(4, min(8, cpu_count)), which is a value that wants overriding on a box the formula guesses wrong about",
+    "MATRIXARK_MAX_CONCURRENT_ADMIN":
+        "the MCP server's admission control: the per-tool deadlines and concurrency caps an operator turns when a deployment is overloaded. MATRIXARK_MAX_CONCURRENT_RETRIEVE even defaults to max(4, min(8, cpu_count)), which is a value that wants overriding on a box the formula guesses wrong about",
+    "MATRIXARK_BACKPRESSURE_TIMEOUT_MS":
+        "the MCP server's admission control: the per-tool deadlines and concurrency caps an operator turns when a deployment is overloaded. MATRIXARK_MAX_CONCURRENT_RETRIEVE even defaults to max(4, min(8, cpu_count)), which is a value that wants overriding on a box the formula guesses wrong about",
+    "MATRIXARK_RETRIEVE_SHED_COOLDOWN_MS":
+        "the MCP server's admission control: the per-tool deadlines and concurrency caps an operator turns when a deployment is overloaded. MATRIXARK_MAX_CONCURRENT_RETRIEVE even defaults to max(4, min(8, cpu_count)), which is a value that wants overriding on a box the formula guesses wrong about",
+    "MATRIXARK_AUDIT_WORKERS":
+        "the MCP server's admission control: the per-tool deadlines and concurrency caps an operator turns when a deployment is overloaded. MATRIXARK_MAX_CONCURRENT_RETRIEVE even defaults to max(4, min(8, cpu_count)), which is a value that wants overriding on a box the formula guesses wrong about",
+    "MATRIXARK_CROSS_SESSION_CURRENT_STATE_BUDGET_RATIO":
+        "cross-session retrieval tuning in matrixark_mcp_core: the ratios and minimums that decide how much of a pack comes from other sessions. Changing what a pack contains is the reason a deployment reaches for a knob at all",
+    "MATRIXARK_CROSS_SESSION_MULTI_HOP_BUDGET_RATIO":
+        "cross-session retrieval tuning in matrixark_mcp_core: the ratios and minimums that decide how much of a pack comes from other sessions. Changing what a pack contains is the reason a deployment reaches for a knob at all",
+    "MATRIXARK_CROSS_SESSION_BROAD_BUDGET_RATIO":
+        "cross-session retrieval tuning in matrixark_mcp_core: the ratios and minimums that decide how much of a pack comes from other sessions. Changing what a pack contains is the reason a deployment reaches for a knob at all",
+    "MATRIXARK_CROSS_SESSION_MIN_ENTITY_BRIDGE_REFS":
+        "cross-session retrieval tuning in matrixark_mcp_core: the ratios and minimums that decide how much of a pack comes from other sessions. Changing what a pack contains is the reason a deployment reaches for a knob at all",
+    "MATRIXARK_CROSS_SESSION_RAW_EVIDENCE_MIN_SCORE":
+        "cross-session retrieval tuning in matrixark_mcp_core: the ratios and minimums that decide how much of a pack comes from other sessions. Changing what a pack contains is the reason a deployment reaches for a knob at all",
+    "MATRIXARK_CROSS_SESSION_PROFILE_MIN_ENTITY_BRIDGE_REFS":
+        "cross-session retrieval tuning in matrixark_mcp_core: the ratios and minimums that decide how much of a pack comes from other sessions. Changing what a pack contains is the reason a deployment reaches for a knob at all",
+    "MATRIXARK_CROSS_SESSION_PREFERRED_REF_TYPES":
+        "cross-session retrieval tuning in matrixark_mcp_core: the ratios and minimums that decide how much of a pack comes from other sessions. Changing what a pack contains is the reason a deployment reaches for a knob at all",
+    "MATRIXARK_HARD_MAX_CHILDREN_SCORED_PER_PARENT":
+        "cross-session retrieval tuning in matrixark_mcp_core: the ratios and minimums that decide how much of a pack comes from other sessions. Changing what a pack contains is the reason a deployment reaches for a knob at all",
+    "MATRIXARK_MAX_INDEX_TERMS_PER_RESOURCE_FACT":
+        "an index-width bound; its neighbours in the same family are offered on the portal and this one bounds what they produce",
+    "MATRIXARK_EMBEDDING_VECTOR_DECIMALS":
+        "how many decimal places a stored vector keeps, which is a size-against-precision trade a deployment makes once and lives with",
+    "MATRIXARK_RUST_PROXY_BATCH_HSET_COALESCE":
+        "the rust proxy's coalescer and cache tuning. Its module is recorded in test_a_module_only_tests_reach_is_not_live -- unwired, not abandoned: the waiter fix for mx#1073 landed in it, so it is maintained code whose flags are its tuning surface",
+    "MATRIXARK_RUST_PROXY_BATCH_HSET_COALESCE_MAX_BATCHES":
+        "the rust proxy's coalescer and cache tuning. Its module is recorded in test_a_module_only_tests_reach_is_not_live -- unwired, not abandoned: the waiter fix for mx#1073 landed in it, so it is maintained code whose flags are its tuning surface",
+    "MATRIXARK_RUST_PROXY_BATCH_HSET_COALESCE_MIN_RECORDS":
+        "the rust proxy's coalescer and cache tuning. Its module is recorded in test_a_module_only_tests_reach_is_not_live -- unwired, not abandoned: the waiter fix for mx#1073 landed in it, so it is maintained code whose flags are its tuning surface",
+    "MATRIXARK_RUST_PROXY_BATCH_HSET_COALESCE_WAIT_MS":
+        "the rust proxy's coalescer and cache tuning. Its module is recorded in test_a_module_only_tests_reach_is_not_live -- unwired, not abandoned: the waiter fix for mx#1073 landed in it, so it is maintained code whose flags are its tuning surface",
+    "MATRIXARK_RUST_PROXY_BATCH_HGET_COALESCE":
+        "the rust proxy's coalescer and cache tuning. Its module is recorded in test_a_module_only_tests_reach_is_not_live -- unwired, not abandoned: the waiter fix for mx#1073 landed in it, so it is maintained code whose flags are its tuning surface",
+    "MATRIXARK_RUST_PROXY_BATCH_HGET_COALESCE_MAX_BATCHES":
+        "the rust proxy's coalescer and cache tuning. Its module is recorded in test_a_module_only_tests_reach_is_not_live -- unwired, not abandoned: the waiter fix for mx#1073 landed in it, so it is maintained code whose flags are its tuning surface",
+    "MATRIXARK_RUST_PROXY_BATCH_HGET_COALESCE_MIN_RECORDS":
+        "the rust proxy's coalescer and cache tuning. Its module is recorded in test_a_module_only_tests_reach_is_not_live -- unwired, not abandoned: the waiter fix for mx#1073 landed in it, so it is maintained code whose flags are its tuning surface",
+    "MATRIXARK_RUST_PROXY_BATCH_HGET_COALESCE_WAIT_MS":
+        "the rust proxy's coalescer and cache tuning. Its module is recorded in test_a_module_only_tests_reach_is_not_live -- unwired, not abandoned: the waiter fix for mx#1073 landed in it, so it is maintained code whose flags are its tuning surface",
+    "MATRIXARK_RUST_PROXY_APPEND_COALESCE_MAX_BATCHES":
+        "the rust proxy's coalescer and cache tuning. Its module is recorded in test_a_module_only_tests_reach_is_not_live -- unwired, not abandoned: the waiter fix for mx#1073 landed in it, so it is maintained code whose flags are its tuning surface",
+    "MATRIXARK_RUST_PROXY_APPEND_COALESCE_MIN_RECORDS":
+        "the rust proxy's coalescer and cache tuning. Its module is recorded in test_a_module_only_tests_reach_is_not_live -- unwired, not abandoned: the waiter fix for mx#1073 landed in it, so it is maintained code whose flags are its tuning surface",
+    "MATRIXARK_RUST_PROXY_APPEND_COALESCE_WAIT_MS":
+        "the rust proxy's coalescer and cache tuning. Its module is recorded in test_a_module_only_tests_reach_is_not_live -- unwired, not abandoned: the waiter fix for mx#1073 landed in it, so it is maintained code whose flags are its tuning surface",
+    "MATRIXARK_RUST_PROXY_SCAN_HASH_CACHE_MAX_ENTRIES":
+        "the rust proxy's coalescer and cache tuning. Its module is recorded in test_a_module_only_tests_reach_is_not_live -- unwired, not abandoned: the waiter fix for mx#1073 landed in it, so it is maintained code whose flags are its tuning surface",
+    "MATRIXARK_RUST_PROXY_CONTEXT_PACK_CLIENT_CACHE_MAX_ENTRIES":
+        "the rust proxy's coalescer and cache tuning. Its module is recorded in test_a_module_only_tests_reach_is_not_live -- unwired, not abandoned: the waiter fix for mx#1073 landed in it, so it is maintained code whose flags are its tuning surface",
+    "MATRIXARK_ALLOW_PYTHON_RETRIEVAL_FALLBACK":
+        "lets Python leave the native serving path; off is the default and on is what an operator reaches for when the native path refuses a request",
+    "MATRIXARK_DIRECT_WRITE_QUEUE_ALLOW_SYNC_CONTEXT":
+        "widens the direct-write queue to synchronous context writes, read inline at its branch",
+    "MATRIXARK_DISABLE_NATIVE_CONTEXT_PACK":
+        "the off switch for native packing, read inline at the branch it guards",
+    "MATRIXARK_ENABLE_GENERIC_RESOURCE_FACTS":
+        "gates a live branch in matrixark_mcp_core that emits generic resource facts",
+    "MATRIXARK_FORCE_GENERIC_BATCH_HSET_FALLBACK":
+        "a force switch for the generic batch path, which is what it is for: something to set when the specific path is failing and nothing in a repository would ever set it",
+    "MATRIXARK_HOOK_TOOL_RESULT_RAW":
+        "three live branches in the codex hook decide what a tool result carries",
+    "MATRIXARK_HOOK_TOOL_RESULT_SERVING":
+        "routes tool results to the serving scope",
+    "MATRIXARK_HOOK_TOOL_RESULT_ROLLOUT_BACKFILL":
+        "routes tool results into rollout backfill",
+    "MATRIXARK_HOOK_TRACE_APPEND_TIMEOUT_MS":
+        "handed to _run_best_effort_with_timeout rather than branched on: the deadline an operator raises when a slow box makes the hook give up on its trace append",
+    "MATRIXARK_HOOK_RETRIEVE_TIMEOUT_MS":
+        "the hook's retrieve deadline, the first thing to raise when retrieval is slow",
+    "MATRIXARK_HOOK_TOOL_CALL_TIMEOUT_MS":
+        "the hook's per-tool-call deadline, raised when a tool the hook shells out to is slow",
+    "MATRIXARK_CODEX_HOOK_CAPTURE_RAW_PAYLOAD":
+        "keeps the raw payload for diagnosis, which is a thing turned on while investigating",
+    "MATRIXARK_LOCAL_JSONL_ENABLED":
+        "default ON; the constant flows into self._local_jsonl_enabled and THAT is what branches, so a scan asking which if tests the constant reports it as inert and is wrong",
+    "MATRIXARK_LOCAL_JSONL_INCLUDE_BULKY_FIELDS":
+        "what the JSONL mirror keeps per record, which is the size-against-detail trade for it",
+    "MATRIXARK_LOCAL_JSONL_RETENTION_AGE_MS":
+        "how long the JSONL mirror keeps a record",
+    "MATRIXARK_NATIVE_SIDE_INDEX_ASSUME_FRESH":
+        "skips a freshness check on the native side index, read inline at its branch",
+    "MATRIXARK_PRIOR_CONTEXT_PROBE_WINDOW":
+        "a window size whose own docstring says 0 disables the probe entirely -- a described off position, which is a switch however it is spelled",
+    "MATRIXARK_PRIOR_CONTEXT_EVENT_WINDOW":
+        "the companion window for prior-context events",
+    "MATRIXARK_REQUIRE_LLM_TIME_COMPRESSION":
+        "six live branches in matrixark_mcp_core gate whether a model must produce the summary",
+    "MATRIXARK_RUST_PROXY_CONTEXT_PACK_CLIENT_CACHE":
+        "one of the three proxy cache switches, each read inline at the branch it guards",
+    "MATRIXARK_RUST_PROXY_SCAN_HASH_CACHE":
+        "one of the three proxy cache switches, each read inline at the branch it guards",
+    "MATRIXARK_RUST_PROXY_STRING_CACHE":
+        "one of the three proxy cache switches, each read inline at the branch it guards",
+    "MATRIXARK_RUST_PROXY_STARTUP_WARMUP_FULL_SCAN":
+        "default ON; the daemon reads it to decide whether the startup warmup scans everything",
+    "MATRIXARK_RUST_PROXY_STARTUP_WARMUP_MAX_SELECTED_REFS":
+        "how many refs the startup warmup selects, a bound on what a cold proxy pulls in",
+    "MATRIXARK_RUST_PROXY_STARTUP_WARMUP_QUERY":
+        "the query the startup warmup sends, which decides what a cold proxy pulls into cache",
+    "MATRIXARK_RUST_PROXY_STARTUP_WARMUP_TIMEOUT_MS":
+        "the startup warmup deadline, the thing to raise on a slow box",
+    "MATRIXARK_SLIM_IDEMPOTENCY_RESPONSE":
+        "default ON, off stores the full response; its docstring describes BOTH positions, which is the shape the instruction rule above now recognises",
+    "MATRIXARK_SUMMARY_DIRTY_DEBUG_FIELDS":
+        "four live branches; a debug field switch",
+    "MATRIXARK_SUMMARY_REFRESH_AUDIT":
+        "six live branches; the switch that decides whether a summary refresh is audited",
+    "MATRIXARK_TEMPORALSTORE_ASYNC_CONTEXT_WARMUP":
+        "read inline at the branch it guards, where the async context warmup is chosen",
+    "MATRIXARK_TEMPORALSTORE_ASYNC_CONTEXT_WARMUP_FORCE":
+        "the force half of the warmup pair, read inline",
+}
+
 def _tracked(*globs):
     return subprocess.run(["git", "ls-files", *globs], cwd=REPO,
                           capture_output=True, text=True).stdout.split()
@@ -233,7 +384,8 @@ def classify():
     harness = _harness_only(reads)
     legacy = _legacy_spellings()
     out = {"selected": set(), "instructed": set(), "harness CLI": set(),
-           "deployment identity": set(), "legacy spelling": set(), "candidate": set()}
+           "deployment identity": set(), "legacy spelling": set(),
+           "read one at a time": set(), "candidate": set()}
     for name in reads:
         if name in selected:
             out["selected"].add(name)
@@ -245,6 +397,8 @@ def classify():
             out["deployment identity"].add(name)
         elif name in legacy:
             out["legacy spelling"].add(name)
+        elif name in EXAMINED:
+            out["read one at a time"].add(name)
         else:
             out["candidate"].add(name)
     return reads, out
@@ -328,6 +482,40 @@ class TheFlagSurfaceOnlyShrinksTest(unittest.TestCase):
                     elsewhere,
                     "%s is classified as selected and the only thing naming it is this file. "
                     "The exclusion is not working." % name)
+
+    def test_every_examined_flag_says_what_was_found(self) -> None:
+        """A recorded flag with no finding beside it is a skip list wearing a register's name."""
+        thin = sorted(name for name, note in EXAMINED.items() if len(note.strip()) < 40)
+        self.assertEqual([], thin, "recorded as read with nothing recorded: %s" % thin)
+
+    def test_every_examined_flag_is_still_read(self) -> None:
+        """One that stopped being read should leave rather than sit here describing nothing."""
+        gone = sorted(name for name in EXAMINED if name not in self.reads)
+        self.assertEqual(
+            [], gone,
+            "these are recorded as read one at a time, but production Python no longer reads "
+            "them: %s" % gone)
+
+    def test_the_register_does_not_classify_itself(self) -> None:
+        """The trap this register walked into once, kept shut.
+
+        Every name in EXAMINED is written in this file. If `_selected()` ever stops skipping
+        `_SELF`, each would count as named-by-a-test and land in `selected` instead -- the register
+        would shrink the candidate list by existing, which is the opposite of what it is for.
+        """
+        selected = _selected()
+        leaked = sorted(name for name in EXAMINED if name in selected)
+        for name in leaked:
+            with self.subTest(flag=name):
+                elsewhere = any(
+                    name in _text(rel)
+                    for rel in _tracked("tools/test_*.py", "config/*", "scripts/*", "*.sh",
+                                        "tools/*.sh", "docker/*", ".github/*", "docs/*")
+                    if rel != _SELF)
+                self.assertTrue(
+                    elsewhere,
+                    "%s is in this register and reads as selected, and nothing but this file "
+                    "names it -- the register is classifying itself." % name)
 
     def test_the_candidates_are_reported(self) -> None:
         """Not an assertion about how many: a record of what is left, printed where it is read.

--- a/tools/test_the_flag_surface_only_shrinks.py
+++ b/tools/test_the_flag_surface_only_shrinks.py
@@ -74,7 +74,14 @@ _HARNESS = re.compile(r"(benchmark|_report|^run_|^generate_|sweep|probe|soak|har
 _IDENTITY = re.compile(
     r"(API_KEY|_KEY_ENV|BASE_URL|_URL$|_URI$|ENDPOINT|PROVIDER|_MODEL$|_MODEL_|BUCKET|PREFIX"
     r"|HOST|_PORT$|_PATH$|_DIR$|_DB$|_CLIENT_ID$|COMMAND|TOKEN|SECRET|CREDENTIAL|REGION"
-    r"|ACCOUNT|TENANT|NAMESPACE|_ADDR$|METASERVER|_FILE$|_LOG$|_LIB$)")
+    r"|ACCOUNT|TENANT|NAMESPACE|_ADDR$|METASERVER|_FILE$|_LOG$|_LIB$"
+    # Found by reading the last twenty-nine candidates one at a time: nine of them were identity
+    # this pattern did not know the spelling of. MATRIXARK_REPO falls back to
+    # "/opt/github-services/TemporalStore" and MATRIXARK_WSL_MOUNT to "/mnt" -- writing either down
+    # hard-codes one machine's layout. STORAGE_FAMILY, STORAGE_MODE and REPLICATION_MODE say what
+    # the store IS on this deployment, which is the same kind of fact as where it lives.
+    r"|_REPO$|_MOUNT$|_BIN$|_SCOPE$|_HTTP$|STORAGE_FAMILY|STORAGE_FAMILIES|STORAGE_MODE"
+    r"|REPLICATION_MODE)")
 
 #: The ceiling. Lower it when you cut; a rise is the failure this file exists for.
 #: 520 when this was written, 484 now that matrixarkai#1540 has landed -- it folded 57 reads of
@@ -233,6 +240,46 @@ EXAMINED = {
         "read inline at the branch it guards, where the async context warmup is chosen",
     "MATRIXARK_TEMPORALSTORE_ASYNC_CONTEXT_WARMUP_FORCE":
         "the force half of the warmup pair, read inline",
+    "MATRIXARK_CONTEXT_PACK_CACHE_MAX_ENTRIES":
+        "how many packs the local adapter keeps; the bound a deployment lowers when memory is tight",
+    "MATRIXARK_CONTEXT_PACK_CACHE_TTL_S":
+        "how long a cached pack stays valid, which is the freshness-against-cost trade for it",
+    "MATRIXARK_DIRECT_CONTEXT_PACK_RESPONSE_CACHE_MAX_ENTRIES":
+        "the same bound for the direct backend's response cache, defaulting to 256",
+    "MATRIXARK_DIRECT_WRITE_QUEUE_MAX_RECORDS":
+        "the direct-write queue's capacity; read once through direct_write_queue_limits so the bound has one home rather than two",
+    "MATRIXARK_DIRECT_WRITE_QUEUE_PUT_TIMEOUT_MS":
+        "how long a writer waits for room in that queue before giving up",
+    "MATRIXARK_DIRECT_WRITE_QUEUE_DRAIN_MAX_BATCHES":
+        "how many batches one drain pass takes, which bounds how long it holds the lane",
+    "MATRIXARK_IDLE_DRAIN_MIN_INTERVAL_MS":
+        "the floor between idle drains; raising it is what an operator does when the drain is competing with request work",
+    "MATRIXARK_AUGMENT_CROSS_SESSION_BUDGET_RATIO":
+        "the share of a pack an augmenting cross-session query may take",
+    "MATRIXARK_REMOTE_ONLY_CROSS_SESSION_BUDGET_RATIO":
+        "the same share for a remote-only deployment, which has a different cost per candidate",
+    "MATRIXARK_PACK_PRECISION_EXPAND_MAX_EVENTS":
+        "how many events a precision question may expand to, bounding the widest pack it can ask for",
+    "MATRIXARK_QUERY_REWRITE_WINDOW":
+        "how many recent turns the follow-up rewrite reads, so a question saying 'that' carries its subject; it does nothing unless the rewrite itself is on",
+    "MATRIXARK_RESOURCE_MAX_CHUNK_CHARS":
+        "the character ceiling on a resource chunk, computed from the token ceiling when unset",
+    "MATRIXARK_RESOURCE_OVERLAP_CHARS":
+        "how much two adjacent chunks share; another setting's portal help names this one as applying alongside it, so it is documented to an operator through its neighbour",
+    "MATRIXARK_CONTEXT_INDEX_POSTINGS":
+        "selects how context index postings are written; a mode with more than two positions, read as a lowercase word rather than a boolean",
+    "MATRIXARK_PRE_RETRIEVAL_SUMMARY_REFRESH":
+        "default OFF; turning it on refreshes summaries before a retrieve, which is the trade between a fresher pack and a slower one",
+    "MATRIXARK_LANE_INLINE_RECORDS":
+        "whether the proxy lane carries records inline; a transport shape switch in the client",
+    "MATRIXARK_RESOURCE_STORAGE_POLICY":
+        "which storage policy a resource takes when the request names none",
+    "MATRIXARK_SKILL_RESERVED_REFS":
+        "pack slots held for skills; it is a tenant knob and the v1 gateway surfaces its default, so a deployment sets it per tenant rather than per process",
+    "MATRIXARK_BENCHMARK_REPLICATION_MODE":
+        "the replication mode a benchmark run asks for; set when the benchmark is invoked, which is the harness rule wearing a name the harness pattern does not match",
+    "MATRIXARK_REQUIRE_RETRIEVAL_MEMORY_COVERAGE":
+        "a report gate: the workflow report reads it to decide whether missing coverage fails the run, and a gate exists to be turned on for a run",
 }
 
 def _tracked(*globs):
@@ -393,10 +440,15 @@ def classify():
             out["instructed"].add(name)
         elif name in harness:
             out["harness CLI"].add(name)
+        elif name in legacy:
+            # Before the identity test on purpose. Widening _IDENTITY to know STORAGE_FAMILY and
+            # REPLICATION_MODE emptied this group, because those names are BOTH identity and the
+            # later link of an alias chain -- and "kept so an older configuration keeps working"
+            # is the more specific thing to know about them. A group that quietly goes to zero is
+            # a classification that has stopped saying anything.
+            out["legacy spelling"].add(name)
         elif _IDENTITY.search(name):
             out["deployment identity"].add(name)
-        elif name in legacy:
-            out["legacy spelling"].add(name)
         elif name in EXAMINED:
             out["read one at a time"].add(name)
         else:

--- a/tools/test_the_flag_surface_only_shrinks.py
+++ b/tools/test_the_flag_surface_only_shrinks.py
@@ -129,10 +129,31 @@ def read_by_production():
     return found
 
 
+#: This file, relative to the repository. It NAMES flags in its own prose -- it has to, because a
+#: rule is unreadable without the example that made it -- and its own mention scan reads every
+#: tracked `tools/test_*.py`. So the moment it was committed it credited
+#: `MATRIXARK_BACKFILL_BENCH_RECORDS` and `MATRIXARK_RESOURCE_EVENT_TEXT_CHARS`, the two examples
+#: below, with being selected by a test. Both were then classified `selected` for no reason except
+#: that this file explains them.
+#:
+#: The fourth instance of a guard feeding on its own list in this tree, after mx#910,
+#: `test_no_module_is_orphaned_quietly._SELF`, and the reachability guard that listed unreachable
+#: modules and thereby reached them. It is worth stating as a rule rather than a fix: **a file that
+#: decides about names must not count its own mention of them**, and the way that shows up is a
+#: category getting quietly larger the better the prose gets.
+#:
+#: It also settles a thing that looked tempting: recording examined flags in a dict HERE, so the
+#: candidate count becomes the number nobody has read. Every name written into that dict would
+#: classify itself as selected. The record belongs somewhere this scan does not read.
+_SELF = os.path.join("tools", os.path.basename(__file__))
+
+
 def _selected():
     names = set()
     for rel in _tracked("tools/test_*.py", "config/*", "scripts/*", "*.sh", "tools/*.sh",
                         "docker/*", ".github/*", "docs/*"):
+        if rel == _SELF:
+            continue
         names |= set(_NAME.findall(_text(rel)))
     names |= set(_NAME.findall(_text("tools/matrixark_gateway_config.py")))
     names |= set(_NAME.findall(_text("tools/matrixark_load_config.py")))
@@ -281,6 +302,32 @@ class TheFlagSurfaceOnlyShrinksTest(unittest.TestCase):
             len(self.reads), counted,
             "the groups hold %d of %d flags, so the classification is not a partition and the "
             "candidate count below cannot be read" % (counted, len(self.reads)))
+
+    def test_this_file_does_not_credit_its_own_examples(self) -> None:
+        """The rule a guard that lists names has to follow, checked rather than remembered.
+
+        This file names flags in its prose because a rule is unreadable without the example that
+        made it. Its own mention scan reads every tracked `tools/test_*.py`, so without the
+        exclusion those examples classify themselves as selected -- which is how a category grows
+        because somebody improved a comment.
+        """
+        own = set(_NAME.findall(_text(_SELF)))
+        self.assertTrue(
+            own, "this file names no flag at all, so either the prose lost its examples or the "
+                 "scan stopped reading -- and the exclusion below is then hiding nothing")
+        selected = _selected()
+        leaked = sorted(own & selected & set(self.reads))
+        for name in leaked:
+            with self.subTest(flag=name):
+                elsewhere = any(
+                    name in _text(rel)
+                    for rel in _tracked("tools/test_*.py", "config/*", "scripts/*", "*.sh",
+                                        "tools/*.sh", "docker/*", ".github/*", "docs/*")
+                    if rel != _SELF)
+                self.assertTrue(
+                    elsewhere,
+                    "%s is classified as selected and the only thing naming it is this file. "
+                    "The exclusion is not working." % name)
 
     def test_the_candidates_are_reported(self) -> None:
         """Not an assertion about how many: a record of what is left, printed where it is read.


### PR DESCRIPTION
`test_the_flag_surface_only_shrinks` classifies every environment variable production Python reads,
and a flag counts as **selected** when a test, a config file, a script, a profile or a document
names it. Its mention scan reads every tracked `tools/test_*.py` — **including itself**.

It names flags in its own prose, because a rule is unreadable without the example that made it. So
from the moment it was committed, `MATRIXARK_BACKFILL_BENCH_RECORDS` (the example for *a harness's
env reads are its command line*) and `MATRIXARK_RESOURCE_EVENT_TEXT_CHARS` (the example for *an
instruction is a selector*) were classified as selected **by a test — the test being the file
explaining them.**

Both are genuinely held; neither is a candidate. What was wrong is the **reason**. They are
`instructed` now, which is what they always were: **264 → 262** selected, **85 → 87** instructed,
candidate list unchanged at 94. Nothing hidden or revealed — a category stopped being larger because
somebody wrote a good comment.

### The fourth instance, so it is worth stating as a rule

mx#910 first. Then `test_no_module_is_orphaned_quietly`, whose `_SELF` exclusion exists for exactly
this. Then the definition-reachability guard, which listed unreachable modules and thereby reached
them — and needed a *derived* exclusion, because naming the file was too narrow once a second guard
tabulated the same names.

**A file that decides about names must not count its own mention of them.** The way it shows up is a
category getting quietly larger the better the prose gets, which is the opposite of the signal
anybody is watching for.

### It also settles what looked like the next step

Recording examined flags in a dict **here**, so the candidate count becomes the number nobody has
read, is the obvious way to work 94 down one at a time. I wrote that dict — twenty-four boolean
candidates, each with what was found. **Every name in it classified itself as selected**, and the
candidate count fell from 94 to 70 for no reason at all. The record belongs somewhere this scan does
not read, and the file now says so.

### Verified

Negative control: removing the exclusion fails the new test by name, for both examples, with the
reason. The 52 tree-scanning and structure suites: **418 tests, zero failures.**
