### PR TITLE
The under-a-hundred message reported the other ceiling's number

### DIFF
--- a/tools/test_the_flag_surface_only_shrinks.py
+++ b/tools/test_the_flag_surface_only_shrinks.py
@@ -1266,7 +1266,7 @@ class TheFlagSurfaceOnlyShrinksTest(unittest.TestCase):
         self.assertLess(
             MAXIMUM_GATING_CONFIGURABLE, 100,
             "the ceiling itself has been raised to %d. Under a hundred is the target; moving the "
-            "ceiling through it is not the same as meeting it." % MAXIMUM_CONFIGURABLE)
+            "ceiling through it is not the same as meeting it." % MAXIMUM_GATING_CONFIGURABLE)
         self.assertGreaterEqual(
             len(configurable), MAXIMUM_CONFIGURABLE - 25,
             "the surface is %d and the ceiling is %d. Lower it: a ratchet that does not bank a "


### PR DESCRIPTION
When the under-a-hundred target moved off `configurable` and onto the flags that gate a live path,
the assertion changed and its message did not. It interpolated MAXIMUM_CONFIGURABLE while asserting
MAXIMUM_GATING_CONFIGURABLE, so the one message whose whole job is to say WHICH number crossed a
hundred named a different number entirely:

  before   the ceiling itself has been raised to 128 ...   (with the ceiling at 120)
  after    the ceiling itself has been raised to 120 ...

Measured by raising the ceiling to 120 and reading what it says, not by reading the format string.
A wrong number in a failure message costs whoever is standing in front of it at the time, which is
why the gating assertion beside it prints both the count and the ceiling it exceeded.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>