### PR TITLE
The model registry recorded how the provider was typed, and it is used as an identity

### DIFF
--- a/tools/matrixark_mcp_model_registry.py
+++ b/tools/matrixark_mcp_model_registry.py
@@ -9,11 +9,13 @@ import os
 from typing import Any
 
 try:
-    from tools.matrixark_mcp_embeddings import embedding_execution_mode_name
+    from tools.matrixark_mcp_embeddings import (embedding_execution_mode_name,
+                                                embedding_provider_name)
     from tools.matrixark_mcp_identity import now_ms, stable_hash
     from tools.matrixark_mcp_models import compact_model_slug, embedding_model_ref_for_name
 except ModuleNotFoundError:  # Direct script execution from tools/.
-    from matrixark_mcp_embeddings import embedding_execution_mode_name
+    from matrixark_mcp_embeddings import (embedding_execution_mode_name,
+                                          embedding_provider_name)
     from matrixark_mcp_identity import now_ms, stable_hash
     from matrixark_mcp_models import compact_model_slug, embedding_model_ref_for_name
 
@@ -37,7 +39,13 @@ def context_model_registry_record(
         else f"{model_kind}:{compact_model_slug(model_name)}:{model_hash % 10000:04d}",
         "model_name": model_name,
         "model_hash": model_hash,
-        "provider": (os.environ.get("MATRIXARK_EMBEDDING_PROVIDER", "").strip() or "deterministic") if model_kind == "embedding" else "",
+        # WHAT WILL RUN, not what is typed. `embedding_provider_name` draws that line and this
+        # field is on the dispatch side of it: matrixark_mcp_local_adapter._model_registry_identity
+        # puts this string straight into the tuple it de-duplicates registry rows by, so a
+        # deployment that wrote `openai` once and `OpenAI` later got two identities for one encoder
+        # and a duplicate context_model_registry row. A reporting field would be right to keep the
+        # raw spelling; an identity is not a reporting field.
+        "provider": embedding_provider_name() if model_kind == "embedding" else "",
         "execution_mode": embedding_execution_mode_name() if model_kind == "embedding" else "",
         "updated_at_ms": int(updated_at_ms or now_ms()),
     }

--- a/tools/test_matrixark_the_encoder_has_one_model_field.py
+++ b/tools/test_matrixark_the_encoder_has_one_model_field.py
@@ -24,6 +24,18 @@ import os
 import sys
 import unittest
 
+_PROVIDER = "MATRIXARK_EMBEDDING_PROVIDER"
+
+try:  # package path
+    from tools import matrixark_mcp_embeddings as _embeddings
+    from tools import matrixark_mcp_local_adapter as _adapter
+    from tools import matrixark_mcp_model_registry as _registry
+except ImportError:  # Direct script execution from tools/.
+    import matrixark_mcp_embeddings as _embeddings
+    import matrixark_mcp_local_adapter as _adapter
+    import matrixark_mcp_model_registry as _registry
+
+
 TOOLS = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, TOOLS)
 
@@ -219,6 +231,67 @@ class ALauncherSetPathIsReportedTest(Case):
         for provider in ("oss", "openai_compatible", "deterministic"):
             with self.subTest(provider=provider):
                 self.assertEqual([], self.warnings_about_the_path(provider))
