### PR TITLE
What blocks per-bucket restore is where the page list lives

### DIFF
--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -1364,6 +1364,31 @@ pub(super) struct BucketNode {
     pub(super) dirty: bool,
     #[serde(default)]
     pub(super) deleted: bool,
+    /// The three flags of a per-bucket residency lifecycle that does not exist yet.
+    ///
+    /// They describe a bucket whose metadata is known while its data is not resident, which is
+    /// what a load-on-demand store needs: evict a bucket's data, keep enough to find it again,
+    /// load it back when someone asks. The design being followed has exactly that --
+    /// `SlotStore::LoadSlot` reads a slot's page indexes with `index_->GetSlotPages(slot_id)` and
+    /// loads only those pages, and `Index::EvictSlot` drops the node.
+    ///
+    /// WHAT BLOCKS IT HERE is not the missing function. It is where the page list lives.
+    /// `GetSlotPages` answers from the INDEX, which holds per-slot page metadata whether or not
+    /// the slot is resident. Our equivalent, `bucket_index.bucket_map`, is DERIVED:
+    /// `rebuild_bucket_page_ownership` clears it and rebuilds it by walking
+    /// `collect_model_live_page_entries`, which iterates `strings`, `hashes`, `zsets` and the rest
+    /// -- the resident address maps themselves.
+    ///
+    /// So a bucket's page list is a view of its resident data. Evicting the data destroys the only
+    /// record of which pages were the bucket's, and nothing could load it back. That is why these
+    /// flags are never set, and why eviction in the shipped mode drops CACHED PAGES
+    /// (`invalidate_slot`) and never a bucket node -- see the eviction ceiling recorded on
+    /// `how_long_eviction_takes_to_converge`.
+    ///
+    /// Closing it means giving the index a per-bucket page list that survives the bucket leaving
+    /// memory, which is a durable-format change and not a wiring one. Until then, the recorded
+    /// finding that the bucket index is never evicted (~760 B a key) has no mechanism that could
+    /// evict it.
     pub(super) meta_loaded: bool,
     pub(super) loading: bool,
     pub(super) in_memory: bool,


### PR DESCRIPTION
What blocks per-bucket restore is where the page list lives

`BucketNode` carries `meta_loaded`, `loading` and `in_memory` -- three flags of a
per-bucket residency lifecycle -- and nothing ever sets them. Earlier notes in
this area called that architectural and left it there. This says what the
architecture actually is, because "we never wrote LoadSlot" is the wrong summary
and points at the wrong fix.

The design being followed loads a slot like this:

    for (auto& index : index_->GetSlotPages(slot_id, false)) { ... }
    LoadPages(ctrl, context->indexes, &context->pages, ...);

`GetSlotPages` answers from the INDEX. The index holds per-slot page metadata
whether or not that slot's data is resident, so a slot can be dropped
(`Index::EvictSlot`) and read back later from its own page list.

Our equivalent is DERIVED, not stored. `rebuild_bucket_page_ownership` clears
`bucket_index.bucket_map` and rebuilds it by walking
`collect_model_live_page_entries`, which iterates `shard.strings`,
`shard.hashes`, `shard.zsets` and the rest -- the resident address maps
themselves.

So a bucket's page list is a VIEW OF ITS RESIDENT DATA. Evicting the data
destroys the only record of which pages belonged to the bucket, and nothing could
load it back. The missing piece is not a function; it is a durable per-bucket
page list that outlives the bucket leaving memory.

That also explains two things already recorded separately:

  - the three flags are unfed because the lifecycle they describe is not
    implementable against a derived map;
  - eviction in the shipped mode drops CACHED PAGES via `invalidate_slot` and
    never a bucket node, which is the ceiling measured on
    `how_long_eviction_takes_to_converge` -- eviction cannot evict the thing that
    grows, and no tuning changes that.

Closing it is a durable-format change, not wiring. Until then the recorded
finding that the bucket index is never evicted -- about 760 bytes a key -- has no
mechanism that could evict it, and that is worth knowing before anyone tries to
tune eviction into doing it.

Doc only; no behaviour changes.

Full suite: see below.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Full suite: **1777 passed, 1 failed** -- the standing --lib baseline failure on main. No new failure name.
