### PR TITLE
A third module holding copies that differ only in plumbing

### DIFF
--- a/tools/matrixark_mcp_budget_pack.py
+++ b/tools/matrixark_mcp_budget_pack.py
@@ -90,66 +90,21 @@ except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_core_identity import normalize_message_role
 
 
+# `prefer_profile_entities_for_current_state` joined it, and the copy here was NOT a spelling
+# difference. It tested `question_type not in {"current_state", "latest"}` where the live one also
+# lists "profile_memory" -- so a profile_memory query returned unchanged through this module and
+# never got the 0.18 boost the live path gives it. The other difference, an inlined
+# min/max instead of clamp01, does nothing.
 try:  # the implementation lives in matrixark_mcp_core_ref_selection; this module re-exports it
-    from .matrixark_mcp_core_ref_selection import entity_current_state_key
+    from .matrixark_mcp_core_ref_selection import (
+        entity_current_state_key,
+        prefer_profile_entities_for_current_state,
+    )
 except ImportError:  # Direct script execution from tools/.
-    from matrixark_mcp_core_ref_selection import entity_current_state_key
-
-
-def prefer_profile_entities_for_current_state(candidates: list[Json], question_type: str) -> list[Json]:
-    if question_type not in {"current_state", "latest"}:
-        return candidates
-    latest_profile_by_entity: dict[tuple[str, str], Json] = {}
-    latest_profile_by_source_entity_hash: dict[Any, Json] = {}
-    for candidate in candidates:
-        key = entity_current_state_key(candidate)
-        if key is None:
-            continue
-        if str(candidate.get("memory_scope") or "") != "user_profile":
-            continue
-        if str(candidate.get("session_continuity") or "") != "cross_session":
-            continue
-        existing = latest_profile_by_entity.get(key)
-        if existing is None or int(candidate.get("updated_at_ms") or 0) >= int(existing.get("updated_at_ms") or 0):
-            latest_profile_by_entity[key] = candidate
-        for source_entity_hash in candidate.get("source_entity_hashes", []):
-            existing_by_source = latest_profile_by_source_entity_hash.get(source_entity_hash)
-            if existing_by_source is None or int(candidate.get("updated_at_ms") or 0) >= int(existing_by_source.get("updated_at_ms") or 0):
-                latest_profile_by_source_entity_hash[source_entity_hash] = candidate
-    if not latest_profile_by_entity:
-        return candidates
-    adjusted: list[Json] = []
-    for candidate in candidates:
-        key = entity_current_state_key(candidate)
-        profile = latest_profile_by_source_entity_hash.get(candidate.get("ref_hash"))
-        if profile is None and key is not None:
-            profile = latest_profile_by_entity.get(key)
-        if profile is None:
-            adjusted.append(candidate)
-            continue
-        if candidate is profile or candidate.get("ref_hash") == profile.get("ref_hash"):
-            adjusted.append({
-                **candidate,
-                "score": min(1.0, max(0.0, float(candidate.get("score", 0.0)) + 0.18)),
-                "profile_current_state_boost": 0.18,
-                "selection_reason": candidate.get("selection_reason") or "current profile entity preferred over session-local historical state",
-            })
-            continue
-        if str(candidate.get("memory_scope") or "") == "session":
-            adjusted.append({
-                **candidate,
-                "stale_or_superseded": True,
-                "profile_shadowed_by_ref_hash": profile.get("ref_hash"),
-                "profile_shadowed_reason": (
-                    "source_entity_lineage"
-                    if candidate.get("ref_hash") in set(profile.get("source_entity_hashes", []))
-                    else "same_entity_identity"
-                ),
-                "selection_reason": candidate.get("selection_reason") or "session-local entity kept as historical evidence behind current profile state",
-            })
-            continue
-        adjusted.append(candidate)
-    return adjusted
+    from matrixark_mcp_core_ref_selection import (
+        entity_current_state_key,
+        prefer_profile_entities_for_current_state,
+    )
 
 
 try:  # the implementation lives in matrixark_mcp_core_ref_selection; this module re-exports it

--- a/tools/matrixark_mcp_extraction_normalization.py
+++ b/tools/matrixark_mcp_extraction_normalization.py
@@ -661,6 +661,16 @@ except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_core import canonical_entity_name
 
 
+# `dedupe_entities` joined them, and the copy here was missing a whole step: the live one calls
+# `drop_directive_duplicates(out)` before ranking and this one did not. That is the example the
+# diverged-copy guard cites in its own docstring, and the function it dropped is defined only in
+# matrixark_mcp_core -- so the copy could not have called it without this import.
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import dedupe_entities
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import dedupe_entities
+
+
 def entity_retention_priority(entity: Json) -> int:
     entity_type = str(entity.get("entity_type") or "").strip().lower()
     entity_name = str(entity.get("entity_name") or "").strip().lower()
@@ -688,30 +698,6 @@ def entity_retention_priority(entity: Json) -> int:
     if entity_type in {"assistant_decision", "tool_evidence"}:
         return 3
     return 4
