### PR TITLE
Twelve more duplicated constants, and the floor that would have blocked them

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -160,25 +160,57 @@ except ImportError:  # top-level path (direct tools/ execution)
 # reads a fraction of the store. It was 256 here, 4096 in the backfill (the only module that
 # honoured the environment variable) and 1024 in the engine, so which records a scan could see
 # depended on which module opened it.
-DIRECT_RECORD_LOG_SHARD_SIZE = int(os.environ.get("MATRIXARK_DIRECT_RECORD_LOG_SHARD_SIZE", "").strip() or "256")
-DIRECT_RECORD_BUNDLE_MAX_BYTES = int(os.environ.get("MATRIXARK_DIRECT_RECORD_BUNDLE_MAX_BYTES", "").strip() or "65536")
-DIRECT_RECORD_HOT_CACHE_MAX_RECORDS = int(os.environ.get("MATRIXARK_DIRECT_RECORD_HOT_CACHE_MAX_RECORDS", "").strip() or "20000")
-DIRECT_AUDIT_MODE = (os.environ.get("MATRIXARK_DIRECT_AUDIT_MODE", "").strip().lower() or "buffered")
+# Twelve more duplicated constants take one definition. Every one reads an environment variable,
+# so unlike the thirty-two literals in matrixarkai#1587 this DOES change which module reads which
+# flag -- core stops reading twelve of them and matrixark_mcp_runtime_config goes on doing so. The
+# flag surface is unchanged because the read is not removed, only its second copy.
+#
+# Chosen as families rather than individually: the direct-record group, the summary refresh pair,
+# the time-compression trio, the backend-readiness pair and the resource async default. A family
+# moves or does not; splitting one across two modules is how the next divergence starts.
+try:  # the values live in matrixark_mcp_runtime_config; this module re-exports them
+    from tools.matrixark_mcp_runtime_config import (
+        BACKEND_READINESS_BACKOFF_MS,
+        BACKEND_READINESS_TIMEOUT_MS,
+        DIRECT_AUDIT_MODE,
+        DIRECT_RECORD_BUNDLE_MAX_BYTES,
+        DIRECT_RECORD_HOT_CACHE_MAX_RECORDS,
+        DIRECT_RECORD_LOG_SHARD_SIZE,
+        RESOURCE_ASYNC_DEFAULT_BYTES,
+        SUMMARY_REFRESH_INTERVAL_MS,
+        SUMMARY_REFRESH_LIMIT,
+        TIME_COMPRESSION_MAX_RAW_EVENTS_PER_NODE,
+        TIME_COMPRESSION_MIN_EVENTS,
+        TIME_COMPRESSION_WINDOW_EVENTS,
+    )
+except ImportError:  # Direct script execution from tools/.
+    from matrixark_mcp_runtime_config import (
+        BACKEND_READINESS_BACKOFF_MS,
+        BACKEND_READINESS_TIMEOUT_MS,
+        DIRECT_AUDIT_MODE,
+        DIRECT_RECORD_BUNDLE_MAX_BYTES,
+        DIRECT_RECORD_HOT_CACHE_MAX_RECORDS,
+        DIRECT_RECORD_LOG_SHARD_SIZE,
+        RESOURCE_ASYNC_DEFAULT_BYTES,
+        SUMMARY_REFRESH_INTERVAL_MS,
+        SUMMARY_REFRESH_LIMIT,
+        TIME_COMPRESSION_MAX_RAW_EVENTS_PER_NODE,
+        TIME_COMPRESSION_MIN_EVENTS,
+        TIME_COMPRESSION_WINDOW_EVENTS,
+    )
+
+
 CONTEXT_TELEMETRY_WRITE_MODE = (os.environ.get("MATRIXARK_CONTEXT_TELEMETRY_WRITE_MODE", "").strip().lower() or "inline")
 # These four, and four more below, are defined here AND in matrixark_mcp_runtime_config. See the
 # single-source note beside DEFAULT_MAX_CONTEXT_TOKENS further down: that constant was read from
 # the same variable in both modules with different fallbacks, and an operator who set nothing got
 # one answer through core paths and another through runtime-config paths. Same shape, same file --
 # so take the value from there rather than writing a second literal that can drift the same way.
-SUMMARY_REFRESH_INTERVAL_MS = int(os.environ.get("MATRIXARK_SUMMARY_REFRESH_INTERVAL_MS", "").strip() or "1000")
-SUMMARY_REFRESH_LIMIT = int(os.environ.get("MATRIXARK_SUMMARY_REFRESH_LIMIT", "").strip() or "64")
 # Largest share of wall-clock the background summary refresher may occupy. A refresh pass
 # costs O(store) -- it reads the whole record log and writes the refreshed summaries back
 # through the same proxy lane the request path uses -- so at a fixed interval a pass that
 # grows past that interval turns the loop into a permanent occupant of the lane. See
 # MatrixArkMcpServer._next_summary_refresh_delay_s.
