### PR TITLE
The evict stage keeps taking batches while they still help

### DIFF
--- a/crates/temporalstore-rust/src/data_node.rs
+++ b/crates/temporalstore-rust/src/data_node.rs
@@ -904,6 +904,19 @@ pub struct StorageManagerOptions {
     /// Drop rather than dump. Off by default: this is the arm that can lose unflushed state.
     #[serde(default)]
     pub eviction_delete_drop: bool,
+    /// How many victims one evict STAGE may take in total, across repeated batches.
+    ///
+    /// The stage took a single batch of `eviction_batch_limit` and returned, however far the
+    /// pressure still was from the threshold. Measured: 16 victims freeing about 4,800 bytes a
+    /// round against a 1,775,000-byte overage -- roughly 370 rounds, or three hours at a round
+    /// every thirty seconds.
+    ///
+    /// The design being followed keeps taking batches until usage is back under the limit,
+    /// stopping on a per-call COUNT budget rather than after the first batch, and logs that it hit
+    /// the budget rather than that it finished. This is that budget. 0 keeps the old behaviour of
+    /// exactly one batch.
+    #[serde(default = "default_storage_manager_eviction_count_limit")]
+    pub eviction_count_limit: usize,
     /// How many hot buckets one expire stage may take. 0 means NO LIMIT, which is what this
     /// loop has always passed -- so expiry walked the whole deadline map, hot and cold, on every
     /// tick for every loaded shard. The on-demand cycle has always passed a bound (128) and
@@ -943,6 +956,15 @@ pub struct StorageManagerOptions {
     /// behaviour.
     #[serde(default)]
     pub index_gc_max_dump_buckets_per_round: usize,
+}
+
+/// Victims one evict stage may take in total, across repeated batches.
+///
+/// Matches the value the design being followed uses for the same budget.
+pub const DEFAULT_EVICTION_COUNT_LIMIT: usize = 100;
+
+fn default_storage_manager_eviction_count_limit() -> usize {
+    DEFAULT_EVICTION_COUNT_LIMIT
 }
 
 fn default_storage_manager_index_gc_max_entries_per_round() -> usize {
@@ -1004,6 +1026,7 @@ impl Default for StorageManagerOptions {
             eviction_batch_limit: crate::engine::reports::DEFAULT_EVICTION_BATCH_LIMIT,
             eviction_dump_before_evict: false,
             eviction_delete_drop: false,
+            eviction_count_limit: DEFAULT_EVICTION_COUNT_LIMIT,
             // 0 = unbounded, the behaviour this loop has always had. See the field docs.
             // Likewise the cycle's values. 0 meant the expire stage walked the WHOLE deadline
             // map, hot and cold, every tick for every loaded shard, which is what #1469 measured

--- a/crates/temporalstore-rust/src/data_node/runtime_storage.rs
+++ b/crates/temporalstore-rust/src/data_node/runtime_storage.rs
@@ -357,14 +357,78 @@ impl DataNodeRuntime {
         // reclaim_memory above relieves memory by invalidating cached pages, which frees the cache
         // and leaves the index untouched. This is the stage that can actually free a bucket -- and
         // dump it first, so freeing does not strand the log.
+        // Keep taking batches until the pressure is back under the threshold, the count budget
+        // is spent, or a batch stops helping.
+        //
+        // The stage used to take ONE batch and return, however far the pressure still was from the
+        // threshold -- 16 victims freeing about 4,800 bytes against a 1,775,000-byte overage, so
+        // roughly 370 rounds. The design being followed loops instead and stops on a per-call
+        // count budget.
+        //
+        // Three stopping conditions, and all three are needed. The budget bounds the work. The
+        // threshold is the goal. And a batch that frees nothing -- `cooldown`, or one that finds no
+        // victims at all -- means another batch will not help either, which is what stops this
+        // spinning on a shard whose memory is not reclaimable by eviction.
         let eviction = options.enable_evict.then(|| {
-            self.inner.engine.apply_storage_eviction(
+            let mut report = self.inner.engine.apply_storage_eviction(
                 shard_id,
                 options.eviction_memory_pressure_threshold,
                 options.eviction_batch_limit,
                 options.eviction_dump_before_evict,
                 options.eviction_delete_drop,
-            )
+            );
+            // The stage reports what the STAGE did, not what its last batch did.
+            //
+            // Returning the final report alone would describe the batch that stopped the loop --
+            // usually the unproductive one that tripped `cooldown` -- and hide every victim the
+            // earlier batches took. That is the shape of misreporting #1453-#1455 fixed
+            // elsewhere, so the counts are accumulated and `pressure_before` is kept from the
+            // FIRST batch while `pressure_after` comes from the last.
+            let first_pressure_before = report.pressure_before;
+            let mut victims = report.selected_victims.clone();
+            let mut dump_manifest_ids = report.dump_manifest_ids.clone();
+            let mut cache_entries_removed = report.cache_entries_removed;
+            let mut cache_disk_bytes_removed = report.cache_disk_bytes_removed;
+            let mut dropped_object_count = report.dropped_object_count;
+            loop {
+                let taken = victims.len();
+                let more_budget = options.eviction_count_limit > taken;
+                let still_over =
+                    report.pressure_after >= options.eviction_memory_pressure_threshold;
+                // A batch that freed nothing, or found nobody, means the next will not do better.
+                let made_progress = !report.cooldown && !report.selected_victims.is_empty();
+                if !(report.pressure_gate_open && more_budget && still_over && made_progress) {
+                    break;
+                }
+                report = self.inner.engine.apply_storage_eviction(
+                    shard_id,
+                    options.eviction_memory_pressure_threshold,
+                    options
+                        .eviction_batch_limit
+                        .min(options.eviction_count_limit.saturating_sub(taken)),
+                    options.eviction_dump_before_evict,
+                    options.eviction_delete_drop,
+                );
+                victims.extend(report.selected_victims.iter().cloned());
+                dump_manifest_ids.extend(report.dump_manifest_ids.iter().cloned());
+                cache_entries_removed =
+                    cache_entries_removed.saturating_add(report.cache_entries_removed);
+                cache_disk_bytes_removed =
+                    cache_disk_bytes_removed.saturating_add(report.cache_disk_bytes_removed);
+                dropped_object_count =
+                    dropped_object_count.saturating_add(report.dropped_object_count);
+            }
+            crate::engine::reports::StorageEvictionReport {
+                pressure_before: first_pressure_before,
+                selected_victims: victims,
+                dump_manifest_ids,
+                cache_entries_removed,
+                cache_disk_bytes_removed,
+                dropped_object_count,
+                // `cooldown` now means the STAGE freed nothing, not that its last batch did.
+                cooldown: report.pressure_after >= first_pressure_before,
+                ..report
+            }
         });
         if eviction.is_some() {
             executed_stages.push("evict".to_string());

--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -5968,3 +5968,86 @@ fn does_compaction_retrigger_itself() {
          {total_rewritten} page refs rewritten in total, over a store of {KEYS} that never changed"
     );
 }
+
+/// The evict stage keeps taking batches while they still help.
+///
+/// The stage used to take ONE batch of `eviction_batch_limit` and return, however far the pressure
+/// still was from the threshold: measured at 16 victims freeing about 4,800 bytes against a
+/// 1,775,000-byte overage, roughly 370 rounds at a round every thirty seconds. The design being
+/// followed loops until usage is back under the limit and stops on a per-call COUNT budget --
+/// `evict_count_limit` 100 against a batch size of 10 -- rather than after the first batch.
+///
+/// `eviction_count_limit` is that budget. What this asserts is that a round actually spends more
+/// than one batch when the pressure warrants it, and that the report describes the STAGE rather
+/// than its final batch: returning the last report alone would show only the unproductive batch
+/// that stopped the loop and hide every victim taken before it.
+#[test]
+fn the_evict_stage_keeps_going_while_batches_still_help() {
+    const KEYS: usize = 3_000;
+
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+    let runtime = DataNodeRuntime::new_without_workers_with_options(
+        engine,
+        DataNodeRuntimeOptions {
+            worker_threads: 0,
+            max_queue_depth: 4,
+            max_background_queue_depth: 2,
+        },
+    );
+    {
+        let engine = runtime.engine();
+        for index in 0..KEYS {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("evictloop-{index:08}"),
+                    value: vec![b'v'; 128],
+                },
+            });
+        }
+        for index in 0..KEYS {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringGet {
+                    key: format!("evictloop-{index:08}"),
+                },
+            });
+        }
+    }
+
+    let warm = runtime.engine().cache().stats().memory_bytes;
+    // The denominator: with an empty cache the gate stays shut and nothing below means anything.
+    assert!(
+        warm > 0,
+        "the cache held nothing after reading every key back, so eviction has nothing to work on"
+    );
+
+    let options = StorageManagerOptions {
+        enable_evict: true,
+        // A threshold far below what the fixture built, so one batch cannot possibly reach it and
+        // the loop has a reason to keep going.
+        eviction_memory_pressure_threshold: warm / 8,
+        ..StorageManagerOptions::default()
+    };
+    let batch_limit = options.eviction_batch_limit;
+    let report = runtime.run_storage_manager_once(1, options);
+    let eviction = report
+        .eviction
+        .as_ref()
+        .expect("the round ran the evict stage but carried no eviction report");
+
+    assert!(
+        eviction.pressure_gate_open,
+        "eviction did not open its gate on a cache of {warm} bytes, so the loop never ran: {:?}",
+        eviction.skipped_reason
+    );
+    assert!(
+        eviction.selected_victims.len() > batch_limit,
+        "the stage took {} victims with a batch limit of {batch_limit} -- it stopped after one \
+         batch while the pressure was still {} against a threshold of {}",
+        eviction.selected_victims.len(),
+        eviction.pressure_after,
+        eviction.memory_pressure_threshold,
+    );
+}


