### PR TITLE
Two switches whose only effect was to write the duplicate back

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -1171,21 +1171,6 @@ SETTINGS.extend([
             "failing hook blocks the operation it was called from. On is the safer default for "
             "an agent hook: a memory write that cannot happen should not stop the work that "
             "produced it."),
-    Setting("skills.dedupe_skill_chunk_embedding", "skills", "MATRIXARK_DEDUPE_SKILL_CHUNK_EMBEDDING",
-            "Dedupe skill chunk embedding", "bool", "1", "restart",
-            "Stores one vector per skill chunk instead of two. A skill chunk used to store the "
-            "SAME vector twice -- once as embedding_type resource_chunk, once as skill_section, "
-            "under the same ref_hash -- and retrieval keys its vector map on ref_hash alone, so "
-            "the second copy only ever overwrote the first with an identical value. About 37% "
-            "of what a skill ingest writes, for nothing. Off restores the second copy."),
-    Setting("skills.dedupe_skill_chunk_text", "skills", "MATRIXARK_DEDUPE_SKILL_CHUNK_TEXT",
-            "Dedupe skill chunk text", "bool", "1", "restart",
-            "Stores a skill chunk's text once instead of twice. It used to be written byte for "
-            "byte as both resource_chunk and skill_section: measured on a 1.41 MB markdown "
-            "skill, 411 chunks and 411 sections with all 411 section texts identical to a "
-            "chunk's, and resource_chunk was 42.1% of the bytes that ingest wrote. Retrieval "
-            "does not read it -- the skill scan skips resource_chunk and serves the section. "
-            "Off restores the second copy."),
     Setting("storage_engine.index_keyword_limit", "storage_engine", "MATRIXARK_INDEX_KEYWORD_LIMIT",
             "Index keyword limit", "int", "12", "restart",
             "How many terms per chunk reach the lexical index. 12 covers little more than a "

--- a/tools/matrixark_mcp_ingest_resource_chunk_records.py
+++ b/tools/matrixark_mcp_ingest_resource_chunk_records.py
@@ -111,14 +111,6 @@ INDEX_POSTING_LISTS = os.environ.get(
     "MATRIXARK_INDEX_POSTING_LISTS", "1"
 ).strip().lower() not in {"0", "false", "no", "off"}
 
-#: Read like INDEX_ONLY_CONSULTABLE_TERMS above: case folded, whitespace stripped, and every
-#: FALSE_VALUES spelling accepted. It used to be `not in {"0", "false", "False", ""}` with no
-#: strip or lower, so `=off`, `=no` and `=FALSE` all read as TRUE and left the flag on --
-#: a false spelling turning it on rather than off.
-DEDUPE_SKILL_CHUNK_EMBEDDING = os.environ.get(
-    "MATRIXARK_DEDUPE_SKILL_CHUNK_EMBEDDING", "1"
-).strip().lower() not in {"0", "false", "no", "off"}
-
 # A skill chunk's text is written TWICE: once as `resource_chunk` and once as `skill_section`,
 # byte for byte. Measured on a 1.41 MB markdown skill: 411 chunks and 411 sections, and all 411
 # section texts identical to a chunk's -- `resource_chunk` is 42.1% of the bytes a skill ingest
@@ -139,14 +131,6 @@ except ImportError:  # top-level path
         MAX_SECONDARY_INDEX_REFS_PER_POSTING,
         _chunked_refs as chunked_posting_refs,
     )
-
-#: Read like INDEX_ONLY_CONSULTABLE_TERMS above: case folded, whitespace stripped, and every
-#: FALSE_VALUES spelling accepted. It used to be `not in {"0", "false", "False", ""}` with no
-#: strip or lower, so `=off`, `=no` and `=FALSE` all read as TRUE and left the flag on --
-#: a false spelling turning it on rather than off.
-DEDUPE_SKILL_CHUNK_TEXT = os.environ.get(
-    "MATRIXARK_DEDUPE_SKILL_CHUNK_TEXT", "1"
-).strip().lower() not in {"0", "false", "no", "off"}
 
 RESOURCE_APPEND_BATCH_RECORDS = 512
 
@@ -235,7 +219,9 @@ def append_resource_chunk_records(
         # above. Retrieval skips it (`resource_chunk` + `resource_type == "skill"` is filtered out
         # of the resource/skill scan) and the dashboard now reads the section, so writing it costs
         # 42.1% of a skill ingest's bytes for a duplicate nobody reads.
-        if skill_hash is None or not DEDUPE_SKILL_CHUNK_TEXT:
+        # The condition carried `or not <the text switch>` until it was folded. Turning that
+        # switch off did one thing: write the duplicate back.
+        if skill_hash is None:
             owner_record = (
                 resource_record_builders.resource_chunk_record(
                     import_task_hash=resource_import_task_hash,
@@ -280,7 +266,8 @@ def append_resource_chunk_records(
         # its vector map on ref_hash ALONE and both land in it, so the second copy only ever
         # overwrote the first with an identical value - about 37% of what a skill ingest
         # writes, for nothing. Skills now store the skill_section copy only.
-        if skill_hash is None or not DEDUPE_SKILL_CHUNK_EMBEDDING:
+        # The condition carried `or not <the embedding switch>` until it was folded.
+        if skill_hash is None:
             pending_records.append(
                 resource_record_builders.context_embedding_record(
                     embedding_type="resource_chunk",

--- a/tools/test_the_flag_surface_only_shrinks.py
+++ b/tools/test_the_flag_surface_only_shrinks.py
@@ -88,7 +88,7 @@ _IDENTITY = re.compile(
 #: flags nothing sets, and 36 of those were the last read of their variable. Banked here in the
 #: same breath, because a ratchet that does not bank a reduction is the reduction nobody can see
 #: was made, and the check below refuses a ceiling left drifting above the truth.
-MAXIMUM_FLAGS_READ = 484
+MAXIMUM_FLAGS_READ = 482
 
 
 #: Candidates that have been read one at a time, with what was found. **Not a skip list**: the


### PR DESCRIPTION
`MATRIXARK_DEDUPE_SKILL_CHUNK_EMBEDDING` and `MATRIXARK_DEDUPE_SKILL_CHUNK_TEXT` are folded to the
value they have always defaulted to. Both are ON by default, and the portal help for each says what
OFF does in so many words: *"Off restores the second copy."*

What the second copy was, from the commits that added these two (#425 and its follow-up,
2026-08-28 / 29):

| | |
|---|---|
| **the vector** | A skill chunk stored the *same* vector twice — once as `embedding_type resource_chunk`, once as `skill_section`, under the same `ref_hash`. Retrieval keys its vector map on `ref_hash` **alone**, so the second copy only ever overwrote the first with an identical value. About **37%** of what a skill ingest writes, for nothing. |
| **the text** | Written byte for byte as both `resource_chunk` and `skill_section`. Measured on a 1.41 MB markdown skill: 411 chunks, 411 sections, all 411 section texts identical to a chunk's, and `resource_chunk` was **42.1%** of the bytes the ingest wrote. Retrieval never reads it — the skill scan skips `resource_chunk` outright when `resource_type == "skill"` and serves the section. |

So the off position restores a measured write amplification in exchange for nothing any reader
consults. That is not a control an operator chooses between; it is a rollback switch for a fix, and
the fix is two weeks old.

### What folding means here, exactly

Both conditions read `if skill_hash is None or not <switch>:`. With the switch at its default the
second disjunct is never true, so the condition is `if skill_hash is None:` — which is what the two
lines now say. Non-skill chunks still write the record, as they always did; skill chunks stop
writing the duplicate, as they already did. **No behaviour changes at the default**, and the default
is the only value the portal has ever shipped.

The two portal `Setting`s go with them, since a knob that cannot be turned should not be offered.
Neither was in `matrixark_load_config.ENV_MAP`, so no config key is orphaned.

```
flags read   484 -> 482, banked in the ceiling
```

### Reversibility, stated plainly

Reverting this commit restores both switches and their default behaviour. What it cannot restore is
a deployment that had set either to `off` — that deployment would have been paying 37% and 42% of
its skill-ingest writes for copies nothing reads, and after this it stops, silently. Nothing in the
repository sets either, and neither appears in any config file, container or profile.
