### PR TITLE
A manifest-pinned slab no longer freezes the page-GC retain floor

### DIFF
--- a/crates/temporalstore-rust/src/data_node/runtime_storage.rs
+++ b/crates/temporalstore-rust/src/data_node/runtime_storage.rs
@@ -543,11 +543,44 @@ impl DataNodeRuntime {
 
 
         if options.enable_page_gc && stale_page_pressure {
+            // The floor is a MIN over the stale slabs, so a stale slab that can never be deleted
+            // freezes it -- and one always can be. `run_gc_inner` treats every slab named by a
+            // bucket dump manifest as live, so the moment a dump exists, the slab it names is
+            // stale (its pages have moved) and retained (the manifest needs it). `min` then sits
+            // on that slab for ever, the floor never advances, and every slab compaction rolls
+            // afterwards is above it and permanently out of reach.
+            //
+            // Measured before this: the floor froze at 2 while stale slabs climbed to nine and the
+            // collector removed nothing, on a store nobody was writing to. That is the same shape
+            // as #1516, where a reclaim frontier taken as a min over every bucket was pinned for
+            // ever by one clean bucket -- a min over a set with an immovable member.
+            //
+            // So take the min over the slabs that are actually candidates: stale AND not pinned by
+            // a manifest. Excluding them does not make them deletable -- `gc_slabs_before_..`
+            // checks `is_live` itself and still refuses them -- it only stops them dictating how
+            // far back the round is allowed to look.
+            let manifest_pinned_block_slab_ids = self
+                .inner
+                .engine
+                .list_bucket_dump_manifests(shard_id)
+                .into_iter()
+                .flat_map(|manifest| manifest.block_slab_ids.into_iter())
+                .collect::<std::collections::BTreeSet<_>>();
             let retain_block_slabs_from_id = lifecycle_plan
                 .stale_block_slab_ids
                 .iter()
+                .filter(|slab_id| !manifest_pinned_block_slab_ids.contains(slab_id))
                 .min()
-                .map(|slab_id| slab_id.saturating_add(1));
+                .map(|slab_id| slab_id.saturating_add(1))
+                // Every stale slab is manifest-pinned: nothing to collect this round, and the
+                // floor must not fall back to 0 -- that would read as "retain nothing".
+                .or_else(|| {
+                    lifecycle_plan
+                        .stale_block_slab_ids
+                        .iter()
+                        .min()
+                        .map(|slab_id| slab_id.saturating_add(1))
+                });
             let response = run_gc_inner(
                 &self.inner,
                 GcRequest {

--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -6316,3 +6316,103 @@ fn what_an_index_gc_round_costs() {
         );
     }
 }
+
+/// What does the page-GC retain floor authorise, round by round? Prints.
+///
+///   cargo test -p temporalstore-rust --lib what_the_retain_floor_authorises \
+///       -- --ignored --nocapture --test-threads=1
+///
+/// #1563 measured eleven slabs left after ten idle rounds: compaction rolls one a round and page
+/// GC removes none, so `stale_page_pressure` never closes and compaction re-triggers for ever.
+///
+/// The floor is the first suspect. The periodic stage computes it as
+///
+///     stale_block_slab_ids.iter().min().saturating_add(1)
+///
+/// and `stale_block_slab_ids` is every slab NOT in the live set -- so the floor is derived FROM
+/// the stale set. Taking the minimum and adding one authorises deleting slabs strictly below the
+/// OLDEST stale slab, which is at most that one slab, however many are stale.
+///
+/// This prints, per round, how many slabs are stale, what floor that produces, and how many the
+/// collector actually removed. If removed stays at zero while stale climbs, the floor is not the
+/// whole story; if removed is one a round while compaction adds one, it is a treadmill.
+#[test]
+#[ignore]
+fn what_the_retain_floor_authorises() {
+    const KEYS: usize = 400;
+    const ROUNDS: usize = 10;
+
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+    let runtime = DataNodeRuntime::new_without_workers_with_options(
+        engine,
+        DataNodeRuntimeOptions {
+            worker_threads: 0,
+            max_queue_depth: 4,
+            max_background_queue_depth: 2,
+        },
+    );
+    {
+        let engine = runtime.engine();
+        for index in 0..KEYS {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::HashSet {
+                    key: format!("retainfloor-{index:05}"),
+                    field: "f".to_string(),
+                    value: vec![b'v'; 64],
+                },
+            });
+        }
+        engine
+            .block_store()
+            .roll_slab()
+            .expect("rolling a slab should succeed");
+        for index in 0..KEYS {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::HashSet {
+                    key: format!("retainfloor-{index:05}"),
+                    field: "f".to_string(),
+                    value: vec![b'w'; 72],
+                },
+            });
+        }
+    }
+
+    eprintln!("  round  slabs  stale  floor  gc_ran  removed");
+    let options = StorageManagerOptions::default();
+    for round in 0..ROUNDS {
+        let plan = runtime
+            .engine()
+            .storage_lifecycle_plan(crate::engine::reports::StorageLifecycleRequest {
+                shard_id: 1,
+                ..Default::default()
+            });
+        let stale = plan.stale_block_slab_ids.len();
+        let floor = plan
+            .stale_block_slab_ids
+            .iter()
+            .min()
+            .map(|id| id.saturating_add(1))
+            .unwrap_or(0);
+        let slabs = runtime
+            .engine()
+            .block_store()
+            .slab_ids()
+            .map(|ids| ids.len())
+            .unwrap_or(0);
+
+        let report = runtime.run_storage_manager_once(1, options.clone());
+        let gc_ran = report
+            .executed_stages
+            .iter()
+            .any(|stage| stage == "reclaim_page");
+        let removed = report
+            .gc_report
+            .as_ref()
+            .map(|gc| gc.block_slabs_removed)
+            .unwrap_or(0);
+        eprintln!("  {round:>5}  {slabs:>5}  {stale:>5}  {floor:>5}  {gc_ran:>6}  {removed:>7}");
+    }
+}

