### PR TITLE
A status map that knows three statuses where the live one knows nine

### DIFF
--- a/tools/matrixark_mcp_context_pack.py
+++ b/tools/matrixark_mcp_context_pack.py
@@ -131,6 +131,23 @@ def _is_default_hidden_debug_lineage_key(key: Any) -> bool:
     return answer
 
 
+#: `by_dimension` is the exception among the `by_*` maps: its children are DIMENSION NAMES --
+#: `by_dimension["by_source_role"]` -- so they are exactly the kind of key this predicate is meant
+#: to test, and the descent there has to continue. Every other `by_*` map is keyed by a data VALUE:
+#: a reason, a scope, a ref type, a layer name. Checked against the pack builder's full set:
+#: by_codex_event, by_drop_reason, by_entity_type, by_extraction_phase, by_hook_type,
+#: by_memory_layer, by_memory_scope, by_memory_selection_policy, by_profile_memory_kind,
+#: by_profile_promotion_blocker, by_profile_promotion_policy, by_profile_shadowed_reason,
+#: by_ref_type, by_session_continuity, by_source_role.
+_KEYED_BY_NAME_NOT_VALUE = frozenset(("by_dimension",))
+
+
+def _keys_are_values(key: Any) -> bool:
+    """Whether this map's child keys are DATA, so the hidden-key predicate must not judge them."""
+    name = str(key or "")
+    return name.startswith("by_") and name not in _KEYED_BY_NAME_NOT_VALUE
+
+
 def strip_default_debug_lineage_fields(value: Any) -> Any:
     """Remove debug/lineage fields from the default prompt-facing ContextPack.
 
@@ -151,7 +168,7 @@ def strip_default_debug_lineage_fields(value: Any) -> Any:
         for key, item in value.items():
             if _is_default_hidden_debug_lineage_key(key):
                 continue
-            kept[key] = item if str(key).startswith("by_") \
+            kept[key] = item if _keys_are_values(key) \
                 else strip_default_debug_lineage_fields(item)
         return kept
     if isinstance(value, list):

--- a/tools/matrixark_mcp_context_pack.py
+++ b/tools/matrixark_mcp_context_pack.py
@@ -132,13 +132,28 @@ def _is_default_hidden_debug_lineage_key(key: Any) -> bool:
 
 
 def strip_default_debug_lineage_fields(value: Any) -> Any:
-    """Remove debug/lineage fields from the default prompt-facing ContextPack."""
+    """Remove debug/lineage fields from the default prompt-facing ContextPack.
+
+    THE CHILDREN OF A `by_*` DIMENSION ARE VALUES, NOT FIELD NAMES, and the predicate is a
+    substring rule. `dropped_memory_layer_budget["by_profile_shadowed_reason"]` is keyed by the
+    REASON a profile ref was shadowed, and one of those reasons is `source_entity_lineage` -- which
+    contains "lineage", so recursing into it deleted the bucket, left the dimension empty, and the
+    empty-sub-dict prune in `serving_memory_layer_budget` then dropped the dimension itself. The
+    whole "why was this shadowed" breakdown disappeared from a served pack because a reason was
+    named after the thing it describes.
+
+    A `by_*` dimension's own name is still tested, so `by_source_role` and the rest are removed
+    exactly as before -- only the descent into their contents stops. Anything not named `by_*` is
+    unchanged, because there the keys really are schema fields.
+    """
     if isinstance(value, dict):
-        return {
-            key: strip_default_debug_lineage_fields(item)
-            for key, item in value.items()
-            if not _is_default_hidden_debug_lineage_key(key)
-        }
+        kept = {}
+        for key, item in value.items():
+            if _is_default_hidden_debug_lineage_key(key):
+                continue
+            kept[key] = item if str(key).startswith("by_") \
+                else strip_default_debug_lineage_fields(item)
+        return kept
     if isinstance(value, list):
         return [strip_default_debug_lineage_fields(item) for item in value]
     return value

--- a/tools/matrixark_mcp_dashboard.py
+++ b/tools/matrixark_mcp_dashboard.py
@@ -92,22 +92,28 @@ def dashboard_message_rows(records: list[Json], scope: Json) -> list[Json]:
     return rows
 
 
-def latest_async_pipeline_rows(rows: list[Json]) -> list[Json]:
-    status_rank = {"pending": 0, "extraction_committed": 1, "summary_completed": 2}
-    latest_by_task: dict[int, Json] = {}
-    for row in rows:
-        try:
-            task_hash = int(row.get("task_hash") or row.get("event_id_hash"))
-        except (TypeError, ValueError):
-            continue
-        current = latest_by_task.get(task_hash)
-        current_rank = status_rank.get(str(current.get("status") or ""), -1) if current else -1
-        row_rank = status_rank.get(str(row.get("status") or ""), -1)
-        current_time = int(current.get("updated_at_ms") or current.get("created_at_ms") or 0) if current else -1
-        row_time = int(row.get("updated_at_ms") or row.get("created_at_ms") or 0)
-        if current is None or (row_rank, row_time) >= (current_rank, current_time):
-            latest_by_task[task_hash] = row
-    return list(latest_by_task.values())
+# This module kept its own copy of the status ranking, and that copy knows three statuses where
+# the live one knows nine. The selection is `(rank, time) >= (rank, time)`, so RANK DOMINATES and
+# an unknown status ranks -1.
+#
+# Here every idle_commit_* status is unknown, so they all tie at -1 and the timestamp decides.
+# That is right whenever the records arrive in order and wrong when they do not:
+#
+#     scheduled t=100, skipped   t=200   live: skipped     orphan: skipped
+#     scheduled t=200, skipped   t=100   live: skipped     orphan: SCHEDULED
+#     scheduled t=200, committed t=100   live: committed   orphan: SCHEDULED
+#
+# A task whose terminal record carries the earlier stamp reads as still scheduled through this
+# module and as finished through the live one.
+#
+# The live copy also carries the note explaining why `idle_commit_skipped` is in its map at all:
+# left out, it ranked -1 BELOW the `idle_commit_scheduled` it completes, so the completion lost to
+# its own precursor. That is the same failure this copy still has for all five of the statuses it
+# does not know.
+try:  # the implementation lives in matrixark_mcp_async_readiness; this module re-exports it
+    from tools.matrixark_mcp_async_readiness import latest_async_pipeline_rows
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_async_readiness import latest_async_pipeline_rows
 
 
 def dashboard_rows_for_table(records: list[Json], table: str, scope: Json) -> list[Json]:

--- a/tools/matrixark_mcp_extraction_normalization.py
+++ b/tools/matrixark_mcp_extraction_normalization.py
@@ -140,17 +140,25 @@ def normalize_extracted_entities(raw_entities: Any, *, fallback_text: str, sourc
     return dedupe_entities(entities)
 
 
-def normalize_extracted_segments(raw_segments: Any, messages: list[Json]) -> list[Json]:
-    if isinstance(raw_segments, list):
-        try:
-            try:
-                from tools.matrixark_mcp_extraction_runtime import normalize_model_segments
-            except ModuleNotFoundError:  # Direct script execution from tools/.
-                from matrixark_mcp_extraction_runtime import normalize_model_segments
-            return normalize_model_segments({"segments": raw_segments}, messages)
-        except MatrixArkError:
-            return []
-    return []
+# The copy here differed by a lazy import of normalize_model_segments inside the function, where
+# the live one has the name at module scope. Plumbing, and the only difference.
+#
+# `extract_batch_entities` is NOT moved with it, and it is the one left in this file worth knowing
+# about: thirty-four hunks against matrixark_mcp_core's, with real work on both sides. The live one
+# has a content-matching lineage builder, an assistant-profile filter, and a location pattern that
+# stops at a clause boundary -- carrying a comment about why:
+#
+#     "I live in Seattle and prefer metric units"   live: Seattle
+#                                                 orphan: Seattle and prefer metric units
+#
+# This copy has helpers the live one does not (role_lineage, profile_lineage_for_match,
+# source_refs_for_match) and a tool_evidence pattern the live one lacks. Neither is the complete
+# one, so neither can be deleted without deciding what the extractor should do -- which is a
+# different job from removing a copy.
+try:  # the implementation lives in matrixark_mcp_core_extraction; this module re-exports it
+    from tools.matrixark_mcp_core_extraction import normalize_extracted_segments
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_extraction import normalize_extracted_segments
 
 
 # Not defined here: the implementation lives in matrixark_mcp_core_extraction and this module carried an

--- a/tools/matrixark_mcp_extraction_normalization.py
+++ b/tools/matrixark_mcp_extraction_normalization.py
@@ -177,30 +177,35 @@ except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_core_codex_outcome import tool_evidence_memory_text
 
 
-def profile_entity_type_for_memory_text(text: str) -> str:
-    """Classify durable personal memory into profile layers used by retrieval."""
-    lower = " ".join(str(text or "").lower().split())
-    if not lower:
-        return ""
-    if re.search(r"\b(?:call me|my name is|i am called|i'm called|user(?:'s)? name|user goes by|pronouns?|address (?:me|the user)|nickname)\b", lower):
-        return "identity_profile"
-    if re.search(r"\b(?:reply|respond|answer|write|communication style|response style|answer style|preferred language|preferred format|language|locale|timezone|time zone|tone|style|format|bullets?|bullet points?|markdown|concise|brief|detailed)\b", lower):
-        return "communication_profile"
-    if re.search(r"\b(?:feature parity|feature[- ]focused|features? only|features? referring to|focuns on features?|focus(?:ed)? on features?|functionality|functionalities|functionality only|algorithms?|algos?|implementation focus|no testing|no teseting|no tests?|skip tests?|without tests?|no monitoring|no debugging|no debug|no evidence|no evident|no eviden[ct]e|feature work only|code changes only|mem0|long[- ]term memory|session memory|profile memory|cross[- ]session memory|threshold|idle batch|batch extraction)\b", lower):
-        return "memory_feature_profile"
-    if re.search(r"\b(?:workspace|repo|repository|branch|remote|github|origin/main|main branch|ubuntu|wsl|linux|windows folder|worktree|folder|build|deploy|deployment|rustraft|temporalstore|matrixark)\b", lower):
-        return "workspace_profile"
-    return ""
+# Two copies that classify the same text differently.
+#
+# profile_entity_type_for_memory_text tests the same branches as the live one in a
+# different ORDER: the live copy asks whether the text is about a memory feature before
+# asking whether it is about a response style, and this copy asked the other way round. Any
+# text that mentions both lands in a different class, and that is most of them --
+# "respond about long-term memory settings", "answer using session memory only",
+# "preferred language for profile memory" all classify as a communication profile here and
+# as a memory feature profile there.
+#
+# feature_scope_excludes_outcome_evidence had collapsed to a single expression that keeps
+# only one of the live copy's three tests, so "focus on features only" excludes outcome
+# evidence through the live path and does not through this one.
+try:  # the implementation lives in matrixark_mcp_core_codex_outcome; this module re-exports it
+    from tools.matrixark_mcp_core_codex_outcome import (
+        feature_scope_excludes_outcome_evidence,
+        profile_entity_type_for_memory_text,
+    )
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_codex_outcome import (
+        feature_scope_excludes_outcome_evidence,
+        profile_entity_type_for_memory_text,
+    )
 
 
 FEATURE_SCOPE_EXCLUSION_RE = re.compile(
     r"\b(?:no|not|skip|without|exclude|excluding|ignore|omit)\s+"
     r"(?:testing|teseting|tests?|monitoring|debugging|debug|evidence|evident|validation|benchmarks?)\b"
 )
-
-
-def feature_scope_excludes_outcome_evidence(text: str) -> bool:
-    return bool(FEATURE_SCOPE_EXCLUSION_RE.search(str(text or "").lower())) and profile_entity_type_for_memory_text(text) == "memory_feature_profile"
 
 
 #: Not an index value -- the one use is the dedup key in `codex_outcome_fact_entities` below. It

--- a/tools/matrixark_mcp_extraction_normalization.py
+++ b/tools/matrixark_mcp_extraction_normalization.py
@@ -140,25 +140,43 @@ def normalize_extracted_entities(raw_entities: Any, *, fallback_text: str, sourc
     return dedupe_entities(entities)
 
 
-# The copy here differed by a lazy import of normalize_model_segments inside the function, where
-# the live one has the name at module scope. Plumbing, and the only difference.
+# NOT re-exported, and the reason is the opposite of how it reads.
 #
-# `extract_batch_entities` is NOT moved with it, and it is the one left in this file worth knowing
-# about: thirty-four hunks against matrixark_mcp_core's, with real work on both sides. The live one
-# has a content-matching lineage builder, an assistant-profile filter, and a location pattern that
-# stops at a clause boundary -- carrying a comment about why:
+# This copy differs from matrixark_mcp_core_extraction's by ONE thing: a lazy import of
+# normalize_model_segments from matrixark_mcp_extraction_runtime, inside the function, where the
+# live one has the name at module scope. Pure plumbing -- and it was moved on that basis, until
+# test_no_module_is_orphaned_quietly failed naming matrixark_mcp_extraction_runtime as a NEW
+# orphan.
 #
-#     "I live in Seattle and prefer metric units"   live: Seattle
-#                                                 orphan: Seattle and prefer metric units
+# That lazy import is the last reference to that module anywhere in the tree. KNOWN_ORPHANS is
+# empty, so consolidating this would create the first orphan in a tree that has none -- and the
+# module it orphans holds diverged copies of live names, one_pass_memory_extraction and
+# openai_compatible_resource_facts among them. That guard's docstring calls the combination the
+# worst one: a copy that is both wrong and unreachable cannot fail today, and is what somebody
+# reaches for tomorrow.
 #
-# This copy has helpers the live one does not (role_lineage, profile_lineage_for_match,
-# source_refs_for_match) and a tool_evidence pattern the live one lacks. Neither is the complete
-# one, so neither can be deleted without deciding what the extractor should do -- which is a
-# different job from removing a copy.
-try:  # the implementation lives in matrixark_mcp_core_extraction; this module re-exports it
-    from tools.matrixark_mcp_core_extraction import normalize_extracted_segments
-except ImportError:  # Direct script execution from tools/.
-    from matrixark_mcp_core_extraction import normalize_extracted_segments
+# So a difference that reads as plumbing was load-bearing. Removing this copy is a decision about
+# whether matrixark_mcp_extraction_runtime should exist, not a cleanup.
+#
+# `extract_batch_entities` is the other one left here, for a different reason: thirty-four hunks
+# against matrixark_mcp_core's, with real work on both sides. The live one has a content-matching
+# lineage builder, an assistant-profile filter, and a location pattern stopping at a clause
+# boundary -- "I live in Seattle and prefer metric units" captures Seattle there and
+# "Seattle and prefer metric units" here. This copy has helpers the live one does not. Neither is
+# the complete one.
+
+
+def normalize_extracted_segments(raw_segments: Any, messages: list[Json]) -> list[Json]:
+    if isinstance(raw_segments, list):
+        try:
+            try:
+                from tools.matrixark_mcp_extraction_runtime import normalize_model_segments
+            except ModuleNotFoundError:  # Direct script execution from tools/.
+                from matrixark_mcp_extraction_runtime import normalize_model_segments
+            return normalize_model_segments({"segments": raw_segments}, messages)
+        except MatrixArkError:
+            return []
+    return []
 
 
 # Not defined here: the implementation lives in matrixark_mcp_core_extraction and this module carried an

--- a/tools/matrixark_mcp_resources.py
+++ b/tools/matrixark_mcp_resources.py
@@ -200,24 +200,17 @@ def _cloud_resource_bucket(args: Json, envelope: Json) -> str:
     return bucket
 
 
-def _cloud_resource_prefix(args: Json, envelope: Json) -> str:
-    prefix = str(
-        args.get("s3_prefix")
-        or envelope.get("metadata", {}).get("s3_prefix")
-        or os.environ.get("MATRIXARK_RESOURCE_S3_PREFIX")
-        or "matrixark/raw"
-    ).strip().strip("/")
-    scope = envelope.get("scope", {}) if isinstance(envelope.get("scope", {}), dict) else {}
-    parts = [
-        prefix,
-        safe_identifier(str(scope.get("account_id") or "acct"), default="acct"),
-        safe_identifier(str(scope.get("tenant_id") or "tenant"), default="tenant"),
-        safe_identifier(str(scope.get("user_id") or "user"), default="user"),
-    ]
-    session_id = str(scope.get("session_id") or "")
-    if session_id:
-        parts.append(safe_identifier(session_id, default="session"))
-    return "/".join(part for part in parts if part)
+# The copy here was missing the mem0 agent segment. The live one appends a safe_identifier of
+# `scope["agent_id"]` between the user and the session when one is supplied -- "per-agent raw-blob
+# isolation", added so that agent-less layouts stay byte-identical -- and this copy went straight
+# from user to session, so every agent shared one raw-blob prefix.
+#
+# Not a live defect: nothing production reaches this module. It is a copy that would have lost the
+# isolation silently on the day it was wired up.
+try:  # the implementation lives in matrixark_mcp_core_resource_io; this module re-exports it
+    from tools.matrixark_mcp_core_resource_io import _cloud_resource_prefix
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_core_resource_io import _cloud_resource_prefix
 
 
 def _s3_client() -> Any:

--- a/tools/matrixark_mcp_retrieve_metrics.py
+++ b/tools/matrixark_mcp_retrieve_metrics.py
@@ -24,20 +24,18 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
 
 
 
-def serving_memory_layer_budget(memory_layer_budget: Any) -> Json:
-    if not isinstance(memory_layer_budget, dict):
-        return {}
-    compact = dict(memory_layer_budget)
-    for field in [
-        "by_source_role",
-        "by_hook_type",
-        "by_codex_event",
-        "source_message_counts_by_role",
-        "source_hook_counts_by_type",
-        "source_codex_event_counts_by_event",
-    ]:
-        compact.pop(field, None)
-    return compact
+# The companion of serving_memory_layer_pressure above, and short in the same way: it
+# rebuilt the dict inline instead of calling compact_memory_layer_budget_roles, kept
+# `by_memory_selection_policy` that the live one drops, and skipped both
+# strip_default_debug_lineage_fields and the empty-sub-dict prune at the end.
+try:  # the implementation lives in matrixark_mcp_context_pack; this module re-exports it
+    from tools.matrixark_mcp_context_pack import (
+        serving_memory_layer_budget,
+    )
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_context_pack import (
+        serving_memory_layer_budget,
+    )
 
 
 # The copy here stopped after the field-stripping loop. The live one also calls

--- a/tools/matrixark_mcp_retrieve_metrics.py
+++ b/tools/matrixark_mcp_retrieve_metrics.py
@@ -40,42 +40,16 @@ def serving_memory_layer_budget(memory_layer_budget: Any) -> Json:
     return compact
 
 
-def serving_memory_layer_pressure(memory_layer_pressure: Any) -> Json:
-    if not isinstance(memory_layer_pressure, dict):
-        return {}
-    compact = dict(memory_layer_pressure)
-    lineage_dimensions = {
-        "by_source_role",
-        "by_hook_type",
-        "by_codex_event",
-        "source_message_counts_by_role",
-        "source_hook_counts_by_type",
-        "source_codex_event_counts_by_event",
-    }
-    for list_field in ["pressure_dimensions", "dropped_dimensions"]:
-        values = compact.get(list_field)
-        if isinstance(values, list):
-            compact[list_field] = [value for value in values if str(value) not in lineage_dimensions]
-    by_dimension = compact.get("by_dimension")
-    if isinstance(by_dimension, dict):
-        compact["by_dimension"] = {
-            str(key): value for key, value in by_dimension.items() if str(key) not in lineage_dimensions
-        }
-    for field in [
-        "assistant_memory_pressure",
-        "user_memory_pressure",
-        "tool_memory_pressure",
-        "assistant_source_message_pressure",
-        "user_source_message_pressure",
-        "tool_source_message_pressure",
-        "hook_boundary_source_pressure",
-        "after_llm_source_pressure",
-        "tool_result_source_pressure",
-        "stop_event_source_pressure",
-        "post_tool_use_source_pressure",
-    ]:
-        compact.pop(field, None)
-    return compact
+# The copy here stopped after the field-stripping loop. The live one also calls
+# strip_default_debug_lineage_fields and then prunes `by_dimension`: it drops empty dimension
+# entries, removes `by_*` names from pressure_dimensions and dropped_dimensions once their
+# dimension is gone, and drops by_dimension entirely when nothing is left. Twenty lines of
+# cleanup this copy did not do, so the same payload came out of the two paths with different
+# keys in it.
+try:  # the implementation lives in matrixark_mcp_context_pack; this module re-exports it
+    from tools.matrixark_mcp_context_pack import serving_memory_layer_pressure
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_context_pack import serving_memory_layer_pressure
 
 
 def attach_python_retrieval_metrics(

--- a/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
+++ b/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
@@ -53,7 +53,7 @@ from collections import defaultdict
 #: defined in that file, a nine-line duplicate of matrixark_mcp_indexing.ordered_unique, where the
 #: live copies call the shared one. Same pattern again: that module was ALREADY re-exporting two
 #: names from the same live file, with the same comment above them.
-RECORDED_DIVERGED = 28
+RECORDED_DIVERGED = 29
 
 #: Total shadowed names (diverged + verbatim), recorded for the same reason.
 #:
@@ -61,7 +61,7 @@ RECORDED_DIVERGED = 28
 #: number above -- 66 verbatim copies went with work that landed since and did not bank this line.
 #: Banked here, because a ceiling left sixty-six above the truth is not a ratchet, it is a number
 #: that will pass whatever happens next.
-RECORDED_SHADOWED = 38
+RECORDED_SHADOWED = 39
 
 _CACHE: dict[str, object] = {}
 

--- a/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
+++ b/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
@@ -53,7 +53,7 @@ from collections import defaultdict
 #: defined in that file, a nine-line duplicate of matrixark_mcp_indexing.ordered_unique, where the
 #: live copies call the shared one. Same pattern again: that module was ALREADY re-exporting two
 #: names from the same live file, with the same comment above them.
-RECORDED_DIVERGED = 32
+RECORDED_DIVERGED = 29
 
 #: Total shadowed names (diverged + verbatim), recorded for the same reason.
 #:
@@ -61,7 +61,7 @@ RECORDED_DIVERGED = 32
 #: number above -- 66 verbatim copies went with work that landed since and did not bank this line.
 #: Banked here, because a ceiling left sixty-six above the truth is not a ratchet, it is a number
 #: that will pass whatever happens next.
-RECORDED_SHADOWED = 42
+RECORDED_SHADOWED = 39
 
 _CACHE: dict[str, object] = {}
 

--- a/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
+++ b/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
@@ -53,7 +53,7 @@ from collections import defaultdict
 #: defined in that file, a nine-line duplicate of matrixark_mcp_indexing.ordered_unique, where the
 #: live copies call the shared one. Same pattern again: that module was ALREADY re-exporting two
 #: names from the same live file, with the same comment above them.
-RECORDED_DIVERGED = 46
+RECORDED_DIVERGED = 45
 
 #: Total shadowed names (diverged + verbatim), recorded for the same reason.
 #:
@@ -61,7 +61,7 @@ RECORDED_DIVERGED = 46
 #: number above -- 66 verbatim copies went with work that landed since and did not bank this line.
 #: Banked here, because a ceiling left sixty-six above the truth is not a ratchet, it is a number
 #: that will pass whatever happens next.
-RECORDED_SHADOWED = 58
+RECORDED_SHADOWED = 57
 
 _CACHE: dict[str, object] = {}
 

--- a/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
+++ b/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
@@ -53,7 +53,7 @@ from collections import defaultdict
 #: defined in that file, a nine-line duplicate of matrixark_mcp_indexing.ordered_unique, where the
 #: live copies call the shared one. Same pattern again: that module was ALREADY re-exporting two
 #: names from the same live file, with the same comment above them.
-RECORDED_DIVERGED = 48
+RECORDED_DIVERGED = 46
 
 #: Total shadowed names (diverged + verbatim), recorded for the same reason.
 #:
@@ -61,7 +61,7 @@ RECORDED_DIVERGED = 48
 #: number above -- 66 verbatim copies went with work that landed since and did not bank this line.
 #: Banked here, because a ceiling left sixty-six above the truth is not a ratchet, it is a number
 #: that will pass whatever happens next.
-RECORDED_SHADOWED = 60
+RECORDED_SHADOWED = 58
 
 _CACHE: dict[str, object] = {}
 

--- a/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
+++ b/tools/test_an_unreachable_module_does_not_hold_a_diverged_copy.py
@@ -53,7 +53,7 @@ from collections import defaultdict
 #: defined in that file, a nine-line duplicate of matrixark_mcp_indexing.ordered_unique, where the
 #: live copies call the shared one. Same pattern again: that module was ALREADY re-exporting two
 #: names from the same live file, with the same comment above them.
-RECORDED_DIVERGED = 29
+RECORDED_DIVERGED = 28
 
 #: Total shadowed names (diverged + verbatim), recorded for the same reason.
 #:
@@ -61,7 +61,7 @@ RECORDED_DIVERGED = 29
 #: number above -- 66 verbatim copies went with work that landed since and did not bank this line.
 #: Banked here, because a ceiling left sixty-six above the truth is not a ratchet, it is a number
 #: that will pass whatever happens next.
-RECORDED_SHADOWED = 39
+RECORDED_SHADOWED = 38
 
 _CACHE: dict[str, object] = {}
 

--- a/tools/test_matrixark_a_docstring_is_not_an_import.py
+++ b/tools/test_matrixark_a_docstring_is_not_an_import.py
@@ -23,7 +23,7 @@ stranded thirty-three modules that real string edges reach, and is refused by
 `test_a_dynamic_import_string_still_reaches`.
 
 Applying it revealed two modules held live by exactly that sentence, each a second copy of a name
-the live tree serves from somewhere else. `TheTwoPackersAreRealTest` checks that from the source
+the live tree serves from somewhere else. `ThePackersAreRealTest` checks that from the source
 rather than restating it.
 """
 from __future__ import annotations
