### PR TITLE
The whole-store fallback is reported, not just counted

### DIFF
--- a/tools/matrixark_temporal_direct_backend.py
+++ b/tools/matrixark_temporal_direct_backend.py
@@ -3,6 +3,8 @@
 """_TemporalDirectBackendMixin methods split from matrixark_mcp_temporal_adapters.MatrixArkTemporalStoreDirectAdapter (mixin)."""
 from __future__ import annotations
 
+import sys as _sys
+
 try:
     from tools.matrixark_mcp_env import env_bool
 except ImportError:  # Direct script execution from tools/.
@@ -21,6 +23,14 @@ try:  # package path
 except ImportError:
     from matrixark_temporal_location_codec import compact_location, compact_location_list
 
+#: Which spelling of `matrixark_mcp_temporal_adapters` THIS process resolved to. Both can be
+#: loaded at once -- the suite puts the repository root and tools/ on the path -- and they
+#: are two module objects with two separate copies of any module-level state. Anything that
+#: reaches back into that module later has to reach the same one, and a symbol's __module__
+#: will not say which: every name imported below is itself re-exported from somewhere else,
+#: so MatrixArkLocalAdapter.__module__ answers matrixark_mcp_local_adapter.
+_ADAPTERS_MODULE = "tools.matrixark_mcp_temporal_adapters"
+
 try:  # names owned by the parent module
     from tools.matrixark_mcp_temporal_adapters import (
     MatrixArkLocalAdapter,
@@ -36,6 +46,7 @@ try:  # names owned by the parent module
     time,
 )
 except ImportError:
+    _ADAPTERS_MODULE = "matrixark_mcp_temporal_adapters"
     from matrixark_mcp_temporal_adapters import (
     MatrixArkLocalAdapter,
     MatrixArkServiceMetrics,
@@ -275,6 +286,38 @@ class _TemporalDirectBackendMixin:
                     f'matrixark_backend_append_engine_ms{{backend="{backend}"}} {round(self._append_engine_ms_avg(), 3)}',
                 ]
             )
+            # The counter exists, is tested, and was reported nowhere. Its own docstring says why
+            # it was written: "the fallback is otherwise undetectable from outside: a measured
+            # degraded window did TEN whole-corpus reads and wrote nothing at all, and from the
+            # caller it looked like a normal request that was merely slow." A number kept for that
+            # reason and printed on no surface leaves the window just as invisible.
+            #
+            # One series per scan site rather than a total, because which scan gave up is the part
+            # that says where to look; a total only says the store got slower.
+            # Resolved here rather than imported at module scope, for two separate reasons.
+            #
+            # matrixark_mcp_temporal_adapters imports this module back, and the counter is
+            # defined after that point, so a module-level import of the NAME fails on a
+            # partially initialised module -- the same reason expand_record_bundles is
+            # imported inside its caller below.
+            #
+            # And it comes from `_ADAPTERS_MODULE`, the module object this file imported,
+            # rather than a fresh import by name. A fresh `from tools.X import y` reads
+            # whichever spelling that import reaches, which can be the OTHER module object
+            # with its own empty counter -- the metric then renders empty while the count is
+            # being kept a few frames away. That is what this rendered before.
+            adapters = _sys.modules.get(_ADAPTERS_MODULE)
+            fallbacks = adapters.full_read_fallback_counts() if adapters is not None else {}
+            if fallbacks:
+                lines.append(
+                    "# HELP matrixark_full_read_fallbacks_total Scoped scans that gave up and "
+                    "read the whole store instead.")
+                lines.append("# TYPE matrixark_full_read_fallbacks_total counter")
+                for scan, count in sorted(fallbacks.items()):
+                    safe = str(scan).replace("\\", "").replace('"', "").replace("\n", "")
+                    lines.append(
+                        f'matrixark_full_read_fallbacks_total{{backend="{backend}",'
+                        f'scan="{safe}"}} {int(count)}')
             return "\n".join(lines) + "\n"
 
     def backend_metrics(self) -> Json:

--- a/tools/test_a_scoped_scan_that_gives_up_says_so.py
+++ b/tools/test_a_scoped_scan_that_gives_up_says_so.py
@@ -94,12 +94,89 @@ def every_silent_branch_now_announces():
           "the helper must still count the fallback it takes")
 
 
