### PR TITLE
A sixth boolean vocabulary, and the same module's numbers crashing on a blank value

### DIFF
--- a/tools/matrixark_mcp_rust_proxy_config.py
+++ b/tools/matrixark_mcp_rust_proxy_config.py
@@ -9,8 +9,25 @@ import os
 from typing import Any
 
 
+try:  # pragma: no cover - import shape differs when run as a package
+    from matrixark_mcp_env import FALSE_VALUES, env_bool
+except ImportError:  # pragma: no cover
+    from tools.matrixark_mcp_env import FALSE_VALUES, env_bool
+
+
 def _env_bool(name: str, default: str = "1") -> bool:
-    return os.environ.get(name, default).strip().lower() not in {"0", "false", "no"}
+    """A boolean flag, in the one vocabulary.
+
+    This used to be `... not in {"0", "false", "no"}` -- a DENY list where every other reader in
+    the tree uses an allow list, and one that is missing `off`. So `MATRIXARK_RUST_PROXY_SHARED_
+    PROCESS=off` left the flag ON, and so did `=disabled`. test_env_flag_vocabulary settled this
+    vocabulary after boolean flags were found parsed six different ways, and it did not catch this
+    one: its scan reads `os.environ.get("NAME")` written out, and this reads `os.environ.get(name)`
+    where the name is a PARAMETER. The same blind spot hid seventy flags from the surface count.
+
+    Delegating rather than restating: a vocabulary stated twice is the thing that was being fixed.
+    """
+    return env_bool(name, default.strip().lower() not in FALSE_VALUES)
 
 
 def _env_int(name: str, default: str, *, minimum: int = 1) -> int:

