### PR TITLE
A durability test file that says it is failing, and is not

### DIFF
--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -8218,6 +8218,85 @@ fn what_the_compaction_preamble_walks() {
     );
 }
 
+/// What does ONE write cost in durability barriers, and where do they land? Prints.
+///
+///   cargo test --release -p temporalstore-rust --lib what_a_write_costs_in_barriers -- --ignored --nocapture
+///
+/// "COMMAND BATCHING" IS THE WRONG AXIS FOR THIS LOG, and an earlier note used it anyway.
+///
+/// A record here states its RESULTS, not the operation that produced them: `outcomes` carry an
+/// address and, where no page backs the state, the bytes themselves, plus a `meta` flag. The
+/// `command` field is an `Option` and is ABSENT by default -- `TS_WAL_DATA_ONLY` is on -- so
+/// "batch N commands into one record" describes a log this is not.
+///
+/// What is worth separating is these two, because only one of them is a sync question:
+///
+///   * GROUP COMMIT -- many appends, one fsync. `engine_wal_group_commit` implements it: a waiter
+///     whose `durable_seq` already covers its required sequence returns without syncing, so
+///     concurrent writers share one barrier.
+///   * RECORD AGGREGATION -- many writes' results in ONE record, and therefore one barrier. That
+///     is a record-shape question. The design being followed aggregates its log items this way,
+///     which is where the earlier note's framing came from.
+///
+/// Group commit only helps when writers OVERLAP. A single-threaded writer waits for nobody, so it
+/// cannot share a barrier with anyone, and the per-write cost is whatever one write takes on its
+/// own. That is the case this measures, because it is the one the ingest path actually runs.
+///
+/// `durability_metrics` counts barriers BY SITE, so this says which sync is paid rather than just
+/// how many. Read the per-write column: a value near 1.0 for a site means every single write pays
+/// that barrier.
+#[test]
+#[ignore]
+fn what_a_write_costs_in_barriers() {
+    for records in [500usize, 2_000] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            16 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+
+        // Reset AFTER load_shard: opening the store takes barriers of its own, and counting those
+        // against the writes would overstate the per-write cost on the smaller fixture.
+        crate::durability_metrics::reset();
+        let started = std::time::Instant::now();
+        for index in 0..records {
+            let response = engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("barrier-{index:06}"),
+                    value: vec![b'v'; 64],
+                },
+            });
+            assert!(response.status.ok, "write {index}: {:?}", response.status);
+        }
+        let elapsed_ms = started.elapsed().as_micros() as f64 / 1000.0;
+        let counts = crate::durability_metrics::snapshot();
+        let total: u64 = counts.values().copied().sum();
+
+        // Denominator: a run that took no barriers at all would make every ratio below zero and
+        // say nothing about what a write costs.
+        assert!(
+            total > 0,
+            "no durability barriers were recorded, so this measures nothing",
+        );
+
+        eprintln!(
+            "  [barriers] {records:>5} writes in {elapsed_ms:>8.1} ms -> {total:>6} barriers = \
+{:>5.2} per write",
+            total as f64 / records as f64,
+        );
+        for (site, count) in counts {
+            eprintln!(
+                "  [barriers]          {site:<38} {count:>6} = {:>5.2} per write",
+                count as f64 / records as f64,
+            );
+        }
+    }
+}
+
 /// What does each individual plan call WALK? Prints.
 ///
 ///   cargo test --release -p temporalstore-rust --lib what_each_plan_call_walks -- --ignored --nocapture

--- a/crates/temporalstore-rust/tests/wal_single_barrier_recovery.rs
+++ b/crates/temporalstore-rust/tests/wal_single_barrier_recovery.rs
@@ -4,61 +4,52 @@
 //! WAL-replay recovery under the single write-path durability barrier -- now the DEFAULT (only the
 //! WAL takes a synchronous fdatasync per write; the data-page fdatasync and the served-index delta
 //! fdatasync are both deferred, and recovery is base-only). After a crash, EVERY acked write must
