### PR TITLE
Thirty-two duplicated literals take one definition

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -70,8 +70,83 @@ def _mcp_debug_log(message: str) -> None:
             fh.write(f"{time.time():.3f} {message}\n")
     except Exception:
         pass
-MAX_PRIOR_MESSAGES = 8
-MAX_PRIOR_CHARS = 4096
+# Thirty-two constants that this module and matrixark_mcp_runtime_config both spelled out, with
+# byte-identical text in each file. Every one is a pure literal -- no environment read anywhere in
+# the expression -- which is why they are moved together while the other forty-three are not: no
+# guard that asks "which module reads flag X" can change answer over these, because none of them
+# reads a flag.
+try:  # the values live in matrixark_mcp_runtime_config; this module re-exports them
+    from tools.matrixark_mcp_runtime_config import (
+        BACKEND_READINESS_CONNECT_TIMEOUT_MS,
+        DEFAULT_BUSINESS_WEIGHT,
+        DEFAULT_CROSS_SESSION_BUDGET_RATIO,
+        DEFAULT_CROSS_SESSION_MAX_BUDGET_RATIO,
+        DEFAULT_CROSS_SESSION_MAX_BUDGET_TOKENS,
+        DEFAULT_CROSS_SESSION_PROFILE_BUDGET_RATIO,
+        DEFAULT_CROSS_SESSION_PROFILE_MAX_BUDGET_RATIO,
+        DEFAULT_CROSS_SESSION_PROFILE_MAX_BUDGET_TOKENS,
+        DEFAULT_SHARED_RESOURCE_BUDGET_RATIO,
+        DEFAULT_SHARED_RESOURCE_MAX_BUDGET_RATIO,
+        DEFAULT_SHARED_RESOURCE_MAX_BUDGET_TOKENS,
+        DEFAULT_SHARED_SKILL_BUDGET_RATIO,
+        DEFAULT_SHARED_SKILL_MAX_BUDGET_RATIO,
+        DEFAULT_SHARED_SKILL_MAX_BUDGET_TOKENS,
+        DEFAULT_TIME_DECAY_HALFLIFE_MS,
+        DEFAULT_TIME_DECAY_TOLERANCE_MS,
+        DEFAULT_TIME_WEIGHT,
+        DIRECT_AUDIT_BUFFER_MAX_RECORDS,
+        DIRECT_AUDIT_FLUSH_INTERVAL_MS,
+        DIRECT_WRITE_BACKOFF_MS,
+        DIRECT_WRITE_RETRIES,
+        DIRECT_WRITE_THROTTLE_MS,
+        MAX_PRIOR_CHARS,
+        MAX_PRIOR_MESSAGES,
+        RESOURCE_ASYNC_DEFAULT_PATH_COUNT,
+        RESOURCE_ASYNC_DEFAULT_TEXT_CHARS,
+        SUMMARY_REFRESH_MAX_BACKOFF_MS,
+        SUMMARY_REFRESH_MAX_DUTY,
+        TIME_COMPRESSION_MAX_WINDOWS_PER_REFRESH,
+        TIME_COMPRESSION_MIN_EVENT_AGE_MS,
+        TIME_COMPRESSION_RAW_EVENT_TTL_AFTER_COMPRESSION_MS,
+        TIME_COMPRESSION_REINFORCEMENT_PROTECT_MS,
+    )
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_runtime_config import (
+        BACKEND_READINESS_CONNECT_TIMEOUT_MS,
+        DEFAULT_BUSINESS_WEIGHT,
+        DEFAULT_CROSS_SESSION_BUDGET_RATIO,
+        DEFAULT_CROSS_SESSION_MAX_BUDGET_RATIO,
+        DEFAULT_CROSS_SESSION_MAX_BUDGET_TOKENS,
+        DEFAULT_CROSS_SESSION_PROFILE_BUDGET_RATIO,
+        DEFAULT_CROSS_SESSION_PROFILE_MAX_BUDGET_RATIO,
+        DEFAULT_CROSS_SESSION_PROFILE_MAX_BUDGET_TOKENS,
+        DEFAULT_SHARED_RESOURCE_BUDGET_RATIO,
+        DEFAULT_SHARED_RESOURCE_MAX_BUDGET_RATIO,
+        DEFAULT_SHARED_RESOURCE_MAX_BUDGET_TOKENS,
+        DEFAULT_SHARED_SKILL_BUDGET_RATIO,
+        DEFAULT_SHARED_SKILL_MAX_BUDGET_RATIO,
+        DEFAULT_SHARED_SKILL_MAX_BUDGET_TOKENS,
+        DEFAULT_TIME_DECAY_HALFLIFE_MS,
+        DEFAULT_TIME_DECAY_TOLERANCE_MS,
+        DEFAULT_TIME_WEIGHT,
+        DIRECT_AUDIT_BUFFER_MAX_RECORDS,
+        DIRECT_AUDIT_FLUSH_INTERVAL_MS,
+        DIRECT_WRITE_BACKOFF_MS,
+        DIRECT_WRITE_RETRIES,
+        DIRECT_WRITE_THROTTLE_MS,
+        MAX_PRIOR_CHARS,
+        MAX_PRIOR_MESSAGES,
+        RESOURCE_ASYNC_DEFAULT_PATH_COUNT,
+        RESOURCE_ASYNC_DEFAULT_TEXT_CHARS,
+        SUMMARY_REFRESH_MAX_BACKOFF_MS,
+        SUMMARY_REFRESH_MAX_DUTY,
+        TIME_COMPRESSION_MAX_WINDOWS_PER_REFRESH,
+        TIME_COMPRESSION_MIN_EVENT_AGE_MS,
+        TIME_COMPRESSION_RAW_EVENT_TTL_AFTER_COMPRESSION_MS,
+        TIME_COMPRESSION_REINFORCEMENT_PROTECT_MS,
+    )
+
+
 # EMBEDDING_DIM lives with the encoder that uses it. core carried its own copy of this
 # constant, left from when it also carried its own embedding_for_text -- and because the
 # serving modules pull core in with `import *`, a copy here is the one they would resolve.
