### PR TITLE
Thirty-one shared constants take one definition, and the guard comparing them was inert

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -172,10 +172,41 @@ try:  # the values live in matrixark_mcp_runtime_config; this module re-exports 
     from tools.matrixark_mcp_runtime_config import (
         BACKEND_READINESS_BACKOFF_MS,
         BACKEND_READINESS_TIMEOUT_MS,
+        CONTEXT_TELEMETRY_WRITE_MODE,
+        DEFAULT_BUDGET_FILL_POLICY,
+        DEFAULT_CROSS_SESSION_BROAD_BUDGET_RATIO,
+        DEFAULT_CROSS_SESSION_CURRENT_STATE_BUDGET_RATIO,
+        DEFAULT_CROSS_SESSION_MAX_CANDIDATES,
+        DEFAULT_CROSS_SESSION_MAX_SESSIONS,
+        DEFAULT_CROSS_SESSION_MIN_BUDGET_TOKENS,
+        DEFAULT_CROSS_SESSION_MIN_ENTITY_BRIDGE_REFS,
+        DEFAULT_CROSS_SESSION_MIN_SCORE,
+        DEFAULT_CROSS_SESSION_MULTI_HOP_BUDGET_RATIO,
+        DEFAULT_CROSS_SESSION_PARALLELISM,
+        DEFAULT_CROSS_SESSION_PREFERRED_REF_TYPES,
+        DEFAULT_CROSS_SESSION_PROFILE_MAX_CANDIDATES,
+        DEFAULT_CROSS_SESSION_PROFILE_MAX_SESSIONS,
+        DEFAULT_CROSS_SESSION_PROFILE_MIN_ENTITY_BRIDGE_REFS,
+        DEFAULT_CROSS_SESSION_RAW_EVIDENCE_MIN_SCORE,
+        DEFAULT_ENTITY_MERGE_OPERATOR,
+        DEFAULT_MAX_CANDIDATES_PER_NODE,
+        DEFAULT_MAX_CHILDREN_SCORED_PER_PARENT,
+        DEFAULT_MAX_GLOBAL_CANDIDATES,
+        DEFAULT_MAX_SELECTED_REFS,
+        DEFAULT_NEAR_DUPLICATE_OVERLAP_THRESHOLD,
+        DEFAULT_RETRIEVAL_MIN_SCORE,
+        DEFAULT_SHARED_CONTEXT_MIN_SCORE,
+        DEFAULT_TOP_K_PER_LAYER,
         DIRECT_AUDIT_MODE,
         DIRECT_RECORD_BUNDLE_MAX_BYTES,
         DIRECT_RECORD_HOT_CACHE_MAX_RECORDS,
         DIRECT_RECORD_LOG_SHARD_SIZE,
+        HARD_MAX_CHILDREN_SCORED_PER_PARENT,
+        MATRIXARK_ALLOW_PYTHON_HOT_CACHE,
+        MATRIXARK_MCP_PROFILE,
+        MATRIXARK_REQUIRE_BACKEND_READY,
+        MATRIXARK_REQUIRE_NATIVE_CANDIDATE_PREFILTER,
+        MATRIXARK_REQUIRE_NATIVE_CONTEXT_PACK,
         RESOURCE_ASYNC_DEFAULT_BYTES,
         SUMMARY_REFRESH_INTERVAL_MS,
         SUMMARY_REFRESH_LIMIT,
@@ -187,10 +218,41 @@ except ImportError:  # Direct script execution from tools/.
     from matrixark_mcp_runtime_config import (
         BACKEND_READINESS_BACKOFF_MS,
         BACKEND_READINESS_TIMEOUT_MS,
+        CONTEXT_TELEMETRY_WRITE_MODE,
+        DEFAULT_BUDGET_FILL_POLICY,
+        DEFAULT_CROSS_SESSION_BROAD_BUDGET_RATIO,
+        DEFAULT_CROSS_SESSION_CURRENT_STATE_BUDGET_RATIO,
+        DEFAULT_CROSS_SESSION_MAX_CANDIDATES,
+        DEFAULT_CROSS_SESSION_MAX_SESSIONS,
+        DEFAULT_CROSS_SESSION_MIN_BUDGET_TOKENS,
+        DEFAULT_CROSS_SESSION_MIN_ENTITY_BRIDGE_REFS,
+        DEFAULT_CROSS_SESSION_MIN_SCORE,
+        DEFAULT_CROSS_SESSION_MULTI_HOP_BUDGET_RATIO,
+        DEFAULT_CROSS_SESSION_PARALLELISM,
+        DEFAULT_CROSS_SESSION_PREFERRED_REF_TYPES,
+        DEFAULT_CROSS_SESSION_PROFILE_MAX_CANDIDATES,
+        DEFAULT_CROSS_SESSION_PROFILE_MAX_SESSIONS,
+        DEFAULT_CROSS_SESSION_PROFILE_MIN_ENTITY_BRIDGE_REFS,
+        DEFAULT_CROSS_SESSION_RAW_EVIDENCE_MIN_SCORE,
+        DEFAULT_ENTITY_MERGE_OPERATOR,
+        DEFAULT_MAX_CANDIDATES_PER_NODE,
+        DEFAULT_MAX_CHILDREN_SCORED_PER_PARENT,
+        DEFAULT_MAX_GLOBAL_CANDIDATES,
+        DEFAULT_MAX_SELECTED_REFS,
+        DEFAULT_NEAR_DUPLICATE_OVERLAP_THRESHOLD,
+        DEFAULT_RETRIEVAL_MIN_SCORE,
+        DEFAULT_SHARED_CONTEXT_MIN_SCORE,
+        DEFAULT_TOP_K_PER_LAYER,
         DIRECT_AUDIT_MODE,
         DIRECT_RECORD_BUNDLE_MAX_BYTES,
         DIRECT_RECORD_HOT_CACHE_MAX_RECORDS,
         DIRECT_RECORD_LOG_SHARD_SIZE,
+        HARD_MAX_CHILDREN_SCORED_PER_PARENT,
+        MATRIXARK_ALLOW_PYTHON_HOT_CACHE,
+        MATRIXARK_MCP_PROFILE,
+        MATRIXARK_REQUIRE_BACKEND_READY,
+        MATRIXARK_REQUIRE_NATIVE_CANDIDATE_PREFILTER,
+        MATRIXARK_REQUIRE_NATIVE_CONTEXT_PACK,
         RESOURCE_ASYNC_DEFAULT_BYTES,
         SUMMARY_REFRESH_INTERVAL_MS,
         SUMMARY_REFRESH_LIMIT,
@@ -200,7 +262,6 @@ except ImportError:  # Direct script execution from tools/.
     )
 
 
-CONTEXT_TELEMETRY_WRITE_MODE = (os.environ.get("MATRIXARK_CONTEXT_TELEMETRY_WRITE_MODE", "").strip().lower() or "inline")
 # These four, and four more below, are defined here AND in matrixark_mcp_runtime_config. See the
 # single-source note beside DEFAULT_MAX_CONTEXT_TOKENS further down: that constant was read from
 # the same variable in both modules with different fallbacks, and an operator who set nothing got
@@ -211,12 +272,7 @@ CONTEXT_TELEMETRY_WRITE_MODE = (os.environ.get("MATRIXARK_CONTEXT_TELEMETRY_WRIT
 # through the same proxy lane the request path uses -- so at a fixed interval a pass that
 # grows past that interval turns the loop into a permanent occupant of the lane. See
 # MatrixArkMcpServer._next_summary_refresh_delay_s.
-MATRIXARK_MCP_PROFILE = (os.environ.get("MATRIXARK_MCP_PROFILE", "").strip().lower() or "dev")
 # MATRIXARK_ALLOW_LOCAL_BACKEND comes from matrixark_mcp_runtime_config, above.
-MATRIXARK_REQUIRE_BACKEND_READY = os.environ.get("MATRIXARK_REQUIRE_BACKEND_READY", "").strip().lower()
-MATRIXARK_REQUIRE_NATIVE_CONTEXT_PACK = os.environ.get("MATRIXARK_REQUIRE_NATIVE_CONTEXT_PACK", "").strip().lower()
-MATRIXARK_ALLOW_PYTHON_HOT_CACHE = os.environ.get("MATRIXARK_ALLOW_PYTHON_HOT_CACHE", "").strip().lower()
-MATRIXARK_REQUIRE_NATIVE_CANDIDATE_PREFILTER = os.environ.get("MATRIXARK_REQUIRE_NATIVE_CANDIDATE_PREFILTER", "").strip().lower()
 
 # Single source of truth: reuse the runtime-config default so core and
 # matrixark_mcp_runtime_config agree out-of-the-box (both were previously
@@ -270,8 +326,6 @@ MAX_INDEX_TERMS_PER_RESOURCE_FACT = int(os.environ.get("MATRIXARK_MAX_INDEX_TERM
 MAX_SECONDARY_INDEX_RECORDS_PER_OPERATION = 128
 MAX_SECONDARY_INDEX_REFS_PER_POSTING = int(os.environ.get("MATRIXARK_MAX_SECONDARY_INDEX_REFS_PER_POSTING", "").strip() or "512")
 SECONDARY_INDEX_TIME_BUCKET_MS = int(os.environ.get("MATRIXARK_SECONDARY_INDEX_TIME_BUCKET_MS", "").strip() or "60000")
-DEFAULT_MAX_CHILDREN_SCORED_PER_PARENT = int(os.environ.get("MATRIXARK_MAX_CHILDREN_SCORED_PER_PARENT", "").strip() or "100000")
-HARD_MAX_CHILDREN_SCORED_PER_PARENT = int(os.environ.get("MATRIXARK_HARD_MAX_CHILDREN_SCORED_PER_PARENT", "").strip() or "100000")
 # ------------------------------------------------------------------------------------------------
 # Secondary-index dimension pruning (Lever 2).
 #
@@ -330,40 +384,12 @@ MAX_CONTEXT_REF_CHARS = 4096
 # 0.05, and the engine request builder sent a bare 0.0 that overrode both -- so the threshold a
 # deployment got depended on which surface the request came through.
 # test_the_score_threshold_has_one_value pins the file and the code together.
-DEFAULT_RETRIEVAL_MIN_SCORE = float(os.environ.get("MATRIXARK_RETRIEVAL_MIN_SCORE", "").strip() or "0.05")
-DEFAULT_TOP_K_PER_LAYER = int(os.environ.get("MATRIXARK_TOP_K_PER_LAYER", "").strip() or "8")
-DEFAULT_MAX_CANDIDATES_PER_NODE = int(os.environ.get("MATRIXARK_MAX_CANDIDATES_PER_NODE", "").strip() or "1024")
-DEFAULT_MAX_GLOBAL_CANDIDATES = int(os.environ.get("MATRIXARK_MAX_GLOBAL_CANDIDATES", "").strip() or "512")
 # 1000, matching config/temporalstore.toml. The config declared 1000 while this said 64 and
 # the engine used 24, so the number a deployment got depended on which surface it came from.
 # test_the_ref_cap_has_one_value pins all of them together.
-DEFAULT_MAX_SELECTED_REFS = int(os.environ.get("MATRIXARK_MAX_SELECTED_REFS", "").strip() or "1000")
-DEFAULT_BUDGET_FILL_POLICY = (os.environ.get("MATRIXARK_BUDGET_FILL_POLICY", "").strip().lower() or "quality_first")
 # Near-duplicate suppression threshold (see matrixark_mcp_runtime_config for the
 # canonical definition). Reused here so the ref-selection path shares one source
 # of truth for the knob.
-DEFAULT_NEAR_DUPLICATE_OVERLAP_THRESHOLD = float(
-    os.environ.get("MATRIXARK_NEAR_DUPLICATE_OVERLAP_THRESHOLD", "").strip() or "0.85"
-)
-DEFAULT_CROSS_SESSION_CURRENT_STATE_BUDGET_RATIO = float(os.environ.get("MATRIXARK_CROSS_SESSION_CURRENT_STATE_BUDGET_RATIO", "").strip() or "0.20")
-DEFAULT_CROSS_SESSION_MULTI_HOP_BUDGET_RATIO = float(os.environ.get("MATRIXARK_CROSS_SESSION_MULTI_HOP_BUDGET_RATIO", "").strip() or "0.20")
-DEFAULT_CROSS_SESSION_BROAD_BUDGET_RATIO = float(os.environ.get("MATRIXARK_CROSS_SESSION_BROAD_BUDGET_RATIO", "").strip() or "0.15")
-DEFAULT_CROSS_SESSION_MAX_SESSIONS = int(os.environ.get("MATRIXARK_CROSS_SESSION_MAX_SESSIONS", "").strip() or "3")
-DEFAULT_CROSS_SESSION_MAX_CANDIDATES = int(os.environ.get("MATRIXARK_CROSS_SESSION_MAX_CANDIDATES", "").strip() or "24")
-DEFAULT_CROSS_SESSION_MIN_ENTITY_BRIDGE_REFS = int(os.environ.get("MATRIXARK_CROSS_SESSION_MIN_ENTITY_BRIDGE_REFS", "").strip() or "2")
-DEFAULT_CROSS_SESSION_PARALLELISM = int(os.environ.get("MATRIXARK_CROSS_SESSION_PARALLELISM", "").strip() or "4")
-DEFAULT_CROSS_SESSION_MIN_BUDGET_TOKENS = int(os.environ.get("MATRIXARK_CROSS_SESSION_MIN_BUDGET_TOKENS", "").strip() or "256")
-DEFAULT_CROSS_SESSION_MIN_SCORE = float(os.environ.get("MATRIXARK_CROSS_SESSION_MIN_SCORE", "").strip() or "0.20")
-DEFAULT_CROSS_SESSION_RAW_EVIDENCE_MIN_SCORE = float(os.environ.get("MATRIXARK_CROSS_SESSION_RAW_EVIDENCE_MIN_SCORE", "").strip() or "0.45")
-DEFAULT_CROSS_SESSION_PROFILE_MAX_SESSIONS = int(os.environ.get("MATRIXARK_CROSS_SESSION_PROFILE_MAX_SESSIONS", "").strip() or "6")
-DEFAULT_CROSS_SESSION_PROFILE_MAX_CANDIDATES = int(os.environ.get("MATRIXARK_CROSS_SESSION_PROFILE_MAX_CANDIDATES", "").strip() or "48")
-DEFAULT_CROSS_SESSION_PROFILE_MIN_ENTITY_BRIDGE_REFS = int(os.environ.get("MATRIXARK_CROSS_SESSION_PROFILE_MIN_ENTITY_BRIDGE_REFS", "").strip() or "3")
-DEFAULT_CROSS_SESSION_PREFERRED_REF_TYPES = tuple(
-    item.strip()
-    for item in (os.environ.get("MATRIXARK_CROSS_SESSION_PREFERRED_REF_TYPES", "").strip() or "entity,summary,compression").split(",")
-    if item.strip()
-)
-DEFAULT_SHARED_CONTEXT_MIN_SCORE = float(os.environ.get("MATRIXARK_SHARED_CONTEXT_MIN_SCORE", "").strip() or "0.20")
 TIME_COMPRESSION_SUMMARY_PROVIDER = (os.environ.get("MATRIXARK_TIME_COMPRESSION_SUMMARY_PROVIDER", "").strip().lower() or "deterministic")
 TIME_COMPRESSION_SUMMARY_MODEL = (
     os.environ.get("MATRIXARK_TIME_COMPRESSION_SUMMARY_MODEL", "").strip()
@@ -433,7 +459,6 @@ SUMMARY_LLM_PROVIDER = (
 SUMMARY_LLM_MODEL = EXTRACTION_LLM_MODEL
 SUMMARY_LLM_MAX_TOKENS = int(os.environ.get("MATRIXARK_SUMMARY_MAX_TOKENS", "").strip() or "900")
 # ENABLE_LLM_MERGE_OPERATOR comes from matrixark_mcp_runtime_config, above.
-DEFAULT_ENTITY_MERGE_OPERATOR = os.environ.get("MATRIXARK_ENTITY_MERGE_OPERATOR", "EUA_MERGE").strip().upper() or "EUA_MERGE"
 _OSS_SEGMENT_MODEL_CACHE: dict[str, Any] = {}
 _OSS_UNDERSTANDING_PROTOTYPE_CACHE: dict[str, dict[str, list[float]]] = {}
 _EMBEDDING_VECTOR_CACHE: dict[tuple[str, str], list[float]] = {}

--- a/tools/test_runtime_config_core_default_agreement.py
+++ b/tools/test_runtime_config_core_default_agreement.py
@@ -56,8 +56,32 @@ def _env_get_call(node: ast.AST) -> ast.Call | None:
     return None
 
 
-def env_backed_defaults(path: pathlib.Path) -> dict[str, tuple[str, object]]:
-    """Map module-level constant name -> (env var, fallback literal)."""
+def _or_fallback(node: ast.AST) -> object | None:
+    """The literal after ``or`` in ``os.environ.get(NAME, "").strip() or "8"``.
+
+    THE SECOND ARGUMENT IS NOT THE DEFAULT IN THIS TREE, and reading it as one made this guard
+    inert for 42 of the 43 constants it compares: nearly every constant here is written
+    ``int(os.environ.get("MATRIXARK_X", "").strip() or "8")``, so the second argument is the empty
+    string on BOTH sides and the agreement assertion was comparing "" with "". Two modules could
+    have differed by any amount -- 8 against 99 -- and this file would have passed, which is
+    exactly the divergence it was written after. Verified by mutation: injecting a second
+    DEFAULT_TOP_K_PER_LAYER of 99 beside a runtime_config of 8 passed before this and fails now.
+
+    The empty second argument is not sloppiness: `os.environ.get(NAME, "").strip() or "8"` treats a
+    variable set to whitespace the same as one not set at all, which a bare default does not.
+    `test_numeric_defaults_agree` already resolves the same shape; this is that rule applied to the
+    two config modules.
+    """
+    for child in ast.walk(node):
+        if isinstance(child, ast.BoolOp) and isinstance(child.op, ast.Or):
+            last = child.values[-1]
+            if isinstance(last, ast.Constant):
+                return last.value
+    return None
+
+
+def _declared_here(path: pathlib.Path) -> dict[str, tuple[str, object]]:
+    """Constants this file declares itself: name -> (env var, effective fallback literal)."""
     tree = ast.parse(path.read_text(encoding="utf-8"))
     found: dict[str, tuple[str, object]] = {}
     for node in tree.body:
@@ -67,8 +91,56 @@ def env_backed_defaults(path: pathlib.Path) -> dict[str, tuple[str, object]]:
         if not isinstance(target, ast.Name) or not target.id.isupper():
             continue
         call = _env_get_call(node.value)
-        if call is not None:
-            found[target.id] = (call.args[0].value, call.args[1].value)
+        if call is None:
+            continue
+        fallback = call.args[1].value
+        if fallback == "":
+            through_or = _or_fallback(node.value)
+            if through_or is not None:
+                fallback = through_or
+        found[target.id] = (call.args[0].value, fallback)
+    return found
+
+
+def _imported_from(path: pathlib.Path) -> dict[str, str]:
+    """Upper-case names this file gets by importing them, and the module they come from."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    out: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or not node.module:
+            continue
+        module = node.module.rsplit(".", 1)[-1]
+        for alias in node.names:
+            if alias.asname is None and alias.name.isupper():
+                out[alias.name] = module
+    return out
+
+
+def env_backed_defaults(path: pathlib.Path) -> dict[str, tuple[str, object]]:
+    """Map constant name -> (env var, fallback literal), INCLUDING ones reached by import.
+
+    A name a module gets by importing it is that module's constant as far as any reader is
+    concerned: `from matrixark_mcp_runtime_config import DEFAULT_TOP_K_PER_LAYER` and a local
+    `DEFAULT_TOP_K_PER_LAYER = int(os.environ.get(...))` are indistinguishable at every call site.
+    Reading only local declarations made this guard's subject VANISH when the duplicates it exists
+    to compare were folded into one definition: the shared set went to zero and the vacuity floor
+    below fired -- a floor measured from a population that the improvement removes, which is the
+    failure mode the comment on that floor already warns about.
+
+    Following the import does not weaken the agreement question, it settles it: two names that
+    resolve to ONE definition cannot disagree, where two kept in step by hand can. What the floor
+    now protects is that the extractor still finds them at all.
+    """
+    found = _declared_here(path)
+    for name, module in _imported_from(path).items():
+        if name in found:
+            continue
+        source = path.parent / (module + ".py")
+        if not source.exists():
+            continue
+        declared = _declared_here(source)
+        if name in declared:
+            found[name] = declared[name]
     return found
 
 
@@ -89,11 +161,32 @@ class RuntimeConfigAgreesWithCore(unittest.TestCase):
         # fails loudly on that while surviving any legitimate move in the count.
         self.assertGreater(len(self.core), 20, "core parse found too few constants")
         self.assertGreater(len(self.runtime), 20, "runtime_config parse found too few")
+        shared = set(self.core) & set(self.runtime)
         self.assertGreater(
-            len(set(self.core) & set(self.runtime)),
+            len(shared),
             20,
             "expected a large shared constant set between the two modules",
         )
+        # The shared set is now shared by IMPORT rather than by duplication, so this asserts the
+        # mechanism that makes it so. Without it the extractor could quietly go back to reading
+        # local declarations only, the shared set would collapse to whatever duplication remains,
+        # and the agreement assertion would be true of almost nothing.
+        # The comparison must be about real values. It was not: reading the second argument of
+        # os.environ.get gave "" for 42 of these 43, so the agreement below held between two empty
+        # strings. A count of how many carry a real literal is the thing to hold.
+        with_a_value = [n for n in shared if self.core[n][1] != ""]
+        self.assertGreater(
+            len(with_a_value), 20,
+            "only %d of %d shared constants resolve to a real fallback literal. The rest compare "
+            "\"\" against \"\", which is an agreement assertion that cannot fail -- see "
+            "_or_fallback." % (len(with_a_value), len(shared)))
+        imported = _imported_from(TOOLS / "matrixark_mcp_core.py")
+        self.assertGreater(
+            len(set(imported) & shared), 20,
+            "at most %d of the shared constants reach matrixark_mcp_core by import. They were "
+            "folded into one definition on purpose; if they are being counted as shared because "
+            "they are DUPLICATED again, that is the divergence this file exists to prevent."
+            % len(set(imported) & shared))
 
     def test_wrapped_definitions_are_covered(self) -> None:
         # A constant written across several lines: the line-based matcher this replaced skipped

--- a/tools/test_the_ref_cap_has_one_value.py
+++ b/tools/test_the_ref_cap_has_one_value.py
@@ -8,6 +8,7 @@ the existing numeric-defaults guard could not see it because that guard only sca
 
 This is the narrow guard for that one setting, checked where it is actually written.
 """
+import ast
 import os
 import re
 import sys
@@ -34,16 +35,84 @@ def config_value():
     return None
 
 
+SURFACES = ("matrixark_mcp_core.py", "matrixark_mcp_runtime_config.py")
+
+CONSTANT = "DEFAULT_MAX_SELECTED_REFS"
+VARIABLE = "MATRIXARK_MAX_SELECTED_REFS"
+CAST = int
+
+_DECLARES = re.compile(
+    r'DEFAULT_MAX_SELECTED_REFS = int\(os\.environ\.get\("MATRIXARK_MAX_SELECTED_REFS",.*?"(\d+)"'
+)
+
+# ---------------------------------------------------------------------------------------------
+# A surface satisfies this file two ways: it reads the environment variable itself, or it imports
+# the constant from a module that does. The second is the STRONGER of the two -- one definition
+# reached by import cannot drift from itself, where two kept in step can -- so following the import
+# is not a relaxation of the question. What is still refused is a surface that binds the name to a
+# literal, and a surface whose imports disagree about where the value comes from.
+#
+# The same twenty lines are in test_the_shard_size_has_one_value.py and
+# test_the_score_threshold_has_one_value.py. That is deliberate rather than lazy: these three run
+# as scripts, a guard importing another guard is what test_matrixark_no_cross_test_imports exists
+# to stop, and a tools/ module only the tests import is exactly what
+# test_a_module_only_tests_reach_is_not_live records as unreachable. Three copies of a rule is a
+# real cost; a fourth entry in that list and a new cross-test edge were the larger ones.
+
+
+def _body(name):
+    return open(os.path.join(HERE, name), encoding="utf-8").read()
+
+
+def _hardcodes(body):
+    """The name bound to a bare number -- the failure this whole file exists to catch."""
+    for node in ast.walk(ast.parse(body)):
+        if not isinstance(node, ast.Assign):
+            continue
+        names = [t.id for t in node.targets if isinstance(t, ast.Name)]
+        if CONSTANT in names and isinstance(node.value, ast.Constant):
+            if isinstance(node.value.value, (int, float)) and not isinstance(node.value.value, bool):
+                return node.value.value
+    return None
+
+
+def _imports_from(body):
+    """Every module this file imports the constant from, as file names.
+
+    Plural on purpose: the re-export in matrixark_mcp_core.py is a try/except pair of imports
+    maintained separately, and two branches naming two different modules is the same divergence
+    this guard is about, one level up.
+    """
+    out = []
+    for node in ast.walk(ast.parse(body)):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            for alias in node.names:
+                if alias.name == CONSTANT and alias.asname is None:
+                    out.append(node.module.rsplit(".", 1)[-1] + ".py")
+    return out
+
+
+def _resolve(name, seen=()):
+    """The value a surface uses, and the file that declares it."""
+    if name in seen:
+        return None, None
+    body = _body(name)
+    if _hardcodes(body) is not None:
+        return None, None
+    match = _DECLARES.search(body)
+    if match:
+        return CAST(match.group(1)), name
+    sources = set(_imports_from(body))
+    if len(sources) != 1:
+        return None, None
+    source = sources.pop()
+    if not os.path.exists(os.path.join(HERE, source)):
+        return None, None
+    return _resolve(source, seen + (name,))
+
+
 def python_defaults():
-    found = {}
-    for name in ("matrixark_mcp_core.py", "matrixark_mcp_runtime_config.py"):
-        body = open(os.path.join(HERE, name), encoding="utf-8").read()
-        match = re.search(
-            r'DEFAULT_MAX_SELECTED_REFS = int\(os\.environ\.get\("MATRIXARK_MAX_SELECTED_REFS",.*?"(\d+)"',
-            body,
-        )
-        found[name] = int(match.group(1)) if match else None
-    return found
+    return {name: _resolve(name)[0] for name in SURFACES}
 
 
 def rust_default():
@@ -69,6 +138,29 @@ def every_surface_declares_the_same_cap():
         len(distinct) == 1,
         "max_selected_refs disagrees across surfaces: %s" % (values,),
     )
+
+
+
+def every_surface_honours_the_environment_variable():
+    """A surface need not contain the variable name; what it must not do is arrive at a value the
+    variable cannot reach. So the question is asked of whichever file DECLARES the value for that
+    surface -- itself when it reads the environment, and the module it imports from when it does
+    not.
+    """
+    for name in SURFACES:
+        _value, declaring = _resolve(name)
+        check(
+            declaring is not None,
+            "%s neither reads %s nor imports the constant from a module that does"
+            % (name, VARIABLE),
+        )
+        if declaring is None:
+            continue
+        check(
+            VARIABLE in _body(declaring),
+            "%s takes its value from %s, which hardcodes it instead of reading %s"
+            % (name, declaring, VARIABLE),
+        )
 
 
 def the_request_builder_does_not_re_default_it():
@@ -125,6 +217,7 @@ def a_caller_can_still_ask_for_everything():
 
 for test in (
     every_surface_declares_the_same_cap,
+    every_surface_honours_the_environment_variable,
     the_request_builder_does_not_re_default_it,
     a_caller_can_still_ask_for_everything,
 ):

--- a/tools/test_the_score_threshold_has_one_value.py
+++ b/tools/test_the_score_threshold_has_one_value.py
@@ -8,6 +8,7 @@ said otherwise -- so raising it in the file changed nothing, which is the worst 
 The existing numeric-defaults guard cannot see this: it scans `os.environ.get(VAR, literal)` reads,
 not config files and not a literal inline in a dict.
 """
+import ast
 import os
 import re
 import sys
@@ -34,16 +35,84 @@ def config_value():
     return None
 
 
+SURFACES = ("matrixark_mcp_core.py", "matrixark_mcp_runtime_config.py")
+
+CONSTANT = "DEFAULT_RETRIEVAL_MIN_SCORE"
+VARIABLE = "MATRIXARK_RETRIEVAL_MIN_SCORE"
+CAST = float
+
+_DECLARES = re.compile(
+    r'DEFAULT_RETRIEVAL_MIN_SCORE = float\(os\.environ\.get\("MATRIXARK_RETRIEVAL_MIN_SCORE",.*?"([\d.]+)"'
+)
+
+# ---------------------------------------------------------------------------------------------
+# A surface satisfies this file two ways: it reads the environment variable itself, or it imports
+# the constant from a module that does. The second is the STRONGER of the two -- one definition
+# reached by import cannot drift from itself, where two kept in step can -- so following the import
+# is not a relaxation of the question. What is still refused is a surface that binds the name to a
+# literal, and a surface whose imports disagree about where the value comes from.
+#
+# The same twenty lines are in test_the_shard_size_has_one_value.py and
+# test_the_score_threshold_has_one_value.py. That is deliberate rather than lazy: these three run
+# as scripts, a guard importing another guard is what test_matrixark_no_cross_test_imports exists
+# to stop, and a tools/ module only the tests import is exactly what
+# test_a_module_only_tests_reach_is_not_live records as unreachable. Three copies of a rule is a
+# real cost; a fourth entry in that list and a new cross-test edge were the larger ones.
+
+
+def _body(name):
+    return open(os.path.join(HERE, name), encoding="utf-8").read()
+
+
+def _hardcodes(body):
+    """The name bound to a bare number -- the failure this whole file exists to catch."""
+    for node in ast.walk(ast.parse(body)):
+        if not isinstance(node, ast.Assign):
+            continue
+        names = [t.id for t in node.targets if isinstance(t, ast.Name)]
+        if CONSTANT in names and isinstance(node.value, ast.Constant):
+            if isinstance(node.value.value, (int, float)) and not isinstance(node.value.value, bool):
+                return node.value.value
+    return None
+
+
+def _imports_from(body):
+    """Every module this file imports the constant from, as file names.
+
+    Plural on purpose: the re-export in matrixark_mcp_core.py is a try/except pair of imports
+    maintained separately, and two branches naming two different modules is the same divergence
+    this guard is about, one level up.
+    """
+    out = []
+    for node in ast.walk(ast.parse(body)):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            for alias in node.names:
+                if alias.name == CONSTANT and alias.asname is None:
+                    out.append(node.module.rsplit(".", 1)[-1] + ".py")
+    return out
+
+
+def _resolve(name, seen=()):
+    """The value a surface uses, and the file that declares it."""
+    if name in seen:
+        return None, None
+    body = _body(name)
+    if _hardcodes(body) is not None:
+        return None, None
+    match = _DECLARES.search(body)
+    if match:
+        return CAST(match.group(1)), name
+    sources = set(_imports_from(body))
+    if len(sources) != 1:
+        return None, None
+    source = sources.pop()
+    if not os.path.exists(os.path.join(HERE, source)):
+        return None, None
+    return _resolve(source, seen + (name,))
+
+
 def python_defaults():
-    found = {}
-    for name in ("matrixark_mcp_core.py", "matrixark_mcp_runtime_config.py"):
-        body = open(os.path.join(HERE, name), encoding="utf-8").read()
-        match = re.search(
-            r'DEFAULT_RETRIEVAL_MIN_SCORE = float\(os\.environ\.get\("MATRIXARK_RETRIEVAL_MIN_SCORE",.*?"([\d.]+)"',
-            body,
-        )
-        found[name] = float(match.group(1)) if match else None
-    return found
+    return {name: _resolve(name)[0] for name in SURFACES}
 
 
 def the_file_and_the_code_agree():
@@ -55,6 +124,29 @@ def the_file_and_the_code_agree():
         check(value is not None, "%s no longer declares the threshold" % name)
     distinct = {v for v in values.values() if v is not None}
     check(len(distinct) == 1, "the score threshold disagrees across surfaces: %s" % (values,))
+
+
+
+def every_surface_honours_the_environment_variable():
+    """A surface need not contain the variable name; what it must not do is arrive at a value the
+    variable cannot reach. So the question is asked of whichever file DECLARES the value for that
+    surface -- itself when it reads the environment, and the module it imports from when it does
+    not.
+    """
+    for name in SURFACES:
+        _value, declaring = _resolve(name)
+        check(
+            declaring is not None,
+            "%s neither reads %s nor imports the constant from a module that does"
+            % (name, VARIABLE),
+        )
+        if declaring is None:
+            continue
+        check(
+            VARIABLE in _body(declaring),
+            "%s takes its value from %s, which hardcodes it instead of reading %s"
+            % (name, declaring, VARIABLE),
+        )
 
 
 def the_request_builder_does_not_re_default_it():
@@ -105,6 +197,7 @@ def the_engine_treats_absent_as_return_everything_scoring():
 
 for test in (
     the_file_and_the_code_agree,
+    every_surface_honours_the_environment_variable,
     the_request_builder_does_not_re_default_it,
     the_engine_treats_absent_as_return_everything_scoring,
 ):

--- a/tools/test_two_modules_do_not_read_the_same_variable.py
+++ b/tools/test_two_modules_do_not_read_the_same_variable.py
@@ -41,7 +41,7 @@ RUNTIME = "matrixark_mcp_runtime_config.py"
 #: file raises against sweeping, and it does not apply to a constant that reads no flag.
 #:
 #: The remaining 43 DO read the environment, and they stay one at a time.
-RECORDED_DUPLICATED = 31
+RECORDED_DUPLICATED = 0
 
 #: Defined in both and NOT identical, with the reason. `matrixark_mcp_core` binds
 #: DEFAULT_MAX_CONTEXT_TOKENS to the value it imported from runtime_config under an alias, which is


### PR DESCRIPTION
matrixark_mcp_core and matrixark_mcp_runtime_config both declared the same 31 env-backed
constants, byte for byte. Core's copies are removed and re-exported from the existing block, so
there is one definition and it cannot drift. RECORDED_DUPLICATED 31 -> 0.

Nothing moved. Core's module namespace was dumped before and after and compared whole: 164 names
both times, none lost, none gained, no value changed.

WHAT THE CONSOLIDATION BROKE, AND WHY EACH FIX IS THE GUARD'S REAL PROPERTY

Three guards read a literal declaration out of matrixark_mcp_core and went red when the literal
became an import. All three now resolve one import hop, on the same reasoning: a surface satisfies
them either by reading the environment variable itself or by importing the constant from a module
that does, and the second is the STRONGER of the two, because one definition cannot drift from
itself where two kept in step can.

  test_the_ref_cap_has_one_value
  test_the_score_threshold_has_one_value
  test_runtime_config_core_default_agreement

Following an import could relax a guard into nothing, so each refusal is proved by mutation:

  core binds the name to a literal                  FAILS
  the declaring module stops reading the variable   FAILS
  core's two import branches disagree               FAILS
  the extractor stops following imports             FAILS
  a re-duplicated constant disagrees                FAILS

The third of those is new and is a hazard the import hop introduces rather than one it inherits:
core's re-export is a try/except pair of separately maintained import lists, and two branches
naming two different modules is the same divergence these files exist to catch, one level up.

THE AGREEMENT GUARD WAS COMPARING "" WITH "" FOR 42 OF ITS 43 CONSTANTS

Found because a mutation that should have failed did not. test_runtime_config_core_default_agreement
read the SECOND ARGUMENT of os.environ.get as the default. Nearly every constant in these two
modules is written

    int(os.environ.get("MATRIXARK_TOP_K_PER_LAYER", "").strip() or "8")

where the second argument is the empty string and the real fallback is after the `or`. So the
agreement assertion compared two empty strings: core could have said 99 where runtime_config says
8 and this file would have passed, which is precisely the divergence it was written after
(DEFAULT_MAX_CONTEXT_TOKENS, 128000 against 500000). Injecting exactly that passed before and
fails now, naming the constant and both values.

  vacuous comparisons   42 of 43  ->  5 of 43

The five that remain are flags whose default really is empty. The empty second argument is not
sloppiness either: it makes a variable set to whitespace behave like one not set, which a bare
default does not. test_numeric_defaults_agree already resolved this shape; this is that rule
applied to the two config modules.

A FLOOR THAT THE IMPROVEMENT WOULD HAVE BROKEN

test_both_modules_were_actually_parsed requires more than 20 shared constants. Folding 31
duplicates into one definition took the shared set to zero and fired it -- a vacuity floor
measured from a population that the improvement removes, which the comment above that floor
already warns about. It now counts constants reached by import, and asserts the mechanism: more
than 20 of the shared set must arrive in core BY IMPORT, so an extractor that quietly reverts to
local declarations fails rather than passing on whatever duplication is left.

Full tools suite: 82 failing names against a recorded baseline of 106, and the two not in the
baseline were chased down. One is this consolidation's and is fixed above. The other,
test_and_the_effective_value_did_not_move, reproduces identically on a tree WITHOUT this change
when MATRIXARK_RETRIEVAL_MIN_SCORE is set -- another test leaves it at 0.20 in the process
environment. Not this change; the known set_var race.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>