### PR TITLE
An index-GC round costs the log, and has no cursor to resume from

### DIFF
--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -6224,3 +6224,85 @@ fn what_a_bucket_dump_costs() {
         assert!(!manifest.manifest_id.is_empty());
     }
 }
+
+/// Does an index-GC round cost the LOG or the records it removes? Prints.
+///
+///   cargo test -p temporalstore-rust --lib what_an_index_gc_round_costs \
+///       -- --ignored --nocapture --test-threads=1
+///
+/// `index_gc_max_entries_per_round` bounds how many index-log records a round REMOVES -- 256 by
+/// default, reachable since #1524. What it does not bound is the read: the report opens with
+/// `scan(shard_id, 0, u64::MAX, u64::MAX)`, the whole log, every round, and there is no cursor
+/// anywhere to resume from.
+///
+/// The design being followed keeps a persistent `gc_scan_iterator_` and advances it with `Next()`
+/// for `index_gc_max_num_per_round` entries, so a round reads what it is budgeted for and the next
+/// round continues from there rather than starting over.
+///
+/// If the cost here grows with the LOG while the removal stays capped, this is the same shape as
+/// the expiry walk (#1545), the compaction scan (#1547) and the whole-shard dump (#1559): the work
+/// is bounded, the scan is not, and the knob counts the bounded half.
+#[test]
+#[ignore]
+fn what_an_index_gc_round_costs() {
+    eprintln!("  index_records   round_ms   removed");
+    for writes in [2_000usize, 8_000, 32_000] {
+        let engine = TemporalEngine::default();
+        engine.load_shard(1);
+        let runtime = DataNodeRuntime::new_without_workers_with_options(
+            engine,
+            DataNodeRuntimeOptions {
+                worker_threads: 0,
+                max_queue_depth: 4,
+                max_background_queue_depth: 2,
+            },
+        );
+        {
+            let engine = runtime.engine();
+            // Overwrite a bounded key space so records genuinely become garbage and the stage has
+            // something to remove; with distinct keys almost every record is the live version of a
+            // key and the removal would be zero for reasons that say nothing about scan cost.
+            for index in 0..writes {
+                engine.execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringSet {
+                        key: format!("idxscan-{:08}", index % 500),
+                        value: vec![b'v'; 64],
+                    },
+                });
+            }
+        }
+        let before = runtime
+            .engine()
+            .index_log_store()
+            .scan(1, 0, u64::MAX, u64::MAX)
+            .map(|records| records.len())
+            .unwrap_or(0);
+
+        // Only the index stage, so the number is this stage's and not a whole round's.
+        let options = StorageManagerOptions {
+            enable_prepare: false,
+            enable_wal_reclaim: false,
+            enable_memory_reclaim: false,
+            enable_expire: false,
+            enable_page_gc: false,
+            enable_page_compaction: false,
+            enable_metrics_reap: false,
+            ..StorageManagerOptions::default()
+        };
+        let started = Instant::now();
+        runtime.run_storage_manager_once(1, options);
+        let elapsed = started.elapsed().as_millis();
+
+        let after = runtime
+            .engine()
+            .index_log_store()
+            .scan(1, 0, u64::MAX, u64::MAX)
+            .map(|records| records.len())
+            .unwrap_or(0);
+        eprintln!(
+            "  {before:>13}   {elapsed:>8}   {:>7}",
+            before.saturating_sub(after)
+        );
+    }
+}


### PR DESCRIPTION
An index-GC round costs the log, and has no cursor to resume from

`index_gc_max_entries_per_round` bounds how many index-log records a round
REMOVES -- 256 by default, reachable since #1524. It does not bound the read. The
report opens with

    .scan(request.shard_id, 0, u64::MAX, u64::MAX)

-- the whole log, every round -- and there is no cursor anywhere to resume from:
`index_gc_cursor`, `gc_scan_cursor` and `index_gc_scan` match nothing outside
tests.

Measured, with only the index stage enabled:

    index_records   round_ms   removed
             2000        395         0
             8000        480         0
            32000       1601       256

At 32,000 records the stage read the log to remove 256 -- the cap exactly -- and
took 1,601 ms doing it. At 2,000 and 8,000 it removed NOTHING and still cost 395
and 480 ms.

The design being followed keeps a persistent `gc_scan_iterator_` and advances it
with `Next()` for `index_gc_max_num_per_round` entries, so a round reads what it
is budgeted for and the next continues from where it stopped rather than starting
over. Its gate is O(1) too -- a maintained `valid_item_count_` and two running
averages -- against our full decode, though #1524 measured that gate at 0.27% of
the stage, so the scan is the part that matters.

FOURTH INSTANCE OF ONE SHAPE

  - expiry walked the keyspace to find due keys          FIXED #1545
  - compaction scans every collection for a 2,048 budget      #1547
  - a dump serialises the whole shard index for one bucket    #1559
  - index GC reads the whole log to remove 256                here

Work bounded, scan not, and the knob that looks like the round bound counts the
bounded half each time.

ONE THING THIS NUMBER IS NOT

It is the STAGE, not the GC scan alone. This stage also takes the whole-dirty-set
dump -- deliberately unbounded, and #1559 measured a dump as costing the whole
shard index whatever it is asked for. So part of the 395 ms at 2,000 records is
that dump, and the two cannot be separated without disabling something the stage
needs to advance its floor. What the table shows is the stage's cost against log
size with removal pinned at 0 or 256; it does not attribute that cost between the
scan and the dump.

No behaviour changes. The probe is #[ignore] and prints.

Full suite: see below.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Full suite: **1777 passed, 1 failed** -- the standing --lib baseline failure on main. No new failure name.
