### PR TITLE
Two mixins imported their own parent, so which one broke depended on walk order

### DIFF
--- a/tools/test_matrixark_no_cross_test_imports.py
+++ b/tools/test_matrixark_no_cross_test_imports.py
@@ -64,8 +64,6 @@ KNOWN = {
     "test_matrixark_python_module_boundaries.py",
     "test_matrixark_readiness_sources.py",
     "test_matrixark_user_policy.py",
-    "test_python_module_boundaries_part2.py",
-    "test_python_module_boundaries_part3.py",
 }
 
 #: Pairs where each module imports the OTHER at import time. A one-directional cross-import
@@ -104,8 +102,6 @@ KNOWN_MUTUAL = {
     ("test_codex_pipeline_part3", "test_matrixark_codex_hook_pipeline"),
     ("test_codex_pipeline_part4", "test_matrixark_codex_hook_pipeline"),
     ("test_codex_pipeline_part5", "test_matrixark_codex_hook_pipeline"),
-    ("test_matrixark_python_module_boundaries", "test_python_module_boundaries_part2"),
-    ("test_matrixark_python_module_boundaries", "test_python_module_boundaries_part3"),
 }
 
 def _cross_importers() -> dict:

--- a/tools/test_python_module_boundaries_part2.py
+++ b/tools/test_python_module_boundaries_part2.py
@@ -4,31 +4,28 @@
 from __future__ import annotations
 
 import os
-from unittest import mock
 
 try:  # package path
     from tools.matrixark_mcp_core import *  # noqa: F401,F403
 except ImportError:
     from matrixark_mcp_core import *  # noqa: F401,F403
 
-try:  # names owned by the parent module
-    from tools.test_matrixark_python_module_boundaries import (
-    REPO_ROOT,
-    TOOLS_DIR,
-    importlib,
-    mock,
-    re,
-    sys,
-)
-except ImportError:
-    from test_matrixark_python_module_boundaries import (
-    REPO_ROOT,
-    TOOLS_DIR,
-    importlib,
-    mock,
-    re,
-    sys,
-)
+# The parent imports the mixin class from this file, so anything this file imports FROM the parent
+# is a cycle: whichever module `unittest discover` reaches first fails with a partially initialised
+# import, and which one that is depends on the order the files are walked in. It is an order-
+# dependent error rather than a permanent one, which is worse -- it appeared as a NEW ratchet
+# failure on a branch that had not touched either file.
+#
+# Nothing shared was actually being borrowed. REPO_ROOT and TOOLS_DIR are two lines, and the rest
+# were STDLIB modules reached through another test file. Imported directly, the cycle is gone.
+import importlib
+import re
+import sys
+from unittest import mock
+from pathlib import Path as _Path
+
+REPO_ROOT = _Path(__file__).resolve().parents[1]
+TOOLS_DIR = REPO_ROOT / "tools"
 
 
 class _ModuleBoundaryPart2:

--- a/tools/test_python_module_boundaries_part3.py
+++ b/tools/test_python_module_boundaries_part3.py
@@ -8,20 +8,20 @@ try:  # package path
 except ImportError:
     from matrixark_mcp_core import *  # noqa: F401,F403
 
-try:  # names owned by the parent module
-    from tools.test_matrixark_python_module_boundaries import (
-    REPO_ROOT,
-    TOOLS_DIR,
-    ast,
-    importlib,
-)
-except ImportError:
-    from test_matrixark_python_module_boundaries import (
-    REPO_ROOT,
-    TOOLS_DIR,
-    ast,
-    importlib,
-)
+# The parent imports the mixin class from this file, so anything this file imports FROM the parent
+# is a cycle: whichever module `unittest discover` reaches first fails with a partially initialised
+# import, and which one that is depends on the order the files are walked in. It is an order-
+# dependent error rather than a permanent one, which is worse -- it appeared as a NEW ratchet
+# failure on a branch that had not touched either file.
+#
+# Nothing shared was actually being borrowed. REPO_ROOT and TOOLS_DIR are two lines, and the rest
+# were STDLIB modules reached through another test file. Imported directly, the cycle is gone.
+import ast
+import importlib
+from pathlib import Path as _Path
+
+REPO_ROOT = _Path(__file__).resolve().parents[1]
+TOOLS_DIR = REPO_ROOT / "tools"
 
 
 def _code_line_count(source: str) -> int:


### PR DESCRIPTION
test_matrixark_python_module_boundaries imports the mixin classes _ModuleBoundaryPart2 and
_ModuleBoundaryPart3, and both of those imported names back from it. Whichever module the loader
reaches first fails:

  on main            importing part3 first -> ImportError: cannot import name
                     '_ModuleBoundaryPart3' from partially initialized module (circular import)
                     importing part2 first -> the same for _ModuleBoundaryPart2
  on this branch     both import cleanly

An order-dependent error is worse than a permanent one. It surfaced as a NEW ratchet failure --
test_shared_pack_builder_reports_profile_shadowed_dropped_budget -- on a branch that had not
touched either file, and it is not in the recorded baseline, because whether it fails depends on
the order the suite happens to walk in.

NOTHING SHARED WAS ACTUALLY BEING BORROWED

  part2   REPO_ROOT, TOOLS_DIR, importlib, mock, re, sys
  part3   REPO_ROOT, TOOLS_DIR, ast, importlib

REPO_ROOT and TOOLS_DIR are two lines. Everything else is a STDLIB module being reached through
another test file -- part2 was already doing `from unittest import mock` two lines above the block
that imported `mock` from the parent as well. Imported directly, the cycle is gone and no value
changes.

Run from the repository root, where these are meant to run, the parent gives an identical
11 failures / 17 errors before and after. Run by name from tools/, the error count goes 85 -> 84:
exactly the one import error this removes.

THE OTHER ELEVEN PAIRS ARE NOT THIS

test_matrixark_no_cross_test_imports records 13 mutually importing pairs. All 13 are a parent and
a split-out mixin, and all 13 reach a stdlib module through a test module. These two are the only
ones where that is ALL they borrow; the other eleven also share real fixtures -- _HashStoreClient,
FastHookLocalAdapter, MatrixArkMcpServer -- and breaking those cycles means deciding where a
fixture lives, which is a different change. KNOWN and KNOWN_MUTUAL are struck rather than left: the
guard demanded it, and its own message says why a list allowed to go stale describes a tree that no
longer exists.

  KNOWN_MUTUAL   13 -> 11

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>