### PR TITLE
Fingerprint a dump manifest only when a bucket consults it

### DIFF
--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -762,16 +762,24 @@ impl TemporalEngine {
         // finish in ten minutes with a core pegged at 100%. Reclaim is the only thing that
         // removes WAL and index-log bytes, so a shard large enough to need it was a shard on
         // which it could not run.
-        let manifest_fingerprints = manifests
-            .iter()
-            .map(|manifest| {
-                crate::engine::decode_index_bytes(&manifest.index_bytes)
-                    .ok()
-                    .map(|manifest_state| {
-                        bucket_generation_fingerprints_by_bucket(&manifest_state)
-                    })
-            })
-            .collect::<Vec<_>>();
+        // Fingerprint a manifest only when a bucket actually reaches it.
+        //
+        // This was an EAGER pass over every retained manifest, and each entry is a full
+        // shard-sized walk: `bucket_generation_fingerprints_by_bucket` calls
+        // `collect_live_page_entries`. So the plan paid one whole-shard walk PER RETAINED
+        // MANIFEST, every round, before knowing whether any bucket would consult them --
+        // measured by `which_stages_walk_every_live_page` as the bulk of reclaim_wal's 16x.
+        //
+        // The search below is newest-first and short-circuits, and most buckets match the
+        // newest manifest, so nearly all of those walks were computed and thrown away.
+        //
+        // `None` = not computed yet. `Some(None)` = computed, and its index would not decode
+        // (which matched nothing before and matches nothing now). `Some(Some(map))` = computed.
+        // The memo lives for THIS call only, so there is no cross-round staleness question: a
+        // manifest's index bytes cannot change while one plan is being built.
+        let mut manifest_fingerprints: Vec<
+            Option<Option<BTreeMap<u32, BTreeSet<String>>>>,
+        > = (0..manifests.len()).map(|_| None).collect();
 
         // Index each manifest's bucket summaries BY ROUTING BUCKET, once.
         //
@@ -802,32 +810,50 @@ impl TemporalEngine {
             .collect::<Vec<_>>();
 
         for summary in &bucket_summaries {
-            let matching_manifest = manifests
-                .iter()
-                .enumerate()
-                .rev()
-                .find(|(manifest_index, manifest)| {
-                    // A manifest whose index will not decode matched nothing before and
-                    // matches nothing now.
-                    let Some(manifest_bucket_fingerprints) =
-                        manifest_fingerprints[*manifest_index].as_ref()
-                    else {
-                        return false;
-                    };
-                    manifest_summaries_by_bucket[*manifest_index]
-                        .get(&summary.routing_bucket)
-                        .is_some_and(|candidates| {
-                            candidates.iter().any(|manifest_summary| {
-                                bucket_dump_summary_matches_current_generation(
-                                    manifest_summary,
-                                    summary,
-                                    manifest_bucket_fingerprints,
-                                    &current_bucket_fingerprints,
-                                )
-                            })
-                        })
-                })
-                .map(|(_, manifest)| manifest);
+            // Same search as before -- newest manifest first, first match wins -- written as a
+            // loop rather than `find` so the fingerprint memo above can be filled on demand.
+            //
+            // The CHEAP test now comes first. A manifest carrying no summary for this bucket
+            // could never match (the predicate's first condition is that the routing buckets are
+            // equal), so asking that before fingerprinting skips the walk entirely for every
+            // manifest that does not cover this bucket.
+            let mut matching_manifest = None;
+            for (manifest_index, manifest) in manifests.iter().enumerate().rev() {
+                let Some(candidates) =
+                    manifest_summaries_by_bucket[manifest_index].get(&summary.routing_bucket)
+                else {
+                    continue;
+                };
+                if manifest_fingerprints[manifest_index].is_none() {
+                    manifest_fingerprints[manifest_index] = Some(
+                        crate::engine::decode_index_bytes(&manifest.index_bytes)
+                            .ok()
+                            .map(|manifest_state| {
+                                bucket_generation_fingerprints_by_bucket(&manifest_state)
+                            }),
+                    );
+                }
+                // A manifest whose index will not decode matched nothing before and matches
+                // nothing now.
+                let Some(manifest_bucket_fingerprints) = manifest_fingerprints[manifest_index]
+                    .as_ref()
+                    .expect("fingerprint memo filled above")
+                    .as_ref()
+                else {
+                    continue;
+                };
+                if candidates.iter().any(|manifest_summary| {
+                    bucket_dump_summary_matches_current_generation(
+                        manifest_summary,
+                        summary,
+                        manifest_bucket_fingerprints,
+                        &current_bucket_fingerprints,
+                    )
+                }) {
+                    matching_manifest = Some(manifest);
+                    break;
+                }
+            }
             let Some(manifest) = matching_manifest else {
                 // No manifest covers this bucket. It is still allowed to hold the logs only from
                 // its own oldest undumped write, PROVIDED it can name that point in both logs.

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -7760,6 +7760,81 @@ saved {:>7.2} ms per round",
     }
 }
 
+/// Building the WAL reclaim plan must not get dearer for every dump manifest that is retained.
+///
+/// `bucket_generation_fingerprints_by_bucket` walks every live page in the shard. The plan used
+/// to call it once per retained manifest, EAGERLY, before knowing whether any bucket would consult
+/// them -- so the plan's cost scaled with how many manifests happened to be retained, a quantity
+/// that has nothing to do with what the round was asked to do.
+///
+/// The fingerprints are now computed on first use, and a manifest that carries no summary for a
+/// bucket is skipped before it is fingerprinted at all. This pins that: quadrupling the manifest
+/// count must not multiply the live-page scan volume.
+#[test]
+fn fingerprinting_does_not_scale_with_the_manifest_count() {
+    let scan_volume_for = |manifest_count: usize| -> (u64, usize) {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            16 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        for round in 0..manifest_count {
+            // Write between manifests so each one lands on a distinct index-log sequence: the
+            // manifest id is {shard}-{sequence}-{ms}, and two built back to back inside one
+            // millisecond with no write between them would collide.
+            for index in 0..64 {
+                let response = engine.execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringSet {
+                        key: format!("fp-{round:03}-{index:04}"),
+                        value: vec![b'v'; 64],
+                    },
+                });
+                assert!(response.status.ok, "write: {:?}", response.status);
+            }
+            let _ = engine.create_bucket_dump_manifest(1, Vec::new());
+        }
+        let manifests = engine.list_bucket_dump_manifests(1).len();
+
+        crate::engine::reset_live_page_scan_entries();
+        let _ = engine.storage_wal_reclaim_plan(1, Vec::new(), Vec::new());
+        (crate::engine::live_page_scan_entries(), manifests)
+    };
+
+    let (few_volume, few_manifests) = scan_volume_for(2);
+    let (many_volume, many_manifests) = scan_volume_for(8);
+
+    // Denominators. Without these, a fixture that retained one manifest either way -- or that
+    // scanned nothing -- would satisfy the ratio below while measuring nothing at all.
+    assert!(
+        many_manifests > few_manifests,
+        "fixture did not actually retain more manifests: {few_manifests} then {many_manifests}",
+    );
+    assert!(
+        few_volume > 0 && many_volume > 0,
+        "the plan scanned no live pages, so this measures nothing: {few_volume} then {many_volume}",
+    );
+
+    // The 8-manifest shard also holds 4x the records, so its per-plan walk is legitimately
+    // larger. What must NOT happen is the walk multiplying by the MANIFEST count on top of that.
+    // Normalise by records to separate the two.
+    let few_per_record = few_volume as f64 / (2 * 64) as f64;
+    let many_per_record = many_volume as f64 / (8 * 64) as f64;
+    eprintln!(
+        "  {few_manifests} manifests -> {few_volume} entries ({few_per_record:.1}/record); \
+{many_manifests} manifests -> {many_volume} entries ({many_per_record:.1}/record)",
+    );
+    assert!(
+        many_per_record <= few_per_record * 1.5,
+        "the WAL reclaim plan's scan volume grew with the manifest count: \
+{few_manifests} manifests = {few_per_record:.1} entries/record, \
+{many_manifests} manifests = {many_per_record:.1} entries/record",
+    );
+}
+
 ///   cargo test --features alloc-probe -p temporalstore-rust --lib what_a_bounded_slot_range_saves -- --ignored --nocapture --test-threads=1
 #[test]
 #[ignore]