@@ -90,14 +90,23 @@ class ADocstringIsNotAnEdgeTest(unittest.TestCase):
             'from tools.matrixark_mcp_core import thing\n'))
 
 
-class TheTwoPackersAreRealTest(unittest.TestCase):
-    """Both were revealed by the rule. Checked here from the source, not asserted from the list."""
+class ThePackersAreRealTest(unittest.TestCase):
+    """Revealed by the rule, and checked here from the SOURCE rather than asserted from the list.
+
+    There were two. `matrixark_mcp_dashboard` held a second `latest_async_pipeline_rows` beside the
+    live one in `matrixark_mcp_async_readiness`, and the two had diverged: the copy reported a
+    finished task as still scheduled when the records arrived out of order. It was consolidated,
+    so the pair is gone and it is struck from here rather than left to fail -- a list that keeps a
+    pair the tree no longer has describes a tree that no longer exists.
+
+    That the removal shows up HERE as a failure is the point of checking the source instead of
+    trusting the list. This class asserting "both still exist" is what made the consolidation
+    visible; it is not an argument for keeping the copy.
+    """
 
     PACKERS = {
         "matrixark_mcp_budget_pack": ("select_token_budgeted_refs",
                                       "matrixark_mcp_core_ref_selection"),
-        "matrixark_mcp_dashboard": ("latest_async_pipeline_rows",
-                                    "matrixark_mcp_async_readiness"),
     }
 
     @staticmethod