@@ -88,12 +163,7 @@ except ImportError:  # top-level path (direct tools/ execution)
 DIRECT_RECORD_LOG_SHARD_SIZE = int(os.environ.get("MATRIXARK_DIRECT_RECORD_LOG_SHARD_SIZE", "").strip() or "256")
 DIRECT_RECORD_BUNDLE_MAX_BYTES = int(os.environ.get("MATRIXARK_DIRECT_RECORD_BUNDLE_MAX_BYTES", "").strip() or "65536")
 DIRECT_RECORD_HOT_CACHE_MAX_RECORDS = int(os.environ.get("MATRIXARK_DIRECT_RECORD_HOT_CACHE_MAX_RECORDS", "").strip() or "20000")
-DIRECT_WRITE_RETRIES = 3
-DIRECT_WRITE_BACKOFF_MS = 25
-DIRECT_WRITE_THROTTLE_MS = 0
 DIRECT_AUDIT_MODE = (os.environ.get("MATRIXARK_DIRECT_AUDIT_MODE", "").strip().lower() or "buffered")
-DIRECT_AUDIT_BUFFER_MAX_RECORDS = 128
-DIRECT_AUDIT_FLUSH_INTERVAL_MS = 1000
 CONTEXT_TELEMETRY_WRITE_MODE = (os.environ.get("MATRIXARK_CONTEXT_TELEMETRY_WRITE_MODE", "").strip().lower() or "inline")
 # These four, and four more below, are defined here AND in matrixark_mcp_runtime_config. See the
 # single-source note beside DEFAULT_MAX_CONTEXT_TOKENS further down: that constant was read from
