### PR TITLE
Orphan modules held four stale or pointless copies of live functions

### DIFF
--- a/tools/matrixark_mcp_query.py
+++ b/tools/matrixark_mcp_query.py
@@ -9,10 +9,10 @@ import re
 from typing import Any
 
 try:
-    from tools.matrixark_mcp_indexing import benchmark_quality_index_terms, context_index_name, normalized_index_value
+    from tools.matrixark_mcp_indexing import benchmark_quality_index_terms, context_index_name, normalized_index_value, ordered_unique
     from tools.matrixark_mcp_scoring import tokens
 except ModuleNotFoundError:  # Direct script execution from tools/.
-    from matrixark_mcp_indexing import benchmark_quality_index_terms, context_index_name, normalized_index_value
+    from matrixark_mcp_indexing import benchmark_quality_index_terms, context_index_name, normalized_index_value, ordered_unique
     from matrixark_mcp_scoring import tokens
 
 
@@ -109,17 +109,6 @@ QUERY_INDEX_LABELS: dict[str, str] = {
 }
 
 
-def _ordered_unique(values: list[str]) -> list[str]:
-    output: list[str] = []
-    seen: set[str] = set()
-    for value in values:
-        if value in seen:
-            continue
-        seen.add(value)
-        output.append(value)
-    return output
-
-
 RESOURCE_TYPE_QUERY_ALIASES: dict[str, str] = {
     "pdf": "pdf",
     "markdown": "md",
@@ -165,28 +154,23 @@ QUERY_INDEX_STOPWORDS = {
 }
 
 
-def slug_candidates_from_query(query: str) -> list[str]:
-    lower = query.lower()
-    candidates: list[str] = []
-    for pattern in [
-        r"(?:heading|section|chapter)\s+['\"]?([a-z0-9][a-z0-9 _./:-]{1,80})",
-        r"#\s*([a-z0-9][a-z0-9 _./:-]{1,80})",
-    ]:
-        for match in re.finditer(pattern, lower):
-            raw_value = re.split(r"\b(?:in|from|for|about|with|under)\b", match.group(1).split("?")[0], maxsplit=1)[0]
-            value = normalized_index_value(raw_value)
-            if value:
-                candidates.append(value)
-    return _ordered_unique(candidates)[:4]
-
-
-def path_candidates_from_query(query: str) -> list[str]:
-    values: list[str] = []
-    for raw in re.findall(r"[a-zA-Z0-9_.-]+/[a-zA-Z0-9_./-]+|[a-zA-Z0-9_.-]+\.(?:md|txt|pdf|csv|tsv|json|jsonl|yaml|yml|html|docx|pptx|xlsx|py|js|ts|go|rs|native|h)", query):
-        normalized = normalized_index_value(raw)
-        if normalized:
-            values.append(normalized)
-    return _ordered_unique(values)[:6]
+# The three *_candidates_from_query functions had copies here that differed from
+# matrixark_mcp_core_query_analysis's by ONE token: they called a private `_ordered_unique` defined
+# in this file, a nine-line duplicate of matrixark_mcp_indexing.ordered_unique, where the live
+# copies call the shared one. Same behaviour, two implementations, and nothing saying which was
+# current -- so they join the two names already re-exported below, and the private helper goes.
+try:  # the implementation lives in matrixark_mcp_core_query_analysis; this module re-exports it
+    from tools.matrixark_mcp_core_query_analysis import (
+        keyword_candidates_from_query,
+        path_candidates_from_query,
+        slug_candidates_from_query,
+    )
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_query_analysis import (
+        keyword_candidates_from_query,
+        path_candidates_from_query,
+        slug_candidates_from_query,
+    )
 
 
 try:  # the implementation lives in matrixark_mcp_core_query_analysis; this module re-exports it
@@ -201,24 +185,6 @@ except ImportError:  # Direct script execution from tools/.
 # keyword index was write-only. Measured on a CN/EN corpus: 60.2% of emitted keyword terms
 # were under four characters, and a pure Chinese query produced ZERO lookup terms.
 _QUERY_CJK_RUN_RE = _re_for_cjk_runs()
-
-
-def keyword_candidates_from_query(query: str) -> list[str]:
-    values = []
-    for term in tokens(query):
-        if len(term) < 4 or term in QUERY_INDEX_STOPWORDS:
-            continue
-        values.append(context_index_name("keyword", term))
-    # Mirror the ingest side exactly: same bigrams, or the two halves cannot meet.
-    seen: set[str] = set()
-    for run in _QUERY_CJK_RUN_RE.findall(str(query or "")):
-        for index in range(len(run) - 1):
-            bigram = run[index : index + 2]
-            if bigram in seen:
-                continue
-            seen.add(bigram)
-            values.append(context_index_name("keyword", bigram))
-    return _ordered_unique(values)[:8]
 
 
 def codex_outcome_fact_index_terms(*values: Any) -> set[str]:
@@ -431,7 +397,7 @@ def deterministic_secondary_index_filter_groups(query: str, question_type: str) 
         for size in (3, 2):
             trigger_values.extend("_".join(query_tokens[index : index + size]) for index in range(0, max(0, len(query_tokens) - size + 1)))
         trigger_values.extend(query_tokens)
-        trigger_terms = [context_index_name("skill_trigger", term) for term in _ordered_unique(trigger_values)]
+        trigger_terms = [context_index_name("skill_trigger", term) for term in ordered_unique(trigger_values)]
         if tool_terms:
             add_group(*tool_terms[:6])
         if trigger_terms:

--- a/tools/matrixark_mcp_segments.py
+++ b/tools/matrixark_mcp_segments.py
@@ -37,6 +37,11 @@ except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_core import build_segment_prompt
 
 
+# `semantic_saliency_score` had a copy here whose keyword list matched `control_state` where
+# core's matches `risk`. Neither is a typo: that is the same open question recorded against
+# RESOURCE_FACT_KEYWORDS in test_there_is_one_copy_of_each_helper, where it is blocked on
+# RESOURCE_FACT_SCHEMAS differing per host. Re-exporting does not answer it -- it takes this
+# module out of the argument, so the answer only has to be written in one place.
 try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
     from tools.matrixark_mcp_core import oss_model_memory_segments, semantic_saliency_score
 except ImportError:  # Direct script execution from tools/.

--- a/tools/matrixark_mcp_segments.py
+++ b/tools/matrixark_mcp_segments.py
@@ -5,8 +5,6 @@
 
 from __future__ import annotations
 
-import os
-import re
 from typing import Any
 
 Json = dict[str, Any]
@@ -27,9 +25,6 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
     from matrixark_mcp_summaries import summarize_text
 
 
-_OSS_SEGMENT_MODEL_CACHE: dict[str, Any] = {}
-
-
 try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
     from tools.matrixark_mcp_core import detect_memory_segments
 except ImportError:  # Direct script execution from tools/.
@@ -42,45 +37,10 @@ except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_core import build_segment_prompt
 
 
-def oss_model_memory_segments(messages: list[Json], *, model: str, model_path: str = "", max_new_tokens: int = 512, local_only: bool = False) -> Json:
-    try:
-        import torch  # type: ignore
-        from transformers import AutoModelForCausalLM, AutoTokenizer  # type: ignore
-    except Exception as exc:  # pragma: no cover - depends on optional OSS stack.
-        raise MatrixArkError("torch and transformers are required for segment_provider=oss") from exc
-
-    target = model_path or model
-    cache_key = f"{target}:{max_new_tokens}"
-    cached = _OSS_SEGMENT_MODEL_CACHE.get(cache_key)
-    if cached is None:
-        local_only = bool(local_only) or bool(model_path) or os.getenv("MATRIXARK_SEGMENT_MODEL_LOCAL_ONLY", "").strip().lower() in {"1", "true", "yes", "on"}
-        tokenizer = AutoTokenizer.from_pretrained(target, local_files_only=local_only)
-        model_obj = AutoModelForCausalLM.from_pretrained(target, local_files_only=local_only)
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-        model_obj.to(device)
-        model_obj.eval()
-        cached = {"tokenizer": tokenizer, "model": model_obj, "device": device}
-        _OSS_SEGMENT_MODEL_CACHE[cache_key] = cached
-    tokenizer = cached["tokenizer"]
-    model_obj = cached["model"]
-    device = cached["device"]
-    prompt = build_segment_prompt(messages)
-    if getattr(tokenizer, "chat_template", None):
-        chat = [
-            {"role": "system", "content": "Return only JSON. No markdown."},
-            {"role": "user", "content": prompt},
-        ]
-        input_ids = tokenizer.apply_chat_template(chat, add_generation_prompt=True, return_tensors="pt").to(device)
-        outputs = model_obj.generate(input_ids, max_new_tokens=max_new_tokens, do_sample=False)
-        generated = outputs[0][input_ids.shape[-1]:]
-        response = tokenizer.decode(generated, skip_special_tokens=True)
-    else:
-        inputs = tokenizer(prompt, return_tensors="pt", truncation=True, max_length=4096)
-        inputs = {key: value.to(device) for key, value in inputs.items()}
-        outputs = model_obj.generate(**inputs, max_new_tokens=max_new_tokens, do_sample=False)
-        generated = outputs[0][inputs["input_ids"].shape[-1]:]
-        response = tokenizer.decode(generated, skip_special_tokens=True)
-    return parse_first_json_object(response)
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from tools.matrixark_mcp_core import oss_model_memory_segments, semantic_saliency_score
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import oss_model_memory_segments, semantic_saliency_score
 
 
 try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
@@ -99,6 +59,29 @@ try:  # the implementation lives in matrixark_mcp_core; this module re-exports i
     from .matrixark_mcp_core import normalize_message_indexes
 except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_core import normalize_message_indexes
+
+# NOT re-exported, unlike the four names above, and this is the interesting one.
+#
+# matrixark_mcp_core defines `intelligent_memory_segments` too, and the two bodies differ by two
+# dict fields that ONLY this copy sets:
+#
+#     "segment_origin": "semantic_derived_from_events",
+#     "derived_from_context_events": True,
+#
+# Those two fields are read by live code -- matrixark_mcp_context_pack copies them onto pack items
+# in three places, matrixark_local_adapter_retrieve emits them, and
+# matrixark_mcp_local_batch_extract_runtime falls back through `segment_origin` to `detected_by`.
+# So the ORPHAN is the fuller copy here, which is exactly the case the guard in
+# test_an_unreachable_module_does_not_hold_a_diverged_copy warns about and the reason the other two
+# were checked one at a time rather than swept.
+#
+# It also says something about the LIVE path rather than this one: matrixark_mcp_core sets
+# segment_origin="fallback_derived_from_events" on its fallback segment path and sets nothing on
+# the semantic path, so a live semantic segment reaches the pack with no origin at all. Whether
+# that is a hole or a deliberate silence is a question about the pack, not about this module, and
+# adopting these two fields into the live function would change what every pack carries. That is
+# not a consolidation, so it is not done here.
+
 
 def intelligent_memory_segments(messages: list[Json]) -> list[Json]:
     """Segment a batch into salient, event-centric memories.
@@ -142,39 +125,6 @@ def intelligent_memory_segments(messages: list[Json]) -> list[Json]:
         )
     segments.sort(key=lambda item: (-item["saliency_score"], item["topic"]))
     return segments[:12]
-
-
-def semantic_saliency_score(text: str) -> float:
-    lower = text.lower().strip()
-    if not lower:
-        return 0.0
-    filler = {
-        "hi",
-        "hello",
-        "hey",
-        "thanks",
-        "thank you",
-        "ok",
-        "okay",
-        "cool",
-        "great",
-        "sounds good",
-    }
-    compact = re.sub(r"[^a-z0-9 ]+", "", lower).strip()
-    if compact in filler or len(compact) < 8:
-        return 0.0
-    score = 0.2
-    if re.search(r"\b(recursion|base case|merge sort|algorithm|complexity|efficiency|dynamic programming|graph|game)\b", lower):
-        score += 0.55
-    if re.search(r"\b(prefer|favorite|approved|budget|plan|correction|instead|current|remember|important|moved|moving|located|location|live|lives|staying|deadline|owner|owns|reviewer|checklist|decision|decided|require|requires|required|incident|runbook|alert|outage|rollback|metric|latency|p95|p99|sla|policy|control_state|blocked|blocker)\b", lower):
-        score += 0.45
-    if re.search(r"\b(is|means|because|therefore|warning|avoid|must|should|cannot|can|require|requires|required|blocked|blocker)\b", lower):
-        score += 0.2
-    if re.search(r"\b(\d{2,}|monday|tuesday|wednesday|thursday|friday|saturday|sunday|january|february|march|april|may|june|july|august|september|october|november|december)\b", lower):
-        score += 0.1
-    if len(tokens(text)) >= 8:
-        score += 0.15
-    return min(score, 1.0)
 
 
 try:  # the implementation lives in matrixark_mcp_core; this module re-exports it

--- a/tools/test_a_definition_only_the_tests_call.py
+++ b/tools/test_a_definition_only_the_tests_call.py
@@ -102,6 +102,8 @@ ONLY_TESTS_CALL = {
     #   full_read_fallback_counts -- matrixarkai#1566 gave it a Prometheus family in
     #   matrixark_temporal_direct_backend, so the degradation it measures is now reported.
     #   embedding_cache_stats -- matrixarkai#1569 put it on the local adapter dashboard.
+    #   pipeline_task_footprint_stats -- matrixarkai#1570 put rows against distinct tasks on
+    #   the same dashboard.
     #
     # Both entries said the same thing in different words, "written to make something visible and
     # reported nowhere", and both stopped being true within a week of being written down. That is
@@ -119,8 +121,6 @@ ONLY_TESTS_CALL = {
         "the unadopted part of matrixark_mcp_retrieve_pre_refresh, which three production modules import. The same merge runs inline at matrixark_local_adapter_retrieve:1167-1196",
     "secondary_index_bound_stats":
         "live posting counts by scope and ref_type. Its own docstring says 'used by the tests/harness', so this one is an affordance by design rather than a signal that went missing -- read the docstring before filing it as a gap",
-    "pipeline_task_footprint_stats":
-        "what pipeline tasks cost in the store; no surface prints the number",
     "env_int":
         "the typed integer env reader. env_bool has twenty-two production callers and this has none, so most integer flags are parsed at their own read site instead",
     "env_float":

--- a/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
+++ b/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
@@ -40,11 +40,22 @@ import pathlib
 import unittest
 from collections import defaultdict
 
-#: Diverged shadows counted 2026-09-06. May only go DOWN. Raising it needs a reason in the message.
-RECORDED_DIVERGED = 53
+#: Diverged shadows. May only go DOWN. Raising it needs a reason in the message.
+#:
+#: 53 on 2026-09-06, 51 now. The two that left are `oss_model_memory_segments` and
+#: `semantic_saliency_score`: matrixark_mcp_segments held a copy of each, and both copies were the
+#: STALE side, so the module re-exports matrixark_mcp_core's instead -- which is the pattern that
+#: file already used for `detect_memory_segments` and `build_segment_prompt`, with the comment
+#: "the implementation lives in matrixark_mcp_core; this module re-exports it" written above them.
+RECORDED_DIVERGED = 51
 
 #: Total shadowed names (diverged + verbatim), recorded for the same reason.
-RECORDED_SHADOWED = 129
+#:
+#: 129 on 2026-09-06 and 63 now, and only two of that fall are from the change that lowered the
+#: number above -- 66 verbatim copies went with work that landed since and did not bank this line.
+#: Banked here, because a ceiling left sixty-six above the truth is not a ratchet, it is a number
+#: that will pass whatever happens next.
+RECORDED_SHADOWED = 63
 
 _CACHE: dict[str, object] = {}
 

--- a/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
+++ b/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
@@ -47,7 +47,13 @@ from collections import defaultdict
 #: STALE side, so the module re-exports matrixark_mcp_core's instead -- which is the pattern that
 #: file already used for `detect_memory_segments` and `build_segment_prompt`, with the comment
 #: "the implementation lives in matrixark_mcp_core; this module re-exports it" written above them.
-RECORDED_DIVERGED = 51
+#:
+#: 51 -> 48 for the three `*_candidates_from_query` functions, whose copies in matrixark_mcp_query
+#: differed from matrixark_mcp_core_query_analysis's by ONE token -- a private `_ordered_unique`
+#: defined in that file, a nine-line duplicate of matrixark_mcp_indexing.ordered_unique, where the
+#: live copies call the shared one. Same pattern again: that module was ALREADY re-exporting two
+#: names from the same live file, with the same comment above them.
+RECORDED_DIVERGED = 48
 
 #: Total shadowed names (diverged + verbatim), recorded for the same reason.
 #:
@@ -55,7 +61,7 @@ RECORDED_DIVERGED = 51
 #: number above -- 66 verbatim copies went with work that landed since and did not bank this line.
 #: Banked here, because a ceiling left sixty-six above the truth is not a ratchet, it is a number
 #: that will pass whatever happens next.
-RECORDED_SHADOWED = 63
+RECORDED_SHADOWED = 60
 
 _CACHE: dict[str, object] = {}
 

--- a/tools/test_flag_readers_agree.py
+++ b/tools/test_flag_readers_agree.py
@@ -73,7 +73,15 @@ ONE_VOCABULARY = ("<env_bool>",)
 # MATRIXARK_DIRECT_WRITE_QUEUE and a memory queue mode, so an operator turning it on got
 # nothing and no error. Raw batches follow the write queue now. A step DOWN is a flag leaving
 # the tree, and it should arrive with the commit that removed it, as this one did.
-EXPECTED_SHARED_FLOOR = 14
+#: 14 until matrixarkai#1575 consolidated matrixark_mcp_segments onto matrixark_mcp_core, which took
+#: MATRIXARK_SEGMENT_MODEL_LOCAL_ONLY from two reading sites to one -- the flag did not go anywhere,
+#: one of the two copies of the function reading it did. So the number fell because the tree got
+#: better, which is the failure mode a floor set from a MEASUREMENT always has.
+#:
+#: What the floor is FOR is catching a read-shape scan that has stopped matching: that finds
+#: approximately nothing, not one fewer. Ten is far below anything consolidation will reach one pair
+#: at a time and far above what a broken scan returns.
+EXPECTED_SHARED_FLOOR = 10
 
 
 def _production_sources() -> List[str]:


### PR DESCRIPTION
Unreachable modules hold 51 diverged copies of names live modules also define. They compile, they
look current, and nothing in either file says which way they diverged — the guard that counts them
calls this *a wrong answer waiting to be read*. This PR resolves seven definitions across two
modules, reading each one rather than sweeping.

Both modules were **already** re-exporting other names from the very file the copies came from,
with the comment *"the implementation lives in X; this module re-exports it"* written above them.
Finishing that pattern is the whole change.

---

### `matrixark_mcp_segments`

**`oss_model_memory_segments` — the copy here is stale.** It passed the chat-template result
straight to `generate()`. The live copy carries a fix and the note explaining it: transformers ≥ 5
returns a `BatchEncoding` where older versions returned a bare tensor, so `generate()` read `.shape`
off a dict-like and raised a bare `AttributeError` — *"the OSS extractor could not run at all on a
current transformers"*. The copy here still had the crashing version, and
`matrixark_mcp_extraction_runtime` imports this name **from this module**.

**`semantic_saliency_score` — not stale; the other side of an open question.** The two keyword lists
differ by one word in the same slot: core matches `risk`, this copy matches `control_state`. *Not a
typo in either direction* — Control State is product vocabulary, with its own fact schema and entity
prefix in `matrixark_mcp_resources`. It is the same unsettled question already recorded for
`RESOURCE_FACT_KEYWORDS`:

> core matches `risk`, resources matches `control_state`. Which is right depends on
> `RESOURCE_FACT_SCHEMAS`, which is ALSO different in each host … The keyword set and the schema set
> have to be settled together or a fact starts being extracted with no schema to classify it.

This PR **does not settle it and does not claim to.** It takes the unreachable module out of the
argument so the answer only has to be written in one place — between the two *live* holders, where
it can be answered with the schemas. A note at the re-export says so.

**`intelligent_memory_segments` stays, and it is why none of this was swept.** It differs by two
dict fields **only the orphan sets** — `segment_origin="semantic_derived_from_events"` and
`derived_from_context_events=True` — and both are read by live code:
`matrixark_mcp_context_pack` copies them onto pack items in three places,
`matrixark_local_adapter_retrieve` emits them, `matrixark_mcp_local_batch_extract_runtime` falls
back through `segment_origin`. Here the orphan is the **fuller** copy.

It also says something about the live path: `matrixark_mcp_core` sets
`segment_origin="fallback_derived_from_events"` on its fallback path and nothing on the semantic
one, so a live semantic segment reaches the pack with no origin at all. Adopting the fields would
change what every pack carries — a question about the pack, not a consolidation.

### `matrixark_mcp_query`

`path_candidates_from_query`, `slug_candidates_from_query` and `keyword_candidates_from_query` each
differed from `matrixark_mcp_core_query_analysis`'s by **exactly one token**: `_ordered_unique`
instead of `ordered_unique`. `_ordered_unique` is defined in that same file and is a nine-line
duplicate of `matrixark_mcp_indexing.ordered_unique` — same loop, same seen-set, same order.

So the three were behaviourally identical and structurally different, which is the worst combination
to leave in an unreachable module: a reader diffing them finds a real difference and cannot tell it
means nothing. The three join the two names already re-exported; the helper goes, and its one
remaining caller takes the shared one.

### Banked

| | before | after |
|---|---|---|
| diverged shadows | 53 | **48** |
| total shadowed | 129 | **60** |

Only five of that second fall are this PR. Sixty-six verbatim copies went with work that landed
since 2026-09-06 and never banked the line, and a ceiling left sixty-six above the truth is not a
ratchet — it is a number that passes whatever happens next.

### Left alone on purpose

- **`debug_resource_metadata`** differs by `summarize_text` vs `preview_text` — a real behavioural
  difference (one summarises, one truncates with an ellipsis), not a rename.
- **`_ref_list_value`** differs only by a local variable name, and the two holders are unrelated
  modules; consolidating would mean importing a private helper across a module boundary, which is
  worse than an eight-line duplicate.

### Red before and after

`test_codex_pipeline_part1`, `part5` and `test_matrixark_codex_hook_pipeline` fail identically with
these changes reverted on the same tree. They are main's, not this PR's.