--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -6416,3 +6416,208 @@ fn what_the_retain_floor_authorises() {
         eprintln!("  {round:>5}  {slabs:>5}  {stale:>5}  {floor:>5}  {gc_ran:>6}  {removed:>7}");
     }
 }
+
+/// Why does a stale slab below the retain floor survive? Prints.
+///
+///   cargo test -p temporalstore-rust --lib why_a_stale_slab_below_the_floor_survives \
+///       -- --ignored --nocapture --test-threads=1
+///
+/// #1564 measured the page-GC retain floor freezing at 2 while stale slabs climbed to nine and the
+/// collector removed nothing. The floor freezes because it is `min(stale) + 1`, so it cannot rise
+/// past the oldest stale slab -- but that only explains the freeze if the oldest stale slab is
+/// itself unremovable, and it sits BELOW the floor, which the formula does authorise.
+///
+/// `gc_slabs_before_with_live_refs_selected` keeps a slab below the floor for exactly two reasons,
+/// and the report names both: it is the CURRENT slab, or it is LIVE. And the periodic stage widens
+/// "live" beyond pages -- `run_gc_inner` adds every slab named by a bucket dump manifest:
+///
+///     for manifest in inner.engine.list_bucket_dump_manifests(request.shard_id) {
+///         live_block_slab_ids.extend(manifest.block_slab_ids.iter().copied());
+///     }
+///
+/// So a manifest written before compaction relocated the pages still names the OLD slabs. This
+/// separates the three: live-by-page, live-by-manifest, and current.
+#[test]
+#[ignore]
+fn why_a_stale_slab_below_the_floor_survives() {
+    const KEYS: usize = 400;
+    const ROUNDS: usize = 6;
+
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+    let runtime = DataNodeRuntime::new_without_workers_with_options(
+        engine,
+        DataNodeRuntimeOptions {
+            worker_threads: 0,
+            max_queue_depth: 4,
+            max_background_queue_depth: 2,
+        },
+    );
+    {
+        let engine = runtime.engine();
+        for index in 0..KEYS {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::HashSet {
+                    key: format!("whysurvive-{index:05}"),
+                    field: "f".to_string(),
+                    value: vec![b'v'; 64],
+                },
+            });
+        }
+        engine
+            .block_store()
+            .roll_slab()
+            .expect("rolling a slab should succeed");
+        for index in 0..KEYS {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::HashSet {
+                    key: format!("whysurvive-{index:05}"),
+                    field: "f".to_string(),
+                    value: vec![b'w'; 72],
+                },
+            });
+        }
+    }
+
+    eprintln!("  round  slabs  floor  live_by_page  live_by_manifest  manifests  removed  ret_live  ret_current");
+    let options = StorageManagerOptions::default();
+    for round in 0..ROUNDS {
+        let engine = runtime.engine();
+        let plan = engine.storage_lifecycle_plan(crate::engine::reports::StorageLifecycleRequest {
+            shard_id: 1,
+            ..Default::default()
+        });
+        let floor = plan
+            .stale_block_slab_ids
+            .iter()
+            .min()
+            .map(|id| id.saturating_add(1))
+            .unwrap_or(0);
+        let live_by_page = engine.live_block_slab_ids_all_shards();
+        let manifests = engine.list_bucket_dump_manifests(1);
+        let live_by_manifest = manifests
+            .iter()
+            .flat_map(|manifest| manifest.block_slab_ids.iter().copied())
+            .collect::<std::collections::BTreeSet<_>>();
+        let slabs = engine
+            .block_store()
+            .slab_ids()
+            .map(|ids| ids.len())
+            .unwrap_or(0);
+
+        let report = runtime.run_storage_manager_once(1, options.clone());
+        let gc = report.gc_report.as_ref();
+        let removed = gc.map(|g| g.block_slabs_removed).unwrap_or(0);
+        let ret_live = gc.map(|g| g.block_slabs_retained_live).unwrap_or(0);
+        eprintln!(
+            "  {round:>5}  {slabs:>5}  {floor:>5}  {:>12}  {:>16}  {:>9}  {removed:>7}  {ret_live:>8}  {:>11}",
+            live_by_page.len(),
+            live_by_manifest.len(),
+            manifests.len(),
+            "-"
+        );
+    }
+}
+
+/// An idle shard stops accumulating slabs: the collector keeps pace with compaction.
+///
+/// The page-GC retain floor is a MIN over the stale slabs, and `run_gc_inner` treats every slab
+/// named by a bucket dump manifest as live. So once a dump exists, the slab it names is stale (its
+/// pages have moved) and retained (the manifest needs it) -- and `min` sat on that slab for ever.
+/// The floor never advanced, every slab compaction rolled afterwards was above it, and the store
+/// grew a slab a round on a shard nobody was writing to: measured at eleven slabs after ten rounds,
+/// with the collector removing nothing after the first.
+///
+/// Same shape as #1516, where a reclaim frontier taken as a min over every bucket was pinned by one
+/// clean bucket. The floor now takes its min over stale slabs that are NOT manifest-pinned, so it
+/// advances past them; they stay protected by the `is_live` check that was already refusing them.
+///
+/// This asserts the property that failed: an idle shard reaches a steady slab count instead of
+/// climbing. It writes NOTHING after the fixture, so any growth is the loop's own doing.
+#[test]
+fn an_idle_shard_stops_accumulating_slabs() {
+    const KEYS: usize = 400;
+    const ROUNDS: usize = 10;
+
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+    let runtime = DataNodeRuntime::new_without_workers_with_options(
+        engine,
+        DataNodeRuntimeOptions {
+            worker_threads: 0,
+            max_queue_depth: 4,
+            max_background_queue_depth: 2,
+        },
+    );
+    {
+        let engine = runtime.engine();
+        for index in 0..KEYS {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::HashSet {
+                    key: format!("idleslabs-{index:05}"),
+                    field: "f".to_string(),
+                    value: vec![b'v'; 64],
+                },
+            });
+        }
+        // Roll, then rewrite everything: the first slab holds nothing live, which is a stale slab
+        // for a few hundred records instead of the gigabyte a natural roll would need.
+        engine
+            .block_store()
+            .roll_slab()
+            .expect("rolling a slab should succeed");
+        for index in 0..KEYS {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::HashSet {
+                    key: format!("idleslabs-{index:05}"),
+                    field: "f".to_string(),
+                    value: vec![b'w'; 72],
+                },
+            });
+        }
+    }
+
+    let slabs_before = runtime
+        .engine()
+        .block_store()
+        .slab_ids()
+        .map(|ids| ids.len())
+        .unwrap_or(0);
+    let options = StorageManagerOptions::default();
+    let mut compacted_rounds = 0usize;
+    for _ in 0..ROUNDS {
+        let report = runtime.run_storage_manager_once(1, options.clone());
+        if report
+            .executed_stages
+            .iter()
+            .any(|stage| stage == "compact_pages")
+        {
+            compacted_rounds += 1;
+        }
+    }
+    let slabs_after = runtime
+        .engine()
+        .block_store()
+        .slab_ids()
+        .map(|ids| ids.len())
+        .unwrap_or(0);
+
+    // The denominator: if compaction never ran it rolled no slabs, and a flat count would say
+    // nothing about whether the collector can keep up with it.
+    assert!(
+        compacted_rounds > 0,
+        "compaction never ran, so nothing rolled a slab and this measures an idle collector"
+    );
+    // A slab a round would be {ROUNDS} more. Steady state is a small constant; the bound is
+    // deliberately loose so this fails on GROWTH, not on one slab of slack.
+    assert!(
+        slabs_after <= slabs_before + 2,
+        "an idle shard grew from {slabs_before} to {slabs_after} slabs over {ROUNDS} rounds \
+         ({compacted_rounds} of them compacting) -- the collector is not keeping pace, so the \
+         retain floor has stopped advancing again"
+    );
+}


