### PR TITLE
One maintenance round walks every live page thirty-five times

### DIFF
--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -3934,6 +3934,82 @@ fn what_the_index_gc_gate_costs() {
     }
 }
 
+/// How many times does ONE maintenance round materialize EVERY live page? Prints.
+///
+///   cargo test --release -p temporalstore-rust --lib how_many_times_a_round_walks_every_live_page -- --ignored --nocapture
+///
+/// `collect_live_page_entries` builds a fresh `Vec<LiveBlockEntry>` holding every live page in the
+/// shard. It has roughly twenty call sites, and a single periodic round reaches many of them:
+/// `storage_wal_reclaim_plan` (via `bucket_storage_summaries`), `storage_lifecycle_plan`, the
+/// compaction preamble, eviction victim selection, dump-manifest creation. None of them shares a
+/// result with the next.
+///
+/// This is why the stage timings look the way they do. `what_the_index_gc_gate_costs` attributes
+/// the index-GC stage as roughly 60% `storage_wal_reclaim_plan` and 30% `storage_lifecycle_plan`
+/// at every corpus size, both scaling linearly with the record count -- 234 ms and 120 ms
+/// respectively at 16,000 records, on a loop whose period is 30 s. Neither number is bounded by
+/// anything the round was asked to do.
+///
+/// The multiplier below is the thing to fix, and it is the honest way to size it: not "this stage
+/// is slow" but "the round walks the whole shard N times, and N is a property of how the stages
+/// are wired rather than of how much work the round was asked to do".
+#[test]
+#[ignore]
+fn how_many_times_a_round_walks_every_live_page() {
+    for records in [2_000usize, 8_000] {
+        let engine = TemporalEngine::default();
+        engine.load_shard(1);
+        for index in 0..records {
+            let response = engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("walks-{index:06}"),
+                    value: vec![b'v'; 64],
+                },
+            });
+            assert!(response.status.ok, "write {index}: {:?}", response.status);
+        }
+
+        // Measured BEFORE the runtime takes the engine, and before the counter is reset, so this
+        // report's own walk is not counted against the round.
+        let live_pages: u64 = engine
+            .bucket_storage_summaries(1)
+            .iter()
+            .map(|summary| summary.page_ref_count as u64)
+            .sum();
+
+        let runtime = DataNodeRuntime::new_without_workers_with_options(
+            engine,
+            DataNodeRuntimeOptions {
+                worker_threads: 0,
+                max_queue_depth: 4,
+                max_background_queue_depth: 2,
+            },
+        );
+
+        crate::engine::reset_live_page_scan_entries();
+        let started = std::time::Instant::now();
+        let report = runtime.run_storage_manager_once(1, StorageManagerOptions::default());
+        let round_ms = started.elapsed().as_micros() as f64 / 1000.0;
+        let scanned = crate::engine::live_page_scan_entries();
+
+        // Denominators. A shard with no live pages, or a round that walked nothing, would make
+        // the ratio below meaningless rather than zero.
+        assert!(live_pages > 0, "fixture stored no live pages");
+        assert!(
+            scanned > 0,
+            "the round materialized no live-page entries, so it never reached the stages this measures",
+        );
+
+        eprintln!(
+            "  [walks] {records:>6} records, {live_pages:>6} live pages -> round {round_ms:>8.1} ms \
+materialized {scanned:>8} live-page entries = {:>5.1}x the shard, stages {:?}",
+            scanned as f64 / live_pages as f64,
+            report.executed_stages,
+        );
+    }
+}
+
 #[test]
 fn the_dump_cap_bounds_a_stage_but_not_a_round() {
     // Two facts, and the second is the surprising one.


### PR DESCRIPTION
`collect_live_page_entries` builds a fresh `Vec<LiveBlockEntry>` holding **every live page in the
shard**. It has roughly twenty call sites, and a single periodic round reaches many of them
independently — `storage_wal_reclaim_plan` (via `bucket_storage_summaries`),
`storage_lifecycle_plan`, the compaction preamble, eviction victim selection, dump-manifest
creation. None shares a result with the next.

`how_many_times_a_round_walks_every_live_page` (added here) counts it directly, using the
`LIVE_PAGE_SCAN_ENTRIES` instrumentation that already existed for exactly this question.

| records | live pages | round | entries materialized | multiplier |
|---|---|---|---|---|
| 2,000 | 2,000 | 225.7 ms | 70,000 | **35.0×** |
| 8,000 | 8,000 | 930.2 ms | 280,000 | **35.0×** |

Exactly 35.0× at both sizes. The multiplier is **structural** — a property of how the stages are
wired, not of corpus size — which is why the stage timings scale linearly with the record count
and are bounded by nothing the round was asked to do.

## Thirty-five is a floor

Only **five of the nine stages ran** in this fixture: `prepare`, `reclaim_wal`, `expire`,
`reclaim_index`, `reap_metrics`. Evict, reclaim_memory, reclaim_page and compact_pages did not.

Compaction's preamble alone adds six more whole-shard passes — `validate_shard_page_ownership`,
`collect_live_block_slab_ids`, `compaction_utility_report`, `storage_object_lifecycle_report`,
`compaction_model_layout_reports`, `object_manager_runtime_report` — all before any budget is
consulted, and all while holding the shard **write** lock.

## Why this is the number to fix

`what_the_index_gc_gate_costs` attributes the index-GC stage as roughly 60%
`storage_wal_reclaim_plan` and 30% `storage_lifecycle_plan` at every corpus size — 234 ms and
120 ms at 16,000 records, on a loop whose period is 30 s.

Chasing either as "a slow stage" misses the shape. Both are slow for the same reason, and so are
the stages around them. The honest statement is not *this stage is slow* but **the round walks the
whole shard thirty-five times**.

This is the fourth instance of a pattern already recorded three times: the per-round budgets bound
how much work a stage **does**; none of them bounds how much of the shard it **reads** to decide.

## What a fix looks like, and what it is not

Not a cache with a lifetime — the stages mutate (compaction relocates, eviction deletes), so a
memoized snapshot held across mutation would be wrong.

Two shapes that are sound:

1. **Hoist within one immutable borrow.** The compaction preamble's six passes run back to back on
   the same `&ShardState` under one write lock, with no mutation between them. They can share a
   single materialization passed down as a slice. Local, safe, and six passes become one.
2. **Per-bucket aggregates maintained incrementally** (`page_ref_count`, `physical_bytes`, slab
   ids), so `bucket_storage_summaries` is `O(buckets)` rather than `O(live pages)`.

Attributing the 35× per stage is the next step and needs no production change: the stage toggles in
`StorageManagerOptions` already allow running one stage at a time and diffing the counter.

## Verification

Measurement only; no behaviour changes. The probe is `#[ignore]`, so it does not run in the suite.
It asserts both denominators — a shard with no live pages, or a round that materialized nothing,
fails loudly rather than reporting a meaningless ratio.

`cargo test -p temporalstore-rust --lib -- --test-threads=1` — see below.
