### PR TITLE
The compaction decision is per object and belongs to the model

### DIFF
--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -5847,6 +5847,28 @@ fn an_expired_key_is_removed_in_a_bounded_number_of_rounds() {
 /// The waste measured above is real and worth fixing. It is not fixable by asking a question about
 /// space alone, which is what both attempts did.
 ///
+/// WHERE THE ANSWER ACTUALLY LIVES, found later: the decision is PER OBJECT and belongs to the
+/// MODEL, not to the shard. Their compactor asks one per object and skips on an empty answer:
+///
+///     auto res = ModelManager::CompactPagesHint(model_id, object_pages[object_id]);
+///     if (page_indexes.empty()) { continue; }   // no need compaction
+///
+/// and a single-page model answers empty unconditionally -- their string model's whole
+/// implementation is `return {};` with the comment "we keep data in single page, so no need do
+/// compaction".
+///
+/// That is why all three global conditions were refused. There is no shard-wide predicate for
+/// "needs compacting", because two objects in the same shard, on the same slab, with the same
+/// staleness, get different answers depending on their model. It also explains why
+/// `feature_compaction_rewrites_shared_packed_page_once` survives a skip that a string would not:
+/// feature objects are packed across pages and genuinely have something to consolidate.
+///
+/// Ours has no such hint. `compact_shard_pages_with_budgets` walks `strings`, `hashes`, `zsets`,
+/// `lists` and `sets` and relocates every live page, so it rewrites single-page objects that
+/// cannot benefit. Adding the hint is not a small change -- declining to relocate an object leaves
+/// its pages on the old slab, which keeps that slab live and changes what page GC may collect --
+/// but it is the shape the answer has to take, and it is not the shape either attempt above tried.
+///
 /// This measures the difference the only way that separates them -- run compaction until there is
 /// nothing left to move, then time one more round. Whatever that round costs is scan, not work. If
 /// it grows with the shard, the scan is the cost; if it is flat, the budget already bounds


### PR DESCRIPTION
#1550 and #1553 record three attempts at a shard-wide "should this round compact" condition. The
suite refused all three, and those notes concluded a real fix needs a layout signal. This records
where that signal actually lives, because it is not shaped the way any of the three attempts
assumed.

## The decision is per object, and the model answers it

A compactor of this design asks **one question per object** and skips on an empty answer:

    auto res = ModelManager::CompactPagesHint(model_id, object_pages[object_id]);
    if (page_indexes.empty()) { continue; }   // no need compaction

A single-page model answers empty unconditionally. The string model's entire implementation is
`return {};`, with the comment "we keep data in single page, so no need do compaction".

## Why that explains three refused attempts

There is **no shard-wide predicate** for "needs compacting". Two objects in the same shard, on the
same slab, with identical staleness, get different answers because they have different models.
Every attempt above asked the question at shard granularity, which is why the suite kept refusing
them — it was right to.

It also explains a specific test that looked anomalous at the time:
`feature_compaction_rewrites_shared_packed_page_once` survives a skip that a string would not.
Feature objects are packed across pages and genuinely have something to consolidate; strings do not.

## Where ours stands

`compact_shard_pages_with_budgets` has no such hint. It walks `strings`, `hashes`, `zsets`, `lists`
and `sets` and relocates every live page, so it rewrites single-page objects that cannot benefit
from being rewritten.

## Why this is a note and not a fix

Declining to relocate an object leaves its pages on the old slab, which keeps that slab live and
changes what page GC may collect. A per-model hint is therefore **coupled to the collector**, not a
local filter inside the relocation loop. That is the shape the answer has to take, it is not the
shape any of the three attempts tried, and recording it beats making a fourth guess.

## Verification

Doc only — this adds comments to an `#[ignore]` probe; no behaviour changes.

`cargo test -p temporalstore-rust --lib -- --test-threads=1` → **1778 passed, 1 failed**. The single
failure is `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the standing `--lib`
baseline failure on main, not introduced here.
