### PR TITLE
Two imports were overwritten fifteen lines later

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -156,8 +156,12 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
         DEFAULT_MAX_CONTEXT_TOKENS as _RUNTIME_DEFAULT_MAX_CONTEXT_TOKENS,
     )
 DEFAULT_MAX_CONTEXT_TOKENS = _RUNTIME_DEFAULT_MAX_CONTEXT_TOKENS
-CONTEXT_PACK_DEBUG_REFS = env_bool("MATRIXARK_CONTEXT_PACK_DEBUG_REFS", False)
-AUDIT_DEBUG_PAYLOAD = env_bool("MATRIXARK_AUDIT_DEBUG_PAYLOAD", False)
+# CONTEXT_PACK_DEBUG_REFS and AUDIT_DEBUG_PAYLOAD were re-read here, fifteen lines below the import
+# that already binds both. The import was dead: a second `env_bool` call on the same variable with
+# the same default, shadowing the name it had just been given. Identical on every spelling today --
+# "", 1, 0, on, off, true, yes and a word that parses as neither -- which is exactly why nobody
+# noticed, and exactly what makes it a trap: a change to either definition in
+# matrixark_mcp_runtime_config would never have reached this module.
 
 MAX_SECONDARY_INDEX_TERMS_PER_RECORD = int(os.environ.get("MATRIXARK_MAX_SECONDARY_INDEX_TERMS_PER_RECORD", "").strip() or "10")
 SECONDARY_INDEX_POSTING_BUCKET_MS = int(os.environ.get("MATRIXARK_SECONDARY_INDEX_POSTING_BUCKET_MS", "").strip() or "60000")

