### PR TITLE
Why eviction stalls: the mode, not the pacing or the sampler

### DIFF
--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -5020,6 +5020,24 @@ fn what_a_page_gc_round_walks() {
 /// Each arm builds its OWN store. A first version shared one runtime across both arms, so the
 /// second arm inherited a cache the first had already drained and reported zeros that meant
 /// nothing.
+///
+/// WHY IT STALLS, which #1555 left open. Not pacing and not selection -- both of those match the
+/// design being followed already:
+///
+///   - pacing: #1555 gave the stage a count budget, so it keeps taking batches while they help.
+///   - selection: `evict_sampler` lives on `ShardState`, so the sampler's cursor and pool persist
+///     across calls. That is the same persistent-iterator shape their `PolicyLru` uses.
+///
+/// The ceiling is the MODE. With `eviction_delete_drop` false -- the shipped default, mode
+/// `evict_cache` -- a victim is handled by `cache.invalidate_slot(shard_id, routing_bucket)` and
+/// nothing else. Eviction can free exactly what is CACHED. Once the cached pages of the eligible
+/// buckets are gone, another batch frees nothing, `cooldown` is set, and the loop correctly stops.
+///
+/// So eviction cannot converge below the cached set by construction, and the bucket node itself is
+/// never dropped. That is the same architectural blocker as restore: there is no per-bucket
+/// load-back path, so nothing may evict a bucket node and expect to read it again. Raising the
+/// budget, changing the sampler, or looping harder cannot move this number -- the fix is a load
+/// path, or a deliberate decision to run this stage in `delete_drop`.
 #[test]
 #[ignore]
 fn how_long_eviction_takes_to_converge() {


### PR DESCRIPTION
Why eviction stalls: the mode, not the pacing or the sampler

#1555 closed the pacing difference and said plainly that eviction still does not
reach its threshold, leaving the cause open. It is not pacing and it is not
victim selection -- both of those already match the design being followed:

  - pacing: #1555 gave the stage a count budget, so it keeps taking batches
    while they help, and stops when one does not.
  - selection: `evict_sampler` lives on `ShardState`, so the sampler's cursor
    and pool persist across calls. That is the same persistent-iterator shape
    their PolicyLru uses, and I went looking for it expecting it to be missing.

The ceiling is the MODE. With `eviction_delete_drop` false -- the shipped
default, mode `evict_cache` -- a victim is handled by

    self.cache.invalidate_slot(shard_id, victim.routing_bucket)

and nothing else. Eviction frees exactly what is CACHED. Once the cached pages
of the eligible buckets are gone, another batch frees nothing, `cooldown` is set,
and the loop correctly stops. The measured stall -- 16 victims freeing ~4,800
bytes, then ~900, then nothing by round six -- is that set being exhausted, not a
budget running out.

So eviction cannot converge below the cached set by construction, and it never
drops a bucket NODE. That is the same architectural blocker as restore: there is
no per-bucket load-back path, so nothing may evict a bucket node and expect to
read it back. It also explains why raising the budget did not help, and predicts
that changing the sampler or looping harder will not either.

This matters for the recorded finding that our bucket index is never evicted from
memory, at about 760 bytes a key: eviction is not the mechanism that will fix it
in the shipped mode, and no amount of tuning makes it one. What would: a load
path, or a deliberate decision to run this stage in `delete_drop`, which deletes
objects rather than dropping caches and is a data-loss-shaped choice rather than
a tuning one.

Doc only; no behaviour changes.

Full suite: unchanged -- this adds comments to an #[ignore] probe.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
