### PR TITLE
Who walks the shard, answered by the compiler

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -48,7 +48,8 @@ pub(crate) use storage_bucket_internals::uncovered_maintenance;
 mod storage_bucket_internals;
 pub use storage_bucket_internals::{
     bucket_page_index_visits, bucket_visit_sites, layout_by_caller, live_page_scan_entries,
-    reset_bucket_page_index_visits, reset_live_page_scan_entries,
+    live_page_scan_sites_snapshot, reset_bucket_page_index_visits,
+    reset_live_page_scan_entries, reset_live_page_scan_sites,
 };
 mod compaction;
 mod storage_reporting;

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -815,6 +815,41 @@ fn note_site(site: &std::sync::atomic::AtomicU64, count: usize) {
     note_bucket_page_visits(count);
 }
 
+/// Per-CALLER attribution for [`LIVE_PAGE_SCAN_ENTRIES`], keyed by the source location that asked.
+///
+/// The total alone says a round walks the shard N times; it does not say WHO. Attributing it by
+/// hand hit a wall: `apply_storage_lifecycle` measures 10.0x while every one of its callees sums
+/// to 6.0x, and the remaining four walks are inside the body where no probe row can reach them.
+/// Two earlier attributions failed the same way and were only closed by finding a call that no
+/// grep had matched -- once a bare expression at the end of a function.
+///
+/// `#[track_caller]` gives the answer with NO call-site changes, which matters because this
+/// function has about twenty of them and a threaded-through label would have to be right at every
+/// one to be trustworthy. The location is resolved at compile time; the cost here is one map
+/// update per CALL, on a path that is already walking every live page in the shard.
+fn live_page_scan_sites() -> &'static std::sync::Mutex<std::collections::BTreeMap<String, u64>> {
+    static SITES: std::sync::OnceLock<
+        std::sync::Mutex<std::collections::BTreeMap<String, u64>>,
+    > = std::sync::OnceLock::new();
+    SITES.get_or_init(|| std::sync::Mutex::new(std::collections::BTreeMap::new()))
+}
+
+/// Entries materialized per calling site since the last reset, as `file:line -> entries`.
+pub fn live_page_scan_sites_snapshot() -> std::collections::BTreeMap<String, u64> {
+    live_page_scan_sites()
+        .lock()
+        .map(|sites| sites.clone())
+        .unwrap_or_default()
+}
+
+/// Clear the per-site tallies. Pairs with [`reset_live_page_scan_entries`].
+pub fn reset_live_page_scan_sites() {
+    if let Ok(mut sites) = live_page_scan_sites().lock() {
+        sites.clear();
+    }
+}
+
+#[track_caller]
 pub(super) fn collect_live_page_entries(shard: &ShardState) -> Vec<LiveBlockEntry> {
     let entries = if !shard.bucket_index.bucket_map.is_empty() {
         collect_bucket_index_live_page_entries(shard)
@@ -822,6 +857,12 @@ pub(super) fn collect_live_page_entries(shard: &ShardState) -> Vec<LiveBlockEntr
         collect_model_live_page_entries(shard)
     };
     LIVE_PAGE_SCAN_ENTRIES.fetch_add(entries.len() as u64, std::sync::atomic::Ordering::Relaxed);
+    let caller = std::panic::Location::caller();
+    if let Ok(mut sites) = live_page_scan_sites().lock() {
+        *sites
+            .entry(format!("{}:{}", caller.file(), caller.line()))
+            .or_insert(0) += entries.len() as u64;
+    }
     entries
 }
 

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -8297,6 +8297,89 @@ fn what_a_write_costs_in_barriers() {
     }
 }
 