@@ -107,8 +177,6 @@ SUMMARY_REFRESH_LIMIT = int(os.environ.get("MATRIXARK_SUMMARY_REFRESH_LIMIT", ""
 # through the same proxy lane the request path uses -- so at a fixed interval a pass that
 # grows past that interval turns the loop into a permanent occupant of the lane. See
 # MatrixArkMcpServer._next_summary_refresh_delay_s.
-SUMMARY_REFRESH_MAX_DUTY = 0.2
-SUMMARY_REFRESH_MAX_BACKOFF_MS = 300000
 BACKEND_READINESS_TIMEOUT_MS = int(os.environ.get("MATRIXARK_BACKEND_READINESS_TIMEOUT_MS", "").strip() or "30000")
 BACKEND_READINESS_BACKOFF_MS = int(os.environ.get("MATRIXARK_BACKEND_READINESS_BACKOFF_MS", "").strip() or "200")
 MATRIXARK_MCP_PROFILE = (os.environ.get("MATRIXARK_MCP_PROFILE", "").strip().lower() or "dev")
@@ -117,7 +185,6 @@ MATRIXARK_REQUIRE_BACKEND_READY = os.environ.get("MATRIXARK_REQUIRE_BACKEND_READ
 MATRIXARK_REQUIRE_NATIVE_CONTEXT_PACK = os.environ.get("MATRIXARK_REQUIRE_NATIVE_CONTEXT_PACK", "").strip().lower()
 MATRIXARK_ALLOW_PYTHON_HOT_CACHE = os.environ.get("MATRIXARK_ALLOW_PYTHON_HOT_CACHE", "").strip().lower()
 MATRIXARK_REQUIRE_NATIVE_CANDIDATE_PREFILTER = os.environ.get("MATRIXARK_REQUIRE_NATIVE_CANDIDATE_PREFILTER", "").strip().lower()
-BACKEND_READINESS_CONNECT_TIMEOUT_MS = 1000
 
 # Single source of truth: reuse the runtime-config default so core and
 # matrixark_mcp_runtime_config agree out-of-the-box (both were previously
@@ -227,13 +294,7 @@ MAX_RESOURCE_FACTS_PER_RESOURCE = 8
 MAX_RESOURCE_FACTS_PER_CHUNK = 2
 ENABLE_GENERIC_RESOURCE_FACTS = env_bool("MATRIXARK_ENABLE_GENERIC_RESOURCE_FACTS", False)
 RESOURCE_ASYNC_DEFAULT_BYTES = int(os.environ.get("MATRIXARK_RESOURCE_ASYNC_DEFAULT_BYTES", "").strip() or str(2 * 1024 * 1024))
-RESOURCE_ASYNC_DEFAULT_TEXT_CHARS = 200000
-RESOURCE_ASYNC_DEFAULT_PATH_COUNT = 32
 MAX_CONTEXT_REF_CHARS = 4096
-DEFAULT_TIME_DECAY_TOLERANCE_MS = 24 * 60 * 60 * 1000
-DEFAULT_TIME_DECAY_HALFLIFE_MS = 7 * 24 * 60 * 60 * 1000
-DEFAULT_TIME_WEIGHT = 0.18
-DEFAULT_BUSINESS_WEIGHT = 0.22
 # 0.05, which is what config/temporalstore.toml declares. The code said 0.20, the config said
 # 0.05, and the engine request builder sent a bare 0.0 that overrode both -- so the threshold a
 # deployment got depended on which surface the request came through.
@@ -253,13 +314,9 @@ DEFAULT_BUDGET_FILL_POLICY = (os.environ.get("MATRIXARK_BUDGET_FILL_POLICY", "")
 DEFAULT_NEAR_DUPLICATE_OVERLAP_THRESHOLD = float(
     os.environ.get("MATRIXARK_NEAR_DUPLICATE_OVERLAP_THRESHOLD", "").strip() or "0.85"
 )
-DEFAULT_CROSS_SESSION_BUDGET_RATIO = 0.12  # build default; live_float reads the environment
 DEFAULT_CROSS_SESSION_CURRENT_STATE_BUDGET_RATIO = float(os.environ.get("MATRIXARK_CROSS_SESSION_CURRENT_STATE_BUDGET_RATIO", "").strip() or "0.20")
 DEFAULT_CROSS_SESSION_MULTI_HOP_BUDGET_RATIO = float(os.environ.get("MATRIXARK_CROSS_SESSION_MULTI_HOP_BUDGET_RATIO", "").strip() or "0.20")
 DEFAULT_CROSS_SESSION_BROAD_BUDGET_RATIO = float(os.environ.get("MATRIXARK_CROSS_SESSION_BROAD_BUDGET_RATIO", "").strip() or "0.15")
-DEFAULT_CROSS_SESSION_PROFILE_BUDGET_RATIO = 0.30  # build default; live_float reads the environment
-DEFAULT_CROSS_SESSION_MAX_BUDGET_TOKENS = 262144  # build default; live_int reads the environment
-DEFAULT_CROSS_SESSION_PROFILE_MAX_BUDGET_TOKENS = 327680  # build default; live_int reads the environment
 DEFAULT_CROSS_SESSION_MAX_SESSIONS = int(os.environ.get("MATRIXARK_CROSS_SESSION_MAX_SESSIONS", "").strip() or "3")
 DEFAULT_CROSS_SESSION_MAX_CANDIDATES = int(os.environ.get("MATRIXARK_CROSS_SESSION_MAX_CANDIDATES", "").strip() or "24")
 DEFAULT_CROSS_SESSION_MIN_ENTITY_BRIDGE_REFS = int(os.environ.get("MATRIXARK_CROSS_SESSION_MIN_ENTITY_BRIDGE_REFS", "").strip() or "2")
@@ -267,8 +324,6 @@ DEFAULT_CROSS_SESSION_PARALLELISM = int(os.environ.get("MATRIXARK_CROSS_SESSION_
 DEFAULT_CROSS_SESSION_MIN_BUDGET_TOKENS = int(os.environ.get("MATRIXARK_CROSS_SESSION_MIN_BUDGET_TOKENS", "").strip() or "256")
 DEFAULT_CROSS_SESSION_MIN_SCORE = float(os.environ.get("MATRIXARK_CROSS_SESSION_MIN_SCORE", "").strip() or "0.20")
 DEFAULT_CROSS_SESSION_RAW_EVIDENCE_MIN_SCORE = float(os.environ.get("MATRIXARK_CROSS_SESSION_RAW_EVIDENCE_MIN_SCORE", "").strip() or "0.45")
-DEFAULT_CROSS_SESSION_MAX_BUDGET_RATIO = 0.50  # the guard, not the setting: the share below is what decides
-DEFAULT_CROSS_SESSION_PROFILE_MAX_BUDGET_RATIO = 0.60  # the guard, not the setting: the share below is what decides
 DEFAULT_CROSS_SESSION_PROFILE_MAX_SESSIONS = int(os.environ.get("MATRIXARK_CROSS_SESSION_PROFILE_MAX_SESSIONS", "").strip() or "6")
 DEFAULT_CROSS_SESSION_PROFILE_MAX_CANDIDATES = int(os.environ.get("MATRIXARK_CROSS_SESSION_PROFILE_MAX_CANDIDATES", "").strip() or "48")
 DEFAULT_CROSS_SESSION_PROFILE_MIN_ENTITY_BRIDGE_REFS = int(os.environ.get("MATRIXARK_CROSS_SESSION_PROFILE_MIN_ENTITY_BRIDGE_REFS", "").strip() or "3")
@@ -277,20 +332,10 @@ DEFAULT_CROSS_SESSION_PREFERRED_REF_TYPES = tuple(
     for item in (os.environ.get("MATRIXARK_CROSS_SESSION_PREFERRED_REF_TYPES", "").strip() or "entity,summary,compression").split(",")
     if item.strip()
 )
-DEFAULT_SHARED_RESOURCE_BUDGET_RATIO = 0.25  # build default; live_float reads the environment
-DEFAULT_SHARED_RESOURCE_MAX_BUDGET_RATIO = 0.50  # the guard, not the setting: the share below is what decides
-DEFAULT_SHARED_RESOURCE_MAX_BUDGET_TOKENS = 262144  # build default; live_int reads the environment
-DEFAULT_SHARED_SKILL_BUDGET_RATIO = 0.10  # build default; live_float reads the environment
-DEFAULT_SHARED_SKILL_MAX_BUDGET_RATIO = 0.50  # the guard, not the setting: the share below is what decides
-DEFAULT_SHARED_SKILL_MAX_BUDGET_TOKENS = 262144  # build default; live_int reads the environment
 DEFAULT_SHARED_CONTEXT_MIN_SCORE = float(os.environ.get("MATRIXARK_SHARED_CONTEXT_MIN_SCORE", "").strip() or "0.20")
 TIME_COMPRESSION_MAX_RAW_EVENTS_PER_NODE = int(os.environ.get("MATRIXARK_TIME_COMPRESSION_MAX_RAW_EVENTS_PER_NODE", "").strip() or "256")
 TIME_COMPRESSION_WINDOW_EVENTS = int(os.environ.get("MATRIXARK_TIME_COMPRESSION_WINDOW_EVENTS", "").strip() or "64")
 TIME_COMPRESSION_MIN_EVENTS = int(os.environ.get("MATRIXARK_TIME_COMPRESSION_MIN_EVENTS", "").strip() or "8")
-TIME_COMPRESSION_MAX_WINDOWS_PER_REFRESH = 4
-TIME_COMPRESSION_MIN_EVENT_AGE_MS = 0
-TIME_COMPRESSION_RAW_EVENT_TTL_AFTER_COMPRESSION_MS = 2592000000
-TIME_COMPRESSION_REINFORCEMENT_PROTECT_MS = 2592000000
 TIME_COMPRESSION_SUMMARY_PROVIDER = (os.environ.get("MATRIXARK_TIME_COMPRESSION_SUMMARY_PROVIDER", "").strip().lower() or "deterministic")
 TIME_COMPRESSION_SUMMARY_MODEL = (
     os.environ.get("MATRIXARK_TIME_COMPRESSION_SUMMARY_MODEL", "").strip()

--- a/tools/test_numeric_defaults_agree.py
+++ b/tools/test_numeric_defaults_agree.py
@@ -267,15 +267,41 @@ class TheRankingWeightsAreWrittenOnceTest(unittest.TestCase):
     NAMES = ("DEFAULT_TIME_WEIGHT", "DEFAULT_BUSINESS_WEIGHT")
 
     @staticmethod
-    def _module_constants(stem):
+    def _module_constants(stem, _resolve_imports=True):
+        """Module-scope constants, INCLUDING ones this module gets by importing them.
+
+        A name a module imports from the other is that module's constant as far as any reader
+        is concerned, and it is the strongest form of agreement available: one definition, so
+        the two cannot drift. Reading only literal assignments made consolidation look like the
+        constant had vanished -- which is how this file failed on matrixarkai#1587, where
+        thirty-two duplicated literals were each reduced to a single definition.
+
+        The `differ` check below is unaffected: two INDEPENDENT literal assignments still have
+        to match, and that is the disagreement this file exists for. An imported name agreeing
+        with itself is not a weaker answer than agreeing by hand -- it is the answer the hand
+        version was approximating."""
         with io.open(os.path.join(TOOLS, stem + ".py"), encoding="utf-8") as handle:
             tree = ast.parse(handle.read())
         found = {}
+        imported = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module and "matrixark_" in node.module:
+                for alias in node.names:
+                    if alias.name.isupper():
+                        imported.add((node.module.rsplit(".", 1)[-1],
+                                      alias.asname or alias.name, alias.name))
         for node in tree.body:
             if isinstance(node, ast.Assign) and len(node.targets) == 1 \
                     and isinstance(node.targets[0], ast.Name) \
                     and isinstance(node.value, ast.Constant):
                 found[node.targets[0].id] = node.value.value
+        if _resolve_imports:
+            for module, bound, original in sorted(imported):
+                if bound in found:
+                    continue
+                source = TheRankingWeightsAreWrittenOnceTest._module_constants(module, False)
+                if original in source:
+                    found[bound] = source[original]
         return found
 
     @staticmethod
@@ -332,10 +358,22 @@ class TheRankingWeightsAreWrittenOnceTest(unittest.TestCase):
         # guard's business -- so this sees thirty of the seventy-eight names the two modules share.
         # An extractor that stopped matching returns approximately nothing; ten fails loudly on
         # that and does not move when a constant is added or folded.
+        # The floor is on the EXTRACTOR, not on the shared set.
+        #
+        # It required more than ten names in BOTH modules, reasoning that an extractor which had
+        # stopped matching returns approximately nothing. True while the two modules held thirty
+        # duplicated literals; false as a floor, because the shared set also falls when the
+        # duplication is REMOVED -- and it fell to zero in matrixarkai#1587, which gave each of
+        # those literals a single definition. A floor that cannot tell "the scan broke" from
+        # "there is nothing left to disagree" fails on the better outcome.
+        #
+        # So it asks what it was really asking: can this scan find constants at all.
+        runtime_only = self._module_constants("matrixark_mcp_runtime_config", False)
         self.assertGreater(
-            len(shared), 10,
-            "only %d constants are defined in both modules; the extractor has probably stopped "
-            "recognising them and this compares almost nothing" % len(shared))
+            len(runtime_only), 10,
+            "only %d literal constants were parsed out of matrixark_mcp_runtime_config; the "
+            "extractor has stopped recognising them and everything below compares nothing"
+            % len(runtime_only))
         differ = {name: (core[name], runtime[name])
                   for name in shared if core[name] != runtime[name]}
         self.assertEqual(

--- a/tools/test_two_modules_do_not_read_the_same_variable.py
+++ b/tools/test_two_modules_do_not_read_the_same_variable.py
@@ -32,8 +32,16 @@ TOOLS = os.path.dirname(os.path.abspath(__file__))
 CORE = "matrixark_mcp_core.py"
 RUNTIME = "matrixark_mcp_runtime_config.py"
 
-#: Constants defined identically in both modules, counted 2026-09-12. May only go DOWN.
-RECORDED_DUPLICATED = 77
+#: Constants defined identically in both modules. May only go DOWN.
+#:
+#: 77 -> 75 when matrixarkai#1577 removed the two shadowed re-reads, then -> 43 when the
+#: thirty-two PURE LITERALS moved to one definition. Those thirty-two were separated on a
+#: rule, not by taste: no environment read anywhere in the expression, so no guard that asks
+#: "which module reads flag X" could change answer over them -- which is the objection this
+#: file raises against sweeping, and it does not apply to a constant that reads no flag.
+#:
+#: The remaining 43 DO read the environment, and they stay one at a time.
+RECORDED_DUPLICATED = 43
 
 #: Defined in both and NOT identical, with the reason. `matrixark_mcp_core` binds
 #: DEFAULT_MAX_CONTEXT_TOKENS to the value it imported from runtime_config under an alias, which is


### PR DESCRIPTION
`matrixark_mcp_core` and `matrixark_mcp_runtime_config` both spelled out 75 constants with
byte-identical text in each file. **Thirty-two are pure literals** — `0.22`, `4096`,
`7 * 24 * 60 * 60 * 1000` — with no environment read anywhere in the expression. Those move to one
definition, which core re-exports.

| | |
|---|---|
| duplicated identically | 77 → **43** |

(−2 from #1577, which removed the two shadowed re-reads; −32 here.)

### Why these move together when the other 43 do not

#1577 refused to sweep, and gave a specific reason: every guard that asks *"which module reads flag
X"* changes answer on the same commit, and one real divergence hiding among identical-looking moves
is invisible in the diff.

**That objection is about flag reads.** It does not apply to a constant that reads no flag — and
these thirty-two were selected by exactly that test (no `Call`, `Name` or `Attribute` anywhere in
the expression), not by looking at them and judging. The flag surface is unchanged across this
commit, which is the prediction that rule makes and the check that confirms it.

The remaining 43 *do* read the environment and stay one at a time.

### Verified by value, not by reading

All thirty-two were recorded from a live import before the change and compared after: **zero values
differ**, and every non-interned one is now the *same object* as `matrixark_mcp_runtime_config`'s
rather than an equal copy.

`DEFAULT_MAX_CONTEXT_TOKENS` remains the one shared name that is **not** identical, and stays that
way — core binds it from the aliased import, which is the shape the other 43 are still missing.
