### PR TITLE
A class that subclassed its own name

### DIFF
--- a/tools/matrixark_http.py
+++ b/tools/matrixark_http.py
@@ -350,6 +350,12 @@ def _namespace_and_table(args: Json) -> tuple[str, str]:
     )
 
 
+# The abstract reader. It used to be REBOUND immediately below by `class _HookStoreReader(
+# _HookStoreReader)`, the native reader taking its base's name -- which is legal, and meant the two
+# Rust readers further down declared `(_HookStoreReader)` and inherited the NATIVE one instead of
+# this. Harmless only because all three override every member; a method added to the native reader
+# would have been handed to both of them silently, and `isinstance(x, _HookStoreReader)` meant "is
+# the native reader" rather than "is a reader at all".
 class _HookStoreReader:
     name = "unknown"
 
@@ -360,7 +366,7 @@ class _HookStoreReader:
         raise NotImplementedError
 
 
-class _HookStoreReader(_HookStoreReader):
+class _NativeHookStoreReader(_HookStoreReader):
     name = "native"
 
     def __init__(self, args: Json) -> None:
@@ -682,7 +688,7 @@ def query_codex_hook_messages(args: Json) -> Json:
     errors: list[Json] = []
     if backend in {"both", "native"}:
         try:
-            readers.append(("native", _HookStoreReader(args)))
+            readers.append(("native", _NativeHookStoreReader(args)))
         except Exception as exc:
             errors.append({"backend": "native", "error": str(exc)})
     if backend in {"both", "rust", "rust-service"}:

--- a/tools/test_codex_hook_output_part3.py
+++ b/tools/test_codex_hook_output_part3.py
@@ -1341,7 +1341,9 @@ class _CodexHookOutputPart3:
 
 
     def test_codex_hook_messages_both_skips_local_proxy_debug_reader(self) -> None:
-        original_native = matrixark_http._HookStoreReader
+        # The native reader is _NativeHookStoreReader; `_HookStoreReader` is the abstract base
+        # all three subclass. It used to be both, because the native class took its base's name.
+        original_native = matrixark_http._NativeHookStoreReader
         original_service = matrixark_http._RustServiceHookStoreReader
         original_local = matrixark_http._RustLocalHookStoreReader
         calls = []
@@ -1356,7 +1358,7 @@ class _CodexHookOutputPart3:
                 return None
 
         try:
-            matrixark_http._HookStoreReader = lambda args: calls.append("native") or EmptyReader()
+            matrixark_http._NativeHookStoreReader = lambda args: calls.append("native") or EmptyReader()
             matrixark_http._RustServiceHookStoreReader = lambda args: calls.append("rust-service") or EmptyReader()
 
             def fail_local(args):
@@ -1365,7 +1367,7 @@ class _CodexHookOutputPart3:
             matrixark_http._RustLocalHookStoreReader = fail_local
             matrixark_http.query_codex_hook_messages({"backend": "both", "top_k": 1})
         finally:
-            matrixark_http._HookStoreReader = original_native
+            matrixark_http._NativeHookStoreReader = original_native
             matrixark_http._RustServiceHookStoreReader = original_service
             matrixark_http._RustLocalHookStoreReader = original_local
 

--- a/tools/test_no_top_level_name_is_defined_twice.py
+++ b/tools/test_no_top_level_name_is_defined_twice.py
@@ -46,6 +46,15 @@ SELF = Path(__file__).name
 
 #: 167 modules when this was written. A floor, so a scan that stops reaching the tree fails here
 #: rather than passing with nothing to look at.
+#: The exempt idiom as source, so the control below does not need a live instance of it.
+IDIOM_SNIPPET = """class C:
+    pass
+
+
+class C(C):
+    pass
+"""
+
 EXPECTED_MODULE_FLOOR = 120
 
 Definition = "ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef"
@@ -141,27 +150,36 @@ class NoTopLevelNameIsDefinedTwiceTest(unittest.TestCase):
             "pass below means nothing" % (len(modules), EXPECTED_MODULE_FLOOR))
 
     def test_the_scan_still_finds_duplicates_and_still_exempts_the_idiom(self) -> None:
-        """Mechanism control, and the only case in the tree that exercises the exemption.
+        """Mechanism control. SYNTHETIC now, for the same reason the overload branch above is.
 
