### PR TITLE
The encoder cache reports its own numbers

### DIFF
--- a/tools/matrixark_local_adapter_dashboard.py
+++ b/tools/matrixark_local_adapter_dashboard.py
@@ -10,6 +10,11 @@ except ImportError:
     from matrixark_mcp_core import *  # noqa: F401,F403
     from matrixark_mcp_core import _mcp_debug_log  # import * skips underscore names
 
+try:  # package path
+    from tools.matrixark_mcp_embeddings import embedding_cache_stats
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_embeddings import embedding_cache_stats
+
 try:  # names owned by the parent module
     from tools.matrixark_mcp_local_adapter import (
     Any,
@@ -819,6 +824,15 @@ class _LocalAdapterDashboardMixin:
             "deferred_tasks": deferred_tasks,
             "deferred_stages": deferred_stages,
             "record_count": len(records),
+            # The encoder cache's own numbers, which existed and were printed nowhere. Its
+            # docstring says it reports "hits, misses, evictions and current size -- so cache
+            # behaviour is observable", and nothing observed it: a cache whose hit rate no surface
+            # carries is one whose capacity nobody can tell is wrong.
+            #
+            # Here rather than on the Prometheus surface because it belongs with the other
+            # embedding numbers -- how much of the scope is encoded, at which widths, by which
+            # model -- and this is the payload an operator already opens to ask that.
+            "cache": embedding_cache_stats(),
         }
 
     def ingestion_dashboard(self, args: Json) -> Json:

--- a/tools/test_matrixark_embedding_status.py
+++ b/tools/test_matrixark_embedding_status.py
@@ -174,6 +174,47 @@ class EmbeddingRouteTest(unittest.TestCase):
         self.assertEqual("backend_error", json.loads(body)["error"])
 
 
+class TheEncoderCacheReportsItsOwnNumbersTest(unittest.TestCase):
+    """The cache kept hits, misses and a hit rate, and no surface carried them.
+
+    Its docstring says it exists "so cache behaviour is observable". Nothing observed it, which
+    leaves the one number that says whether the capacity is wrong -- the hit rate -- visible only
+    to a debugger.
+    """
+
+    @staticmethod
+    def _cache_module():
+        """The module object the DASHBOARD imported, not a fresh one.
+
+        Both spellings of a tools module can be loaded at once here, and each keeps its own cache
+        counters. Reading the wrong one shows an empty cache and reads as broken wiring -- which
+        is exactly what happened to the same shape in matrixarkai#1566.
+        """
+        import matrixark_local_adapter_dashboard as dashboard
+        return sys.modules[dashboard.embedding_cache_stats.__module__]
+
+    def test_the_status_payload_carries_the_cache(self) -> None:
+        status = _adapter([_embedding()]).embedding_status({})
+        self.assertIn("cache", status, "the encoder cache numbers are not on the payload")
+        for field in ("hits", "misses", "evictions", "entries", "capacity", "hit_rate"):
+            with self.subTest(field=field):
+                self.assertIn(field, status["cache"])
+
+    def test_the_payload_reads_the_cache_rather_than_a_literal(self) -> None:
+        """The positive control. A dict of zeros written inline would pass the check above."""
+        cache = self._cache_module()
+        before = dict(_adapter([_embedding()]).embedding_status({})["cache"])
+        stats = cache._EMBEDDING_CACHE_STATS
+        stats["hits"] = int(stats.get("hits", 0)) + 3
+        after = _adapter([_embedding()]).embedding_status({})["cache"]
+        self.assertEqual(
+            int(before["hits"]) + 3, int(after["hits"]),
+            "three more hits did not reach the payload, so it is not reading the cache")
+        self.assertNotEqual(
+            before.get("hit_rate"), after.get("hit_rate"),
+            "the hit rate did not move with the hits, so it is not derived from them")
+
+
 class EmbeddingToolRegistrationTest(unittest.TestCase):
     def test_the_tool_is_gated_like_any_other_read_of_the_store(self) -> None:
         from matrixark_mcp_core import MATRIXARK_TOOL_SCOPES


### PR DESCRIPTION
`embedding_cache_stats` says it exists so *"cache behaviour is observable"* — hits, misses,
evictions, entries, capacity and a derived hit rate. **Nothing observed it.** The one number that
says whether the capacity is wrong was visible only to a debugger.

It is on the `embedding_status` payload now, beside the other embedding numbers an operator already
opens that tool to ask — how much of the scope is encoded, at which widths, by which model. That is
where *"and the cache is missing four times in five"* belongs, rather than the Prometheus text,
which carries backend command counters.

**Second of this shape**, after the whole-store fallback counter in #1566. Both were written because
somebody wanted the behaviour visible, and both stopped one step short of a surface — so the number
existed, the tests passed, and the thing stayed as invisible as before.

### The test reads the dashboard's module object, not a fresh import

Both spellings of a tools module can be loaded at once in the suite, and each keeps its own
counters. Reading the wrong one shows an empty cache and looks like broken wiring — exactly what
happened to this shape in #1566 and cost several passes there.

Two checks: the payload carries every field, and **a positive control that it reads the cache rather
than a dict of zeros** — three more hits must arrive as three more hits, and the hit rate must move
with them.

### Verified

The 30 suites naming the embedding status, the dashboard, the embeddings module or the cache:
**303 tests, zero failures.**
