### PR TITLE
The dashboard says what the store holds, not only what the page shows

### DIFF
--- a/tools/matrixark_local_adapter_dashboard.py
+++ b/tools/matrixark_local_adapter_dashboard.py
@@ -10,6 +10,11 @@ except ImportError:
     from matrixark_mcp_core import *  # noqa: F401,F403
     from matrixark_mcp_core import _mcp_debug_log  # import * skips underscore names
 
+try:  # package path
+    from tools.matrixark_pipeline_task_slim import pipeline_task_footprint_stats
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_pipeline_task_slim import pipeline_task_footprint_stats
+
 try:  # names owned by the parent module
     from tools.matrixark_mcp_local_adapter import (
     Any,
@@ -863,6 +868,19 @@ class _LocalAdapterDashboardMixin:
             "totals": totals,
             "rows": page,
             "record_count": len(records),
+            # What the STORE holds, against what this page shows, from records already read.
+            #
+            # `totals["async_pipeline"]` is the collapsed view: `_dashboard_rows_for_table` folds
+            # re-stamped rows to the latest one, so forty rows for one task appear as one. That is
+            # right for a page and it is why the page cannot show the footprint -- the number looks
+            # fine precisely because the collapse worked. This reports both, so the saving is
+            # visible rather than invisible. The two knobs that trade this footprint --
+            # collapse_pipeline_task_rows and slim_terminal_pipeline_tasks -- are reported with it,
+            # because a control whose unit is invisible on the same page asks the reader to decide
+            # blind, which is the argument `_footprint_summary` makes in the gateway.
+            #
+            # pipeline_task_footprint_stats computed all of this already and no surface carried it.
+            "pipeline_task_footprint": pipeline_task_footprint_stats(records),
         }
 
     # A response this size is a deliberate ceiling, not a guess: a skill or attachment can be

--- a/tools/test_pipeline_task_slim.py
+++ b/tools/test_pipeline_task_slim.py
@@ -231,5 +231,69 @@ class EndToEndTest(unittest.TestCase):
                          "readiness / dashboard / positional / extraction-signal answers must be identical")
 
 
+class TheDashboardSaysRowsAgainstDistinctTasksTest(unittest.TestCase):
+    """`totals["async_pipeline"]` counts rows. It cannot say whether forty rows are forty tasks
+    or one task written forty times, and those are different problems.
+
+    pipeline_task_footprint_stats worked that out already and no surface carried it.
+    """
+
+    @staticmethod
+    def _adapter(rows):
+        import matrixark_mcp_local_adapter as adapter_module
+
+        class _Fixed(adapter_module.MatrixArkLocalAdapter):  # type: ignore[misc]
+            def __init__(self, records):
+                self._rows = records
+
+            def read_all(self):
+                return self._rows
+
+        return _Fixed(rows)
+
+    @staticmethod
+    def _task(identity, status):
+        return {"record_type": slim.PIPELINE_TASK_RECORD_TYPE, "task_hash": identity,
+                "status": status, "scope_key": "tenant/user"}
+
+    def test_the_payload_separates_rows_from_tasks(self):
+        rows = [self._task(1, "queued"), self._task(1, "running"),
+                self._task(1, "committed"), self._task(2, "queued")]
+        out = self._adapter(rows).ingestion_dashboard({"table": "async_pipeline"})
+        footprint = out.get("pipeline_task_footprint")
+        self.assertIsNotNone(footprint, "the dashboard does not carry the pipeline-task footprint")
+        self.assertEqual(4, footprint["pipeline_tasks"], "rows")
+        self.assertEqual(2, footprint["distinct_tasks"], "distinct tasks")
+        self.assertEqual(1, footprint["finished"],
+                         "only 'committed' is in FINISHED_STATUSES here")
+
+    def test_it_reports_what_the_store_holds_not_what_the_page_shows(self):
+        """The point of carrying it, and the thing I had backwards at first.
+
+        `totals["async_pipeline"]` is the COLLAPSED view -- `_dashboard_rows_for_table` already
+        folds re-stamped rows to the latest one, so four rows for one task show as one. That is
+        right for a page, and it means the page cannot show what the store is actually holding.
+        The footprint reports both, so the saving the collapse knob is making is visible instead
+        of being the reason the number looks fine.
+        """
+        one_task_many_rows = [self._task(7, "queued"), self._task(7, "running"),
+                              self._task(7, "running"), self._task(7, "committed")]
+        out = self._adapter(one_task_many_rows).ingestion_dashboard({"table": "async_pipeline"})
+        footprint = out["pipeline_task_footprint"]
+        self.assertEqual(1, out["totals"]["async_pipeline"],
+                         "the table collapses re-stamped rows to the latest")
+        self.assertEqual(4, footprint["pipeline_tasks"],
+                         "the store holds four rows, which the collapsed table cannot say")
+        self.assertEqual(1, footprint["distinct_tasks"], "for one task")
+
+    def test_the_two_knobs_that_trade_this_are_reported_with_it(self):
+        """A control whose unit is invisible on the same page asks the reader to decide blind."""
+        out = self._adapter([]).ingestion_dashboard({"table": "async_pipeline"})
+        footprint = out["pipeline_task_footprint"]
+        for knob in ("collapse_enabled", "slim_enabled"):
+            with self.subTest(knob=knob):
+                self.assertIn(knob, footprint)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
`pipeline_task_footprint_stats` counts pipeline-task rows, distinct tasks, finished ones and slimmed
ones, and reports the two knobs that trade that footprint. **No surface carried any of it.** It is
on the ingestion dashboard now, computed from records that method has already read, so it costs
nothing extra.

### What I had backwards, and why it makes the case better

I wrote this expecting `totals["async_pipeline"]` to be a raw row count that could not tell forty
tasks from one task written forty times. **It is not** — `_dashboard_rows_for_table` already folds
re-stamped rows to the latest one, so four rows for one task show as **one**. The test caught it.

That is right for a page, and it is exactly why the page could not show the footprint: **the number
looks fine precisely because the collapse worked.** So the value is not *rows versus tasks* — it is
what the **store** holds against what the **page** shows, which is the saving the collapse knob is
making and the thing an operator deciding whether to turn it on cannot otherwise see.

### Third of this shape

After the whole-store fallback counter (#1566) and the encoder cache (#1569). All three were written
so behaviour would be observable, all three **stopped one step short of a surface**, and in all
three the number existed and the tests passed while the thing stayed invisible.

### Verified

Three checks, including one that would have caught my own mistake: four rows for one task must
report `totals` 1 and `pipeline_tasks` 4, and the two knobs must be reported beside the number they
trade.

The 30 suites naming the ingestion dashboard, the slim levers or the async pipeline: **544 tests,
153 failures, the same 153 by name on pristine main, none new.** (That set includes the codex hook
pipeline and two modules whose module-level `SkipTest` the by-name loader reports as an error.)