-        `matrixark_http._HookStoreReader` is defined twice, deliberately, the second naming the
-        first as its base. It must be SEEN as a duplicate and then EXEMPTED. If it stops being
-        seen, the scan has stopped finding duplicates and the rule below is vacuous; if it stops
-        being exempted, the exemption has broken and the rule is about to reject a valid idiom.
+        `matrixark_http._HookStoreReader` used to be the one real case: defined twice, the second
+        naming the first as its base. It is gone -- not because the exemption is wrong, but because
+        the exemption answers a narrower question than the one that mattered there.
+
+        WHAT IT ESTABLISHES is that the FIRST definition stays reachable, as the base of the
+        second. True, and enough to say the earlier code is not dead. WHAT IT DOES NOT TOUCH is
+        what the NEXT class inherits. Two more readers below declared `(_HookStoreReader)` meaning
+        the abstract one and got the native one, because by then the name had been rebound, so
+        their MRO ran through an __init__ that opens libtemporalstore.so. Nothing broke -- all
+        three override every member -- but a method added to the native reader would have been
+        handed to both of them silently.
+
+        So the idiom is still valid Python and still exempt; it simply has no instance here any
+        more. Controlled synthetically rather than deleted, because a branch that never runs is a
+        branch nobody notices breaking -- the argument this file already makes for
+        `_is_overload_or_property_pair`.
         """
-        tree = ast.parse((REPO / "tools/matrixark_http.py").read_text(encoding="utf-8"))
-        copies = [n for n in tree.body
-                  if isinstance(n, ast.ClassDef) and n.name == "_HookStoreReader"]
-        self.assertEqual(
-            2, len(copies),
-            "matrixark_http no longer defines _HookStoreReader twice, so nothing in the tree "
-            "exercises the exemption -- point this control at whatever uses the idiom now, or "
-            "drop the exemption if nothing does")
+        snippet = ast.parse(IDIOM_SNIPPET)
+        copies = [n for n in snippet.body if isinstance(n, ast.ClassDef) and n.name == "C"]
+        self.assertEqual(2, len(copies), "the synthetic snippet no longer defines C twice")
         self.assertTrue(
-            extends_the_earlier(copies[1], "_HookStoreReader"),
-            "the second _HookStoreReader no longer names the first in its bases")
+            extends_the_earlier(copies[1], "C"),
+            "a second definition naming the first as its base is no longer recognised, so the "
+            "exemption has broken and the rule is about to reject a valid idiom")
         self.assertNotIn(
             "_HookStoreReader", {name for _, name, _, _ in collect_shadowed()},
-            "the exemption stopped applying to the idiom it was derived for")
+            "matrixark_http defines _HookStoreReader twice again -- see matrixarkai#1584 for why "
+            "the second copy was given its own name rather than exempted")
 
     def test_the_exemption_reads_definition_time_and_not_the_body(self) -> None:
         """Positive control on the classifier, on both sides of the line it draws."""

--- a/tools/test_no_top_level_name_is_defined_twice.py
+++ b/tools/test_no_top_level_name_is_defined_twice.py
@@ -176,10 +176,16 @@ class NoTopLevelNameIsDefinedTwiceTest(unittest.TestCase):
             extends_the_earlier(copies[1], "C"),
             "a second definition naming the first as its base is no longer recognised, so the "
             "exemption has broken and the rule is about to reject a valid idiom")
-        self.assertNotIn(
-            "_HookStoreReader", {name for _, name, _, _ in collect_shadowed()},
-            "matrixark_http defines _HookStoreReader twice again -- see matrixarkai#1584 for why "
-            "the second copy was given its own name rather than exempted")
+        # Asked of the FILE, not of collect_shadowed(). The exemption removes the name from that
+        # set by construction, so a check against it can never fail and would be decoration.
+        http = ast.parse((REPO / "tools/matrixark_http.py").read_text(encoding="utf-8"))
+        again = [n.lineno for n in http.body
+                 if isinstance(n, ast.ClassDef) and n.name == "_HookStoreReader"]
+        self.assertLessEqual(
+            len(again), 1,
+            "matrixark_http defines _HookStoreReader at lines %s again. The idiom is exempt and "
+            "stays exempt -- but it is what made two later readers inherit the native reader "
+            "instead of the abstract one, so see matrixarkai#1584 before restoring it." % again)
 
     def test_the_exemption_reads_definition_time_and_not_the_body(self) -> None:
         """Positive control on the classifier, on both sides of the line it draws."""


### PR DESCRIPTION
`matrixark_http` had:

```python
class _HookStoreReader:                      # the abstract reader
    ...
class _HookStoreReader(_HookStoreReader):    # the NATIVE reader, taking its base's name
    ...
```

Legal Python: at class-definition time the name still refers to the base, so the subclass is built
correctly — and then the name is rebound to the subclass.

The cost landed on what was written next. Both Rust readers below declare `(_HookStoreReader)`,
meaning the abstract one, and got the **native** one — whose `__init__` puts `sdk/python` on
`sys.path`, imports `temporalstore.client` and opens `libtemporalstore.so`. The runtime MRO said so:

```
_RustServiceHookStoreReader -> _HookStoreReader(native) -> _HookStoreReader(abstract) -> object
```

### It never broke, and that is the part worth stating

All three override `__init__`, `get_string`, `hget` and `name`, so nothing from the native reader
was ever reached. What the shape set up was quieter than a break:

- a method added to the native reader would have been handed to both Rust readers, silently;
- the abstract base could not be named by anything, so nothing could extend it on purpose;
- `isinstance(reader, _HookStoreReader)` meant *"is the native reader"* and read as *"is a reader"* —
  and it is used as a type annotation in three places that mean the second.

The native reader is now `_NativeHookStoreReader`, its one construction site follows, and all three
readers subclass the abstract base. **No behaviour changes** — every inherited member was overridden.

### The guard is over the whole tree

This was the **only** instance of a module-scope def or class bound twice across 290 files, which is
why the check scans the tree rather than the file: one instance is a fix, the check is what keeps it
at one. Mutation-tested by restoring the self-subclassing — it fails and names the file and both line
numbers.

Assignment rebinding is deliberately *not* checked: module-scope constants are legitimately rebound
under `try`/`except` import fallbacks throughout this tree, and flagging those would be noise. The
import-then-reassign case has its own guard in `test_two_modules_do_not_read_the_same_variable`
(#1577).
