### PR TITLE
The WAL has no path that puts many commands in one record

### DIFF
--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -9899,4 +9899,64 @@ mod tests {
         }
         set_wal_segment_bytes_for_test(None);
     }
+
+    /// What does writing one record per command cost against batching them? Prints.
+    ///
+    ///   cargo test -p temporalstore-rust --lib what_per_command_records_cost \
+    ///       -- --ignored --nocapture --test-threads=1
+    ///
+    /// `append_batch_as_one_record` puts N commands in ONE record, and the design being followed
+    /// works that way for every write: items accumulate into one oplog and `Commit` serialises the
+    /// batch as a single stream append. Ours reaches the batch entries only from the explicit
+    /// stream-batch API -- an ordinary write takes `append_with_sync` and gets a record to itself.
+    ///
+    /// The difference is per-record framing, paid once per command instead of once per batch. This
+    /// measures it directly: the same commands down both paths, same store settings, comparing
+    /// BYTES ON DISK.
+    ///
+    /// Compression is deliberately left at the store default for both arms. An earlier probe in
+    /// this area reported compression as batching, so the two must not move together here.
+    #[test]
+    #[ignore]
+    fn what_per_command_records_cost() {
+        fn commands(count: usize, value_len: usize) -> Vec<Command> {
+            (0..count)
+                .map(|index| Command::StringSet {
+                    key: format!("walbatch-{index:06}"),
+                    value: vec![b'v'; value_len],
+                })
+                .collect()
+        }
+
+        eprintln!("  value_b  count   one_by_one_b   batch_atomic_b   records   ratio");
+        for value_len in [16usize, 64, 256] {
+            for count in [64usize, 512] {
+                let one_by_one_dir = tempfile::tempdir().expect("temp dir");
+                let one_by_one = LocalWriteAheadLogStore::new(one_by_one_dir.path());
+                for command in commands(count, value_len) {
+                    one_by_one
+                        .append_with_sync(1, command, false)
+                        .expect("append");
+                }
+                let one_by_one_bytes = one_by_one.stats(1).bytes_written;
+
+                let batched_dir = tempfile::tempdir().expect("temp dir");
+                let batched = LocalWriteAheadLogStore::new(batched_dir.path());
+                let records = batched
+                    .append_batch_atomic(1, commands(count, value_len), false)
+                    .expect("append batch");
+                let batched_bytes = batched.stats(1).bytes_written;
+
+                let ratio = if batched_bytes == 0 {
+                    0.0
+                } else {
+                    one_by_one_bytes as f64 / batched_bytes as f64
+                };
+                eprintln!(
+                    "  {value_len:>7}  {count:>5}   {one_by_one_bytes:>12}   {batched_bytes:>14}   {:>7}   {ratio:>5.2}x",
+                    records.len()
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
The WAL has no path that puts many commands in one record

The design being followed batches at the logger: every write accumulates into one
oplog, and Commit serialises the whole batch as a SINGLE stream append with one
id and one size. A burst of N writes costs one record's framing.

We have two batch entries and neither does that for commands:

  - `append_batch_as_one_record` really does write ONE record, and takes
    `Vec<WalOutcomeItem>` -- outcome-shaped payloads, not commands. Reachable
    only from the stream-batch path.
  - `append_batch_atomic` takes `Vec<Command>` and returns
    `Vec<WriteAheadLogRecord>` -- one record per command. It is atomic in
    ORDERING, not in framing.

Measured, same commands down both paths, same store settings:

    value_b  count   one_by_one_b   batch_atomic_b   records   ratio
         16     64           3776             4160        64    0.91x
         16    512          30593            34562       512    0.89x
         64     64           6848             7232        64    0.95x
         64    512          55169            59138       512    0.93x
        256     64           4156             4540        64    0.92x
        256    512          33661            37630       512    0.89x

`records` is the count `append_batch_atomic` returned: N, never one. And the
ratio is below 1 at every size, so the batch entry writes MORE than appending one
by one -- about six to eight bytes per command of extra marker. Batching commands
through it costs framing rather than saving it.

So the ordinary write path cannot amortise record framing over a burst, and
neither can the batch entry that accepts commands. Closing that means either
teaching the one-record entry to carry commands or giving the write path a commit
boundary to accumulate against; both change the record format or the write path,
which is more than a probe should decide.

One reading note for whoever picks this up: the 256-byte rows cost LESS than the
64-byte rows, because the fixture's repeated bytes compress. The absolute numbers
are compressed sizes; the comparison between the two arms is what this measures,
and both arms share the setting. An earlier probe in this area reported
compression as batching, which is why the two are held fixed here.

No behaviour changes. The probe is #[ignore] and prints.

Full suite: see below.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Full suite: **1777 passed, 1 failed** -- the standing --lib baseline failure on main. No new failure name.
