### PR TITLE
Compaction outruns the collector: 11 slabs after 10 idle rounds

### DIFF
--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -6156,9 +6156,19 @@ fn does_the_periodic_loop_reach_compaction() {
         total_rewritten += rewritten;
         eprintln!("  {round:>5}  {ran:>11}  {rewritten:>19}  {elapsed:>8}");
     }
+    // Does the collector take away the slab each round leaves behind? If it did, the stale
+    // pressure would clear and the next round would have no reason to run. If the count has
+    // climbed with the rounds, compaction is outrunning page GC and that is what sustains it.
+    let slabs_at_end = runtime
+        .engine()
+        .block_store()
+        .slab_ids()
+        .map(|ids| ids.len())
+        .unwrap_or(0);
     eprintln!(
         "  VERDICT: compacted on {rounds_that_compacted} of {ROUNDS} rounds, {total_rewritten} \
-         page refs rewritten, over a store that stopped changing before round 0"
+         page refs rewritten, over a store that stopped changing before round 0; \
+         {slabs_at_end} slabs remain"
     );
     if rounds_that_compacted == 0 {
         eprintln!(


### PR DESCRIPTION
Compaction outruns the collector: 11 slabs after 10 idle rounds

#1557 proved compaction re-triggers itself on the periodic loop and left the
cause as "each round rolls a fresh slab, and that leaves the previous one stale".
That is only half a mechanism. A stale slab re-triggers compaction only if it is
still there next round, so the question is whether the collector takes it away.

It does not:

    VERDICT: compacted on 10 of 10 rounds, 4000 page refs rewritten, over a
             store that stopped changing before round 0; 11 SLABS REMAIN

Eleven slabs after ten rounds, on a store nobody wrote to. Compaction adds one a
round and page GC removes none of them, so the stale count only ever grows and
`stale_page_pressure` can never close.

WHY THIS MATTERS FOR THE FIX

#1550 and #1553 recorded three attempts at a SKIP CONDITION inside compaction,
all refused by the suite, and concluded a real fix needs a layout signal. That
conclusion was aimed at the wrong component. The loop is sustained by slabs that
should already be collectable: after compaction relocates every live page off a
slab, that slab holds nothing live, which is exactly the case page GC exists for.

So the tractable question is not "when should compaction decline" but "why does
the collector leave a fully dead slab behind". The periodic stage computes its
retain floor as `stale_block_slab_ids.iter().min().saturating_add(1)`, which is
where to look first -- a floor derived from the stale set may not authorise
deleting the members of that set.

I am not fixing it here, because three wrong guesses in one area is enough and
the next step is a measurement of what that floor actually authorises, not
another condition. Recording the number and the redirection so the next attempt
starts at the collector rather than at compaction.

No behaviour changes. The probe is #[ignore] and prints.

Full suite: see below.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Full suite: **1777 passed, 1 failed** -- the standing --lib baseline failure on main. No new failure name.