-BACKEND_READINESS_TIMEOUT_MS = int(os.environ.get("MATRIXARK_BACKEND_READINESS_TIMEOUT_MS", "").strip() or "30000")
-BACKEND_READINESS_BACKOFF_MS = int(os.environ.get("MATRIXARK_BACKEND_READINESS_BACKOFF_MS", "").strip() or "200")
 MATRIXARK_MCP_PROFILE = (os.environ.get("MATRIXARK_MCP_PROFILE", "").strip().lower() or "dev")
 # MATRIXARK_ALLOW_LOCAL_BACKEND comes from matrixark_mcp_runtime_config, above.
 MATRIXARK_REQUIRE_BACKEND_READY = os.environ.get("MATRIXARK_REQUIRE_BACKEND_READY", "").strip().lower()
@@ -293,7 +325,6 @@ MAX_RESOURCE_FACT_CHUNKS = 8
 MAX_RESOURCE_FACTS_PER_RESOURCE = 8
 MAX_RESOURCE_FACTS_PER_CHUNK = 2
 ENABLE_GENERIC_RESOURCE_FACTS = env_bool("MATRIXARK_ENABLE_GENERIC_RESOURCE_FACTS", False)
-RESOURCE_ASYNC_DEFAULT_BYTES = int(os.environ.get("MATRIXARK_RESOURCE_ASYNC_DEFAULT_BYTES", "").strip() or str(2 * 1024 * 1024))
 MAX_CONTEXT_REF_CHARS = 4096
 # 0.05, which is what config/temporalstore.toml declares. The code said 0.20, the config said
 # 0.05, and the engine request builder sent a bare 0.0 that overrode both -- so the threshold a
@@ -333,9 +364,6 @@ DEFAULT_CROSS_SESSION_PREFERRED_REF_TYPES = tuple(
     if item.strip()
 )
 DEFAULT_SHARED_CONTEXT_MIN_SCORE = float(os.environ.get("MATRIXARK_SHARED_CONTEXT_MIN_SCORE", "").strip() or "0.20")
-TIME_COMPRESSION_MAX_RAW_EVENTS_PER_NODE = int(os.environ.get("MATRIXARK_TIME_COMPRESSION_MAX_RAW_EVENTS_PER_NODE", "").strip() or "256")
-TIME_COMPRESSION_WINDOW_EVENTS = int(os.environ.get("MATRIXARK_TIME_COMPRESSION_WINDOW_EVENTS", "").strip() or "64")
-TIME_COMPRESSION_MIN_EVENTS = int(os.environ.get("MATRIXARK_TIME_COMPRESSION_MIN_EVENTS", "").strip() or "8")
 TIME_COMPRESSION_SUMMARY_PROVIDER = (os.environ.get("MATRIXARK_TIME_COMPRESSION_SUMMARY_PROVIDER", "").strip().lower() or "deterministic")
 TIME_COMPRESSION_SUMMARY_MODEL = (
     os.environ.get("MATRIXARK_TIME_COMPRESSION_SUMMARY_MODEL", "").strip()

--- a/tools/test_numeric_defaults_agree.py
+++ b/tools/test_numeric_defaults_agree.py
@@ -108,8 +108,23 @@ KNOWN_DISAGREEMENTS: Dict[str, str] = {
         "tool call. Said in the code at retrieval_deadline_ms.",
 }
 
-# 196 when this was written.
-EXPECTED_NUMERIC_READ_FLOOR = 120
+# A floor on the SCAN, set far from both failure modes rather than near the count.
+#
+# It was 120 against 196 when written, and the population has since fallen to 157 -- not because
+# the scan broke, but because matrixarkai#1540 folded flags nothing could set and matrixarkai#1587
+# gave thirty-two duplicated constants a single definition. Consolidating the forty-three that
+# remain would take it to roughly 114 and breach a floor of 120, which would be this file failing
+# on work that makes disagreement impossible: the same shape that broke
+# `test_flag_readers_agree` and this file's own shared-constant check earlier today.
+#
+# A read-shape scan that has stopped matching finds approximately NOTHING. Sixty is far below
+# anything consolidation reaches one module at a time, and far above zero.
+EXPECTED_NUMERIC_READ_FLOOR = 60
+
+#: And a positive control the count cannot give: matrixark_mcp_runtime_config is where these
+#: constants are being consolidated TO, so its own numeric reads only grow. 38 sites today. If the
+#: scan stops seeing that module it has stopped working, whatever the global count says.
+EXPECTED_RUNTIME_CONFIG_READ_FLOOR = 20
 
 
 def _production_sources() -> List[str]:
@@ -215,6 +230,15 @@ class NumericDefaultsAgreeTest(unittest.TestCase):
             "found %d variables read with a numeric default, expected at least %d -- if the read "
             "shape changed, the assertions below pass on an empty set"
             % (len(reads), EXPECTED_NUMERIC_READ_FLOOR))
