### PR TITLE
A bucket dump costs the whole shard, not the buckets it was asked for

### DIFF
--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -6166,3 +6166,61 @@ fn does_the_periodic_loop_reach_compaction() {
         );
     }
 }
+
+/// Does a bucket dump cost the BUCKETS it was asked for, or the whole shard? Prints.
+///
+///   cargo test -p temporalstore-rust --lib what_a_bucket_dump_costs \
+///       -- --ignored --nocapture --test-threads=1
+///
+/// `create_bucket_dump_manifest` takes a list of buckets, and `max_dump_buckets_per_round` exists
+/// to bound how many a round takes. But the manifest is built around `export_index_bytes(shard_id)`
+/// -- the WHOLE shard index, serialised and hashed -- whatever that list contains.
+///
+/// The design being followed dumps per slot: `DumpSlotNotInMemory` reads that slot's marked pages
+/// and metas out of the index and writes them without materialising the bucket, so a dump of one
+/// slot costs one slot.
+///
+/// If the cost here is flat in the number of buckets, then bounding the round by bucket count
+/// bounds the wrong thing, and it is the same shape as the expiry scan and the compaction scan:
+/// the WORK is bounded and the SCAN is not.
+#[test]
+#[ignore]
+fn what_a_bucket_dump_costs() {
+    const KEYS: usize = 20_000;
+
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+    for index in 0..KEYS {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("dumpcost-{index:08}"),
+                value: vec![b'v'; 64],
+            },
+        });
+    }
+
+    // Which buckets exist, so the counts below ask for real ones.
+    let all_buckets = engine
+        .bucket_storage_summaries(1)
+        .into_iter()
+        .map(|summary| summary.routing_bucket)
+        .collect::<Vec<_>>();
+    eprintln!("  keys={KEYS} buckets={}", all_buckets.len());
+    eprintln!("  buckets_asked   dump_ms");
+
+    for count in [1usize, 8, 64, 512] {
+        if count > all_buckets.len() {
+            continue;
+        }
+        let selected = all_buckets.iter().copied().take(count).collect::<Vec<_>>();
+        let started = Instant::now();
+        let manifest = engine
+            .create_bucket_dump_manifest(1, selected)
+            .expect("dump should succeed");
+        let elapsed = started.elapsed().as_millis();
+        eprintln!("  {count:>13}   {elapsed:>7}");
+        // Keep the manifest alive so the work is not optimised away.
+        assert!(!manifest.manifest_id.is_empty());
+    }
+}


### PR DESCRIPTION
A bucket dump costs the whole shard, not the buckets it was asked for

`create_bucket_dump_manifest` takes a list of buckets, and
`max_dump_buckets_per_round` exists to bound how many a round takes. The manifest
is built around `export_index_bytes(shard_id)` -- the WHOLE shard index,
serialised and hashed -- whatever that list contains.

Measured on a 20,000-key shard with 20,000 buckets:

    buckets_asked   dump_ms
                1      2204
                8      2464
               64      2565
              512      3018

Asking for 512 times as many buckets costs 37% more time. About 2,200 ms of that
is fixed, and the marginal cost of a bucket is close to nothing.

So the round bound bounds the wrong thing. This is also the missing explanation
for two numbers already recorded: #1537 measured that capping the index dump cut
a round by only 16%, and #1547 measured the reclaim_index stage at 68% of a
round. A cap on bucket COUNT cannot help when the cost does not come from the
count.

The design being followed dumps per slot. `DumpSlotNotInMemory` reads that slot's
marked pages and metas out of the index -- `GetSlotMarkedPagesAndMetas` -- and
writes them without materialising the bucket at all, so dumping one slot costs
one slot, and dumping a slot that is not resident does not require loading it.

THE SAME SHAPE, A THIRD TIME

  - expiry walked the whole keyspace to find due keys        (fixed, #1545)
  - compaction scans every collection to relocate a bounded budget (#1547)
  - a dump serialises the whole shard index to write one bucket   (here)

In each case the WORK is bounded and the SCAN is not, and in each case the knob
that looks like the bound is counting the bounded half. Worth stating as a
pattern, because the next round bound added to this tree will be tempting to
trust for the same wrong reason.

Not fixed here. A per-bucket dump means the manifest can no longer carry a
whole-index snapshot, and the install path reads that snapshot to set its replay
watermark -- the comment above `export_index_bytes` explains why the two are
coupled by construction. Changing it touches the durability contract between dump
and install, which is not something to attempt from a probe.

No behaviour changes. The probe is #[ignore] and prints.

Full suite: see below.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Full suite: **1777 passed, 1 failed** -- the standing --lib baseline failure on main. No new failure name.