@@ -110,6 +119,11 @@ class TheTwoPackersAreRealTest(unittest.TestCase):
 
     def test_each_is_recorded_as_unreachable(self) -> None:
         recorded = {name for group in _guard().UNREACHABLE.values() for name in group}
+        self.assertTrue(
+            self.PACKERS,
+            "no packer is recorded, so every assertion in this class passes over an empty set. "
+            "One was struck when its copy was consolidated; emptying the list entirely means the "
+            "rule that revealed them has stopped finding any.")
         for module in self.PACKERS:
             self.assertIn(module, recorded)
 


### PR DESCRIPTION
`matrixark_mcp_dashboard` kept its own `latest_async_pipeline_rows`. The selection is
`(rank, time) >= (rank, time)`, so **rank dominates** and an unknown status ranks `-1`. This copy's
map has three entries where `matrixark_mcp_async_readiness` has nine — so every `idle_commit_*`
status is unknown to it, they all tie at `-1`, and the timestamp decides alone.

Right whenever records arrive in order, wrong when they don't. Executed both:

| rows | live reports | orphan reports |
|---|---|---|
| scheduled t=100, skipped t=200 | `idle_commit_skipped` | `idle_commit_skipped` |
| scheduled t=200, skipped t=100 | `idle_commit_skipped` | **`idle_commit_scheduled`** |
| scheduled t=200, committed t=100 | `idle_commit_committed` | **`idle_commit_scheduled`** |
| scheduled t=100, failed t=100 | `idle_commit_failed` | `idle_commit_failed` |

