### PR TITLE
The index collector asks the cheap question first

### DIFF
--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -1110,6 +1110,63 @@ impl TemporalEngine {
         lifecycle_report: Option<&StorageLifecycleReport>,
         request: &StorageManagerCycleRequest,
     ) -> StorageIndexGcReport {
+        // THE CHEAP QUESTIONS FIRST.
+        //
+        // Everything below this point reads the WHOLE index log and decodes every record, and
+        // this report is built on EVERY maintenance round -- every 30 s on the periodic loop --
+        // whether or not the collector can possibly run. With the shipped defaults
+        // (`enable_index_gc: true`, a 768 KiB byte threshold) a shard whose index log is under
+        // that threshold paid a full scan and a full decode, every round, purely to establish
+        // that it was never eligible. `what_the_index_gc_gate_costs` measures that round.
+        //
+        // WHY THE CHEAP BYTE TEST IS SOUND, which is the part worth checking rather than
+        // assuming. `log_len_bytes` is the FILE length. `bytes_before` below sums what `scan`
+        // hands back, which is each record's FRAMED LINE (`decode_line` is applied to it further
+        // down, so it is the on-disk line, not the payload inside it). The file holds those lines
+        // plus the `\n` terminating each one, and nothing the scan drops is subtracted from the
+        // file, so
+        //
+        //     log_len_bytes >= bytes_before,   always.
+        //
+        // If the file length is already under the threshold then `bytes_before` is under it too,
+        // so the old code would have set `threshold_triggered = false` and skipped. Skipping here
+        // can therefore only ever AGREE with what the scan would have concluded; it cannot skip a
+        // round the scan would have run. The inequality is the whole argument, and it holds in one
+        // direction only -- do NOT invert this to fire EARLY on the cheap number, because a file
+        // length above the threshold does not imply `bytes_before` is.
+        //
+        // ONLY TWO CONDITIONS SKIP, deliberately. `dry_run` does NOT: a dry run exists to report
+        // what a real round WOULD do, so it still pays for the numbers it was asked for. Nor does
+        // an unsafe WAL/index frontier: those counts are the diagnosis for why the frontier is
+        // stuck. The two below are the cases where nobody is asking for a number -- the feature is
+        // off, or the log is too small to be worth collecting.
+        let quick_bytes = self.index_log_store.log_len_bytes(request.shard_id);
+        let quick_threshold_missed = request.index_gc_index_log_bytes_threshold != 0
+            && quick_bytes < request.index_gc_index_log_bytes_threshold;
+        let quick_skip_reason = if !request.enable_index_gc {
+            "index GC disabled"
+        } else if quick_threshold_missed {
+            "index-log byte threshold not reached"
+        } else {
+            ""
+        };
+        if !quick_skip_reason.is_empty() {
+            return StorageIndexGcReport {
+                shard_id: request.shard_id,
+                enabled: request.enable_index_gc,
+                bytes_threshold: request.index_gc_index_log_bytes_threshold,
+                usage_ratio_trigger_basis_points: request
+                    .index_gc_usage_ratio_trigger_basis_points,
+                max_entries_per_round: request.index_gc_max_entries_per_round,
+                retain_from_index_log_sequence: wal_plan.retain_from_index_log_sequence,
+                bytes_before: quick_bytes,
+                bytes_after: quick_bytes,
+                threshold_triggered: !quick_threshold_missed,
+                skipped_reason: quick_skip_reason.to_string(),
+                ..StorageIndexGcReport::default()
+            };
+        }
+
         let records = self
             .index_log_store
             .scan(request.shard_id, 0, u64::MAX, u64::MAX)

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -7666,6 +7666,100 @@ fn what_a_bucket_costs() {
     }
 }
 
