### PR TITLE
Which stages do the walking

### DIFF
--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -4010,6 +4010,125 @@ materialized {scanned:>8} live-page entries = {:>5.1}x the shard, stages {:?}",
     }
 }
 
+/// WHICH stages do the walking? Attributes the round's live-page scan volume per stage. Prints.
+///
+///   cargo test --release -p temporalstore-rust --lib which_stages_walk_every_live_page -- --ignored --nocapture
+///
+/// `how_many_times_a_round_walks_every_live_page` establishes that one round materializes every
+/// live page ~35x. That number says a fix is worth doing but not where to apply it. This names the
+/// stages, by toggling each one off and diffing the scan counter -- the same subtract-one-stage
+/// shape `what_each_maintenance_stage_costs` uses for time, so the two can be read together.
+///
+/// Read the DELTA (all-on minus without-this-stage), not the without-column. A stage that shares
+/// its walks with another stage will under-report here, because switching it off leaves the other
+/// one still walking -- so the deltas are a lower bound per stage and need not sum to the total.
+/// That is a property worth seeing rather than hiding: where the deltas fall well short of the
+/// total, the walking is SHARED, and hoisting one materialization helps more than removing any
+/// single stage would.
+#[test]
+#[ignore]
+fn which_stages_walk_every_live_page() {
+    fn build(objects: usize) -> (tempfile::TempDir, DataNodeRuntime) {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            16 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        for index in 0..objects {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("stage-scan-{index:06}"),
+                    value: vec![b'v'; 96],
+                },
+            });
+        }
+        let runtime = DataNodeRuntime::new_without_workers_with_options(
+            engine,
+            DataNodeRuntimeOptions {
+                worker_threads: 0,
+                max_queue_depth: 4,
+                max_background_queue_depth: 2,
+            },
+        );
+        (dir, runtime)
+    }
+
+    fn scan_once(objects: usize, options: StorageManagerOptions) -> (u64, Vec<String>) {
+        let (_dir, runtime) = build(objects);
+        crate::engine::reset_live_page_scan_entries();
+        let report = runtime.run_storage_manager_once(1, options);
+        (crate::engine::live_page_scan_entries(), report.executed_stages)
+    }
+
+    for objects in [4_000usize] {
+        let (all_on, stages) = scan_once(objects, StorageManagerOptions::default());
+        assert!(
+            all_on > 0,
+            "the round materialized nothing, so this attributes nothing",
+        );
+
+        // WHY the two stages below walk so much: they rebuild the same plans. Both counters
+        // already exist for exactly this question, and a COUNT is immune to whatever else is
+        // running on the box, where a timing would not be.
+        let (_dir, runtime) = build(objects);
+        crate::engine::reset_storage_plan_build_counts();
+        let _ = runtime.run_storage_manager_once(1, StorageManagerOptions::default());
+        let (lifecycle_builds, wal_builds) = crate::engine::storage_plan_build_counts();
+        eprintln!(
+            "  [stage-scan] {objects:>6}   ONE round builds the lifecycle plan {lifecycle_builds} \
+time(s) and the WAL reclaim plan {wal_builds} time(s); each walks the shard"
+        );
+        eprintln!(
+            "  [stage-scan] {objects:>6} objects, everything on -> {all_on:>9} live-page entries \
+= {:>5.1}x the shard, stages {stages:?}",
+            all_on as f64 / objects as f64,
+        );
+
+        for (name, off) in [
+            ("prepare", StorageManagerOptions { enable_prepare: false, ..Default::default() }),
+            ("reclaim_wal", StorageManagerOptions { enable_wal_reclaim: false, ..Default::default() }),
+            ("reclaim_memory", StorageManagerOptions { enable_memory_reclaim: false, ..Default::default() }),
+            ("expire", StorageManagerOptions { enable_expire: false, ..Default::default() }),
+            ("reclaim_page", StorageManagerOptions { enable_page_gc: false, ..Default::default() }),
+            ("compact_pages", StorageManagerOptions { enable_page_compaction: false, ..Default::default() }),
+            ("reclaim_index", StorageManagerOptions { enable_index_gc: false, ..Default::default() }),
+            ("reap_metrics", StorageManagerOptions { enable_metrics_reap: false, ..Default::default() }),
+        ] {
+            // A stage that did not RUN in the all-on round contributes 0 here, and that zero
+            // reads exactly like "this stage does no walking" while meaning "this row measured
+            // nothing". Say which it is. `compact_pages` is the one that matters: it does not run
+            // on this fixture, yet its preamble is six whole-shard passes when it does.
+            let ran = stages.iter().any(|stage| stage == name);
+            let (without, _) = scan_once(objects, off);
+            eprintln!(
+                "  [stage-scan] {objects:>6}   without {name:<15} {without:>9} \
+(stage accounts for {:>9} entries, {:>5.1}x the shard){}",
+                all_on.saturating_sub(without),
+                all_on.saturating_sub(without) as f64 / objects as f64,
+                if ran { "" } else { "   <- DID NOT RUN on this fixture; the zero measures nothing" },
+            );
+        }
+
+        // `enable_evict` is the ONE stage flag that defaults to false (manual `Default` impl, with
+        // a comment saying so), so a subtract-one row for it would toggle nothing and report a
+        // false zero. Measure it the other way round: what turning it ON adds.
+        let (with_evict, evict_stages) = scan_once(
+            objects,
+            StorageManagerOptions { enable_evict: true, ..Default::default() },
+        );
+        eprintln!(
+            "  [stage-scan] {objects:>6}   evict is OFF by default; ON -> {with_evict:>9} \
+(adds {:>9} entries, {:>5.1}x the shard), stages {evict_stages:?}",
+            with_evict.saturating_sub(all_on),
+            with_evict.saturating_sub(all_on) as f64 / objects as f64,
+        );
+    }
+}
+
 #[test]
 fn the_dump_cap_bounds_a_stage_but_not_a_round() {
     // Two facts, and the second is the surprising one.


### PR DESCRIPTION
#1573 established that one maintenance round materializes every live page **~35×**. That says a
fix is worth doing but not where to apply it. This names the stages, by switching each one off and
diffing the live-page scan counter — the same subtract-one-stage shape
`what_each_maintenance_stage_costs` uses for time, so the two read together.

## 4,000 objects, everything on → 140,000 entries = 35.0× the shard

| stage switched off | entries | accounts for | × the shard |
|---|---|---|---|
| `reclaim_index` | 68,000 | **72,000** | **18.0×** |
| `reclaim_wal` | 76,000 | **64,000** | **16.0×** |
| every other stage | 140,000 | 0 | 0.0× |

Two stages are the whole thing. 18 + 16 = 34 of the 35; the remaining ~1× is the round's opening
pressure snapshot. The deltas nearly **sum** to the total, which says the two are not sharing
walks — each does its own.

## Six plan builds, thirty-five walks

The same probe counts the plan builds, using counters that already existed for this question:

```
ONE round builds the lifecycle plan 4 time(s) and the WAL reclaim plan 2 time(s)
```

So the multiplier is **not** "six stages each walking once". Six builds produce thirty-five walks,
because a single build is itself several walks: `bucket_generation_fingerprints_by_bucket` calls
`collect_live_page_entries`, and `storage_wal_reclaim_plan` calls it once for the current state
**and once per retained dump manifest**. That stage's cost therefore scales with how many
manifests are retained — not with anything the round was asked to work on.

## A zero here has two meanings, and the probe now says which

A stage that did not **run** on the fixture also contributes 0, and that zero reads exactly like
"this stage does no walking" while meaning "this row measured nothing". Rows for stages that did
not run are marked.

It matters most for `compact_pages`, which does not run on this fixture and whose preamble is six
whole-shard passes when it does. Reading its 0 as "compaction does not walk" would be exactly
wrong — and that is the reading the unmarked table invited.

`enable_evict` gets the same treatment for the same reason in the other direction: it is the one
stage flag whose `Default` is `false`, so a subtract-one row would toggle nothing and print a
confident zero. It is measured **additively** — what turning it on adds — which is 0, confirming
the sampled eviction path reads off the bucket index without materializing live pages.

## What the numbers mean for a fix

**Not** "cache the plan for the round." The plans are rebuilt because the stages **mutate** between
them: the lifecycle stage dumps and writes manifests immediately before `reclaim_index` runs, so
the plan computed at the top of the round is genuinely stale by then. The rebuild is not gratuitous.

**The safe fix is narrower.** A `BucketDumpManifest` is **immutable** once written — `index_bytes`
never changes — so its fingerprint map is a pure function of an immutable input and can be memoized
by manifest id with no staleness risk at all. That removes the per-manifest walks from every future
round.

**The general fix** is the shape the rest of this storage layer already wants: maintain per-bucket
aggregates incrementally, so rebuilding a plan costs `O(buckets)` rather than `O(live pages)`. The
same change answers the compaction preamble's six passes, the index-GC usage ratio, and the
eviction gate's blindness to index bytes.

## Verification

Measurement only; no behaviour changes. The probe is `#[ignore]`, so it does not run in the suite.
It asserts the round materialized something before attributing anything, so a fixture that walked
nothing fails loudly rather than reporting nine confident zeros.

`cargo test -p temporalstore-rust --lib -- --test-threads=1` — see below.