--- a/tools/test_env_flag_vocabulary.py
+++ b/tools/test_env_flag_vocabulary.py
@@ -13,6 +13,8 @@ misread are not being parsed by hand any more.
 """
 from __future__ import annotations
 
+import ast
+import importlib
 import os
 import pathlib
 import re
@@ -40,6 +42,125 @@ INLINE_PARSE = re.compile(
     r"""os\.environ\.get\(\s*["'](?P<name>[A-Z][A-Z0-9_]+)["'][^)]*\)"""
     r"""\s*\.strip\(\)\s*\.lower\(\)\s*(?:not\s+in|in)\s*\{"""
 )
+
+
+def _answers_a_boolean(node):
+    """Whether a reader answers a BOOLEAN, as against a number or a string.
+
+    Asked two ways, because either alone is wrong here. The annotation `-> bool` is the declarative
+    answer and this tree writes it; the membership test against string words is the structural one,
+    and it catches a reader that forgot the annotation. Without this filter the derivation sweeps up
+    `_env_int` and `env_text`, which answer the same for `on` and `off` because a count and a piece
+    of text SHOULD -- and a test that calls those a vocabulary defect is a test nobody can keep.
+    """
+    if isinstance(node.returns, ast.Name) and node.returns.id == "bool":
+        return True
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Compare) and any(
+                isinstance(op, (ast.In, ast.NotIn)) for op in sub.ops):
+            for operand in sub.comparators:
+                if isinstance(operand, (ast.Set, ast.List, ast.Tuple)) and all(
+                        isinstance(item, ast.Constant) and isinstance(item.value, str)
+                        for item in operand.elts) and operand.elts:
+                    return True
+                if isinstance(operand, ast.Name) and operand.id in ("TRUE_VALUES", "FALSE_VALUES"):
+                    return True
+    return False
+
+
+def _boolean_env_helpers():
+    """(module stem, function name) for every function that answers a BOOLEAN read of its first
+    argument.
+
+    THE INLINE SCAN ABOVE CANNOT SEE THESE, and that is how a sixth vocabulary survived the cleanup
+    that created this file. `INLINE_PARSE` looks for `os.environ.get("NAME").strip().lower() in
+    {...}` -- the name written out at the read. matrixark_mcp_rust_proxy_config had
+
+        def _env_bool(name, default="1"):
+            return os.environ.get(name, default).strip().lower() not in {"0", "false", "no"}
+
+    which is the same deny list this file was written about, missing `off`, with the name arriving
+    as an argument. MATRIXARK_RUST_PROXY_SHARED_PROCESS sits in PREVIOUSLY_MISREAD above with `off`
+    recorded as something that must read False, and it read True AT THE SITE for the whole time
+    this file has existed -- because the assertion up there calls the canonical parser and asks
+    what IT says, which was never in doubt.
+
+    A READER THAT DELEGATES IS STILL A READER. `matrixark_mcp_env.env_bool` reaches os.environ
+    through `env_lower`, and the moment the module above was fixed to delegate as well, a
+    direct-reads-only derivation stopped watching the one reader this was written for. So the
+    relation is propagated to a fixpoint: a function that hands its own first argument to a known
+    reader is a reader.
+    """
+    modules = {}
+    for path in sorted(TOOLS.glob("*.py")):
+        if path.name.startswith("test_"):
+            continue
+        try:
+            modules[path.stem] = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+        except SyntaxError:  # pragma: no cover
+            continue
+
+    functions = []
+    defined = {}
+    imported = {}
+    for stem, tree in modules.items():
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.args.args:
+                functions.append((stem, node, [a.arg for a in node.args.args]))
+                defined.setdefault(stem, set()).add(node.name)
+            if isinstance(node, ast.ImportFrom) and node.module:
+                source = node.module.rsplit(".", 1)[-1]
+                for alias in node.names:
+                    imported.setdefault(stem, {})[alias.asname or alias.name] = source
+
+    def resolve(stem, callee):
+        """Which (module, function) a call inside `stem` refers to.
+
+        KEYED BY MODULE, because a bare name is ambiguous here and the ambiguity is not academic:
+        `_env_bool` is a name-taking reader in matrixark_codex_hook and a VALUE-taking helper in
+        matrixark_v1_gateway, and a name-keyed table credited the second with reading the
+        environment it never touches -- then this test fed it a variable name, got False for both
+        `on` and `off`, and reported a vocabulary defect in a function that has none.
+        """
+        if callee in defined.get(stem, ()):
+            return (stem, callee)
+        source = imported.get(stem, {}).get(callee)
+        if source and callee in defined.get(source, ()):
+            return (source, callee)
+        return None
+
+    reads = {}
+    for _round in range(8):
+        grew = False
+        for stem, node, names in functions:
+            first = names[0]
+            for sub in ast.walk(node):
+                key = None
+                if isinstance(sub, ast.Call):
+                    func = sub.func
+                    if isinstance(func, ast.Attribute) and func.attr in ("get", "getenv") and sub.args:
+                        source = ast.unparse(func.value)
+                        if "environ" in source or source == "os":
+                            key = sub.args[0]
+                    if key is None:
+                        target = resolve(stem, getattr(func, "id", "") or getattr(func, "attr", ""))
+                        if target in reads and len(sub.args) > reads[target]:
+                            key = sub.args[reads[target]]
+                elif isinstance(sub, ast.Subscript) and ast.unparse(sub.value).endswith("environ"):
+                    key = sub.slice
+                if isinstance(key, ast.Name) and key.id == first:
+                    if (stem, node.name) not in reads:
+                        reads[(stem, node.name)] = 0
+                        grew = True
+                    break
+        if not grew:
+            break
+
+    out = []
+    for stem, node, _names in functions:
+        if (stem, node.name) in reads and _answers_a_boolean(node):
+            out.append((stem, node.name))
+    return sorted(set(out))
 
 
 class EnvFlagVocabulary(unittest.TestCase):
@@ -74,6 +195,62 @@ class EnvFlagVocabulary(unittest.TestCase):
         os.environ.pop("MATRIXARK_TEST_VOCAB", None)
         self.assertTrue(env_bool("MATRIXARK_TEST_VOCAB", True))
         self.assertFalse(env_bool("MATRIXARK_TEST_VOCAB", False))