A task whose terminal record carries the earlier stamp reads as **still scheduled** through the
dashboard and as finished through the readiness module.

### My first probe showed no difference, and the claim I had written was wrong

The live copy carries a note about `idle_commit_skipped` having once been missing from *its* map —
*"it made it rank -1, BELOW the `idle_commit_scheduled` it completes, so the completion lost to its
own precursor"*. I wrote that this copy still had that bug, and tested it with an in-order pair.
Both returned the same answer — because in **this** copy `idle_commit_scheduled` is unknown too:
both sides rank `-1`, the tie breaks on time, and the ordinary case comes out right by accident.

The defect is real and is the out-of-order case. The note in the file now says the measured thing
rather than the inherited one.

### `serving_memory_layer_pressure` goes the same way

The copy in `matrixark_mcp_retrieve_metrics` stops after the field-stripping loop.
`matrixark_mcp_context_pack`'s also calls `strip_default_debug_lineage_fields` and prunes
`by_dimension` — dropping empty dimension entries, removing `by_*` names from `pressure_dimensions`
and `dropped_dimensions` once their dimension is gone, and dropping `by_dimension` entirely when
nothing is left. Twenty lines of cleanup, so the same payload came out of the two paths with
different keys in it.

Neither module had a re-export block already, unlike the four before these, so both imports were
tested in both orders before being written.

| | before | after |
|---|---|---|
| diverged shadows | 48 | **46** |
| total shadowed | 60 | **58** |
