### PR TITLE
The object-manager report stops walking twice

### DIFF
--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -734,12 +734,19 @@ fn expiry_scan_budget(limit: usize) -> usize {
         }
         let before_slabs = collect_live_block_slab_ids(shard);
         let before = compaction_utility_report_from_entries(&self.page_store, shard, &entries);
+        let model_layouts_before = compaction_model_layout_reports(&self.page_store, shard);
+        // Ordered so the ONE consumer that takes the Vec by value goes last. These are read-only
+        // reports over unchanged state, so the order among them carries no meaning beyond that.
+        let object_manager_before = object_manager_runtime_report_from_entries(
+            shard_id,
+            shard,
+            &entries,
+            start_routing_bucket,
+            end_routing_bucket,
+        );
         let delete_marked_object_ids_before =
             object_lifecycle_report_from_entries(shard_id, shard, entries, &BTreeSet::new(), |_| 0)
                 .delete_marked_object_ids;
-        let model_layouts_before = compaction_model_layout_reports(&self.page_store, shard);
-        let object_manager_before =
-            object_manager_runtime_report(shard_id, shard, start_routing_bucket, end_routing_bucket);
         let bucket_layout_transition_count_before = object_manager_before.layout_transition_count;
         // Start a round, or continue the one a budget cut short.
         //