+
+class TheRegistryRecordsTheProviderThatWillRun(unittest.TestCase):
+    """One encoder must produce one registry identity, however its name is capitalised.
+
+    `matrixark_mcp_local_adapter._model_registry_identity` puts the record's `provider` string
+    straight into the tuple it de-duplicates `context_model_registry` rows by. The record used to
+    take that string RAW from the environment, so a deployment that wrote `openai` once and
+    `OpenAI` later had two identities for one encoder and wrote a duplicate row:
+
+        openai      -> provider='openai'      three distinct identities
+        OpenAI      -> provider='OpenAI'
+        ' OPENAI '  -> provider='OPENAI'
+
+    `embedding_provider_name` already draws the line this sits on: sites that REPORT what is set
+    keep the raw spelling, sites that DISPATCH on it use the normalised name. An identity is not a
+    reporting field, so this one is on the dispatch side.
+    """
+
+    def setUp(self) -> None:
+        self._saved = os.environ.get(_PROVIDER)
+
+    def tearDown(self) -> None:
+        if self._saved is None:
+            os.environ.pop(_PROVIDER, None)
+        else:
+            os.environ[_PROVIDER] = self._saved
+
+    def test_one_encoder_has_one_registry_identity(self) -> None:
+        identities = set()
+        for spelling in ("openai", "OpenAI", " OPENAI ", "openai "):
+            os.environ[_PROVIDER] = spelling
+            record = _registry.context_model_registry_record("some-model")
+            identities.add(_adapter._model_registry_identity(record))
+        self.assertEqual(
+            1, len(identities),
+            "%d registry identities for one encoder spelled four ways, so a deployment that "
+            "retypes its provider with different capitalisation writes a duplicate "
+            "context_model_registry row every time." % len(identities))
+
+    def test_the_recorded_provider_is_the_one_that_dispatches(self) -> None:
+        """Equal to what the encoder resolves, not merely self-consistent.
+
+        Lowercasing here and lowercasing in the encoder are two rules, and two rules agree until one
+        of them learns a spelling. This asks the encoder.
+        """
+        for spelling in ("OpenAI", "VOYAGE", " oss ", ""):
+            with self.subTest(spelling=spelling):
+                os.environ[_PROVIDER] = spelling
+                record = _registry.context_model_registry_record("some-model")
+                self.assertEqual(
+                    _embeddings.embedding_provider_name(), record.get("provider"),
+                    "the registry recorded %r where the encoder will dispatch on %r"
+                    % (record.get("provider"), _embeddings.embedding_provider_name()))
+
+    def test_a_non_embedding_record_still_carries_no_provider(self) -> None:
+        """The field is empty for other kinds and must stay empty: the change above moved where the
+        value comes from, and a normaliser that answers `deterministic` for everything would fill a
+        field that is meant to be blank."""
+        os.environ[_PROVIDER] = "openai"
+        record = _registry.context_model_registry_record("some-model", model_kind="summary")
+        self.assertEqual("", record.get("provider"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`matrixark_mcp_local_adapter._model_registry_identity` puts the record's `provider` string straight
into the tuple it de-duplicates context_model_registry rows by. The record took that string raw
from the environment, so one encoder spelled three ways is three identities:

  on main                       on this branch
    openai     -> 'openai'        openai     -> 'openai'
    OpenAI     -> 'OpenAI'        OpenAI     -> 'openai'
    ' OPENAI ' -> 'OPENAI'        ' OPENAI ' -> 'openai'
    3 identities                  1 identity

A deployment that retyped its provider with different capitalisation wrote a duplicate registry row
each time. Not data loss -- the identity is a dedup key, not the encoder-conflict check -- and
worth saying plainly, because the same field name in the same record would be a much worse bug if
it were the conflict check.

WHY THIS ONE SITE AND NOT THE OTHER FOUR THAT READ IT UNNORMALISED

`embedding_provider_name` already draws the line, in its own docstring: sites that REPORT the raw
configured string read the variable directly and should, because they answer "what is set", not
"what will run". matrixark_gateway_metrics and the portal display are on that side and are left
alone. An identity is not a reporting field, so this one is not.

Checked before assuming: the other unnormalised readers pass the value into `_encoder_applies`,
`_hosted_encoders_for` and `embedding_provider_effect`, and all three normalise internally --
`OpenAI`, ` openai` and `OPENAI` already behave identically through every one of them. This was
the only site where the raw spelling survived into something that compares strings.

  the raw spelling comes back        FAILS
  the field is filled for every kind FAILS

A third mutation -- lowercasing here instead of calling `embedding_provider_name` -- does NOT fail,
and saying so is the point: the two rules compute the same answer today, so nothing can separate
them until one learns a spelling the other has not. That is the whole reason the guard asks the
encoder rather than restating its rule, and it is also why no test can prove it yet.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>