+
+    def test_no_reader_makes_on_and_off_mean_the_same_thing(self):
+        """Asked of the READER, not of the parser.
+
+        Signature-agnostic on purpose: these helpers take (name), (name, default_str) and
+        (name, default_bool), and pinning the default would test the caller's intent rather than
+        the vocabulary. What no boolean reader may do, whatever its default, is answer the same for
+        `on` as for `off`. A deny list missing `off` fails exactly there, and so does an allow list
+        missing `on` -- the two directions the docstring at the top of this file is about.
+        """
+        probed, offenders = 0, []
+        for stem, func_name in _boolean_env_helpers():
+            try:
+                module = importlib.import_module(stem)
+            except Exception:  # pragma: no cover - a module that will not import is not this test's
+                continue
+            func = getattr(module, func_name, None)
+            if func is None:  # pragma: no cover
+                continue
+            answers = {}
+            for word in ("on", "off"):
+                os.environ["MATRIXARK_TEST_VOCAB"] = word
+                for arguments in (("MATRIXARK_TEST_VOCAB",),
+                                  ("MATRIXARK_TEST_VOCAB", "0"),
+                                  ("MATRIXARK_TEST_VOCAB", False)):
+                    try:
+                        answers[word] = bool(func(*arguments))
+                        break
+                    except Exception:
+                        continue
+            os.environ.pop("MATRIXARK_TEST_VOCAB", None)
+            if len(answers) != 2:
+                continue
+            probed += 1
+            if answers["on"] == answers["off"]:
+                offenders.append("%s.%s reads both `on` and `off` as %s"
+                                 % (stem, func_name, answers["on"]))
+        derived = _boolean_env_helpers()
+        self.assertIn(
+            ("matrixark_mcp_rust_proxy_config", "_env_bool"), derived,
+            "the reader this test was written for is not being probed. It delegates to the "
+            "canonical parser now, so a derivation that only follows a DIRECT os.environ read "
+            "stops watching the one site that was wrong.")
+        self.assertNotIn(
+            ("matrixark_v1_gateway", "_env_bool"), derived,
+            "matrixark_v1_gateway._env_bool takes a VALUE, not a variable name, and never touches "
+            "os.environ. It is here only if the derivation is keyed by bare function name, which "
+            "credits it with what the identically-named readers in two other modules do -- and "
+            "then this test feeds it a variable name, gets False for both `on` and `off`, and "
+            "reports a vocabulary defect in a function that has none.")
+        self.assertGreater(
+            probed, 8,
+            "only %d boolean readers were probed. The derivation finds them by asking which "
+            "functions read os.environ with their first parameter; near zero means it stopped "
+            "matching and this test is asserting nothing." % probed)
+        self.assertEqual(offenders, [], "; ".join(offenders))
 
     def test_the_flags_that_were_misread_now_do_what_they_say(self):
         for name, value, intended, default in PREVIOUSLY_MISREAD:


### PR DESCRIPTION
A sixth boolean vocabulary, on a flag the guard already lists as fixed

matrixark_mcp_rust_proxy_config read booleans with

    os.environ.get(name, default).strip().lower() not in {"0", "false", "no"}

a DENY list, where every other reader in the tree uses an allow list, and one that is missing
`off`. So this, on main:

    MATRIXARK_RUST_PROXY_SHARED_PROCESS=off
      the site that reads it returns:  True
      the canonical parser returns:    False

MATRIXARK_RUST_PROXY_SHARED_PROCESS is already IN the table in test_env_flag_vocabulary, recorded
as a flag that must read False when set to `off`. That file's docstring is about this exact
failure -- "the deny-list {0, false, no} read `off` as ON... three kill-switches stayed on when set
to `off`, which is the opposite of what a kill-switch is for". It has been passing since it was
written while this site kept doing it.

TWO REASONS IT SURVIVED, AND BOTH ARE FIXED

1. The assertion asked the PARSER, not the site. `test_the_flags_that_were_misread_now_do_what_
   they_say` calls the canonical `env_bool` and checks what IT returns for `off`, which was never
   in doubt. The site was never called.

2. The scan that checks nothing hand-rolls a vocabulary looks for
   `os.environ.get("NAME").strip().lower() in {...}` -- the name written out AT the read. Here the
   name arrives as a parameter, so the shape does not match. This is the same blind spot that hid
   seventy flags from the surface count in matrixarkai#1572, in a second file.

