### PR TITLE
The cross-import guard read tree.body, and missed every try-wrapped import

### DIFF
--- a/tools/test_matrixark_no_cross_test_imports.py
+++ b/tools/test_matrixark_no_cross_test_imports.py
@@ -35,6 +35,19 @@ TOOLS = os.path.dirname(os.path.abspath(__file__))
 
 # Modules that already import another test module at import time. This list may only shrink.
 KNOWN = {
+    "test_backend_policy_part1.py",
+    "test_backend_policy_part2.py",
+    "test_backend_policy_part3.py",
+    "test_backend_policy_part4.py",
+    "test_codex_hook_output_part2.py",
+    "test_codex_hook_output_part3.py",
+    "test_codex_pipeline_part1.py",
+    "test_codex_pipeline_part2.py",
+    "test_codex_pipeline_part3.py",
+    "test_codex_pipeline_part4.py",
+    "test_codex_pipeline_part5.py",
+    "test_matrixark_codex_hook_output.py",
+    "test_matrixark_codex_hook_pipeline.py",
     "test_matrixark_deployment_routes.py",
     "test_matrixark_embedding_status.py",
     "test_matrixark_every_live_claim_is_checked.py",
@@ -45,12 +58,55 @@ KNOWN = {
     "test_matrixark_ingestion_retry.py",
     "test_matrixark_live_frames_are_shared.py",
     "test_matrixark_live_strip.py",
+    "test_matrixark_mcp_backend_policy.py",
     "test_matrixark_mem0_console.py",
     "test_matrixark_models.py",
+    "test_matrixark_python_module_boundaries.py",
     "test_matrixark_readiness_sources.py",
     "test_matrixark_user_policy.py",
+    "test_python_module_boundaries_part2.py",
+    "test_python_module_boundaries_part3.py",
 }
 
+#: Pairs where each module imports the OTHER at import time. A one-directional cross-import
+#: shifts what later modules see; a MUTUAL one decides whether either can be LOADED at all, and
+#: the answer depends on what ran before it.
+#:
+#: Demonstrated on test_codex_hook_output_part2. Imported on its own it raises
+#: "cannot import name '_CodexHookOutputPart2' from partially initialized module"; imported
+#: after the sixty-four modules discovery loads ahead of it, it succeeds -- and the parent is
+#: still not in sys.modules at that point. The suite is green because of an order, not because
+#: the cycle is resolved.
+#:
+#: Recorded rather than changed, for the reason the list above is. What must not appear is a
+#: fourteenth, because the order that rescues these is incidental and nothing asserts it.
+#: Source for the control below, written out rather than escaped inline.
+WRAPPED_SNIPPET = """try:
+    from tools.test_x import Fixture
+except ImportError:
+    from test_x import Fixture
+"""
+
+DEFERRED_SNIPPET = """def setUp(self):
+    from test_x import Fixture
+    return Fixture
+"""
+
+KNOWN_MUTUAL = {
+    ("test_backend_policy_part1", "test_matrixark_mcp_backend_policy"),
+    ("test_backend_policy_part2", "test_matrixark_mcp_backend_policy"),
+    ("test_backend_policy_part3", "test_matrixark_mcp_backend_policy"),
+    ("test_backend_policy_part4", "test_matrixark_mcp_backend_policy"),
+    ("test_codex_hook_output_part2", "test_matrixark_codex_hook_output"),
+    ("test_codex_hook_output_part3", "test_matrixark_codex_hook_output"),
+    ("test_codex_pipeline_part1", "test_matrixark_codex_hook_pipeline"),
+    ("test_codex_pipeline_part2", "test_matrixark_codex_hook_pipeline"),
+    ("test_codex_pipeline_part3", "test_matrixark_codex_hook_pipeline"),
+    ("test_codex_pipeline_part4", "test_matrixark_codex_hook_pipeline"),
+    ("test_codex_pipeline_part5", "test_matrixark_codex_hook_pipeline"),
+    ("test_matrixark_python_module_boundaries", "test_python_module_boundaries_part2"),
+    ("test_matrixark_python_module_boundaries", "test_python_module_boundaries_part3"),
+}
 
 def _cross_importers() -> dict:
     """Test modules importing another test module at MODULE level, and what they import.
@@ -66,18 +122,88 @@ def _cross_importers() -> dict:
             tree = ast.parse(io.open(os.path.join(TOOLS, name), encoding="utf-8").read())
         except SyntaxError:
             continue
-        hits = []
-        for node in tree.body:
-            if isinstance(node, ast.ImportFrom) and (node.module or "").startswith("test_"):
-                hits.append(node.module)
-            elif isinstance(node, ast.Import):
-                hits += [alias.name for alias in node.names if alias.name.startswith("test_")]
-        if hits:
-            found[name] = sorted(set(hits))
+        found_here = _module_level_test_imports(tree)
+        if found_here:
+            found[name] = sorted(found_here)
     return found
 
 
+def _module_level_test_imports(tree) -> set:
+    """Test modules imported at IMPORT TIME, including from inside a module-level try/except.
+
+    This used to read `tree.body` alone, which is not the same question as the docstring above
+    asks. Nearly every dual-path import in this tree is written
+
+        try:  # package path
+            from tools.test_x import Fixture
+        except ImportError:
+            from test_x import Fixture
+
+    and a `try` at module level runs when the module is imported, exactly like a bare import. Only
+    an import nested inside a FUNCTION or CLASS body is deferred, and that is the fix this guard
+    prescribes -- so those, and only those, are excluded.
+
+    Reading tree.body missed thirteen mutual pairs. It is the difference between asking "is this
+    statement an import" and "does this import run at import time", and it under-reported silently.
+    """
+    deferred = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            for inner in ast.walk(node):
+                if isinstance(inner, (ast.Import, ast.ImportFrom)):
+                    deferred.add(id(inner))
+    hits = set()
+    for node in ast.walk(tree):
+        if id(node) in deferred:
+            continue
+        if isinstance(node, ast.ImportFrom) and node.module:
+            module = node.module.rsplit(".", 1)[-1]
+            if module.startswith("test_"):
+                hits.add(module)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                module = alias.name.rsplit(".", 1)[-1]
+                if module.startswith("test_"):
+                    hits.add(module)
+    return hits
+
+
 class NoNewCrossTestImportsTest(unittest.TestCase):
+
+    def test_the_scan_sees_a_try_wrapped_import(self) -> None:
+        """The blind spot this scan had, kept as a control rather than a memory.
+
+        It read `tree.body`, so it saw a bare top-level import and missed one inside a
+        module-level try/except -- which is how nearly every dual-path import in this tree is
+        written, and which runs at import time exactly the same. Seventeen cross-importers and
+        all thirteen mutual pairs were invisible to it.
+
+        The other half of the line matters too: an import inside a FUNCTION or CLASS is
+        deferred, and deferring is the fix this guard prescribes. It must not be counted, or the
+        remedy would fail the rule."""
+        wrapped = ast.parse(WRAPPED_SNIPPET)
+        self.assertEqual({"test_x"}, _module_level_test_imports(wrapped),
+                         "a try-wrapped import at module level is no longer seen")
+        deferred = ast.parse(DEFERRED_SNIPPET)
+        self.assertEqual(set(), _module_level_test_imports(deferred),
+                         "an import inside a function is being counted; that is the FIX, not "
+                         "the defect")
+
+    def test_no_new_pair_imports_each_other(self) -> None:
+        """Mutual is worse than one-directional: it decides whether either module loads.
+
+        Fails in both directions, like the list above -- a new pair, or one that stopped being
+        mutual and should be struck."""
+        found = _cross_importers()
+        graph = {name[:-3]: set(mods) for name, mods in found.items()}
+        pairs = {tuple(sorted((left, right))) for left, deps in graph.items()
+                 for right in deps if right in graph and left in graph[right]}
+        self.assertEqual(
+            KNOWN_MUTUAL, pairs,
+            "the set of test modules importing each other has changed. New: %s. Gone: %s -- "
+            "strike those from KNOWN_MUTUAL, because a list allowed to go stale describes a "
+            "tree that no longer exists."
+            % (sorted(pairs - KNOWN_MUTUAL), sorted(KNOWN_MUTUAL - pairs)))
 
     def setUp(self) -> None:
         self.found = _cross_importers()


### PR DESCRIPTION
Its docstring asks whether a test module *"imports another test module at import time"*. Its scan
iterated `tree.body`, which is a narrower question — a bare top-level import counts, and this does
not:

```python
try:  # package path
    from tools.test_x import Fixture
except ImportError:
    from test_x import Fixture
```

A `try` at module level runs when the module is imported, exactly like a bare import. That is how
nearly every dual-path import in this tree is written.

| | before | after |
|---|---|---|
| cross-importers seen | 14 | **31** |
| mutual pairs seen | 0 | **13** |

The distinction the scan should draw is not statement position but whether the import **runs** at
import time, so it now walks the tree and excludes only imports nested inside a function or class —
which are deferred, and deferring is the fix this guard prescribes. Counting those would make the
remedy fail the rule.

### Mutual is a worse shape than one-directional

A one-directional cross-import shifts what later modules see. A **mutual** one decides whether
either module can be *loaded*, and the answer depends on what ran before it. Demonstrated on
`test_codex_hook_output_part2`:

| | |
|---|---|
| imported on its own | `ImportError: cannot import name '_CodexHookOutputPart2' from partially initialized module` |
| imported after the 64 modules discovery loads first | **succeeds** — and the parent is still not in `sys.modules` |

The suite is green because of an *order*, not because the cycle is resolved. Thirteen pairs are in
that position: the four backend-policy parts, two codex-hook-output parts, five codex-pipeline parts
and two module-boundary parts, each with its parent.

### Recorded, not changed

The thirteen are baked into the baseline and work under `unittest discover`. Rewriting them is the
same large, ordering-risky change this guard already declined for the original fourteen. What must
not appear is a **fourteenth** pair — and one that stops being mutual must be struck, so the list
fails in both directions.

Mutation-tested: adding a new mutual pair between two existing cross-importers fails it, and
restoring the old `tree.body` scan fails both the pair check and the control written for it.