### PR DESCRIPTION
The evict stage keeps taking batches while they still help

#1536 measured that eviction takes one batch a round and stops, however far the
pressure still is from its threshold: 16 victims freeing about 4,800 bytes
against a 1,775,000-byte overage, which is roughly 370 rounds -- three hours at a
round every thirty seconds. #1539 fixed the gate so the stage can run at all;
this is the other half.

The design being followed loops: it keeps taking batches until usage is back
under the limit, bounded by a per-call COUNT budget, and reports hitting that
budget rather than stopping after the first batch. Its numbers are
`evict_count_limit` 100 against `evict_batch_size` 10, so up to ten batches.
`eviction_count_limit` is that budget here, defaulted to the same 100 against our
batch limit of 16.

Measured on the same fixture:

    round   victims   freed
        0        80   19,200 B      (was 16 / 4,800 B)
        1        32    4,800 B
        2        48    9,600 B

Up to four times as much reclaimed per round, and the loop stops when the batches
stop helping rather than grinding on.

THREE STOPPING CONDITIONS, ALL NEEDED

The budget bounds the work. The threshold is the goal. And a batch that freed
nothing -- `cooldown`, or one that found no victims -- means the next will not do
better either, which is what keeps this from spinning on a shard whose memory is
not reclaimable by eviction. That third condition is doing the work in practice:
the fixture reaches it after two to five batches.

THE REPORT DESCRIBES THE STAGE, NOT ITS LAST BATCH

Returning the final report alone would describe the batch that STOPPED the loop
-- usually the unproductive one -- and hide every victim taken before it. A first
version did exactly that and reported 16 victims with `cooldown` set on a round
that had actually taken 80. The counts are accumulated, `pressure_before` is kept
from the first batch, and `cooldown` now means the STAGE freed nothing. Same
shape as the misreporting #1453-#1455 fixed elsewhere, which is why it was worth
catching before it shipped.

WHAT THIS DOES NOT FIX

Eviction still does not reach its threshold on that fixture. It stalls because
batches stop being productive, not because it runs out of batches -- so the
remaining problem is victim SELECTION, not pacing. This closes the pacing
difference and no more.

Verified by mutation: setting the budget to a single batch fails the new guard
with "the stage took 16 victims with a batch limit of 16 -- it stopped after one
batch while the pressure was still 957264 against a threshold of 103875". A
denominator assertion comes first, so a fixture whose cache is empty -- where the
gate is correct to stay shut -- fails loudly instead of passing.

Full suite: see below.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Full suite: **1777 passed, 1 failed** -- the standing --lib baseline failure on main. No new failure name.