--- a/crates/temporalstore-rust/src/engine/storage_reporting.rs
+++ b/crates/temporalstore-rust/src/engine/storage_reporting.rs
@@ -502,8 +502,35 @@ pub(super) fn object_manager_runtime_report(
     start_routing_bucket: u32,
     end_routing_bucket: u32,
 ) -> ObjectManagerRuntimeReport {
-    let ownership =
-        bucket_object_page_ownership_report(shard_id, shard, start_routing_bucket, end_routing_bucket);
+    object_manager_runtime_report_from_entries(
+        shard_id,
+        shard,
+        &collect_live_page_entries(shard),
+        start_routing_bucket,
+        end_routing_bucket,
+    )
+}
+
+/// The same report, from live-page entries the caller ALREADY has.
+///
+/// This walked the shard TWICE: once for the ownership report below, and once more at the very end
+/// purely to COUNT entries of eight timestamped kinds. Measured at 2.0x the shard
+/// (`what_the_compaction_preamble_walks`), which is why the compaction preamble could not get
+/// below 7.0x while calling the wrapper form.
+pub(super) fn object_manager_runtime_report_from_entries(
+    shard_id: ShardId,
+    shard: &ShardState,
+    entries: &[LiveBlockEntry],
+    start_routing_bucket: u32,
+    end_routing_bucket: u32,
+) -> ObjectManagerRuntimeReport {
+    let ownership = bucket_object_page_ownership_report_from_entries(
+        shard_id,
+        shard,
+        entries,
+        start_routing_bucket,
+        end_routing_bucket,
+    );
     let object_runtime = object_manager::runtime_report(shard);
     let mut report = ObjectManagerRuntimeReport {
         shard_id,
@@ -602,7 +629,7 @@ pub(super) fn object_manager_runtime_report(
         "context_summary",
         "context_compression",
     ];
-    report.packed_timestamped_page_count = collect_live_page_entries(shard)
+    report.packed_timestamped_page_count = entries
         .iter()
         .filter(|entry| TIMESTAMPED_KINDS.contains(&entry.kind.as_ref()))
         .count() as u64;
@@ -616,13 +643,29 @@ pub(super) fn bucket_object_page_ownership_report(
     start_routing_bucket: u32,
     end_routing_bucket: u32,
 ) -> BucketObjectPageOwnershipReport {
+    bucket_object_page_ownership_report_from_entries(
+        shard_id,
+        shard,
+        &collect_live_page_entries(shard),
+        start_routing_bucket,
+        end_routing_bucket,
+    )
+}
+
+/// The same report, from live-page entries the caller ALREADY has.
+pub(super) fn bucket_object_page_ownership_report_from_entries(
+    shard_id: ShardId,
+    shard: &ShardState,
+    entries: &[LiveBlockEntry],
+    start_routing_bucket: u32,
+    end_routing_bucket: u32,
+) -> BucketObjectPageOwnershipReport {
     let mut report = BucketObjectPageOwnershipReport {
         shard_id,
         first_class_index_present: !shard.bucket_index.bucket_map.is_empty(),
         derived_from_model_maps: shard.bucket_index.bucket_map.is_empty(),
         ..BucketObjectPageOwnershipReport::default()
     };
-    let entries = collect_live_page_entries(shard);
     report.page_ref_count = entries.len();
     for entry in entries {
         let routing_bucket = entry.address.routing_bucket().unwrap_or_default();

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -8010,14 +8010,15 @@ fn what_apply_storage_lifecycle_walks() {
 /// take the same live-page set -- ownership validation, the compaction utility report, and the
 /// object lifecycle report -- and each used to call `collect_live_page_entries` for its own copy.
 ///
-/// Measured at 4,000 objects, one round walked 9.0x the shard; sharing one walk between those
-/// three takes it to 7.0x. The bound below sits between the two, so losing the sharing fails.
+/// Measured at 4,000 objects, one round walked 9.0x the shard when each report walked for itself.
+/// Sharing one walk across the three took it to 7.0x; giving `object_manager_runtime_report` the
+/// same slice -- and stopping its tail from walking again purely to COUNT eight kinds of entry --
+/// took it to 4.0x. The bound below sits between 4 and 7, so losing any of that sharing fails.
 ///
 /// It is a BOUND and not an equality, unlike `the_object_lifecycle_snapshot_walks_the_shard_once`.
 /// That one owns every walk in its function and can name the exact number; this round also walks
-/// for `object_manager_runtime_report` (2.0x) and for the relocation work itself, and those are
-/// legitimately outside what this change controls. Pinning the total exactly would make this test
-/// fail for unrelated reasons.
+/// for the relocation work itself, which is legitimately outside what these changes control.
+/// Pinning the total exactly would make this test fail for unrelated reasons.
 #[test]
 fn a_compaction_round_shares_one_walk_across_its_live_page_consumers() {
     const RECORDS: usize = 1_000;
@@ -8061,11 +8062,12 @@ fn a_compaction_round_shares_one_walk_across_its_live_page_consumers() {
 
     let multiple = walked as f64 / live_pages as f64;
     assert!(
-        multiple <= 8.0,
+        multiple <= 5.0,
         "a compaction round walked {multiple:.1}x the shard ({walked} entries for {live_pages} \
-live pages). Its ownership validation, utility report and object lifecycle report share ONE \
-`collect_live_page_entries`; this was 9.0x when they each walked separately and 7.0x when they \
-share. If a new preamble report needs the live-page set, pass it the existing slice.",
+live pages). Its ownership validation, utility report, object lifecycle report and object-manager \
+report all share ONE `collect_live_page_entries`: 9.0x when each walked for itself, 7.0x with \
+three sharing, 4.0x with all four. If a new preamble report needs the live-page set, pass it the \
+existing slice rather than calling `collect_live_page_entries` again.",
     );
 }
 
@@ -8162,6 +8164,27 @@ fn what_the_compaction_preamble_walks() {
     let walked = crate::engine::live_page_scan_entries();
     total += walked;
     report("object_manager_runtime_report", walked);
+
+    // Split that 2.0x between its two callees rather than inferring which one walks. It calls
+    // exactly these two, and `object_manager::runtime_report` iterates `bucket_index.bucket_map`
+    // directly rather than the live-page set -- so it SHOULD contribute nothing here, and if it
+    // does the assumption is wrong. These two rows are not added to the total above; they are a
+    // breakdown OF it.
+    crate::engine::reset_live_page_scan_entries();
+    let _ = crate::engine::storage_reporting::bucket_object_page_ownership_report(
+        1, shard, 0, u32::MAX,
+    );
+    report(
+        "  of which: bucket_object_page_ownership",
+        crate::engine::live_page_scan_entries(),
+    );
+
+    crate::engine::reset_live_page_scan_entries();
+    let _ = crate::engine::object_manager::runtime_report(shard);
+    report(
+        "  of which: object_manager::runtime_report",
+        crate::engine::live_page_scan_entries(),
+    );
 
     eprintln!(
         "  [preamble] {:<38} {total:>8} entries = {:>5.1}x the shard ({live_pages} live pages)",


### PR DESCRIPTION
[#1589](https://github.com/matrixarkai/TemporalStore/pull/1589) left this named and unfixed:
`object_manager_runtime_report` walked the shard **2.0×** on its own, so a compaction round could
not get below 7.0× while calling it.

## The cause was found by arithmetic that did not add up

Splitting that 2.0× between its two callees:

| | × the shard |
|---|---|
| `object_manager_runtime_report` | **2.0×** |
| of which `bucket_object_page_ownership_report` | 1.0× |
| of which `object_manager::runtime_report` | 0.0× |

One plus zero is not two. The missing walk is at the very **end** of the function, a bare
expression rather than a binding — which is why reading the code had not found it across several
passes:

```rust
report.packed_timestamped_page_count = collect_live_page_entries(shard)
    .iter()
    .filter(|entry| TIMESTAMPED_KINDS.contains(&entry.kind.as_ref()))
    .count() as u64;
```

A whole-shard walk to **count** entries of eight kinds, over a set the function had already
materialized a few lines earlier. It was added to populate a field that "was left at its default
(0)".

## Result

| | before | after |
|---|---|---|
| `object_manager_runtime_report` | 2.0× | **1.0×** (everywhere it is called) |
| one compaction round | 7.0× | **4.0×** |

The round figure **beat the estimate** — 5.0× was expected. The extra saving is that the tail count
helps the **standalone** path too, not only the shared one: the wrapper form now walks once as
well, so every caller benefits, not just the preamble.

Across #1586, #1589 and this, a compaction round went **9.0× → 7.0× → 4.0×**. Five whole-shard
walks removed from every round, all under the shard **write** lock where each read and write queues
behind them.

Both nested reports gain `_from_entries` forms with the old signatures kept as wrappers. The
preamble is reordered so the one consumer that takes the `Vec` **by value** goes last; these are
read-only reports over unchanged state, so the order among them carries no meaning beyond that.

## Verified by mutation, and the guard is tightened

#1589's guard allowed `<= 8.0×`, which at 4.0× would no longer catch a regression back to 7.0× —
the exact failure it exists to detect. A guard that passes while no longer testing anything is
worse than none, because it reads as coverage. It now allows `<= 5.0×`.

Reverting this change alone fails it at exactly **7.0×**, the #1589 state:

```
a compaction round walked 7.0x the shard (7000 entries for 1000 live pages).
```

The message records all three points (9.0 → 7.0 → 4.0) so a future reader can see **which** sharing
was lost, not just that the number moved.

## Verification

`cargo test -p temporalstore-rust --lib -- --test-threads=1` → **1781 passed, 1 failed**. The single
failure is `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the standing `--lib`
baseline failure on main, not introduced here.
