### PR TITLE
A blank value crashed the proxy lane numbers, and the guard for it was scoped out

### DIFF
--- a/tools/matrixark_mcp_rust_proxy_config.py
+++ b/tools/matrixark_mcp_rust_proxy_config.py
@@ -30,12 +30,31 @@ def _env_bool(name: str, default: str = "1") -> bool:
     return env_bool(name, default.strip().lower() not in FALSE_VALUES)
 
 
+def _raw(name: str, default: str) -> str:
+    """The value, with a BLANK treated as unset.
+
+    `MATRIXARK_RUST_PROXY_WRITE_LANES=` -- an export with nothing after the `=`, which is what a
+    shell leaves behind when a variable is built from another that is empty -- reached `int("")`
+    and raised ValueError out of lane configuration. Every other reader in this tree spells the
+    read `os.environ.get(name, "").strip() or default`, so blank means unset for all of them; these
+    two were the only readers where it meant crash.
+
+    A value that is malformed rather than absent still raises, and deliberately: `int("abc")` is an
+    operator error nothing can guess past, and the alternative is a proxy that quietly runs on four
+    lanes because somebody typed `four`. Blank is different because it carries no intent.
+    """
+    value = os.environ.get(name)
+    if value is None or not value.strip():
+        return default
+    return value.strip()
+
+
 def _env_int(name: str, default: str, *, minimum: int = 1) -> int:
-    return max(minimum, int(os.environ.get(name, default)))
+    return max(minimum, int(_raw(name, default)))
 
 
 def _env_seconds_from_ms(name: str, default_ms: str, *, minimum: float = 0.0) -> float:
-    return max(minimum, float(os.environ.get(name, default_ms)) / 1000.0)
+    return max(minimum, float(_raw(name, default_ms)) / 1000.0)
 
 
 try:  # pragma: no cover - import shape differs when run as a package

--- a/tools/test_a_number_read_from_the_environment_survives_a_blank_value.py
+++ b/tools/test_a_number_read_from_the_environment_survives_a_blank_value.py
@@ -27,6 +27,7 @@ smaller problem and a different fix.
 from __future__ import annotations
 
 import ast
+import importlib
 import importlib.util
 import os
 import pathlib
@@ -106,6 +107,83 @@ CASES = [
 ]
 
 
+_PROBE = "MATRIXARK_PROBE_BLANK_NUMBER"
+
+
+def _numeric_reader_helpers():
+    """(module stem, function) for functions that answer a NUMBER read from their first argument.
+
+    A READER THAT DELEGATES IS STILL A READER, and this derivation was written without that and
+    immediately proved why: the moment matrixark_mcp_rust_proxy_config._env_int was fixed to take
+    its value through a `_raw` helper, it stopped calling os.environ.get itself and dropped out of
+    the very list this test exists to watch. A mutation that removed the fix then passed.
+
+    Keyed by (module, function) rather than by bare name: `_env_int` is defined in five modules,
+    and crediting one with what another does is how a helper that never reads the environment ends
+    up being probed as though it did.
+    """
+    modules = {}
+    for path in sorted(TOOLS.glob("*.py")):
+        if path.name.startswith("test_"):
+            continue
+        try:
+            modules[path.stem] = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+        except SyntaxError:  # pragma: no cover
+            continue
+
+    functions, defined, imported = [], {}, {}
+    for stem, tree in modules.items():
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.args.args:
+                functions.append((stem, node))
+                defined.setdefault(stem, set()).add(node.name)
+            if isinstance(node, ast.ImportFrom) and node.module:
+                source = node.module.rsplit(".", 1)[-1]
+                for alias in node.names:
+                    imported.setdefault(stem, {})[alias.asname or alias.name] = source
+
+    def resolve(stem, callee):
+        if callee in defined.get(stem, ()):
+            return (stem, callee)
+        source = imported.get(stem, {}).get(callee)
+        if source and callee in defined.get(source, ()):
+            return (source, callee)
+        return None
+
+    reads = set()
+    for _round in range(8):
+        grew = False
+        for stem, node in functions:
+            first = node.args.args[0].arg
+            for sub in ast.walk(node):
+                key = None
+                if isinstance(sub, ast.Call):
+                    func = sub.func
+                    if isinstance(func, ast.Attribute) and func.attr in ("get", "getenv") \
+                            and sub.args and ast.unparse(func.value) in ("os.environ", "environ", "os"):
+                        key = sub.args[0]
+                    if key is None and resolve(stem, getattr(func, "id", "")) in reads and sub.args:
+                        key = sub.args[0]
+                if isinstance(key, ast.Name) and key.id == first:
+                    if (stem, node.name) not in reads:
+                        reads.add((stem, node.name))
+                        grew = True
+                    break
+        if not grew:
+            break
+
+    out = []
+    for stem, node in functions:
+        if (stem, node.name) not in reads:
+            continue
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name) \
+                    and sub.func.id in ("int", "float"):
+                out.append((stem, node.name))
+                break
+    return sorted(set(out))
+
+
 class ANumberReadFromTheEnvironmentSurvivesABlankValue(unittest.TestCase):
 
     def test_the_scan_reaches_the_tree(self):
