### PR TITLE
A note said this permission refuses "on". Both readers accept it

### DIFF
--- a/tools/matrixark_codex_hook.py
+++ b/tools/matrixark_codex_hook.py
@@ -2227,10 +2227,21 @@ def local_backend_allowed() -> bool:
     there: a permission that half-applies, which is worse than one that does not apply, because
     each half looks correct on its own.
 
-    The wider set in `matrixark_mcp_env.TRUE_VALUES` is deliberately NOT used here. A permission
-    should not gain accepting spellings by inheriting a general helper -- every spelling it gains
-    is another way to turn a production guard off, and the safe direction for a disagreement about
-    a guard is the narrower one.
+    That paragraph described a disagreement this tree no longer has, and it described the fix in
+    the wrong direction. `matrixark_mcp_backends` does not spell the read itself: it imports
+    MATRIXARK_ALLOW_LOCAL_BACKEND from matrixark_mcp_core, which re-exports
+    matrixark_mcp_runtime_config's `env_bool("MATRIXARK_ALLOW_LOCAL_BACKEND", False)`. Both sides
+    go through the same helper and accept the same five spellings, "on" among them. Executing both
+    readers across on/ON/1/yes/true/""/off gives the same answer at every one.
+
+    So the note asserting that "on" is refused here was a recorded constraint outliving its
+    mechanism -- and a stale claim about a PERMISSION is the expensive kind, because someone
+    reading it believes a production guard is narrower than it is.
+
+    The agreement is now checked rather than described, in
+    test_a_permission_resolves_one_way_in_both_readers. Narrowing this function alone would
+    re-create the half-applied permission the original note was written about, in the other
+    direction; the test is what says so.
     """
     return env_bool("MATRIXARK_ALLOW_LOCAL_BACKEND", False)
 

--- a/tools/test_a_definition_only_the_tests_call.py
+++ b/tools/test_a_definition_only_the_tests_call.py
@@ -97,6 +97,18 @@ ONLY_TESTS_CALL = {
         "backend metadata interning, the encoder. PARKED ON PURPOSE, not forgotten: its own comment block says storage_options is the largest field in the store -- 2,139 KB, 13.2% of all record bytes, nine distinct values across 3,610 rows -- and that INTERN_METADATA_FIELDS already names it while the local JSONL codec already tokenises it, so the optimisation landed on the 7-day mirror and not the durable store. The write side is gated OFF because the codec's crash-safety argument does not carry over: the backend would rely on the engine's batch append being atomic, which that comment calls a different claim and unverified, ending 'Do not flip this default until that is settled.' Retiring it deletes measured work with a written open question",
     "backend_expand_records":
         "backend metadata interning, the decoder. Always on by design -- a store written with the flag ON still reads correctly if it is later turned OFF, the same asymmetry the JSONL codec uses",
+    # ADOPTED AND BANKED, so they are no longer on this list:
+    #
+    #   full_read_fallback_counts -- matrixarkai#1566 gave it a Prometheus family in
+    #   matrixark_temporal_direct_backend, so the degradation it measures is now reported.
+    #   embedding_cache_stats -- matrixarkai#1569 put it on the local adapter dashboard.
+    #
+    # Both entries said the same thing in different words, "written to make something visible and
+    # reported nowhere", and both stopped being true within a week of being written down. That is
+    # what this list is FOR: it is not an inventory of debris, it is a queue, and an entry leaving
+    # it by gaining a production caller is the outcome. Removing them here is the banking -- the
+    # check fails on a list that has stopped matching the tree in EITHER direction, which is how
+    # this pair was noticed at all.
     "prepare_retrieval_request":
         "the unadopted part of a PARTLY-ADOPTED extraction. matrixark_mcp_retrieve_request is imported by five production modules; this step is the piece LocalAdapter.retrieve still does inline",
     "prepare_serving_refs":
@@ -105,10 +117,6 @@ ONLY_TESTS_CALL = {
         "the unadopted part of matrixark_mcp_retrieve_planning, and the one with a guard already maintaining it TOWARD adoption. test_a_tenant_override_reaches_the_extracted_ranking_limits calls that module 'a partly-adopted extraction' and exists because the builder once resolved no tenant override at all, so adopting it would have handed every tenant the build default while looking like a pure code move. Do not read this as debris",
     "merge_refreshed_summary_records":
         "the unadopted part of matrixark_mcp_retrieve_pre_refresh, which three production modules import. The same merge runs inline at matrixark_local_adapter_retrieve:1167-1196",
-    "full_read_fallback_counts":
-        "counts how often a scoped scan gave up and read the whole store. Its docstring says it is 'exposed because the fallback is otherwise undetectable from outside: a measured degraded window did TEN whole-corpus reads and wrote nothing at all'. Written to make an invisible degradation visible, and reported nowhere",
-    "embedding_cache_stats":
-        "hits, misses, evictions and size, 'so cache behaviour is observable' -- and nothing observes it",
     "secondary_index_bound_stats":
         "live posting counts by scope and ref_type. Its own docstring says 'used by the tests/harness', so this one is an affordance by design rather than a signal that went missing -- read the docstring before filing it as a gap",
     "pipeline_task_footprint_stats":

--- a/tools/test_a_permission_resolves_one_way_in_both_readers.py
+++ b/tools/test_a_permission_resolves_one_way_in_both_readers.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A permission read in two places must resolve the same way in both.
+
+MATRIXARK_ALLOW_LOCAL_BACKEND is the one control in this tree that says a production profile may
+use a local backend, and two different modules decide it:
+
+* `matrixark_mcp_backends.validate_mcp_backend_policy` refuses the backend unless the constant
+  MATRIXARK_ALLOW_LOCAL_BACKEND is true. It imports that constant from `matrixark_mcp_core`, which
+  re-exports `matrixark_mcp_runtime_config`'s `env_bool("MATRIXARK_ALLOW_LOCAL_BACKEND", False)`.
+* `matrixark_codex_hook.local_backend_allowed` answers the same question for the hook.
+
+They agreed once, disagreed about the spelling "on", and agree again now that both go through the
+same helper. What this file adds is that the agreement is CHECKED. A docstring in the hook said
+for some time that "on" was refused there, which had stopped being true when the read was moved
+onto `env_bool` -- a recorded constraint outliving its mechanism, and an expensive kind to leave
+lying around, because a reader believes a production guard is narrower than it is.
+
+Both readers resolve the flag at IMPORT, so each spelling is checked in its own interpreter. That
+is what makes this a test of the two modules rather than of one import order.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+
+#: Every spelling worth disagreeing about: the four TRUE_VALUES, a capitalised one because the
+#: helper lowercases and a hand-rolled read might not, and two falses including the empty string an
+#: unset variable is indistinguishable from.
+SPELLINGS = ("1", "true", "yes", "on", "ON", "", "off", "nonsense")
+
+_PROBE = """
+import os, sys
+sys.path.insert(0, %r)
+import matrixark_mcp_runtime_config as runtime_config
+import matrixark_codex_hook as hook
+enforced = bool(runtime_config.MATRIXARK_ALLOW_LOCAL_BACKEND)
+asked = bool(hook.local_backend_allowed())
+sys.stdout.write("%%d %%d" %% (enforced, asked))
+"""
+
+
+def _resolve(value):
+    """(what the MCP guard enforces, what the hook answers) for one spelling of the flag."""
+    env = dict(os.environ)
+    if value is None:
+        env.pop("MATRIXARK_ALLOW_LOCAL_BACKEND", None)
+    else:
+        env["MATRIXARK_ALLOW_LOCAL_BACKEND"] = value
+    out = subprocess.run([sys.executable, "-c", _PROBE % TOOLS], env=env,
+                         capture_output=True, text=True, timeout=180)
+    if out.returncode != 0:
+        raise AssertionError("the probe did not run for %r:\n%s" % (value, out.stderr[-2000:]))
+    enforced, asked = out.stdout.strip().split()
+    return enforced == "1", asked == "1"
+
+
+class APermissionResolvesOneWayInBothReadersTest(unittest.TestCase):
+
+    def test_the_two_readers_agree_on_every_spelling(self) -> None:
+        for value in SPELLINGS:
+            with self.subTest(value=value):
+                enforced, asked = _resolve(value)
+                self.assertEqual(
+                    enforced, asked,
+                    "MATRIXARK_ALLOW_LOCAL_BACKEND=%r: the MCP guard enforces %s and the hook "
+                    "answers %s. A permission that half-applies is worse than one that does not "
+                    "apply, because each half looks correct on its own." % (value, enforced, asked))
+
+    def test_an_unset_flag_permits_nothing(self) -> None:
+        """The floor. Both readers agreeing on True everywhere would pass the check above."""
+        enforced, asked = _resolve(None)
+        self.assertFalse(enforced, "the MCP guard permits a local backend with the flag unset")
+        self.assertFalse(asked, "the hook permits a local backend with the flag unset")
+
+    def test_the_probe_can_tell_the_two_readers_apart(self) -> None:
+        """Without this, a probe that read ONE module twice would agree with itself forever.
+
+        `on` is the spelling the two actually disagreed about once, and `1` is the one the refusal
+        message tells an operator to use. Both must turn the permission on, or the check above is
+        agreeing about a flag nothing reads.
+        """
+        for value in ("1", "on"):
+            with self.subTest(value=value):
+                enforced, asked = _resolve(value)
+                self.assertTrue(enforced and asked,
+                                "%r does not permit a local backend in either reader" % value)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`MATRIXARK_ALLOW_LOCAL_BACKEND` is the one control that lets a production profile use a local
backend, and two modules decide it. `matrixark_codex_hook.local_backend_allowed` carried a
paragraph saying the wider value set "is deliberately NOT used here", so that
`MATRIXARK_ALLOW_LOCAL_BACKEND=on` would not permit the backend where the MCP guard refused it.

The function's body is `env_bool("MATRIXARK_ALLOW_LOCAL_BACKEND", False)`, and `env_bool`'s
`TRUE_VALUES` are `{1, true, yes, on}`. So `on` is accepted. The other side accepts it too:
`matrixark_mcp_backends` does not spell the read itself -- it imports the constant from
`matrixark_mcp_core`, which re-exports `matrixark_mcp_runtime_config`'s `env_bool` call.

Executing both readers, each in its own interpreter because both resolve at import:

| value | MCP guard enforces | hook answers |
|---|---|---|
| `on` | True | True |
| `ON` | True | True |
| `1` | True | True |
| `yes` / `true` | True | True |
| `""` (unset) | False | False |
| `off` | False | False |

The two sides were unified by moving both onto the helper, which settled the disagreement in the
**wider** direction; the note kept describing the narrower fix. A recorded constraint outliving
its mechanism is a familiar shape here, and on a *permission* it is the expensive one -- a reader
believes a production guard is tighter than it is, and the belief is written down in the guard's
own file.

**Behaviour is unchanged.** Narrowing this function alone would re-create the half-applied
permission the note was written about, pointing the other way, and nothing in the tree said so.
Now something does.

### The guard

`test_a_permission_resolves_one_way_in_both_readers` runs each spelling in its own interpreter and
carries two controls:

- an unset flag must permit nothing in either reader -- both agreeing on `True` everywhere would
  otherwise pass;
- `1` and `on` must both permit it -- a probe that read one module twice would agree with itself
  forever.

Mutation-tested: restoring the narrow set the note described turns all three checks red, naming
`ON` as the spelling the MCP guard enforces and the hook refuses.

### Second commit: the tests-only list is banked

`test_a_definition_only_the_tests_call` is red on `main`, in the direction that means the tree
moved forwards. `full_read_fallback_counts` gained a Prometheus family in #1566 and
`embedding_cache_stats` went onto the local adapter dashboard in #1569, so neither is called only
by tests any more. Both entries had said the same thing in different words -- written to make
something visible, and reported nowhere -- and both stopped being true within a week of being
recorded.

That is what the list is for: a queue, not an inventory of debris. The check fails on a list that
has stopped matching the tree in *either* direction, which is the only reason this pair was
noticed.