+/// What the cheap index-GC gate SAVES, measured as two arms in ONE process. Prints.
+///
+///   cargo test --release -p temporalstore-rust --lib what_the_cheap_index_gc_gate_saves -- --ignored --nocapture
+///
+/// Two arms, differing only in the byte threshold:
+///
+///   SCAN  threshold 0        -- never missed, so the cheap skip does not fire and the gate reads
+///                               and decodes the whole index log. This is EXACTLY what every round
+///                               did before the skip existed, which is what makes it the baseline.
+///   SKIP  threshold u64::MAX -- always missed, so the gate returns on a file-length check alone.
+///
+/// Run ABBA (skip, scan, scan, skip) inside one process rather than as a before/after across two
+/// builds. This box is shared and its load moves a lot -- another session had a release build
+/// running at load 19 while this was written -- so a sequential before/after measures the box as
+/// much as the change. Interleaving inside one process gives both arms the same machine.
+///
+/// The fixture is deliberately one where the collector CANNOT fire, so the SCAN arm pays for the
+/// scan and nothing else. Both arms are asserted not to have collected, because if either did,
+/// the difference would include collection work and would not be a gate measurement at all.
+#[test]
+#[ignore]
+fn what_the_cheap_index_gc_gate_saves() {
+    for records in [4_000usize, 16_000] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            16 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        for index in 0..records {
+            let response = engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("gate-save-{index:06}"),
+                    value: vec![b'v'; 64],
+                },
+            });
+            assert!(response.status.ok, "write {index}: {:?}", response.status);
+        }
+
+        let log_bytes = engine.index_log_store.log_len_bytes(1);
+        // Denominator: an empty index log would make both arms trivially equal and the whole
+        // comparison vacuous.
+        assert!(log_bytes > 0, "fixture wrote no index log, nothing to scan");
+
+        let plan = engine.storage_lifecycle_plan(crate::engine::reports::StorageLifecycleRequest {
+            shard_id: 1,
+            ..crate::engine::reports::StorageLifecycleRequest::default()
+        });
+        let wal_plan = engine.storage_wal_reclaim_plan(1, Vec::new(), Vec::new());
+
+        // Time ONLY the gate, with both plans hoisted out. Timing the enclosing periodic call
+        // would bury the difference under `storage_lifecycle_plan`, which dominates it and which
+        // this change does not touch.
+        let arm = |threshold: u64| -> (f64, bool) {
+            let request = crate::engine::reports::StorageManagerCycleRequest {
+                shard_id: 1,
+                index_gc_index_log_bytes_threshold: threshold,
+                index_gc_max_entries_per_round:
+                    crate::engine::reports::DEFAULT_INDEX_GC_MAX_ENTRIES_PER_ROUND,
+                ..crate::engine::reports::StorageManagerCycleRequest::default()
+            };
+            let started = std::time::Instant::now();
+            let mut applied = false;
+            for _ in 0..5 {
+                let report = engine.storage_index_gc_report(&plan, &wal_plan, None, &request);
+                applied |= report.applied;
+            }
+            (started.elapsed().as_micros() as f64 / 5.0 / 1000.0, applied)
+        };
+
+        let (skip_a, applied_1) = arm(u64::MAX);
+        let (scan_a, applied_2) = arm(0);
+        let (scan_b, applied_3) = arm(0);
+        let (skip_b, applied_4) = arm(u64::MAX);
+        let skip_ms = (skip_a + skip_b) / 2.0;
+        let scan_ms = (scan_a + scan_b) / 2.0;
+
+        assert!(
+            !(applied_1 || applied_2 || applied_3 || applied_4),
+            "fixture let the collector fire; this probe measures the GATE only",
+        );
+
+        eprintln!(
+            "  [gate-save] {records:>6} records, log {log_bytes:>9} B -> scan {scan_ms:>7.2} ms \
+(arms {scan_a:>6.2}/{scan_b:>6.2})  skip {skip_ms:>7.2} ms (arms {skip_a:>6.2}/{skip_b:>6.2})  \
+saved {:>7.2} ms per round",
+            scan_ms - skip_ms,
+        );
+    }
+}
+
 ///   cargo test --features alloc-probe -p temporalstore-rust --lib what_a_bounded_slot_range_saves -- --ignored --nocapture --test-threads=1
 #[test]
 #[ignore]


### PR DESCRIPTION
`storage_index_gc_report` opened by reading the **whole index log and decoding every record**,
unconditionally, as its first statement — before `enable_index_gc` or the byte threshold were
consulted. It is built on every maintenance round, so with the shipped defaults
(`enable_index_gc: true`, a 768 KiB threshold) a shard whose index log sits under that threshold
paid a full scan and a full decode every 30 s purely to establish it was never eligible.

## Measured

`what_the_cheap_index_gc_gate_saves` (added here) times two arms differing only in the byte
threshold. The SCAN arm reproduces exactly what every round did before this change; the SKIP arm
returns on a file-length check.

| records | log bytes | scan | skip | saved per round |
|---|---|---|---|---|
| 4,000 | 257,504 | 3.08 ms (arms 3.22 / 2.94) | 0.01 ms | **3.07 ms** |
| 16,000 | 1,037,504 | 11.15 ms (arms 11.00 / 11.30) | 0.01 ms | **11.14 ms** |

The arms run **ABBA inside one process**, not as a before/after across two builds. This box is
shared — another job held it at load 19 while this was measured — and a sequential comparison
would have measured the machine as much as the change. The tight arm-to-arm spread is the
evidence that it worked.

## Why the cheap test is sound

`log_len_bytes` is the **file** length. `bytes_before` sums what `scan` returns, which is each
record's **framed line**, and the file holds those lines plus the newline terminating each, so

```
log_len_bytes >= bytes_before,   always.
```

If the file length is under the threshold then `bytes_before` is too, so the old code would have
set `threshold_triggered = false` and skipped. This can therefore only ever **agree** with what
the scan would have concluded — it cannot skip a round the scan would have run.

The inequality holds in one direction only. Do not invert this to fire *early* on the cheap
number: a file length above the threshold does not imply `bytes_before` is.

## Only two conditions skip, deliberately

`dry_run` does **not** skip — a dry run exists to report what a real round *would* do, so it still
pays for the numbers it was asked for. Nor does an unsafe WAL/index frontier, because those counts
are the diagnosis for why the frontier is stuck. The two that skip are the cases where nobody is
asking for a number: the feature is off, or the log is too small to collect.

One reported value changes. A round both below the threshold and with nothing removable used to
report `"no reclaimable index-log entries"` (it learned that first, from the scan) and now reports
`"index-log byte threshold not reached"`. Both are true; the second is establishable without
reading the log.

## What this does not fix, which is most of it

This is **waste removal, not a fix for the stage's cost**, and the numbers say so. Attributing the
stage with `what_the_index_gc_gate_costs`:

| records | whole | `storage_lifecycle_plan` | `storage_wal_reclaim_plan` | this scan |
|---|---|---|---|---|
| 4,000 | 87.5 ms | 27.8 | 54.4 | 5.3 |
| 8,000 | 186.4 ms | 57.5 | 107.5 | 21.5 |
| 16,000 | 387.6 ms | 120.5 | 234.4 | 32.7 |

This scan is 6–12% of it. The rest is the two plans, both scaling linearly with the record count,
on a loop whose period is 30 s. Neither is touched here; a follow-up measures their shared root.

## Verification

`cargo test -p temporalstore-rust --lib -- --test-threads=1` — see below. The probe added here is
`#[ignore]`, so it does not run in the suite.