@@ -142,6 +220,64 @@ class ANumberReadFromTheEnvironmentSurvivesABlankValue(unittest.TestCase):
             "gives these the empty string and the conversion raises -- at module scope, which is "
             "a failed import rather than a bad value. Use "
             'int(os.environ.get(NAME, "").strip() or DEFAULT): %s' % "; ".join(offenders))
+
+    def test_a_numeric_reader_helper_treats_blank_as_unset(self) -> None:
+        """The case the docstring above defers, for the readers where it is not smaller.
+
+        That docstring scopes this file to MODULE SCOPE, on the grounds that the same read inside a
+        function "raises for one caller, which is a smaller problem". That holds for a function
+        called on a request. It does not hold for a reader whose callers run at CONFIGURATION time:
+        matrixark_mcp_rust_proxy_config._env_int is called fifteen times while the lanes are being
+        set up, so `MATRIXARK_RUST_PROXY_WRITE_LANES=` was the same failed startup one frame down.
+
+        Derived rather than listed, and CALLED rather than pattern-matched: a helper takes the
+        variable name as an argument, so there is no text at the read to match on, and what matters
+        is the answer rather than the spelling. A malformed value is still allowed to raise -- that
+        is this file's rule, not an exception to it.
+        """
+        probed, offenders = 0, []
+        for stem, func_name in _numeric_reader_helpers():
+            try:
+                module = importlib.import_module(stem)
+            except Exception:  # pragma: no cover - a module that will not import is not this test
+                continue
+            func = getattr(module, func_name, None)
+            if func is None:  # pragma: no cover
+                continue
+            answered = False
+            for blank in ("", "   "):
+                os.environ[_PROBE] = blank
+                for arguments in ((_PROBE, "4"), (_PROBE, 4), (_PROBE,)):
+                    try:
+                        func(*arguments)
+                        answered = True
+                        break
+                    except TypeError:
+                        continue
+                    except Exception as exc:
+                        offenders.append("%s.%s raises %s when the variable is set to %r"
+                                         % (stem, func_name, type(exc).__name__, blank))
+                        answered = True
+                        break
+                os.environ.pop(_PROBE, None)
+            if answered:
+                probed += 1
+        derived = _numeric_reader_helpers()
+        for named in (("matrixark_mcp_rust_proxy_config", "_env_int"),
+                      ("matrixark_mcp_rust_proxy_config", "_env_seconds_from_ms")):
+            self.assertIn(
+                named, derived,
+                "%s.%s is the reader this test was added for -- fifteen calls while the proxy "
+                "lanes are configured, and `MATRIXARK_RUST_PROXY_WRITE_LANES=` used to raise "
+                "ValueError through it. It reaches os.environ through a helper now, so a "
+                "derivation that only follows a DIRECT read stops watching it, which is the one "
+                "way this test can quietly stop meaning anything." % named)
+        self.assertGreater(
+            probed, 5,
+            "only %d numeric readers were probed. They are derived by asking which functions read "
+            "os.environ with their first parameter and then convert it; near zero means the "
+            "derivation stopped matching and this asserts nothing." % probed)
+        self.assertEqual(offenders, [], "; ".join(offenders))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Found by probing every derived reader helper with malformed values -- possible only because the
helpers are now derived rather than guessed at. Two of twenty-four raise, both here:

    _env_int("MATRIXARK_RUST_PROXY_WRITE_LANES", "4")        with the variable set to ""  -> ValueError
    _env_seconds_from_ms("..._WAIT_MS", "0")                 with the variable set to ""  -> ValueError

`export MATRIXARK_RUST_PROXY_WRITE_LANES=` -- an export with nothing after the `=`, which is what a
shell leaves when a variable is built from another that is empty -- reached `int("")`. Every other
reader in this tree spells it `os.environ.get(name, "").strip() or default`, so blank means unset
for all of them; these two were the only ones where it meant crash, and they are called fifteen
times while the proxy lanes are being configured.

A MALFORMED value still raises, deliberately. That is this file's rule and not an exception to it:
`int("abc")` is an operator error nothing can guess past, and the alternative is a proxy quietly
running on four lanes because somebody typed `four`. Blank is different because it carries no
intent. Measured: "" and "   " give the default, "8" and " 8 " give 8, "0" still clamps to the
minimum, "abc" still raises, unset unchanged.

test_a_number_read_from_the_environment_survives_a_blank_value is the guard for exactly this, and
it does not cover it on purpose -- its docstring scopes itself to module scope because "the same
read inside a function raises for one caller, which is a smaller problem and a different fix". That
holds for a function called on a request. It does not hold for a reader whose callers run at
configuration time: it is the same failed startup, one frame down. This is that different fix, plus
the check that keeps it.

THE CHECK CAUGHT ME REINTRODUCING A MISTAKE I HAD ALREADY FIXED TODAY

The first version derived numeric readers by looking for a DIRECT os.environ read. The moment
_env_int was fixed to take its value through a `_raw` helper it stopped reading os.environ itself,
dropped out of the list, and a mutation that removed the fix passed. That is the same self-defeat
the boolean derivation in the previous commit hit, for the same reason, an hour earlier.

Delegation is followed now, and keyed by (module, function) rather than bare name -- `_env_int` is
defined in five modules. Both readers are also asserted BY NAME, because the count cannot protect
this: a derivation that goes blind reports fewer readers, and fewer readers with no offenders looks
exactly like success.

  the blank guard is removed                     FAILS

  derived numeric readers  7 -> 11

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>