The reader now delegates to the canonical parser rather than restating the vocabulary, since a
vocabulary stated twice is the thing being fixed. Behaviour, measured value by value: `off`, `OFF`
and ` off ` change from True to False, which is the fix; `1/true/yes/on` unchanged; unknown words
and blank still fall to the default; unset unchanged; an explicit default of "0" still gives False.

Two live reads went through it, both default-ON: MATRIXARK_RUST_PROXY_SHARED_PROCESS and
MATRIXARK_RUST_PROXY_DEDICATED_PACK_LANES.

THE GUARD NOW ASKS THE READER

A new check derives every function that answers a boolean read of its first argument and CALLS it,
asserting only that `on` and `off` cannot mean the same thing. Signature-agnostic on purpose:
these helpers take (name), (name, default_str) and (name, default_bool), and pinning a default
would test the caller's intent rather than the vocabulary. A deny list missing `off` fails exactly
there, and so does an allow list missing `on` -- the two directions that file is about.

Three things the derivation had to learn, each because it was wrong first:

  * A reader that DELEGATES is still a reader. The moment this module was fixed to delegate, a
    direct-reads-only derivation stopped watching the one site it was written for. The relation is
    propagated now, which also brings in matrixark_mcp_env.env_bool itself.
  * Only BOOLEAN readers. Unfiltered it swept up `_env_int` and `env_text` and called them
    defective for answering the same to `on` and `off` -- which a count and a piece of text should.
  * Keyed by MODULE, not by bare function name. `_env_bool` is a name-taking reader in two modules
    and a VALUE-taking helper in matrixark_v1_gateway; a name-keyed table credited the third with
    reading an environment it never touches, then fed it a variable name and reported a vocabulary
    defect in a function that has none.

  the deny list comes back                      FAILS
  the derivation stops following delegation     FAILS

and the last of the three is held by a named assertion rather than a count, because the wrong
answer there is a false accusation rather than a missed one.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


---

The same module's numeric readers crashed on a blank value

Found by probing every derived reader helper with malformed values -- possible only because the
helpers are now derived rather than guessed at. Two of twenty-four raise, both here:

    _env_int("MATRIXARK_RUST_PROXY_WRITE_LANES", "4")        with the variable set to ""  -> ValueError
    _env_seconds_from_ms("..._WAIT_MS", "0")                 with the variable set to ""  -> ValueError

`export MATRIXARK_RUST_PROXY_WRITE_LANES=` -- an export with nothing after the `=`, which is what a
shell leaves when a variable is built from another that is empty -- reached `int("")`. Every other
reader in this tree spells it `os.environ.get(name, "").strip() or default`, so blank means unset
for all of them; these two were the only ones where it meant crash, and they are called fifteen
times while the proxy lanes are being configured.

A MALFORMED value still raises, deliberately. That is this file's rule and not an exception to it:
`int("abc")` is an operator error nothing can guess past, and the alternative is a proxy quietly
running on four lanes because somebody typed `four`. Blank is different because it carries no
intent. Measured: "" and "   " give the default, "8" and " 8 " give 8, "0" still clamps to the
minimum, "abc" still raises, unset unchanged.

test_a_number_read_from_the_environment_survives_a_blank_value is the guard for exactly this, and
it does not cover it on purpose -- its docstring scopes itself to module scope because "the same
read inside a function raises for one caller, which is a smaller problem and a different fix". That
holds for a function called on a request. It does not hold for a reader whose callers run at
configuration time: it is the same failed startup, one frame down. This is that different fix, plus
the check that keeps it.

THE CHECK CAUGHT ME REINTRODUCING A MISTAKE I HAD ALREADY FIXED TODAY

The first version derived numeric readers by looking for a DIRECT os.environ read. The moment
_env_int was fixed to take its value through a `_raw` helper it stopped reading os.environ itself,
dropped out of the list, and a mutation that removed the fix passed. That is the same self-defeat
the boolean derivation in the previous commit hit, for the same reason, an hour earlier.

Delegation is followed now, and keyed by (module, function) rather than bare name -- `_env_int` is
defined in five modules. Both readers are also asserted BY NAME, because the count cannot protect
this: a derivation that goes blind reports fewer readers, and fewer readers with no offenders looks
exactly like success.

  the blank guard is removed                     FAILS

  derived numeric readers  7 -> 11

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