+def _direct_backend_probe():
+    """A direct backend far enough along to render its own metrics.
+
+    `_backend_prometheus` lives on the mixin and `_ensure_backend_metric_fields` on the adapter
+    that mixes it in, so neither alone can render. Borrowing the real initialiser keeps this
+    honest: a hand-written stub would let the metric pass here while the shipped path skipped it.
+    """
+    import matrixark_mcp_temporal_adapters as adapters
+    import matrixark_temporal_direct_backend as backend
+
+    initialiser = None
+    for name in dir(adapters):
+        candidate = getattr(adapters, name, None)
+        if isinstance(candidate, type) and "_ensure_backend_metric_fields" in candidate.__dict__:
+            initialiser = candidate.__dict__["_ensure_backend_metric_fields"]
+            break
+    if initialiser is None:
+        return None
+    probe = object.__new__(backend._TemporalDirectBackendMixin)
+    probe.__dict__["_adapters_for_test"] = sys.modules[backend._ADAPTERS_MODULE]
+    probe._client = None
+    probe._backend_ready = True
+    probe._backend_label = lambda: "temporalstore-direct"
+    # `_backend_prometheus` calls this itself, so binding it matters more than calling it once.
+    probe._ensure_backend_metric_fields = lambda: initialiser(probe)
+    initialiser(probe)
+    return probe
+
+
+def the_whole_store_fallback_reaches_the_metrics_surface():
+    """Counting it was half the fix. The window this file exists for stayed invisible because the
+    number was reported on no surface at all."""
+    probe = _direct_backend_probe()
+    if probe is None:
+        check(False, "no class defines _ensure_backend_metric_fields, so this rendered nothing")
+        return
+    # Reported through the module object the BACKEND resolved, not the one this file imported.
+    # Both spellings of matrixark_mcp_temporal_adapters load here, because the harness puts the
+    # repository root and tools/ on the path, and each has its own counter. A deployment loads one
+    # and the distinction does not arise; a test that ignores it watches an empty metric and
+    # concludes the wiring is broken, which is exactly what happened while this was written.
+    adapters = probe.__dict__["_adapters_for_test"]
+    adapters._note_full_read_fallback("a_scan_that_gave_up")
+    adapters._note_full_read_fallback("a_scan_that_gave_up")
+    adapters._note_full_read_fallback("a_different_scan")
+    rendered = probe._backend_prometheus()
+
+    check("# TYPE matrixark_full_read_fallbacks_total counter" in rendered,
+          "the fallback counter is not declared on the metrics surface")
+    check('matrixark_full_read_fallbacks_total{backend="native",scan="a_scan_that_gave_up"} 2'
+          in rendered,
+          "the count for a named scan is missing or wrong:\n%s"
+          % "\n".join(l for l in rendered.splitlines() if "full_read_fallbacks" in l))
+    check('scan="a_different_scan"} 1' in rendered,
+          "one series per scan site: which scan gave up is the part that says where to look")
+
+
+def the_counter_is_what_is_being_read():
+    """A positive control. A metric block built from a literal would pass the check above."""
+    probe = _direct_backend_probe()
+    if probe is None:
+        return
+    adapters = probe.__dict__["_adapters_for_test"]
+    before = adapters.full_read_fallback_counts().get("a_control_scan", 0)
+    rendered = probe._backend_prometheus()
+    check('scan="a_control_scan"' not in rendered,
+          "a scan nothing has reported is already on the surface, so this is not reading the "
+          "counter")
+    adapters._note_full_read_fallback("a_control_scan")
+    rendered = probe._backend_prometheus()
+    check('matrixark_full_read_fallbacks_total{backend="native",scan="a_control_scan"} %d'
+          % (before + 1) in rendered,
+          "reporting one more fallback did not change the surface")
+
+
 for test in (
     a_named_fallback_is_counted_without_any_debug_log,
     an_unnamed_fallback_takes_the_calling_functions_name,
     counting_a_fallback_never_raises,
     the_detail_line_still_needs_the_debug_log,
     every_silent_branch_now_announces,
+    the_whole_store_fallback_reaches_the_metrics_surface,
+    the_counter_is_what_is_being_read,
 ):
     test()
     print("  ran %s" % test.__name__)


### PR DESCRIPTION
`full_read_fallback_counts` says in its own docstring why it exists: *"the fallback is otherwise
undetectable from outside: a measured degraded window did TEN whole-corpus reads and wrote nothing
at all, and from the caller it looked like a normal request that was merely slow."*

**Counting it was half the fix.** It was printed on no surface, so the window stayed exactly as
invisible as before.

```
matrixark_full_read_fallbacks_total{backend="native",scan="candidate_scan"} 2
matrixark_full_read_fallbacks_total{backend="native",scan="placement_scan"} 1
```

Per scan site rather than a total, because **which** scan gave up is the part that says where to
look; a total only says the store got slower. The family is absent entirely when nothing has fallen
back, so a healthy deployment gains no lines.

### Two things this cost, both now carrying the comment they earned

The counter is defined **after** `matrixark_mcp_temporal_adapters` imports this module back, so a
module-level import of the name fails on a partially initialised module. It is resolved inside the
renderer, like `expand_record_bundles` below it.

And resolving it with a fresh `from tools.X import y` **rendered an empty metric while the count was
being kept a few frames away.** Both spellings —`tools.matrixark_mcp_temporal_adapters` and
`matrixark_mcp_temporal_adapters` — can be loaded at once, and they are two module objects with two
separate counters. A deployment loads one and the distinction never arises; anything reaching back
into that module has to reach the same object. `_ADAPTERS_MODULE` records which spelling this
process took, at the point the choice is made.

**A symbol's `__module__` does not answer this**, and I tried it first: every name this file imports
from the adapters module is itself re-exported from somewhere else, so
`MatrixArkLocalAdapter.__module__` answers `matrixark_mcp_local_adapter`.

### The tests go where the incident is already tested

In `test_a_scoped_scan_that_gives_up_says_so`, reporting through the module object the **backend**
resolved — a test that ignores the distinction watches an empty metric and concludes the wiring is
broken, which is what happened while this was written.

Two checks: the family and its per-scan counts appear; and a positive control that the surface reads
the **counter** rather than a literal — a scan nothing has reported must be absent, and reporting one
more must move the number.

### Verified

The 40 suites naming the backend metrics, the Prometheus text or the fallback counter: **372 tests,
4 failures, the same 4 by name on pristine main, none new.**