### PR DESCRIPTION
`bucket_generation_fingerprints_by_bucket` walks **every live page in the shard**.
`storage_wal_reclaim_plan` called it **once per retained dump manifest, eagerly**, before knowing
whether any bucket would consult them. So building the plan cost one whole-shard walk per
manifest, and its cost scaled with how many manifests happened to be retained — not with anything
the round was asked to work on.

The search that consumes them is newest-first and short-circuits, and the predicate's **first**
condition is that the routing buckets are equal. So a manifest carrying no summary for a bucket
could never match — yet was fingerprinted anyway.

## Two changes, both semantics-preserving

1. **Ask the cheap question first.** `manifest_summaries_by_bucket[i].get(&bucket)` is a hash
   lookup, and a miss means this manifest cannot match, so it is skipped before being
   fingerprinted at all.
2. **Compute on first use**, memoized for the rest of the call. The memo lives for **one** plan
   build, so there is no cross-round staleness question: a manifest's index bytes cannot change
   while a single plan is being computed.

The search is still newest-first, first-match-wins, and a manifest whose index will not decode
still matches nothing. `find` became an explicit loop only so the memo could be filled on demand.

## Measured — and the first measurement was the wrong one

`which_stages_walk_every_live_page` reads **identically** before and after: 35.0× total,
`reclaim_wal` 16.0× either way. That fixture is a fresh shard holding almost no manifests, so the
eager pass was already cheap there and this changes nothing on it.

Attributing that stage's 16× to manifest fingerprinting — as an earlier note did — was arithmetic
on an *assumed* manifest count rather than a measured one. What drives that 16× is still
unattributed and should be measured, not guessed at again.

Where this **does** bite is when manifests accumulate, which is the steady state on a live shard.
`fingerprinting_does_not_scale_with_the_manifest_count`, added here:

| manifests | before | after |
|---|---|---|
| 2 | 448 entries (3.5 / record) | 384 entries (3.0 / record) |
| 8 | 3,328 entries (6.5 / record) | 1,536 entries (**3.0** / record) |

Flat instead of growing, and **2.17× less scan volume** at eight manifests.

## Verification

**Mutation:** with the two changes reverted the guard fails with *"the WAL reclaim plan's scan
volume grew with the manifest count: 2 manifests = 3.5 entries/record, 8 manifests = 6.5
entries/record"*.

**Denominators first**, so a fixture that retained no extra manifests — or scanned nothing — fails
loudly instead of satisfying a ratio while measuring nothing. The ratio is normalised per record
because the eight-manifest shard also holds four times the records, and without that the fixture's
own growth would mask the effect being tested.

`cargo test -p temporalstore-rust --lib -- --test-threads=1` → **1779 passed, 1 failed**. The
single failure is `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the standing
`--lib` baseline failure on main, not introduced here.
