### PR TITLE
One walk, three consumers, in the object-lifecycle snapshot

### DIFF
--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -204,19 +204,58 @@ impl TemporalEngine {
         let Some(shard) = shards.get(&shard_id) else {
             return StorageObjectLifecycleReport::default();
         };
-        let ownership = self.validate_shard_page_ownership(shard_id, shard);
-        let mut report = storage_object_lifecycle_report(shard_id, shard);
-        report.owner_mismatch_page_refs = ownership.mismatches.len() as u64;
-        report.missing_owner_page_refs = ownership.missing_owner_page_refs as u64;
+        // ONE walk, three consumers.
+        //
+        // This used to walk the shard THREE times over identical, immutable state: once inside
+        // `validate_shard_page_ownership`, once inside `storage_object_lifecycle_report`, and once
+        // in `collect_live_page_addresses`. Each call to `collect_live_page_entries` materializes
+        // every live page in the shard into a fresh Vec, and measured at 4,000 objects this single
+        // function accounted for 3.0x the shard -- the largest piece of `apply_storage_lifecycle`,
+        // itself 12.0x (`what_each_plan_call_walks`).
+        //
+        // Hoisting is safe HERE in a way it is not across a maintenance round: the read lock is
+        // held for all three, `&ShardState` is immutable throughout, and nothing between them can
+        // change what a walk would find. Elsewhere in the round the stages genuinely mutate
+        // between calls, which is why this is a hoist and not a cache.
+        //
+        // Order matters only because the report CONSUMES the entries: borrow for the two cheap
+        // derivations first, then hand the Vec over last.
+        let entries = collect_live_page_entries(shard);
+
+        let (start_routing_bucket, end_routing_bucket) = self
+            .infos
+            .read()
+            .expect("info lock poisoned")
+            .get(&shard_id)
+            .map(|info| (info.start_routing_bucket, info.end_routing_bucket))
+            .unwrap_or((0, u32::MAX));
+        let ownership = validate_bucket_ownership_index_from_entries(
+            shard_id,
+            shard,
+            &entries,
+            start_routing_bucket,
+            end_routing_bucket,
+        );
+
         // stale_object_ids is the per-slab shortfall of live refs against the slab's own page
         // count, summed. An address naming a slab the store has no report for contributes
         // nothing (the report path gives it page_count 0, so its shortfall saturates to 0).
         let mut live_page_refs_by_slab = BTreeMap::<u64, u64>::new();
-        for address in collect_live_page_addresses(shard) {
+        for entry in &entries {
             *live_page_refs_by_slab
-                .entry(address.block_slab_id)
+                .entry(entry.address.block_slab_id)
                 .or_default() += 1;
         }
+
+        let mut report = object_lifecycle_report_from_entries(
+            shard_id,
+            shard,
+            entries,
+            &BTreeSet::new(),
+            |_| 0,
+        );
+        report.owner_mismatch_page_refs = ownership.mismatches.len() as u64;
+        report.missing_owner_page_refs = ownership.missing_owner_page_refs as u64;
         report.stale_object_ids = block_slab_counts
             .iter()
             .map(|(block_slab_id, _physical_bytes, block_count)| {

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -2763,9 +2763,30 @@ pub(super) fn validate_bucket_ownership_index(
     start_routing_bucket: u32,
     end_routing_bucket: u32,
 ) -> StoragePageOwnershipValidation {
+    validate_bucket_ownership_index_from_entries(
+        shard_id,
+        shard,
+        &collect_live_page_entries(shard),
+        start_routing_bucket,
+        end_routing_bucket,
+    )
+}
+
+/// The same validation against live-page entries the caller ALREADY has.
+///
+/// `collect_live_page_entries` materializes every live page in the shard, and callers that need
+/// several derived reports were each walking for their own copy. Taking a slice lets one walk
+/// serve all of them. The wrapper above keeps the old signature for callers with nothing to share.
+pub(super) fn validate_bucket_ownership_index_from_entries(
+    shard_id: ShardId,
+    shard: &ShardState,
+    entries: &[LiveBlockEntry],
+    start_routing_bucket: u32,
+    end_routing_bucket: u32,
+) -> StoragePageOwnershipValidation {
     let mut validation = StoragePageOwnershipValidation::default();
-    for entry in collect_live_page_entries(shard) {
-        let expected_object_id = expected_live_page_object_id(shard_id, &entry);
+    for entry in entries {
+        let expected_object_id = expected_live_page_object_id(shard_id, entry);
         let expected_routing_bucket =
             page_routing_bucket(&entry.object_key, start_routing_bucket, end_routing_bucket);
         let expected_page_id = entry.address.page_id();

--- a/crates/temporalstore-rust/src/engine/storage_reporting.rs
+++ b/crates/temporalstore-rust/src/engine/storage_reporting.rs
@@ -45,7 +45,7 @@ pub(super) fn storage_object_lifecycle_report_for_buckets_from_model_maps(
     )
 }
 
-fn object_lifecycle_report_from_entries(
+pub(super) fn object_lifecycle_report_from_entries(
     shard_id: ShardId,
     shard: &ShardState,
     entries: Vec<LiveBlockEntry>,

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -7835,6 +7835,71 @@ fn fingerprinting_does_not_scale_with_the_manifest_count() {
     );
 }
 
+/// The object-lifecycle snapshot walks the shard ONCE, not three times.
+///
+/// It derives three things from the live-page set -- page ownership validation, the object
+/// lifecycle report, and the per-slab live-ref counts -- and used to call
+/// `collect_live_page_entries` separately for each. That materializes every live page in the
+/// shard into a fresh Vec, so the call cost 3x the shard, measured by `what_each_plan_call_walks`
+/// as the largest single piece of `apply_storage_lifecycle` (itself 12x).
+///
+/// All three read the SAME `&ShardState` under ONE read lock with nothing mutating between them,
+/// so one walk can serve all three. This pins that. It is deliberately an exact equality rather
+/// than a bound: the number should be the live page count, and a second walk creeping back in is
+/// exactly what this exists to catch.
+#[test]
+fn the_object_lifecycle_snapshot_walks_the_shard_once() {
+    const RECORDS: usize = 1_000;
+
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        16 * 1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    for index in 0..RECORDS {
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("once-{index:06}"),
+                value: vec![b'v'; 64],
+            },
+        });
+        assert!(response.status.ok, "write {index}: {:?}", response.status);
+    }
+
+    let live_pages: u64 = engine
+        .bucket_storage_summaries(1)
+        .iter()
+        .map(|summary| summary.page_ref_count as u64)
+        .sum();
+    // Denominator: with no live pages every walk count is 0 and the equality below would hold
+    // for a shard that stored nothing.
+    assert!(live_pages > 0, "fixture stored no live pages, so this measures nothing");
+
+    crate::engine::reset_live_page_scan_entries();
+    let report = engine.storage_object_lifecycle_snapshot(1);
+    let walked = crate::engine::live_page_scan_entries();
+
+    // The snapshot must still SAY something -- a call that returned an empty report would walk
+    // once trivially and pass.
+    assert!(
+        report.live_page_refs > 0 || report.live_object_ids > 0,
+        "the snapshot reported nothing, so the walk it did was not the real one: {report:?}",
+    );
+
+    assert_eq!(
+        walked, live_pages,
+        "storage_object_lifecycle_snapshot materialized {walked} live-page entries for a shard \
+holding {live_pages} live pages -- that is {:.1} walks, and it should be exactly one. Its three \
+consumers (ownership validation, the lifecycle report, the per-slab ref counts) share one walk; \
+if a fourth consumer was added, give it the slice rather than its own scan.",
+        walked as f64 / live_pages as f64,
+    );
+}
+
 /// `apply_storage_lifecycle` walks the shard TWELVE times. Which of its pieces? Prints.
 ///
 ///   cargo test --release -p temporalstore-rust --lib what_apply_storage_lifecycle_walks -- --ignored --nocapture


### PR DESCRIPTION
`storage_object_lifecycle_snapshot` derives three things from the shard's live-page set — page
ownership validation, the object lifecycle report, and the per-slab live-ref counts — and called
`collect_live_page_entries` **separately for each**. That call materializes every live page in the
shard into a fresh `Vec`, so the function walked the shard three times over identical input.

[#1581](https://github.com/matrixarkai/TemporalStore/pull/1581) measured it as 3.0× the shard — the
largest single piece of `apply_storage_lifecycle`, itself 12.0× and most of the `reclaim_wal`
stage's 16×.

| | before | after |
|---|---|---|
| `storage_object_lifecycle_snapshot` | 3.0× | **1.0×** |
| `apply_storage_lifecycle` | 12.0× | **10.0×** |

Two whole-shard walks removed from every maintenance round, on a loop whose period is 30 s.

## Why hoisting is safe here, and not elsewhere

The read lock is held across all three, `&ShardState` is immutable throughout, and nothing between
them can change what a walk would find. So this is a **hoist, not a cache**: there is no lifetime
over which the materialized set could go stale.

That distinction is the whole reason this is the change being made. Memoizing across a maintenance
**round** is not available on the same terms — the stages genuinely mutate between calls (the
lifecycle stage dumps and writes manifests immediately before `reclaim_index` runs), which is why
the plans are rebuilt rather than shared, and why "cache the plan for the round" would be wrong.

Order inside the function matters only because the lifecycle report **consumes** the entries: the
two cheap derivations borrow first and the `Vec` is handed over last, so nothing is cloned.

The old `validate_bucket_ownership_index` signature is kept as a wrapper around the new
`..._from_entries` form, so callers with nothing to share are untouched.
`object_lifecycle_report_from_entries` already took entries; it only needed widening to
`pub(super)`.

## Verified by mutation

With the hoist reverted, `the_object_lifecycle_snapshot_walks_the_shard_once` fails with:

```
materialized 3000 live-page entries for a shard holding 1000 live pages -- that is 3.0 walks,
and it should be exactly one.
```

The guard asserts **exact equality** rather than a bound, because the failure it exists to catch is
a second walk creeping back in, and a loose bound would admit one. Two denominators come first: the
fixture must hold live pages, and the snapshot must actually report something, so a call returning
an empty report cannot pass by walking once trivially. Its message names the three consumers and
says to pass the slice rather than add a fourth scan.

## Verification

`cargo test -p temporalstore-rust --lib -- --test-threads=1` → **1780 passed, 1 failed**. The
single failure is `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the standing
`--lib` baseline failure on main, not introduced here.