### PR DESCRIPTION
An idle shard grew a slab every thirty seconds, for ever. #1563 measured eleven slabs after ten
rounds on a store nobody was writing to. This finds why and fixes it.

## Why the floor froze

The periodic stage computes

```
retain_block_slabs_from_id = stale_block_slab_ids.iter().min().saturating_add(1)
```

and `run_gc_inner` treats every slab named by a bucket dump manifest as live:

```rust
for manifest in inner.engine.list_bucket_dump_manifests(request.shard_id) {
    live_block_slab_ids.extend(manifest.block_slab_ids.iter().copied());
}
```

So the moment a dump exists, the slab it names is **stale** — compaction has moved its pages — and
**retained**, because the manifest still needs it to stay installable. `min` then sits on that slab
permanently:

| round | manifests | live_by_manifest | removed | retained_live |
|---|---|---|---|---|
| 0 | 0 | 0 | **1** | 0 |
| 1 | 1 | 1 | **0** | **1** |
| 2 | 1 | 1 | **0** | **1** |

Round 0 has no manifest and collects a slab. From round 1 the manifest pins one, `min` stops moving,
and every slab compaction rolls afterwards is above the floor and permanently unreachable:

| round | slabs | stale | floor | removed |
|---|---|---|---|---|
| 0 | 2 | 1 | 1 | 1 |
| 1 | 2 | 1 | **2** | 0 |
| 6 | 7 | 6 | **2** | 0 |
| 9 | 10 | 9 | **2** | 0 |