--- a/tools/test_a_definition_only_the_tests_call.py
+++ b/tools/test_a_definition_only_the_tests_call.py
@@ -102,6 +102,9 @@ ONLY_TESTS_CALL = {
     #   full_read_fallback_counts -- matrixarkai#1566 gave it a Prometheus family in
     #   matrixark_temporal_direct_backend, so the degradation it measures is now reported.
     #   embedding_cache_stats -- matrixarkai#1569 put it on the local adapter dashboard.
+    #   pipeline_task_footprint_stats -- matrixarkai#1570 put rows against distinct tasks on
+    #   the same dashboard. Third of three, and the third to leave within days of being
+    #   written down, which is the list working rather than the list being wrong.
     #
     # Both entries said the same thing in different words, "written to make something visible and
     # reported nowhere", and both stopped being true within a week of being written down. That is
@@ -119,8 +122,6 @@ ONLY_TESTS_CALL = {
         "the unadopted part of matrixark_mcp_retrieve_pre_refresh, which three production modules import. The same merge runs inline at matrixark_local_adapter_retrieve:1167-1196",
     "secondary_index_bound_stats":
         "live posting counts by scope and ref_type. Its own docstring says 'used by the tests/harness', so this one is an affordance by design rather than a signal that went missing -- read the docstring before filing it as a gap",
-    "pipeline_task_footprint_stats":
-        "what pipeline tasks cost in the store; no surface prints the number",
     "env_int":
         "the typed integer env reader. env_bool has twenty-two production callers and this has none, so most integer flags are parsed at their own read site instead",
     "env_float":

--- a/tools/test_two_modules_do_not_read_the_same_variable.py
+++ b/tools/test_two_modules_do_not_read_the_same_variable.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""matrixark_mcp_core and matrixark_mcp_runtime_config define 77 of the same constants, identically.
+
+Each of those is one environment variable read twice, at two import times, into two names that
+happen to agree. They agree today because the text is character-for-character the same in both
+files -- which is not a mechanism, it is a coincidence maintained by hand, and the cost lands on
+whoever edits one of them.
+
+TWO OF THE 77 WERE WORSE THAN DUPLICATED, THEY WERE SHADOWED. matrixark_mcp_core imports
+CONTEXT_PACK_DEBUG_REFS and AUDIT_DEBUG_PAYLOAD from matrixark_mcp_runtime_config and then, fifteen
+lines later, re-read both from the environment. The imported values were overwritten before
+anything could use them, so the import was dead and a change to either definition in
+runtime_config could never have reached core. Both are removed; this file is what stops a third.
+
+WHY A RATCHET AND NOT A SWEEP. Rewriting all 77 at once is the mechanical rewrite this tree has
+been burned by: every guard that reads "module X reads flag Y" changes answer on the same commit,
+and a real divergence hiding among 77 identical-looking moves is invisible in the diff. The number
+may only go DOWN, one reading at a time, and the one that is NOT identical is named below so it is
+never swept in with the rest.
+"""
+from __future__ import annotations
+
+import ast
+import io
+import os
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+
+CORE = "matrixark_mcp_core.py"
+RUNTIME = "matrixark_mcp_runtime_config.py"
+
+#: Constants defined identically in both modules, counted 2026-09-12. May only go DOWN.
+RECORDED_DUPLICATED = 77
+
+#: Defined in both and NOT identical, with the reason. `matrixark_mcp_core` binds
+#: DEFAULT_MAX_CONTEXT_TOKENS to the value it imported from runtime_config under an alias, which is
+#: the shape the other 77 should take -- the one place the pattern is already right.
+DELIBERATELY_UNLIKE = {
+    "DEFAULT_MAX_CONTEXT_TOKENS":
+        "core assigns it from _RUNTIME_DEFAULT_MAX_CONTEXT_TOKENS, the aliased import. Not a "
+        "second read -- the pattern the other 77 are missing",
+}
+
+
+def _constants(name):
+    """NAME -> source text, for every module-scope assignment to an ALL-CAPS name."""
+    src = io.open(os.path.join(TOOLS, name), encoding="utf-8").read()
+    lines = src.splitlines(True)
+    out = {}
+    for node in ast.parse(src).body:
+        target = None
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = getattr(node.targets[0], "id", None)
+        elif isinstance(node, ast.AnnAssign):
+            target = getattr(node.target, "id", None)
+        if target and target.isupper():
+            out[target] = "".join(lines[node.lineno - 1:node.end_lineno]).strip()
+    return out
+
+
+def _shared():
+    """(identical, different) constant names defined by both modules."""
+    core, runtime = _constants(CORE), _constants(RUNTIME)
+    same, other = [], []
+    for name in sorted(set(core) & set(runtime)):
+        (same if core[name] == runtime[name] else other).append(name)
+    return same, other
+
+
+def _shadowed_imports():
+    """Names core imports from runtime_config and then re-assigns at module scope."""
+    src = io.open(os.path.join(TOOLS, CORE), encoding="utf-8").read()
+    tree = ast.parse(src)
+    imported = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module and "runtime_config" in node.module:
+            for alias in node.names:
+                imported.setdefault(alias.asname or alias.name, node.lineno)
+    out = []
+    for node in tree.body:
+        target = None
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = getattr(node.targets[0], "id", None)
+        elif isinstance(node, ast.AnnAssign):
+            target = getattr(node.target, "id", None)
+        if target in imported and node.lineno > imported[target]:
+            out.append((target, imported[target], node.lineno))
+    return out
+
+
+class TwoModulesDoNotReadTheSameVariableTest(unittest.TestCase):
+
+    def test_the_scan_finds_both_modules(self) -> None:
+        """Control on the input. A parse that returns nothing satisfies every check below."""
+        core, runtime = _constants(CORE), _constants(RUNTIME)
+        self.assertGreater(len(core), 50, "only %d constants parsed out of %s" % (len(core), CORE))
+        self.assertGreater(len(runtime), 50,
+                           "only %d constants parsed out of %s" % (len(runtime), RUNTIME))
+
+    def test_no_import_from_the_runtime_config_is_overwritten(self) -> None:
+        """A name imported and then re-read is an import nothing can use.
+
+        Both instances of this read the same variable with the same default as the definition they
+        overwrote, so they agreed -- which is what kept it invisible. The failure it sets up is a
+        change to runtime_config that silently does not reach core.
+        """
+        shadowed = _shadowed_imports()
+        self.assertEqual(
+            [], shadowed,
+            "matrixark_mcp_core imports these from matrixark_mcp_runtime_config and then assigns "
+            "over them, so the import is dead: %s"
+            % ", ".join("%s (imported line %d, overwritten line %d)" % row for row in shadowed))
+
+    def test_the_duplicated_constants_do_not_increase(self) -> None:
+        """The ratchet. One reading at a time; a sweep of 77 is unreviewable."""
+        same, _other = _shared()
+        self.assertLessEqual(
+            len(same), RECORDED_DUPLICATED,
+            "%d constants are now defined identically in both modules, up from %d. Each is one "
+            "environment variable read twice into two names that agree by hand. Names now: %s"
+            % (len(same), RECORDED_DUPLICATED, ", ".join(same)))
+
+    def test_every_non_identical_shared_name_has_a_reason(self) -> None:
+        """The ones that differ are the dangerous ones: same name, two behaviours, no note.
+
+        Listing them by name is safe here in a way it is not elsewhere -- this file compares the
+        SOURCE TEXT of two named modules, so it cannot feed itself the way a scan that counts
+        mentions across the tree can.
+        """
+        _same, other = _shared()
+        for name in other:
+            with self.subTest(name=name):
+                self.assertIn(
+                    name, DELIBERATELY_UNLIKE,
+                    "%s is defined differently in %s and %s and nothing says which is current"
+                    % (name, CORE, RUNTIME))
+        for name in DELIBERATELY_UNLIKE:
+            with self.subTest(recorded=name):
+                self.assertIn(name, other,
+                              "%s is recorded as deliberately unlike and the two definitions now "
+                              "agree, or one is gone -- drop the entry" % name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`matrixark_mcp_core` imports `CONTEXT_PACK_DEBUG_REFS` and `AUDIT_DEBUG_PAYLOAD` from
`matrixark_mcp_runtime_config` — and then re-reads both from the environment fifteen lines below the
import. The imported values were overwritten before anything could use them: **the import was
dead**, and a change to either definition in `runtime_config` could never have reached core.

They agree today. Executed across every spelling:

| value | core | runtime_config |
|---|---|---|
| `""` / `0` / `off` / `garbage` | False | False |
| `1` / `on` / `true` / `yes` | True | True |

Both call `env_bool` on the same variable with the same default. That is why nobody noticed, and
what makes it a trap rather than a typo: the duplication is invisible until the day the two stop
agreeing, and on that day the file that looks authoritative loses.

### Seventy-seven more, deliberately not swept

The two are part of a larger shape: **77 constants are defined identically in both modules** — each
one environment variable read twice, at two import times, into two names that agree because the text
is character-for-character the same in both files. That is not a mechanism; it is a coincidence
maintained by hand.

They are **not** rewritten here. Moving 77 definitions in one commit is the mechanical rewrite this
tree has been burned by: every guard that reads *"module X reads flag Y"* changes answer on the same
commit, and one real divergence hiding among 77 identical-looking moves is invisible in the diff. So
the count is ratcheted — it may only go **down**, one reading at a time.

One shared name is *not* identical, and it is the pattern the other 77 are missing: core binds
`DEFAULT_MAX_CONTEXT_TOKENS` from `_RUNTIME_DEFAULT_MAX_CONTEXT_TOKENS`, the aliased import. It is
recorded by name so it is never swept in with the rest, and the guard fails if it ever becomes
identical *or* disappears.

### The guard

`test_two_modules_do_not_read_the_same_variable` refuses any future import-then-overwrite, ratchets
the 77, checks that every non-identical shared name has a recorded reason, and has a control on its
own input — a parse returning nothing would satisfy every other check.

Mutation-tested by putting one shadowing re-read back: two of the four checks go red and both name
it.

### Also: the tests-only list is banked again

`pipeline_task_footprint_stats` gained a production caller in #1570, which put rows against distinct
tasks on the local adapter dashboard. Third name to leave that list in a week — the list working,
not the list being wrong.
