### PR TITLE
A smaller limit bought a longer string

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -4267,7 +4267,18 @@ def summarize_text(text: str, *, limit: int = 220) -> str:
     compact = " ".join(text.split())
     if len(compact) <= limit:
         return compact
-    return compact[: limit - 3] + "..."
+    # max(0, ...) rather than `limit - 3`. Below a limit of three that subtraction is NEGATIVE, and
+    # a negative slice keeps everything but the last few characters instead of keeping none:
+    #
+    #     summarize_text("abcdefghij", limit=0)  ->  "abcdefg..."    ten characters for a limit of 0
+    #     summarize_text("abcdefghij", limit=2)  ->  "abcdefghi..."  and it GROWS as the limit falls
+    #
+    # Not reachable today -- every call site passes a literal of 96 or more, and the one
+    # caller-supplied budget is floored before it arrives -- so this changes no output any path
+    # currently produces. It is here because the inversion is indefensible whatever the
+    # reachability, and because `preview_text` in matrixark_mcp_resources is a second copy of this
+    # function that already guards it: the extracted copy got the fix and the original never did.
+    return compact[: max(0, limit - 3)] + "..."
 
 
 def deterministic_time_compression_summary(

--- a/tools/test_a_smaller_limit_never_gives_a_longer_string.py
+++ b/tools/test_a_smaller_limit_never_gives_a_longer_string.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A truncating helper must not GROW as its limit falls.
+
+`summarize_text` cut at `limit - 3` to leave room for an ellipsis. Below a limit of three that
+subtraction is negative, and a negative slice keeps everything but the last few characters instead
+of keeping none:
+
+    summarize_text("abcdefghij", limit=0)  ->  "abcdefg..."     ten characters for a limit of zero
+    summarize_text("abcdefghij", limit=2)  ->  "abcdefghi..."   and it GROWS as the limit falls
+
+It was not reachable: every call site passes a literal of 96 or more, and the one caller-supplied
+budget is floored before it arrives. So the fix changed no output any path produces, and that is
+exactly why a test is worth more than the fix -- nothing else in the tree would have noticed the
+behaviour coming back.
+
+WHY THE PROPERTY AND NOT THE CASE. Pinning `summarize_text("abcdefghij", limit=0) == "..."` passes
+for any implementation that special-cases zero. The thing that was wrong is monotonicity: a
+smaller budget must never buy a longer string. That is checked across every limit from 0 upward,
+for both this helper and `preview_text` in matrixark_mcp_resources -- a second copy of the same
+function, which already had the guard. The extracted copy got the fix and the original never did,
+so the pair is checked together and neither can regress alone.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+try:  # package path
+    from tools.matrixark_mcp_core import summarize_text
+    from tools.matrixark_mcp_resources import preview_text
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import summarize_text
+    from matrixark_mcp_resources import preview_text
+
+HELPERS = (("summarize_text", summarize_text), ("preview_text", preview_text))
+
+SAMPLES = (
+    "abcdefghij",
+    "The deployment was blocked by a failing migration and the owner rolled it back.",
+    "one two three four five six seven eight nine ten eleven twelve thirteen",
+    "a" * 300,
+    "   leading and trailing   ",
+    "",
+)
+
+
+class ASmallerLimitNeverGivesALongerStringTest(unittest.TestCase):
+
+    def test_the_output_never_grows_as_the_limit_falls(self) -> None:
+        for name, helper in HELPERS:
+            for text in SAMPLES:
+                previous = None
+                for limit in range(0, 40):
+                    out = helper(text, limit=limit)
+                    if previous is not None:
+                        with self.subTest(helper=name, text=text[:20], limit=limit):
+                            self.assertLessEqual(
+                                len(previous), len(out),
+                                "%s(limit=%d) is %d characters and (limit=%d) is %d -- a smaller "
+                                "budget bought a longer string, which is the negative-slice bug"
+                                % (name, limit - 1, len(previous), limit, len(out)))
+                    previous = out
+
+    def test_a_limit_below_the_ellipsis_yields_only_the_ellipsis(self) -> None:
+        """The specific shape of the old bug, kept as well as the property.
+
+        The property above would also hold for an implementation that returned the whole string at
+        every small limit. It must not: a caller asking for two characters has asked for fewer
+        than the ellipsis costs, and the honest answer is the ellipsis, not the input.
+        """
+        for name, helper in HELPERS:
+            for limit in (0, 1, 2, 3):
+                with self.subTest(helper=name, limit=limit):
+                    self.assertEqual(
+                        "...", helper("abcdefghij", limit=limit),
+                        "%s(limit=%d) should be the bare ellipsis" % (name, limit))
+
+    def test_a_limit_that_fits_returns_the_text_unchanged(self) -> None:
+        """The positive control. Both checks above pass for a helper that returns "..." always."""
+        for name, helper in HELPERS:
+            with self.subTest(helper=name):
+                self.assertEqual("abcdefghij", helper("abcdefghij", limit=220))
+                self.assertEqual("a b c", helper("a  b\t\tc", limit=220),
+                                 "%s should collapse whitespace runs" % name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`summarize_text` cuts at `limit - 3` to leave room for an ellipsis. Below a limit of three that
subtraction is **negative**, and a negative slice keeps everything but the last few characters
instead of keeping none:

```
summarize_text("abcdefghij", limit=0)  ->  "abcdefg..."     ten characters for a limit of zero
summarize_text("abcdefghij", limit=1)  ->  "abcdefgh..."
summarize_text("abcdefghij", limit=2)  ->  "abcdefghi..."   and it GROWS as the limit falls
```

### Not reachable today, said plainly

Every call site passes a literal limit of 96 or more; the two passing a computed `max_chars` are
reached only with 220 and 1200; the one caller-supplied budget is floored at zero before it
arrives. **This changes no output any path currently produces.** It is fixed because the inversion
is indefensible whatever the reachability, and because the day a budget becomes computed is the day
it bites silently — a summary is not something anyone inspects for being *too long*.

### How it was found

`matrixark_mcp_resources.preview_text` is a second copy of this function, and it **already had the
guard** — `max(0, limit - 3)`, plus an rstrip. The extracted copy got the fix and the original never
did. The two were sitting in the diverged-shadow list, the difference read as a naming choice, and
executing both across the edges is what showed it wasn't.

### The test pins the property, not the case

`summarize_text("abcdefghij", limit=0) == "..."` passes for any implementation that special-cases
zero. What was wrong is **monotonicity**: a smaller budget must never buy a longer string. Checked
across every limit from 0 to 40, over six inputs, for *both* copies — so neither can regress alone —
with a positive control that a limit which fits returns the text unchanged (the property alone would
hold for a helper that returned `"..."` always).

Mutation-tested by restoring the negative slice: three checks go red and the message names the limit
pair that inverted.

The remaining difference between the copies is left alone: `preview_text` rstrips before the
ellipsis and routes through `compact_ws`. Both change live output, which is a separate decision.
