### PR TITLE
The two walks inside the lifecycle plan

### DIFF
--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -8293,6 +8293,26 @@ fn what_each_plan_call_walks() {
     let _ = engine.storage_lifecycle_plan(lifecycle_request());
     report("storage_lifecycle_plan", crate::engine::live_page_scan_entries());
 
+    // Split that 2.0x across the three calls it makes. `bucket_storage_summaries` is measured
+    // above at 1.0x, so ONE of the other two carries the second walk -- and neither is an obvious
+    // candidate: `live_block_slab_ids` walks the model maps (which this counter cannot see) and
+    // `storage_reclaim_slab_reports` is documented as a header walk of the page store. Measured
+    // rather than reasoned about, because reasoning about this counter has been wrong before:
+    // `object_manager_runtime_report`'s second walk turned out to be a bare expression at the end
+    // of the function that every grep had missed.
+    //
+    // These rows are a breakdown OF the row above, not additions to the total.
+    crate::engine::reset_live_page_scan_entries();
+    let _ = engine.live_block_slab_ids(1);
+    report("  of which: live_block_slab_ids", crate::engine::live_page_scan_entries());
+
+    crate::engine::reset_live_page_scan_entries();
+    let _ = engine.storage_reclaim_slab_reports(1);
+    report(
+        "  of which: storage_reclaim_slab_reports",
+        crate::engine::live_page_scan_entries(),
+    );
+
     // The unconditional pieces of `apply_storage_lifecycle`. None of them is gated by a request
     // flag -- `what_apply_storage_lifecycle_walks` subtracts every flag and moves nothing -- so
     // they have to be measured directly rather than by toggling the request.


### PR DESCRIPTION
After [#1586](https://github.com/matrixarkai/TemporalStore/pull/1586),
[#1589](https://github.com/matrixarkai/TemporalStore/pull/1589) and
[#1591](https://github.com/matrixarkai/TemporalStore/pull/1591) a maintenance round is **31.0×**
the shard, down from 35.0×. `storage_lifecycle_plan` is the largest single item left: **2.0× per
build, and a round builds it four times** — 8.0× of the 31.

This splits that 2.0×, and it sums cleanly:

| | × the shard |
|---|---|
| `storage_lifecycle_plan` | **2.0×** |
| `bucket_storage_summaries` (measured separately) | 1.0× |
| of which `live_block_slab_ids` | 0.0× |
| of which `storage_reclaim_slab_reports` | 1.0× |

## Why this is a measurement and not a fix

The obvious next hoist is **not the same shape** as the three before it, and the difference
matters.

#1586, #1589 and #1591 all shared a walk between consumers holding **one lock** over an unchanged
`&ShardState`. That is provably safe: there is no lifetime over which the materialized set can go
stale.

`storage_lifecycle_plan` holds no lock. `bucket_storage_summaries` and
`storage_reclaim_slab_reports` each take their own, and they sit about a hundred lines apart with
substantial pure computation between. So sharing a walk means choosing one of:

- **One lock across the whole plan.** Consistent, but extends a read-lock hold across all that
  computation, blocking writers for the span. That is a change to contention in the maintenance
  path, not just to how many times the shard is walked.
- **One snapshot passed to both**, each still taking its own lock. Keeps the holds short, but the
  entries are collected at one moment and used at another. Today the two reports read under
  separate locks and can already disagree; this would instead make them agree on a possibly
  **stale** view.

The second reading is tempting — internal consistency looks like an improvement — but this plan
feeds **reclaim** decisions, and the failure mode of being wrong there is removing records
something still needs. "Arguably safer" is not the standard for that path.

So the 4.0× is real and available, and it needs a deliberate decision about snapshot semantics in
the reclaim planner rather than a mechanical hoist. Recorded with the numbers so whoever takes it
starts from the trade rather than rediscovering it.

## Verification

Measurement only; no behaviour changes. The probe is `#[ignore]`, so it does not run in the suite.

`cargo test -p temporalstore-rust --lib -- --test-threads=1` → **1781 passed, 1 failed**. The single
failure is `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the standing `--lib`
baseline failure on main, not introduced here.