+/// WHO walks the shard, by source location. Prints.
+///
+///   cargo test --release -p temporalstore-rust --lib who_walks_the_shard -- --ignored --nocapture
+///
+/// `what_each_plan_call_walks` measures `apply_storage_lifecycle` at 10.0x the shard while every
+/// one of its callees sums to 6.0x. Four walks are inside the body, and no probe row can reach
+/// them -- each row can only call a function from outside, which is exactly what the missing four
+/// are not.
+///
+/// `collect_live_page_entries` is `#[track_caller]`, so it records the source location that asked.
+/// This prints that tally for one call, which names the four directly instead of inferring them.
+///
+/// Read it as "file:line -> entries materialized". A line appearing with N times the shard's live
+/// page count was entered N times.
+#[test]
+#[ignore]
+fn who_walks_the_shard() {
+    const RECORDS: usize = 4_000;
+
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        16 * 1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    for index in 0..RECORDS {
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("whowalks-{index:06}"),
+                value: vec![b'v'; 64],
+            },
+        });
+        assert!(response.status.ok, "write {index}: {:?}", response.status);
+    }
+    let live_pages: u64 = engine
+        .bucket_storage_summaries(1)
+        .iter()
+        .map(|summary| summary.page_ref_count as u64)
+        .sum();
+    assert!(live_pages > 0, "fixture stored no live pages");
+
+    crate::engine::reset_live_page_scan_entries();
+    crate::engine::reset_live_page_scan_sites();
+    let _ = engine.apply_storage_lifecycle(crate::engine::reports::StorageLifecycleRequest {
+        shard_id: 1,
+        purge_delayed_destroy: true,
+        prune_bucket_dump_manifests: true,
+        roll_forward_bucket_dump_installs: true,
+        ..crate::engine::reports::StorageLifecycleRequest::default()
+    });
+    let total = crate::engine::live_page_scan_entries();
+    let sites = crate::engine::live_page_scan_sites_snapshot();
+
+    assert!(total > 0, "apply_storage_lifecycle walked nothing; this attributes nothing");
+    assert!(
+        !sites.is_empty(),
+        "the per-site tally is empty while the total is {total}; the tracking is not wired",
+    );
+
+    eprintln!(
+        "  [who] apply_storage_lifecycle -> {total} entries = {:>4.1}x the shard ({live_pages} live pages)",
+        total as f64 / live_pages as f64,
+    );
+    let mut rows: Vec<(&String, &u64)> = sites.iter().collect();
+    rows.sort_by(|left, right| right.1.cmp(left.1));
+    for (site, entries) in rows {
+        eprintln!(
+            "  [who]   {:>5.1}x  {entries:>8}  {site}",
+            *entries as f64 / live_pages as f64,
+        );
+    }
+
+    // The tally must ACCOUNT for the total, or it is attributing something else.
+    let summed: u64 = sites.values().copied().sum();
+    assert_eq!(
+        summed, total,
+        "per-site entries {summed} do not sum to the total {total}",
+    );
+}
+
 /// What does each individual plan call WALK? Prints.
 ///
 ///   cargo test --release -p temporalstore-rust --lib what_each_plan_call_walks -- --ignored --nocapture


### PR DESCRIPTION
[#1604](https://github.com/matrixarkai/TemporalStore/pull/1604) shipped an attribution that did not
close: `apply_storage_lifecycle` measures **10.0×** the shard while every one of its callees sums to
**6.0×**. The missing four were inside the body, where a probe row cannot reach — a row can only
call a function from *outside*, which is exactly what those four are not.

`collect_live_page_entries` is now `#[track_caller]` and records the source location that asked.
`who_walks_the_shard` (added here) prints the tally for one call:

```
apply_storage_lifecycle -> 40000 entries = 10.0x the shard (4000 live pages)
  3.0x  12000  engine/storage_reporting.rs:163
  1.0x   4000  engine/recovery_sweep_compact.rs:223
  1.0x   4000  engine/storage_bucket_internals.rs:276
  1.0x   4000  engine/storage_bucket_internals.rs:386
  1.0x   4000  engine/storage_bucket_internals.rs:433
  1.0x   4000  engine/storage_bucket_internals.rs:528
  1.0x   4000  engine/storage_reporting.rs:23
  1.0x   4000  engine/storage_reporting.rs:790
```

Ten of ten. The probe **asserts** the per-site entries sum to the total — a tally that does not add
up is attributing something other than what it claims, which is the failure that produced the
6.0-against-10.0 shortfall in the first place.

The four that no probe could reach turn out to be four **distinct** sites in
`storage_bucket_internals`. They were never going to be found by adding rows.

## Why `#[track_caller]` and not a threaded label

`collect_live_page_entries` has about twenty call sites. A label passed in by hand would have to be
right at **every one** to be trustworthy, and the two earlier attributions in this chain both failed
by missing a call — once a bare expression at the end of a function that every grep had missed. The
compiler supplies the location, so that class of miss is not possible rather than being something
to spot a third time.

The cost is one map update per **call**, on a path already walking every live page in the shard.

## The result, and what it is not yet

`storage_reporting.rs:163` is the loop inside `bucket_storage_summaries`, entered **three times** in
one `apply_storage_lifecycle`:

| caller | |
|---|---|
| `storage_lifecycle_methods.rs:46` | in `storage_lifecycle_plan` |
| `bucket_dump_manifest_methods.rs:39` | in `create_bucket_dump_manifest` |
| `storage_lifecycle_methods.rs:512` | in `clear_dumped_bucket_dirty_state` |

Sharing those would be 2.0× of the 10.0×. It is **not** a mechanical hoist like
[#1586](https://github.com/matrixarkai/TemporalStore/pull/1586): `BucketStorageSummary` carries
`dirty_object_count`, the three calls straddle a dump, and the third runs after it. Whether one
snapshot can serve all three is a question about which state each consumer is entitled to see — a
decision to take deliberately, not because the walks look alike.

## Verification

Measurement and instrumentation only; no behaviour changes to any storage path. The probe is
`#[ignore]`, so it does not run in the suite.

`cargo test -p temporalstore-rust --lib -- --test-threads=1` → **1781 passed, 1 failed**. The single
failure is `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the standing `--lib`
baseline failure on main, not introduced here.