## The same bug as #1516, in a second place

#1516 fixed a reclaim frontier taken as a **min over every bucket**, where one clean bucket pinned
the floor for ever and both logs grew without bound. Identical shape here: a min over a set with a
member that can never move. The WAL and index logs had it; the page store had it too.

## The fix

Take the min over the slabs that are actually candidates — stale **and not** manifest-pinned — so
the floor advances past the pinned one. This does not make a pinned slab deletable:
`gc_slabs_before_with_live_refs` checks `is_live` itself and still refuses it. It only stops that
slab dictating how far back the round may look. When every stale slab is pinned there is nothing to
collect, and the floor falls back to the old value rather than to 0, which would read as "retain
nothing".

| idle rounds | before | after |
|---|---|---|
| slabs after 10 | **11** (growing) | **3** (steady) |
| removed per round | 0 from round 1 | 1 from round 2 |

## What this does not fix

Compaction still runs all ten rounds and still rewrites 400 page refs each time. The manifest-pinned
slab keeps `stale_page_pressure` open, so the stage still has a reason to run. **The disk growth is
stopped; the churn is not.**

The reason is worth recording for whoever takes it next: compaction relocates pages but never marks
the buckets dirty — the data did not change, only its location — so no fresh dump follows and the
manifest goes on naming the old slab. Measured: `manifests` stayed at 1 across all ten rounds. The
obvious repair, dirtying the bucket so the next dump refreshes the manifest, is not obviously safe:
`dirty` feeds `first_dirty_wal_sequence` and the WAL retention floor, so it could trade this churn
for a pinned log. That needs measuring, not guessing. #1550 and #1553 record three attempts at
making compaction decline and why each was refused; this floor is a separate question from that one.

## Verification

Mutation: dropping the filter fails the new guard with "an idle shard grew from 2 to 11 slabs over
10 rounds (10 of them compacting)". A denominator assertion comes first, so a fixture where
compaction never ran — and therefore rolled no slabs — fails loudly instead of passing on a flat
count.

`cargo test -p temporalstore-rust --lib -- --test-threads=1` → **1777 passed, 2 failed**. Both are
accounted for and neither is introduced here:

- `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds` — the standing `--lib` baseline
  failure on main.
- `engine::tests::part1::emptied_buckets_are_dropped_without_walking_the_map` — a per-write cost
  **ratio** assertion, red only under load; this suite ran alongside a second gate. In isolation it
  passes here at **0.79x**, with the cost *falling* as the corpus grows (3,997 µs at 2k → 3,165 µs
  at 20k).