-//! be reconstructed -- the WAL is self-sufficient (it embeds the full command payload), so even if
+//! be reconstructed -- the WAL is self-sufficient (a record states its RESULTS: an outcome item
+//! naming the page's address and, when no page backs it, carrying the bytes themselves), so even if
 //! the deferred-fsync index-log tail AND, as a stronger stress, the pages are lost to a simulated
 //! power cut, replay rebuilds every key. A final phase exercises the TS_WAL_LEGACY_RECOVERY escape
 //! hatch (legacy multi-barrier write + delta-fold recovery) so the fallback stays covered. Each
 //! phase runs in its own subprocess so any mode env var never leaks into the rest of the suite.
 //!
-//! # The premise above no longer holds, and five of these fail because of it
+//! # The hole this header used to describe is FIXED
 //!
-//! "The WAL is self-sufficient (it embeds the full command payload)" was true when this was
-//! written. It is not true now, and nothing here was changed to say so -- these tests have been
-//! failing on main ever since, and the CI step that runs them carries `continue-on-error: true`.
+//! This header used to open "the premise above no longer holds, and five of these fail because of
+//! it", and described a default-path hole in which every acked write was unrecoverable after a
+//! power cut. It then told the reader the CI step carried `continue-on-error: true`, which made it
+//! read as a suppressed data-loss bug sitting on main.
 //!
-//! Three defaults meet to produce it:
-//!
-//!   * single-barrier acks once the WAL is fsynced; the data-page fdatasync is deferred BY DESIGN,
-//!     which is the whole point of the mode and is what the power-loss step models by deleting the
-//!     pages;
-//!   * `TS_WAL_OUTCOME_ITEMS` (default ON) records what a write DID rather than what it was;
-//!   * `TS_WAL_DATA_ONLY` (default ON) then removes the command -- "stop writing the operation into
-//!     a record that already states its results ... the operation is consulted only when there are
-//!     none."
-//!
-//! An outcome states "this object's page is at this address". With the page write deferred and then
-//! lost, the address names nothing and the command that could have re-derived the value is gone.
-//! Staged pages would carry the bytes, but staging happens on the ASYNC storage path; a
-//! synchronous write stages nothing. (This said `TS_BLOCK_IN_WAL` gated it. That flag is gone --
-//! two mentions survive in the whole tree and neither is code, `block_in_wal::stage` is
-//! unconditional, and the inventory does not list it. Anyone deciding the question below by
-//! looking for that switch would find nothing and conclude the analysis was stale, when only the
-//! name was: the async/sync split IS the whole of it.)
-//!
-//! Measured on the store these tests leave behind, with `examples/wal_scan_probe.rs`:
+//! IT IS FIXED. Measured 2026-09-12 on this file, with no mode env set:
 //!
 //! ```text
-//! scan returned 300 record(s)
-//!   carrying a COMMAND to re-run          0
-//!   carrying OUTCOMES                     300  (300 items)
-//!      of those items, carrying a VALUE   0
-//!   carrying STAGED PAGES                 0  (0 bytes)
-//!   undecodable                           0
+//! test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
 //! ```
 //!
-//! So the log is intact and complete -- 300 records, all decoding, `last_sequence` agreeing -- and
-//! holds nothing any replay could rebuild a value from. The failure is not the harness: its
-//! `abort()` models process loss faithfully, the WAL survives it, and the records are all there.
+//! including `wal_is_self_sufficient_when_all_non_wal_state_is_wiped`, which is the strongest case
+//! in the file -- every non-WAL byte removed, replay rebuilding each acked key. A passing run of
+//! that test IS the premise the old header said had stopped being true.
 //!
-//! `legacy_recovery_escape_hatch_delta_fold_recovers_every_ack` still passes, which is the shape of
-//! the thing: the hatch recovers where the default does not.
+//! What closed it: `WalOutcomeItem` carries a `value` beside its `address` (#380, "a record can now
+//! say what a write DID, and a shard can be rebuilt from that alone"). The old analysis was right
+//! that an outcome naming only an address states nothing recoverable when the page write is
+//! deferred and then lost -- the answer was to let the outcome carry the bytes, which is what the
+//! design being followed does with a `value` beside its `page` and a `meta_log` flag to tell them
+//! apart.
 //!
