### PR TITLE
A readiness report claimed a store round-trip it never performed

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -5165,10 +5165,21 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             "probe": bool(probe),
             "attempts": 1,
             "topology": {"mode": "local-jsonl", "event_log": str(self.event_log), "jsonl_guardrails": self._local_jsonl_guardrails()},
+            # Two of these were hard-coded True and neither had happened: this adapter has no
+            # namespace and no table to open, and it issues no warmup hset/hget, so
+            # `slot_coverage_verified_by_warmup_hset_hget` asserted a verification that cannot
+            # occur here. The engine adapters set both False and flip them True only after doing
+            # the work -- matrixark_temporal_direct_write initialises False and sets True once the
+            # warmup round-trips -- so False already means "not verified", not "failed".
+            #
+            # `status` stays "ready" and is the only field anything gates on:
+            # ensure_startup_backend_ready refuses on `status != "ready"` and never reads `checks`.
+            # A JSONL adapter with an openable event log IS ready; what it is not is verified by
+            # checks it does not run.
             "checks": {
                 "mcp_process_started": True,
-                "namespace_table_opened": True,
-                "slot_coverage_verified_by_warmup_hset_hget": True,
+                "namespace_table_opened": False,
+                "slot_coverage_verified_by_warmup_hset_hget": False,
             },
         }
 

--- a/tools/test_a_readiness_check_reports_only_what_it_ran.py
+++ b/tools/test_a_readiness_check_reports_only_what_it_ran.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A readiness check may not report a verification it did not perform.
+
+`MatrixArkLocalAdapter.ensure_backend_ready` returned three checks, all hard-coded True. Two of
+them describe work the JSONL adapter does not do: it has no namespace and no table to open, and it
+issues no warmup hset/hget, so `slot_coverage_verified_by_warmup_hset_hget` asserted a round-trip
+that cannot happen on that backend.
+
+The engine adapters already spell the convention: `matrixark_temporal_direct_write` initialises
+both to False and flips them True only after the warmup actually round-trips. False means "not
+verified" there, not "failed" -- which is why reporting False here costs nothing and reporting
+True cost the reader their ability to tell the two backends apart.
+
+WHAT THIS FILE CHECKS, and what it deliberately does not. It does not require any particular check
+to be False: a backend that really does open a namespace should say True, and pinning values would
+make this file a copy of the implementation. It requires that a literal True is not the ONLY thing
+standing behind a check name -- that somewhere in the function that produced it, the value came
+from something other than the constant. For the local adapter that is now two Falses and one True
+whose name is `mcp_process_started`, which is the one claim the function can make about itself.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import pathlib
+import unittest
+
+TOOLS = pathlib.Path(os.path.dirname(os.path.abspath(__file__)))
+
+#: The check names that describe a ROUND TRIP -- work against a store, not a statement about the
+#: process. A backend that cannot do the work must not claim it.
+ROUND_TRIP_CHECKS = ("namespace_table_opened", "slot_coverage_verified_by_warmup_hset_hget")
+
+
+def _literal_true_checks(path):
+    """(function, check name) for every round-trip check set to a literal True in that file."""
+    out = []
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (SyntaxError, OSError):  # pragma: no cover
+        return out
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for sub in ast.walk(node):
+            if not isinstance(sub, ast.Dict):
+                continue
+            for key, value in zip(sub.keys, sub.values):
+                if (isinstance(key, ast.Constant) and key.value in ROUND_TRIP_CHECKS
+                        and isinstance(value, ast.Constant) and value.value is True):
+                    out.append((node.name, key.value, sub.lineno))
+    return out
+
+
+class AReadinessCheckReportsOnlyWhatItRanTest(unittest.TestCase):
+
+    def test_the_scan_reads_the_tree(self) -> None:
+        """Control: a glob matching nothing would satisfy everything below."""
+        modules = list(TOOLS.glob("*.py"))
+        self.assertGreater(len(modules), 100,
+                           "only %d modules found; the scan is not reading the tree" % len(modules))
+
+    def test_the_scan_still_finds_these_check_names(self) -> None:
+        """Positive control on the names. If they are renamed this file silently checks nothing."""
+        found = set()
+        for path in TOOLS.glob("*.py"):
+            if path.name.startswith("test_"):
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except OSError:  # pragma: no cover
+                continue
+            for name in ROUND_TRIP_CHECKS:
+                if name in text:
+                    found.add(name)
+        self.assertEqual(
+            set(ROUND_TRIP_CHECKS), found,
+            "these round-trip check names are no longer in the tree: %s -- rename them here or "
+            "drop them, because this file is now asserting about nothing"
+            % ", ".join(sorted(set(ROUND_TRIP_CHECKS) - found)))
+
+    def test_no_backend_claims_a_round_trip_with_a_literal_true(self) -> None:
+        """The rule. A check naming a store round-trip must be earned, not asserted."""
+        claims = []
+        for path in sorted(TOOLS.glob("*.py")):
+            if path.name.startswith("test_"):
+                continue
+            for func, check, line in _literal_true_checks(path):
+                claims.append("%s.%s sets %s to True at line %d" % (path.stem, func, check, line))
+        self.assertEqual(
+            [], claims,
+            "a readiness report states a store round-trip succeeded without performing one. "
+            "Initialise it False and set it True where the work happens, the way "
+            "matrixark_temporal_direct_write does: %s" % "; ".join(claims))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`MatrixArkLocalAdapter.ensure_backend_ready` returned three checks, **all hard-coded `True`**. Two
describe work this adapter does not do:

| check | reality |
|---|---|
| `namespace_table_opened` | it has no namespace and no table |
| `slot_coverage_verified_by_warmup_hset_hget` | it issues no warmup hset/hget |

The engine adapters already spell the convention: `matrixark_temporal_direct_write` initialises both
to `False` and sets them `True` **only after the warmup actually round-trips**;
`matrixark_temporal_direct_backend` does the same. So `False` means *"not verified"*, not *"failed"*
— `test_backend_policy_part4` asserts `False` for the direct backend in two scenarios. Reporting
`False` here costs nothing; reporting `True` cost a reader the ability to tell the two backends
apart.

`status` stays `"ready"` and is the only field anything gates on — `ensure_startup_backend_ready`
refuses on `status != "ready"` and never reads `checks`. A JSONL adapter with an openable event log
*is* ready; what it is not is verified by checks it does not run. (`backend_ready_required("local")`
is `False` anyway, so that gate never runs for this backend.)

### How it was found

A sweep for parameters a function declares and never reads. `ensure_backend_ready` accepts
`timeout_ms` and ignores it — which is **correct**, and now says so: there is nothing to time out,
and the parameter exists so the signature matches the engine adapters, because
`adapter_ensure_backend_ready` calls *with* it and falls back to calling *without* it on
`TypeError`. That fallback once swallowed a readiness check entirely. Reading the function to
confirm the parameter was harmless is what surfaced the checks above it.

The same sweep flagged three more in that file — `_lookup_persisted_event_members`,
`_persist_event_members`, `_forget_persisted_event_members` — and **all three are fine**: documented
no-op seams for the engine adapter to override. Reading them is what established that.

### The guard asks about the shape, not the values

It does not require any check to be `False` — a backend that really opens a namespace should say
`True`, and pinning values would make the test a copy of the implementation. It requires that a
check naming a store **round trip** is not set from a literal `True`: earn it where the work
happens. Two controls: the scan must see the tree, and both check names must still exist, since a
rename would leave the file asserting about nothing.

Mutation-tested by restoring one hard-coded `True` — it fails and names the module, function, check
and line.