-
-
-def dedupe_entities(entities: list[Json]) -> list[Json]:
-    seen = set()
-    positions: dict[tuple[Any, str], int] = {}
-    out = []
-    for entity in entities:
-        key = (entity.get("entity_type"), str(entity.get("entity_name", "")).lower())
-        if key in seen:
-            existing = out[positions[key]]
-            if entity_retention_priority(entity) < entity_retention_priority(existing):
-                out[positions[key]] = entity
-                continue
-            if entity.get("entity_type") == "tool_evidence" and existing.get("state"):
-                continue
-            if entity.get("entity_name") == entity.get("entity_type"):
-                out[positions[key]] = entity
-            continue
-        seen.add(key)
-        positions[key] = len(out)
-        out.append(entity)
-    ranked = sorted(enumerate(out), key=lambda item: (entity_retention_priority(item[1]), item[0]))
-    kept_indexes = {index for index, _entity in ranked[:20]}
-    return [entity for index, entity in enumerate(out) if index in kept_indexes]
 
 
 def ordered_unique(values: list[str]) -> list[str]:

--- a/tools/matrixark_mcp_extraction_normalization.py
+++ b/tools/matrixark_mcp_extraction_normalization.py
@@ -237,65 +237,6 @@ except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_core_codex_outcome import CODEX_OUTCOME_ENTITY_TYPES
 
 
-def codex_outcome_fact_entities(
-    text: str,
-    *,
-    role_name: str,
-    source_refs: list[str],
-    source_count: int,
-) -> list[Json]:
-    source_role = "tool" if role_name == "tool" else "assistant"
-    entities: list[Json] = []
-    seen: set[tuple[str, str, str]] = set()
-
-    def outcome_candidate_chunks(compact_line: str) -> list[str]:
-        chunks: list[str] = []
-        for semicolon_part in re.split(r"\s*;\s*", compact_line):
-            for sentence in re.split(
-                r"(?<=[.!?])\s+(?=(?:I|We|Codex|Assistant|Tool|Next|Changed|Outcome|Validation|Blocked|Implemented|Fixed|Added|Removed|Updated|Configured|Installed|Pushed|Published|Deployed|Merged|Rebased|Recovered|Promoted|Indexed|Budgeted|Batched|Flushed)\b)",
-                semicolon_part,
-            ):
-                chunk = sentence.strip()
-                if chunk:
-                    chunks.append(chunk)
-        return chunks or ([compact_line] if compact_line else [])
-
-    for raw_line in str(text or "").splitlines():
-        compact_line = " ".join(raw_line.split()).strip(" -*")
-        for candidate in outcome_candidate_chunks(compact_line):
-            line = summarize_text(re.sub(r"^(?:assistant|tool)\s*:\s*", "", candidate, flags=re.IGNORECASE), limit=220)
-            if not line:
-                continue
-            kind = codex_outcome_fact_kind(line)
-            if not kind:
-                continue
-            entity_type = codex_outcome_entity_type(kind)
-            normalized_fact = normalized_index_value(line)
-            key = (entity_type, source_role, normalized_fact)
-            if key in seen:
-                continue
-            seen.add(key)
-            state = summarize_text(f"{source_role} {kind}: {line}", limit=220)
-            entities.append(
-                {
-                    "entity_type": entity_type,
-                    "entity_name": summarize_text(f"{entity_type}:{normalized_fact or line}", limit=96),
-                    "state": state,
-                    "confidence": 0.9 if kind in {"outcome", "validation"} else 0.86,
-                    "source_refs": source_refs,
-                    "source_roles": [source_role],
-                    "source_role_counts": {source_role: source_count},
-                    "operator": normalize_entity_operator(None, entity_type),
-                    "field_patches": [entity_patch("", summarize_text(state, limit=180))],
-                }
-            )
-            if len(entities) >= 8:
-                break
-        if len(entities) >= 8:
-            break
-    return entities
-
-
 def extract_batch_entities(messages: list[Json], envelope: Json) -> list[Json]:
     entities: list[Json] = []
     text = text_from_messages(messages)
@@ -671,33 +612,29 @@ except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_core import dedupe_entities
 
 
-def entity_retention_priority(entity: Json) -> int:
-    entity_type = str(entity.get("entity_type") or "").strip().lower()
-    entity_name = str(entity.get("entity_name") or "").strip().lower()
-    source_roles = {
-        str(role or "").strip().lower()
-        for role in entity.get("source_roles", [])
-        if str(role or "").strip()
-    }
-    if entity_type in {
-        "identity_profile",
-        "communication_profile",
-        "workspace_profile",
-        "preference",
-        "approval_state",
-        "correction",
-        "memory_feature_profile",
-    }:
-        return 0
-    if "user" in source_roles or entity_type in {"current_plan", "confirmation"}:
-        return 1
-    if entity_type in CODEX_OUTCOME_ENTITY_TYPES:
-        return 2
-    if entity_type in {"assistant_decision", "tool_evidence"} and ":" in entity_name:
-        return 2
-    if entity_type in {"assistant_decision", "tool_evidence"}:
-        return 3
-    return 4
+# `entity_retention_priority` joined them, and this copy was the poorer one in a way that changes
+# what survives a dedupe. It normalised each source role with a bare `strip().lower()` where the
+# live copy calls `normalized_extraction_message_role`, which MAPS aliases -- human and prompt to
+# user, agent/ai/bot/llm/model to assistant, tool_result to tool. Executed both:
+#
+#     source_roles=["user"]     live 1   orphan 1
+#     source_roles=["human"]    live 1   orphan 4
+#     source_roles=["prompt"]   live 1   orphan 4
+#
+# Priority 1 against 4 is kept against dropped when dedupe_entities ranks, so an entity whose role
+# was recorded as "human" was retained through one path and discarded through the other.
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import entity_retention_priority
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import entity_retention_priority
+
+
+# `codex_outcome_fact_entities` differed only by inlining a local: the live copy binds
+# `entity_name` and then uses it, this one called summarize_text in place. Same value.
+try:  # the implementation lives in matrixark_mcp_core_codex_outcome; this module re-exports it
+    from .matrixark_mcp_core_codex_outcome import codex_outcome_fact_entities
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_codex_outcome import codex_outcome_fact_entities
 
 
 def ordered_unique(values: list[str]) -> list[str]:

--- a/tools/matrixark_mcp_extraction_normalization.py
+++ b/tools/matrixark_mcp_extraction_normalization.py
@@ -77,6 +77,20 @@ def normalize_source_role_counts(raw_counts: Any, fallback_roles: list[str] | No
     return counts
 
 
+# NOT re-exported, and this is the one that goes the other way.
+#
+# matrixark_mcp_core_extraction defines normalize_extracted_entities too, and THIS copy is the
+# fuller one: it populates `source_roles` and `source_role_counts` on each entity and the live copy
+# does not. Those are not decorative -- `entity_retention_priority`, re-exported just above, ranks
+# on `"user" in source_roles`, so the field decides what survives a dedupe.
+#
+# It is not evidence of a live hole either: matrixark_mcp_core_codex_outcome and
+# matrixark_mcp_recovery both write source_roles onto entities on live paths, so entities reaching
+# that ranking are not all role-less. Whether THIS normaliser should populate it as well is a
+# question about the extraction path, not a consolidation, and consolidating toward the live copy
+# would silently drop the field.
+
+
 def normalize_extracted_entities(raw_entities: Any, *, fallback_text: str, source_refs: list[str], extracted_by: str) -> list[Json]:
     if not isinstance(raw_entities, list):
         return []
@@ -547,49 +561,6 @@ def extract_batch_entities(messages: list[Json], envelope: Json) -> list[Json]:
     return dedupe_entities(entities)
 
 
-def infer_entity_field_patches(entity_type: str, value: str, text: str) -> list[Json]:
-    patches: list[Json] = []
-    correction = re.search(
-        r"\b(?:correction|correct|wrong|updated|changed)[:\s]+([^.;!?]+?)\s+(?:instead\s+of|not)\s+([^.;!?]+)",
-        text,
-        flags=re.IGNORECASE,
-    )
-    if correction:
-        replace = clean_patch_value(correction.group(1))
-        search = clean_patch_value(correction.group(2))
-        patches.append(entity_patch(search, replace))
-    preference = re.search(
-        r"\b(?:prefer|prefers|favorite|likes?|loves?)\s+([^.;!?]+?)\s+(?:now|instead\s+of|not)\s+([^.;!?]+)",
-        text,
-        flags=re.IGNORECASE,
-    )
-    if entity_type == "preference" and preference:
-        replace = clean_patch_value(preference.group(1))
-        search = clean_patch_value(preference.group(2))
-        patches.append(entity_patch(search, replace))
-    evolving_entity_types = {
-        "preference",
-        "location",
-        "job_status",
-        "current_plan",
-        "family_profile",
-        "identity_profile",
-        "communication_profile",
-        "memory_feature_profile",
-        "workspace_profile",
-        "relationship",
-        "approval_state",
-        "correction",
-        "confirmation",
-        "assistant_decision",
-        "tool_evidence",
-        *CODEX_OUTCOME_ENTITY_TYPES,
-    }
-    if entity_type in evolving_entity_types and not patches and value:
-        patches.append(entity_patch("", summarize_text(value, limit=180)))
-    return patches[:3]
-
-
 try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
     from .matrixark_mcp_core import clean_patch_value
 except ImportError:  # Direct script execution from tools/.
@@ -627,6 +598,22 @@ try:  # the implementation lives in matrixark_mcp_core; this module re-exports i
     from .matrixark_mcp_core import entity_retention_priority
 except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_core import entity_retention_priority
+
+
+# `infer_entity_field_patches` joined them, and the live copy is better in two ways.
+#
+# It has a third branch this one lacked: a negative preference such as "we should avoid tabs in
+# this repository" produces a patch there and nothing here -- executed both ways.
+#
+# And it reads the document through `_whole_text_patch_scans`, an lru_cached helper whose docstring
+# records why: this function is called once per extracted entity and each call re-ran three
+# whole-document regexes, so the work grew as the square of the entity count -- ~33 seconds on a
+# 256 KB markdown ingest against ~1.2 s for a JSON document of the same size. The copy here still
+# inlined the three searches, so it never got that fix either.
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from .matrixark_mcp_core import infer_entity_field_patches
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import infer_entity_field_patches
 
 
 # `codex_outcome_fact_entities` differed only by inlining a local: the live copy binds

--- a/tools/matrixark_mcp_oss_understanding.py
+++ b/tools/matrixark_mcp_oss_understanding.py
@@ -44,24 +44,26 @@ UNDERSTANDING_LABELS: dict[str, str] = {
 _OSS_UNDERSTANDING_PROTOTYPE_CACHE: dict[str, dict[str, list[float]]] = {}
 
 
-def _core_runtime() -> Any:
-    try:
-        from tools import matrixark_mcp_core as core
-    except ModuleNotFoundError:  # Direct script execution from tools/.
-        import matrixark_mcp_core as core
-    return core
-
-
 def require_oss_understanding() -> bool:
     return os.getenv("MATRIXARK_REQUIRE_OSS_UNDERSTANDING", "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 # Not defined here: the implementation lives in matrixark_mcp_core and this module carried an
 # identical second copy of each.
+#
+# The last two joined them by losing a lazy accessor -- import matrixark_mcp_core inside the call
+# and reach names off the module object. The only thing it bought was that this module's copies
+# could say `core.dedupe_entities(...)` where the live ones say `dedupe_entities(...)`. That one
+# token was the entire divergence between them.
+#
+# It looked like cycle avoidance and was not: this import block already binds core at module scope,
+# and matrixark_mcp_core does not import this module at all.
 try:
     from tools.matrixark_mcp_core import (
         oss_encoder_compact_extraction,
         oss_encoder_event_type,
+        oss_encoder_extract_batch_entities,
+        oss_encoder_memory_segments,
         oss_encoder_rank_labels,
         prototype_vectors,
         understanding_provider,
@@ -70,89 +72,11 @@ except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_core import (
         oss_encoder_compact_extraction,
         oss_encoder_event_type,
+        oss_encoder_extract_batch_entities,
+        oss_encoder_memory_segments,
         oss_encoder_rank_labels,
         prototype_vectors,
         understanding_provider,
     )
 
 
-def oss_encoder_extract_batch_entities(messages: list[Json], envelope: Json) -> list[Json]:
-    core = _core_runtime()
-    text = text_from_messages(messages)
-    ranked = oss_encoder_rank_labels(text, UNDERSTANDING_LABELS, limit=8)
-    source_event_ids = envelope.get("source_event_ids", [])
-    source_refs = [str(ref) for ref in source_event_ids] if isinstance(source_event_ids, list) and source_event_ids else [str(index) for index, _ in enumerate(messages)]
-    entities: list[Json] = []
-    for item in ranked:
-        label = str(item["label"])
-        if label == "approval":
-            entity_type = "approval_state"
-        elif label == "status_update":
-            entity_type = "job_status"
-        elif label == "plan_update":
-            entity_type = "current_plan"
-        elif label == "preference_update":
-            entity_type = "preference"
-        else:
-            entity_type = label
-        if float(item["score"]) < 0.42 and entity_type != "session":
-            continue
-        state = summarize_text(f"{entity_type}: {text}", limit=220)
-        entities.append(
-            {
-                "entity_type": entity_type,
-                "entity_name": core.canonical_entity_name(entity_type, state) or entity_type,
-                "state": state,
-                "confidence": round(float(item["score"]), 6),
-                "source_refs": source_refs,
-                "operator": core.normalize_entity_operator(None, entity_type),
-                "field_patches": [entity_patch("", state)] if entity_type != "session" else [],
-                "extracted_by": "oss_encoder",
-            }
-        )
-    if not entities:
-        entities.append(
-            {
-                "entity_type": "session",
-                "entity_name": "session_memory",
-                "state": summarize_text(text, limit=220),
-                "confidence": 0.5,
-                "source_refs": source_refs,
-                "operator": core.normalize_entity_operator(None, "session"),
-                "field_patches": [],
-                "extracted_by": "oss_encoder",
-            }
-        )
-    return core.dedupe_entities(entities)
-
-
-def oss_encoder_memory_segments(messages: list[Json]) -> list[Json]:
-    core = _core_runtime()
-    labeled: dict[str, list[tuple[int, Json, float]]] = {}
-    for index, message in enumerate(messages):
-        text = str(message.get("content", ""))
-        if not text.strip():
-            continue
-        ranked = oss_encoder_rank_labels(text, UNDERSTANDING_LABELS, limit=1)
-        label = str(ranked[0]["label"]) if ranked else "session"
-        score = float(ranked[0]["score"]) if ranked else 0.5
-        labeled.setdefault(label, []).append((index, message, score))
-    segments = []
-    for label, items in labeled.items():
-        indexes = [index for index, _message, _score in items]
-        ranges = core.contiguous_ranges(indexes)
-        segment_text = "\n".join(f"{index}: {message.get('content', '')}" for index, message, _score in items)
-        segments.append(
-            {
-                "topic": label,
-                "coordinate_tuples": ranges,
-                "message_indexes": indexes,
-                "saliency_score": round(sum(score for _index, _message, score in items) / max(len(items), 1), 6),
-                "summary_text": summarize_text(segment_text, limit=420),
-                "text": segment_text,
-                "non_contiguous": len(ranges) > 1,
-                "detected_by": "oss_encoder",
-            }
-        )
-    segments.sort(key=lambda item: (-item["saliency_score"], item["topic"]))
-    return segments[:12]

--- a/tools/matrixark_mcp_query.py
+++ b/tools/matrixark_mcp_query.py
@@ -159,16 +159,38 @@ QUERY_INDEX_STOPWORDS = {
 # in this file, a nine-line duplicate of matrixark_mcp_indexing.ordered_unique, where the live
 # copies call the shared one. Same behaviour, two implementations, and nothing saying which was
 # current -- so they join the two names already re-exported below, and the private helper goes.
+# Six more joined these three by losing a lazy accessor: import matrixark_mcp_core inside the call
+# and reach names off the module object, so a copy said `core.understanding_provider()` where the
+# live one says `understanding_provider()`. That token was their whole divergence.
+#
+# It looked like cycle avoidance and was not. NOTHING imports matrixark_mcp_query at module scope,
+# and this file already binds matrixark_mcp_core_query_analysis here -- which itself imports
+# matrixark_mcp_core at module scope, under a docstring saying "No import-time cycle".
+#
+# The accessor itself STAYS: candidate_index_terms still calls it, and that one diverges from
+# matrixark_mcp_core's by more than a spelling, so it is not part of this move.
 try:  # the implementation lives in matrixark_mcp_core_query_analysis; this module re-exports it
     from tools.matrixark_mcp_core_query_analysis import (
+        build_structured_query_plan,
+        infer_query_type,
+        infer_secondary_index_filter_groups,
         keyword_candidates_from_query,
+        oss_encoder_query_type,
+        oss_encoder_secondary_index_filter_groups,
         path_candidates_from_query,
+        secondary_filter_terms_to_fields,
         slug_candidates_from_query,
     )
 except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_core_query_analysis import (
+        build_structured_query_plan,
+        infer_query_type,
+        infer_secondary_index_filter_groups,
         keyword_candidates_from_query,
+        oss_encoder_query_type,
+        oss_encoder_secondary_index_filter_groups,
         path_candidates_from_query,
+        secondary_filter_terms_to_fields,
         slug_candidates_from_query,
     )
 
@@ -407,52 +429,10 @@ def deterministic_secondary_index_filter_groups(query: str, question_type: str) 
     return groups
 
 
-def secondary_filter_terms_to_fields(groups: list[set[str]]) -> Json:
-    fields: Json = {}
-    for group in groups:
-        for term in sorted(group):
-            if ":" not in term:
-                continue
-            field, value = term.split(":", 1)
-            if not field or not value:
-                continue
-            fields.setdefault(field, [])
-            if value not in fields[field]:
-                fields[field].append(value)
-    return fields
-
-
 try:  # the implementation lives in matrixark_mcp_core_query_analysis; this module re-exports it
     from .matrixark_mcp_core_query_analysis import infer_temporal_window
 except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_core_query_analysis import infer_temporal_window
-
-
-def build_structured_query_plan(
-    query: str,
-    *,
-    question_type: str,
-    secondary_index_filter_groups: list[set[str]],
-    secondary_index_filter_mode: str,
-    reference_time_ms: int,
-) -> Json:
-    secondary_filters = secondary_filter_terms_to_fields(secondary_index_filter_groups)
-    return {
-        "query_type": question_type,
-        "secondary_filters": secondary_filters,
-        "secondary_filter_groups": [sorted(group) for group in secondary_index_filter_groups],
-        "secondary_filter_mode": secondary_index_filter_mode,
-        "temporal_window": infer_temporal_window(query, question_type, reference_time_ms=reference_time_ms),
-        "execution_order": [
-            "query_understanding",
-            "scope_filter",
-            "secondary_index_prefilter",
-            "l0_l1_node_traversal",
-            "leaf_candidate_fetch",
-            "embedding_similarity_time_decay_business_score",
-            "budget_pack_contextpack",
-        ],
-    }
 
 
 def _core_query_runtime() -> Any:
@@ -461,75 +441,6 @@ def _core_query_runtime() -> Any:
     except ModuleNotFoundError:  # Direct script execution from tools/.
         import matrixark_mcp_core as core
     return core
-
-
-def infer_query_type(query: str) -> str:
-    core = _core_query_runtime()
-    lower = query.lower()
-    if (
-        PROFILE_MEMORY_QUERY_RE.search(lower)
-        or PROFILE_MEMORY_STANDING_RULE_QUERY_RE.search(lower)
-        or ACTIVE_MEMORY_GOAL_QUERY_RE.search(lower)
-    ):
-        return "profile_memory"
-    if re.search(r"\b(benchmark|workload|latency|p50|p90|p95|p99|throughput|qps|ops/s|req/s|hit[- ]?rate|read[- ]?hit|quality|recall|precision|locomo|longmemeval|memory[- ]?quality)\b", lower):
-        return "benchmark_quality"
-    if core.understanding_provider() == "oss_encoder":
-        return oss_encoder_query_type(query)
-    if re.search(r"\b(both|together|across|between|compare|combine|sessions|multi-hop|multi session|multi-session|cross session|cross-session|previous sessions|other sessions)\b", lower):
-        return "multi_hop"
-    if re.search(r"\b(when|what date|which date|day|month|year|yesterday|tomorrow|last week|next week|before|after|as of|valid as of)\b", lower):
-        return "date"
-    if CODEX_OUTCOME_QUERY_RE.search(lower):
-        return "evidence"
-    if re.search(r"\b(current|currently|latest|now|still|today|valid|status|preference|prefer|likes|where does|where is|goal|task|requirement|user request|asked codex)\b", lower):
-        return "current_state"
-    if re.search(r"\b(?:assistant|codex)\b.{0,64}\b(?:decide|decided|decision|done|implemented|fixed|push(?:ed)?|commit(?:ted)?|changed|updated|validated|verified)\b", lower):
-        return "current_state"
-    if re.search(r"\b(why|reason|because|feel|felt|emotion|happy|sad|angry|worried|excited)\b", lower):
-        return "why_emotion"
-    if re.search(r"\b(overview|summarize|summary|explore|broad|what is in|what do we know|topics|map|inventory)\b", lower):
-        return "broad_exploration"
-    if re.search(r"\b(evidence|quote|exactly|what did .* say|conversation|dialogue|message)\b", lower):
-        return "evidence"
-    if re.search(r"\b(procedure|steps?|how to|troubleshoot|debug|rollback|runbook|playbook|checklist|fix|remediate|mitigate)\b", lower):
-        return "procedure"
-    return "fact"
-
-
-def infer_secondary_index_filter_groups(query: str, question_type: str) -> list[set[str]]:
-    core = _core_query_runtime()
-    if core.understanding_provider() == "oss_encoder":
-        return oss_encoder_secondary_index_filter_groups(query, question_type)
-    return deterministic_secondary_index_filter_groups(query, question_type)
-
-
-def oss_encoder_query_type(query: str) -> str:
-    core = _core_query_runtime()
-    ranked = core.oss_encoder_rank_labels(query, QUERY_TYPE_LABELS, limit=2)
-    if not ranked:
-        return "fact"
-    top = str(ranked[0]["label"])
-    if len(ranked) > 1 and top == "fact" and float(ranked[1]["score"]) >= float(ranked[0]["score"]) - 0.015:
-        return str(ranked[1]["label"])
-    return top
-
-
-def oss_encoder_secondary_index_filter_groups(query: str, question_type: str) -> list[set[str]]:
-    core = _core_query_runtime()
-    ranked = core.oss_encoder_rank_labels(f"{question_type}: {query}", QUERY_INDEX_LABELS, limit=5)
-    selected = [str(item["label"]) for item in ranked if float(item["score"]) >= 0.46]
-    if not selected and ranked:
-        selected = [str(ranked[0]["label"])]
-    groups: list[set[str]] = deterministic_secondary_index_filter_groups(query, question_type)
-    by_prefix: dict[str, set[str]] = {}
-    for label in selected:
-        prefix = label.split(":", 1)[0]
-        by_prefix.setdefault(prefix, set()).add(label)
-    for labels in by_prefix.values():
-        if labels and labels not in groups:
-            groups.append(labels)
-    return groups[:8]
 
 
 def candidate_index_terms(

--- a/tools/matrixark_mcp_summaries.py
+++ b/tools/matrixark_mcp_summaries.py
@@ -185,6 +185,20 @@ except ImportError:  # Direct script execution from tools/.
     )
 
 
+# `summary_provider` differed from matrixark_mcp_core's by one token -- it called the local
+# `_require_oss_understanding` wrapper below rather than the module-level name -- and
+# `synthesize_context_node_summary` differed by that plus a lazy-import shim for
+# openai_compatible_json_call, which core resolves at module scope anyway. Both were the same
+# implementation wearing different plumbing, and an unreachable module holding a near-copy of a
+# live function is a wrong answer waiting to be read.
+#
+# The wrapper stays: two other call sites in this module still use it.
+try:  # the implementation lives in matrixark_mcp_core; this module re-exports it
+    from tools.matrixark_mcp_core import summary_provider, synthesize_context_node_summary
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import summary_provider, synthesize_context_node_summary
+
+
 def _require_oss_understanding() -> bool:
     try:
         from tools.matrixark_mcp_oss_understanding import require_oss_understanding
@@ -192,78 +206,4 @@ def _require_oss_understanding() -> bool:
         from matrixark_mcp_oss_understanding import require_oss_understanding
     return require_oss_understanding()
 
-
-def summary_provider() -> str:
-    provider = os.environ.get("MATRIXARK_SUMMARY_PROVIDER", SUMMARY_LLM_PROVIDER).strip().lower().replace("-", "_")
-    if provider in {"oss", "open_source", "local_llm", "oss_llm"}:
-        return "openai_compatible"
-    if provider in {"", "deterministic", "rules", "local"} and _require_oss_understanding():
-        raise MatrixArkError("deterministic L0/L1 summary generation is disabled because MATRIXARK_REQUIRE_OSS_UNDERSTANDING=1")
-    return provider or "deterministic"
-
-
-def synthesize_context_node_summary(
-    *,
-    level: str,
-    node_path: list[str],
-    source_text: str,
-    fallback_text: str,
-    max_chars: int,
-    policy: Json,
-) -> tuple[str, Json]:
-    provider = summary_provider()
-    fallback_summary = summarize_text(fallback_text, limit=max_chars)
-    provider_meta: Json = {
-        "provider": provider,
-        "model": SUMMARY_LLM_MODEL if provider in {"openai", "openai_compatible", "openai_compatible_llm"} else "",
-        "fallback_used": False,
-        "summary_level": level,
-    }
-    if provider in {"openai", "openai_compatible", "openai_compatible_llm"}:
-        system = (
-            "You generate MatrixArk ContextNode traversal summaries. Return JSON only. "
-            "The summary must be faithful to the supplied child summaries, entity state, operator state, and recent events. "
-            "For node_l0 return a compact routing abstract. For node_l1 return a richer semantic synthesis for tree-first retrieval. "
-            "Do not invent facts. Prefer current state and resolved contradictions."
-        )
-        user = json.dumps(
-            {
-                "summary_level": level,
-                "node_path": node_path,
-                "generation_policy": policy,
-                "source_text": summarize_text(source_text, limit=5000),
-                "required_json_shape": {"summary_text": "string"},
-            },
-            ensure_ascii=False,
-            sort_keys=True,
-        )
-        try:
-            json_call = globals().get("openai_compatible_json_call")
-            if json_call is None:
-                try:
-                    from tools.matrixark_mcp_extraction_provider import openai_compatible_json_call as json_call
-                except ModuleNotFoundError:  # Direct script execution from tools/.
-                    from matrixark_mcp_extraction_provider import openai_compatible_json_call as json_call
-            result = json_call(
-                system=system,
-                user=user,
-                model=SUMMARY_LLM_MODEL,
-                max_tokens=SUMMARY_LLM_MAX_TOKENS,
-            )
-            summary_text = summarize_text(str(result.get("summary_text") or result.get("summary") or ""), limit=max_chars)
-            if not summary_text:
-                raise MatrixArkError("summary provider returned empty summary_text")
-            provider_meta["execution_mode"] = "llm_json"
-            return summary_text, provider_meta
-        except MatrixArkError:
-            if _require_oss_understanding():
-                raise
-            provider_meta["fallback_used"] = True
-            provider_meta["execution_mode"] = "deterministic_fallback"
-            return fallback_summary, provider_meta
-    if _require_oss_understanding():
-        raise MatrixArkError(f"unsupported OSS summary provider: {provider}")
-    provider_meta["fallback_used"] = True
-    provider_meta["execution_mode"] = "deterministic_fallback"
-    return fallback_summary, provider_meta
 

--- a/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
+++ b/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
@@ -81,7 +81,11 @@ from collections import defaultdict
 #: with a bare strip().lower() where the live copy maps aliases, so an entity recorded with
 #: role "human" scored priority 4 here and 1 there -- dropped against kept, when
 #: dedupe_entities ranks. codex_outcome_fact_entities differed only by inlining a local.
-RECORDED_DIVERGED = 36
+#:
+#: 36 -> 35 for infer_entity_field_patches, where the live copy has a branch this one lacked
+#: (a negative preference produces a patch there and nothing here) AND an lru_cached helper
+#: that fixed a quadratic scan -- 33 s against 1.2 s on a 256 KB ingest. The copy had neither.
+RECORDED_DIVERGED = 35
 
 #: Total shadowed names (diverged + verbatim), recorded for the same reason.
 #:
@@ -89,7 +93,7 @@ RECORDED_DIVERGED = 36
 #: number above -- 66 verbatim copies went with work that landed since and did not bank this line.
 #: Banked here, because a ceiling left sixty-six above the truth is not a ratchet, it is a number
 #: that will pass whatever happens next.
-RECORDED_SHADOWED = 46
+RECORDED_SHADOWED = 45
 
 _CACHE: dict[str, object] = {}
 

--- a/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
+++ b/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
@@ -65,7 +65,12 @@ from collections import defaultdict
 #: reaching their helpers through a lazy `core.` accessor. That accessor looked like cycle
 #: avoidance and was not -- the file already binds core at module scope, and core does not
 #: import it at all -- so it went with them.
-RECORDED_DIVERGED = 44
+#:
+#: 44 -> 40 for six more in matrixark_mcp_query, the same accessor one more time. Four of the
+#: six were diverged and two were verbatim, which is why the total falls by six and this number
+#: by four. The accessor STAYS there: candidate_index_terms still calls it and diverges by more
+#: than a spelling, so it is not part of that move.
+RECORDED_DIVERGED = 40
 
 #: Total shadowed names (diverged + verbatim), recorded for the same reason.
 #:
@@ -73,7 +78,7 @@ RECORDED_DIVERGED = 44
 #: number above -- 66 verbatim copies went with work that landed since and did not bank this line.
 #: Banked here, because a ceiling left sixty-six above the truth is not a ratchet, it is a number
 #: that will pass whatever happens next.
-RECORDED_SHADOWED = 56
+RECORDED_SHADOWED = 50
 
 _CACHE: dict[str, object] = {}
 

--- a/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
+++ b/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
@@ -53,7 +53,13 @@ from collections import defaultdict
 #: defined in that file, a nine-line duplicate of matrixark_mcp_indexing.ordered_unique, where the
 #: live copies call the shared one. Same pattern again: that module was ALREADY re-exporting two
 #: names from the same live file, with the same comment above them.
-RECORDED_DIVERGED = 48
+#:
+#: 48 -> 46 for `summary_provider` and `synthesize_context_node_summary` in matrixark_mcp_summaries,
+#: a module ALREADY re-exporting four names from matrixark_mcp_core. Third module, same shape: the
+#: copies differed by which spelling of require_oss_understanding they called, and in one case by a
+#: lazy-import shim for a name core resolves at module scope. Same implementation, different
+#: plumbing -- which is the hardest kind to read, because the diff is real and means nothing.
+RECORDED_DIVERGED = 46
 
 #: Total shadowed names (diverged + verbatim), recorded for the same reason.
 #:
@@ -61,7 +67,7 @@ RECORDED_DIVERGED = 48
 #: number above -- 66 verbatim copies went with work that landed since and did not bank this line.
 #: Banked here, because a ceiling left sixty-six above the truth is not a ratchet, it is a number
 #: that will pass whatever happens next.
-RECORDED_SHADOWED = 60
+RECORDED_SHADOWED = 58
 
 _CACHE: dict[str, object] = {}
 

--- a/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
+++ b/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
@@ -76,7 +76,12 @@ from collections import defaultdict
 #: acts on, so that query returned unboosted through it -- 0.50 where the live path gives 0.68,
 #: executed both ways. And matrixark_mcp_extraction_normalization's dedupe_entities omitted the
 #: drop_directive_duplicates step entirely, which is the example this file's own docstring cites.
-RECORDED_DIVERGED = 38
+#:
+#: 38 -> 36 for two more in the same file. entity_retention_priority normalised source roles
+#: with a bare strip().lower() where the live copy maps aliases, so an entity recorded with
+#: role "human" scored priority 4 here and 1 there -- dropped against kept, when
+#: dedupe_entities ranks. codex_outcome_fact_entities differed only by inlining a local.
+RECORDED_DIVERGED = 36
 
 #: Total shadowed names (diverged + verbatim), recorded for the same reason.
 #:
@@ -84,7 +89,7 @@ RECORDED_DIVERGED = 38
 #: number above -- 66 verbatim copies went with work that landed since and did not bank this line.
 #: Banked here, because a ceiling left sixty-six above the truth is not a ratchet, it is a number
 #: that will pass whatever happens next.
-RECORDED_SHADOWED = 48
+RECORDED_SHADOWED = 46
 
 _CACHE: dict[str, object] = {}
 

--- a/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
+++ b/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
@@ -70,7 +70,13 @@ from collections import defaultdict
 #: six were diverged and two were verbatim, which is why the total falls by six and this number
 #: by four. The accessor STAYS there: candidate_index_terms still calls it and diverges by more
 #: than a spelling, so it is not part of that move.
-RECORDED_DIVERGED = 40
+#:
+#: 40 -> 38 for two that were NOT plumbing. matrixark_mcp_budget_pack's
+#: prefer_profile_entities_for_current_state omitted "profile_memory" from the question types it
+#: acts on, so that query returned unboosted through it -- 0.50 where the live path gives 0.68,
+#: executed both ways. And matrixark_mcp_extraction_normalization's dedupe_entities omitted the
+#: drop_directive_duplicates step entirely, which is the example this file's own docstring cites.
+RECORDED_DIVERGED = 38
 
 #: Total shadowed names (diverged + verbatim), recorded for the same reason.
 #:
@@ -78,7 +84,7 @@ RECORDED_DIVERGED = 40
 #: number above -- 66 verbatim copies went with work that landed since and did not bank this line.
 #: Banked here, because a ceiling left sixty-six above the truth is not a ratchet, it is a number
 #: that will pass whatever happens next.
-RECORDED_SHADOWED = 50
+RECORDED_SHADOWED = 48
 
 _CACHE: dict[str, object] = {}
 

--- a/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
+++ b/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
@@ -59,7 +59,13 @@ from collections import defaultdict
 #: copies differed by which spelling of require_oss_understanding they called, and in one case by a
 #: lazy-import shim for a name core resolves at module scope. Same implementation, different
 #: plumbing -- which is the hardest kind to read, because the diff is real and means nothing.
-RECORDED_DIVERGED = 46
+#:
+#: 46 -> 44 for the same reason one file along: matrixark_mcp_oss_understanding kept copies of
+#: oss_encoder_memory_segments and oss_encoder_extract_batch_entities that differed only by
+#: reaching their helpers through a lazy `core.` accessor. That accessor looked like cycle
+#: avoidance and was not -- the file already binds core at module scope, and core does not
+#: import it at all -- so it went with them.
+RECORDED_DIVERGED = 44
 
 #: Total shadowed names (diverged + verbatim), recorded for the same reason.
 #:
@@ -67,7 +73,7 @@ RECORDED_DIVERGED = 46
 #: number above -- 66 verbatim copies went with work that landed since and did not bank this line.
 #: Banked here, because a ceiling left sixty-six above the truth is not a ratchet, it is a number
 #: that will pass whatever happens next.
-RECORDED_SHADOWED = 58
+RECORDED_SHADOWED = 56
 
 _CACHE: dict[str, object] = {}
 


### PR DESCRIPTION
`matrixark_mcp_summaries` defines `summary_provider` and `synthesize_context_node_summary`, and
`matrixark_mcp_core` defines both. The module was **already** re-exporting four other names from
that same file, with the comment *"the implementation lives in matrixark_mcp_core; this module
re-exports it"* above each. These two join them.

### What the differences were, and why they mean nothing

`summary_provider` differed by **one token**: it called a local `_require_oss_understanding` wrapper
instead of the module-level name. That wrapper lazily imports
`matrixark_mcp_oss_understanding.require_oss_understanding`, whose body is byte-identical to
`matrixark_mcp_core`'s.

`synthesize_context_node_summary` differed by that plus a lazy-import shim —
`globals().get("openai_compatible_json_call")` falling back to an import — for a name core resolves
at module scope anyway.

That shim is why the **orphan was the larger** of the two: 6,150 characters against 5,403. In this
tree a bigger orphan has twice meant *"the orphan is the complete one"* (#1575 left
`intelligent_memory_segments` alone for exactly that reason). Here it meant the opposite — same
implementation, more plumbing.

Which makes this the hardest kind of divergence to read: the diff is real and says nothing. Anyone
comparing the two finds two genuine differences and no way to tell that neither changes an answer.

The wrapper stays — two other call sites in this module still use it.

| | before | after |
|---|---|---|
| diverged shadows | 48 | **46** |
| total shadowed | 60 | **58** |

Follows #1575, which did the same for `matrixark_mcp_segments` and `matrixark_mcp_query`.