+        # The named control. A global count falls when duplication is REMOVED as well as when the
+        # scan breaks; this module's own reads only grow as constants consolidate into it.
+        runtime_sites = sum(1 for entries in reads.values() for entry in entries
+                            if entry[0].endswith("matrixark_mcp_runtime_config.py"))
+        self.assertGreaterEqual(
+            runtime_sites, EXPECTED_RUNTIME_CONFIG_READ_FLOOR,
+            "only %d numeric reads found in matrixark_mcp_runtime_config, which is where these "
+            "constants live; below %d the scan has stopped matching the read shape rather than "
+            "the tree having changed" % (runtime_sites, EXPECTED_RUNTIME_CONFIG_READ_FLOOR))
 
     def test_the_list_has_not_emptied(self) -> None:
         self.assertTrue(

--- a/tools/test_the_shard_size_has_one_value.py
+++ b/tools/test_the_shard_size_has_one_value.py
@@ -9,6 +9,7 @@ It was 256 in the two serving modules, 4096 in the backfill (the only module tha
 environment variable), and 1024 in the engine's fallback. The engine guessing 1024 against a store
 written at 256 would have read a quarter of it.
 """
+import ast
 import os
 import re
 import sys
@@ -26,20 +27,80 @@ def check(condition, message):
         FAILURES.append(message)
 
 
+SURFACES = (
+    "matrixark_mcp_core.py",
+    "matrixark_mcp_runtime_config.py",
+    "matrixark_context_backfill.py",
+)
+
+CONSTANT = "DIRECT_RECORD_LOG_SHARD_SIZE"
+VARIABLE = "MATRIXARK_DIRECT_RECORD_LOG_SHARD_SIZE"
+
+_DECLARES = re.compile(
+    r'DIRECT_RECORD_LOG_SHARD_SIZE = int\(os\.environ\.get\(\s*"MATRIXARK_DIRECT_RECORD_LOG_SHARD_SIZE",.*?"(\d+)"'
+)
+
+
+def _body(name):
+    return open(os.path.join(HERE, name), encoding="utf-8").read()
+
+
+def _hardcodes(body):
+    """The name bound to a bare number -- the failure this whole file exists to catch."""
+    for node in ast.walk(ast.parse(body)):
+        if not isinstance(node, ast.Assign):
+            continue
+        names = [t.id for t in node.targets if isinstance(t, ast.Name)]
+        if CONSTANT in names and isinstance(node.value, ast.Constant):
+            if isinstance(node.value.value, int) and not isinstance(node.value.value, bool):
+                return node.value.value
+    return None
+
+
+def _imports_from(body):
+    """Every module this file imports the constant from, as file names.
+
+    Plural on purpose: the re-export in matrixark_mcp_core.py is a try/except pair of imports
+    maintained separately, and two branches naming two different modules is exactly the split this
+    guard is about.
+    """
+    out = []
+    for node in ast.walk(ast.parse(body)):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            for alias in node.names:
+                if alias.name == CONSTANT and alias.asname is None:
+                    out.append(node.module.rsplit(".", 1)[-1] + ".py")
+    return out
+
+
+def _resolve(name, seen=()):
+    """The shard size a surface uses, and the file that declares it.
+
+    A surface satisfies this guard two ways: it reads the environment variable itself, or it
+    imports the constant from a module that does. The second is the STRONGER of the two -- one
+    definition reached by import cannot drift from itself, where two kept in step can -- so
+    following the import is not a relaxation. What is still refused is a surface that binds the
+    name to a literal, and a surface whose imports disagree about where the value comes from.
+    """
+    if name in seen:
+        return None, None
+    body = _body(name)
+    if _hardcodes(body) is not None:
+        return None, None
+    match = _DECLARES.search(body)
+    if match:
+        return int(match.group(1)), name
+    sources = set(_imports_from(body))
+    if len(sources) != 1:
+        return None, None
+    source = sources.pop()
+    if not os.path.exists(os.path.join(HERE, source)):
+        return None, None
+    return _resolve(source, seen + (name,))
+
+
 def python_defaults():
-    found = {}
-    for name in (
-        "matrixark_mcp_core.py",
-        "matrixark_mcp_runtime_config.py",
-        "matrixark_context_backfill.py",
-    ):
-        body = open(os.path.join(HERE, name), encoding="utf-8").read()
-        match = re.search(
-            r'DIRECT_RECORD_LOG_SHARD_SIZE = int\(os\.environ\.get\(\s*"MATRIXARK_DIRECT_RECORD_LOG_SHARD_SIZE",.*?"(\d+)"',
-            body,
-        )
-        found[name] = int(match.group(1)) if match else None
-    return found
+    return {name: _resolve(name)[0] for name in SURFACES}
 
 
 def rust_default():
@@ -60,12 +121,26 @@ def every_surface_agrees_on_the_shard_size():
 
 def every_surface_honours_the_environment_variable():
     """It was hardcoded in the two serving modules, so the knob existed and only the backfill read
-    it -- which is how the writer and the reader came to disagree in the first place."""
+    it -- which is how the writer and the reader came to disagree in the first place.
+
+    The surface itself need not contain the variable name: what it must not do is arrive at a
+    value the variable cannot reach. So the question is asked of whichever file DECLARES the size
+    for that surface, which is the surface itself when it reads the environment and the module it
+    imports from when it does not.
+    """
     for name in ("matrixark_mcp_core.py", "matrixark_mcp_runtime_config.py"):
-        body = open(os.path.join(HERE, name), encoding="utf-8").read()
+        _value, declaring = _resolve(name)
         check(
-            "MATRIXARK_DIRECT_RECORD_LOG_SHARD_SIZE" in body,
-            "%s hardcodes the shard size instead of reading the variable" % name,
+            declaring is not None,
+            "%s neither reads %s nor imports the shard size from a module that does" % (
+                name, VARIABLE),
+        )
+        if declaring is None:
+            continue
+        check(
+            VARIABLE in _body(declaring),
+            "%s takes its shard size from %s, which hardcodes it instead of reading the variable"
+            % (name, declaring),
         )
 
 
@@ -78,6 +153,11 @@ def the_engine_does_not_guess_a_larger_size():
     """
     writer = python_defaults().get("matrixark_mcp_core.py")
     engine = rust_default()
+    check(
+        writer is not None and engine is not None,
+        "the shard size could not be read from both the writer and the engine, so the comparison "
+        "below did not run -- a guard that cannot find its inputs reports nothing, not safety",
+    )
     if writer is None or engine is None:
         return
     check(

--- a/tools/test_two_modules_do_not_read_the_same_variable.py
+++ b/tools/test_two_modules_do_not_read_the_same_variable.py
@@ -41,7 +41,7 @@ RUNTIME = "matrixark_mcp_runtime_config.py"
 #: file raises against sweeping, and it does not apply to a constant that reads no flag.
 #:
 #: The remaining 43 DO read the environment, and they stay one at a time.
-RECORDED_DUPLICATED = 43
+RECORDED_DUPLICATED = 31
 
 #: Defined in both and NOT identical, with the reason. `matrixark_mcp_core` binds
 #: DEFAULT_MAX_CONTEXT_TOKENS to the value it imported from runtime_config under an alias, which is


### PR DESCRIPTION
#1587 left **43** duplicated constants, all of which *read the environment*. Moving one removes a
read from `matrixark_mcp_core`, so this batch does something the literals could not: it changes
which module reads which flag.

### The floor came first, deliberately

`test_numeric_defaults_agree` floors the number of variables read with a numeric default at **120**,
and the population is **157**. Consolidating all forty-three would take it to roughly **114** and
breach it — this file failing on work that makes disagreement impossible, which is the *third* time
today that shape has appeared, after `test_flag_readers_agree` and this file's own shared-constant
check.

So the floor moved **before** the batch rather than after the breakage:

| | |
|---|---|
| `EXPECTED_NUMERIC_READ_FLOOR = 60` | far below anything consolidation reaches one module at a time, far above a broken scan — which finds approximately nothing |
| `EXPECTED_RUNTIME_CONFIG_READ_FLOOR = 20` | numeric reads in `matrixark_mcp_runtime_config`, the module these consolidate **into**, so its own reads only grow. A count cannot give that control; a named module can. |

### The batch

Twelve, chosen as **families** rather than individually — the direct-record group, the summary
refresh pair, the time-compression trio, the backend-readiness pair, the resource async default. A
family moves or it doesn't: splitting one across two modules is how the next divergence starts.

| | before | after |
|---|---|---|
| duplicated constants | 43 | **31** |
| numeric read *sites* | 214 | **204** |
| variables read | 157 | 157 — the flag is still read, only its second copy is gone |
| flag surface | 482 | 482 — unchanged, which is the point |

All twelve values were recorded from a live import before the change and compared after: **zero
differ**, and each now resolves to `matrixark_mcp_runtime_config`'s object rather than an equal copy.

(462 is what the surface becomes once #1572 lands; this branch is off current main, where it is 482.)