-//! Fixing it is a choice about what an ack means, not a tidy-up -- an outcome could carry the value
-//! when the page it names is not yet durable; the sync path could stage pages as the async path
-//! does; the command could stay while single-barrier is on; or the page fsync could stop being
-//! deferred in this mode. Each trades write cost against the promise. Whoever takes it should start
-//! from the probe output above rather than from the assertion message, which only says a key was
-//! missing.
+//! The CI note was accurate and remains so, but it is about the BASELINE, not about this file:
+//! `continue-on-error` is set on the whole suite step while a small number of pre-existing lib
+//! failures stand, and the workflow says to flip it off once the baseline is green. None of those
+//! failures is here.
+//!
+//! Left as a warning rather than deleted, because the failure mode it describes is real whenever
+//! an outcome can name a page that is not yet durable. If a future change makes outcomes
+//! address-only again on the synchronous path, this is the file that will catch it, and
+//! `examples/wal_scan_probe.rs` prints exactly what a record is carrying:
+//!
+//! ```text
+//! carrying a COMMAND to re-run / carrying OUTCOMES / of those items, carrying a VALUE
+//! ```
+//!
+//! A run where outcomes carry no value and no command is the shape of the old bug.
 
 use std::process::Command;
 


### PR DESCRIPTION
`tests/wal_single_barrier_recovery.rs` opened with *"the premise above no longer holds, and five
of these fail because of it"*, described a default-path hole in which every acked write is
unrecoverable after a power cut, and printed a probe showing 300 records carrying **0 commands and
0 values**. It then noted the CI step carries `continue-on-error: true`.

Read together, that says the store loses every acked write on the shipped defaults and CI is
hiding it. Measured today, with no mode env set:

```
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

including `wal_is_self_sufficient_when_all_non_wal_state_is_wiped` — the strongest case in the
file, every non-WAL byte removed and replay rebuilding each acked key. A passing run of that test
**is** the premise the header says stopped being true.

## What closed it

`WalOutcomeItem` carries a `value` beside its `address` (#380, *"a record can now say what a write
DID, and a shard can be rebuilt from that alone"*).

The old analysis was right that an outcome naming only an address states nothing recoverable when
the page write is deferred and then lost. The answer was to let the outcome carry the bytes — which
is what the design being followed does, with a `value` beside its `page` and a `meta_log` flag to
tell them apart.

The CI note was accurate and stays: `continue-on-error` is set on the whole suite step while a
small number of pre-existing **lib** failures stand, and the workflow says to flip it off once the
baseline is green. None of those failures is in this file.

The section is **corrected rather than deleted**. The failure mode is real whenever an outcome can
name a page that is not yet durable, so if a future change makes outcomes address-only on the
synchronous path, this file is what catches it — and `examples/wal_scan_probe.rs` prints exactly
what a record carries.

## Two wordings fixed in the same file

Its opening called the WAL *"self-sufficient (it embeds the full command payload)"*. A record does
not embed a command — `command` is an `Option` and is **absent** by default under
`TS_WAL_DATA_ONLY`. It states **results**: an outcome item naming the page's address and, where no
page backs the state, carrying the bytes themselves.

That phrasing matters because it is what sends a reader looking for command-shaped batching in a
log that has none.

## And a measurement, since the same wrong framing produced a question worth answering

`what_a_write_costs_in_barriers` (added here) counts durability barriers by site:

| writes | barriers | per write |
|---|---|---|
| 500 | 501 | **1.00** |
| 2,000 | 2,001 | **1.00** |

all from `engine_wal_group_commit`. Every write takes its own fsync. Group commit is implemented
and correct — a waiter already covered by `durable_seq` returns without syncing — but it can only
merge writers that **overlap**, and a single-threaded ingest writer waits for nobody.

Aggregating several writes' results into one record is a record-shape question and a decision about
what an ack promises, not a tuning change. Measured and recorded rather than changed.

## Verification

`cargo test -p temporalstore-rust --lib -- --test-threads=1` → **1781 passed, 1 failed** (the
standing `--lib` baseline failure, not introduced here), plus
`cargo test -p temporalstore-rust --test wal_single_barrier_recovery` → **8 passed, 0 failed**.
