### PR TITLE
One of those three shard walks must stay fresh

### DIFF
--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -508,6 +508,23 @@ impl TemporalEngine {
             .collect();
         // Current derived generation BEFORE mutation: detects writes that landed after
         // the dump snapshot (those buckets must stay dirty for the next dump).
+        //
+        // DO NOT HOIST THIS INTO A SHARED SNAPSHOT. `who_walks_the_shard` shows
+        // `bucket_storage_summaries` entered THREE times in one `apply_storage_lifecycle` -- here,
+        // in `storage_lifecycle_plan`, and in `create_bucket_dump_manifest` -- and three identical
+        // whole-shard walks in one operation look exactly like something to share. Two of them
+        // can be. This one cannot, and the reason is the line above rather than anything about
+        // locking.
+        //
+        // This walk exists to be FRESH. It is compared against the generation the manifest
+        // CAPTURED, and a bucket whose generation has moved since is skipped so it stays dirty for
+        // the next dump. Feed it a snapshot taken when the plan ran and both sides become equal by
+        // construction: a bucket written to between the dump and this clear compares equal, is
+        // cleared, stops being dirty, is never dumped, and reclaim is then free to advance past the
+        // records it still needed. That is silent data loss, discovered on a later restart.
+        //
+        // The test that would catch it is not obvious either: any fixture that does not write
+        // CONCURRENTLY with a dump will pass a hoisted version happily.
         let current: std::collections::HashMap<u32, u64> =
             bucket_storage_summaries(shard, start_routing_bucket, end_routing_bucket)
                 .into_iter()

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -8297,6 +8297,88 @@ fn what_a_write_costs_in_barriers() {
     }
 }
 
+/// A bucket written to AFTER the dump captured it must stay dirty.
+///
+/// `clear_dumped_bucket_dirty_state` compares each bucket's CURRENT derived generation against the
+/// one the manifest captured, and skips clearing any bucket whose generation moved. That fresh
+/// read is the whole safety property: a bucket dirtied between the dump and the clear still holds
+/// undumped writes, so it must remain dirty for the next dump.
+///
+/// It is also the kind of walk that looks redundant. `who_walks_the_shard` shows
+/// `bucket_storage_summaries` entered three times in one `apply_storage_lifecycle`, and sharing one
+/// snapshot across them would make `captured` and `current` equal BY CONSTRUCTION -- the comparison
+/// would always pass, the bucket would be cleared, and its writes would never be dumped. Reclaim
+/// could then advance past records still needed: silent loss, found on a later restart.
+///
+/// This pins it. The write lands between the manifest and the clear, which is exactly the window
+/// a shared snapshot would erase.
+#[test]
+fn a_bucket_written_after_the_dump_stays_dirty() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        16 * 1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    for index in 0..64 {
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("dumped-{index:04}"),
+                value: vec![b'v'; 64],
+            },
+        });
+        assert!(response.status.ok, "write {index}: {:?}", response.status);
+    }
+
+    let manifest = engine
+        .create_bucket_dump_manifest(1, Vec::new())
+        .expect("manifest should be created");
+    // Denominator: a manifest naming no buckets would make the clear a no-op and the assertion
+    // below vacuous.
+    assert!(
+        !manifest.bucket_ids.is_empty(),
+        "the dump captured no buckets, so this measures nothing",
+    );
+
+    // THE WINDOW. This write lands after the dump captured its bucket and before the clear runs.
+    let late = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringSet {
+            key: "dumped-0000".to_string(),
+            value: vec![b'w'; 96],
+        },
+    });
+    assert!(late.status.ok, "late write: {:?}", late.status);
+
+    let late_bucket = engine
+        .bucket_storage_summaries(1)
+        .into_iter()
+        .find(|summary| summary.dirty_object_count > 0)
+        .map(|summary| summary.routing_bucket);
+    assert!(
+        late_bucket.is_some(),
+        "the late write left no dirty bucket, so the clear below has nothing to get wrong",
+    );
+
+    engine.clear_dumped_bucket_dirty_state(1, &manifest);
+
+    let still_dirty = engine
+        .bucket_storage_summaries(1)
+        .into_iter()
+        .any(|summary| summary.dirty_object_count > 0);
+    assert!(
+        still_dirty,
+        "every bucket was cleared, including one written to AFTER the dump captured it. That \
+bucket's writes are now in no manifest and it will never be dumped, so reclaim may advance past \
+records that are still needed. The freshness of the `current` read in \
+`clear_dumped_bucket_dirty_state` is what prevents this -- it must not be fed a snapshot taken \
+before the dump.",
+    );
+}
+
 /// WHO walks the shard, by source location. Prints.
 ///
 ///   cargo test --release -p temporalstore-rust --lib who_walks_the_shard -- --ignored --nocapture


### PR DESCRIPTION
[#1606](https://github.com/matrixarkai/TemporalStore/pull/1606) showed `bucket_storage_summaries`
entered **three times** in one `apply_storage_lifecycle` — from `storage_lifecycle_plan`, from
`create_bucket_dump_manifest`, and from `clear_dumped_bucket_dirty_state`.

Three identical whole-shard walks in one operation look exactly like something to share, and
[#1586](https://github.com/matrixarkai/TemporalStore/pull/1586),
[#1589](https://github.com/matrixarkai/TemporalStore/pull/1589) and
[#1591](https://github.com/matrixarkai/TemporalStore/pull/1591) all shared walks that looked just
like these.

## This one must not be shared

`clear_dumped_bucket_dirty_state` compares each bucket's **current** derived generation against the
generation the manifest **captured**, and skips clearing any bucket whose generation has moved — a
bucket written to after the dump still holds undumped writes, so it must stay dirty for the next
dump.

Feed it a snapshot taken when the plan ran and the two sides become equal **by construction**. The
comparison always passes, the bucket is cleared, its writes are in no manifest and will never be
dumped, and WAL/index reclaim is then free to advance past records that are still needed. Silent
loss, discovered on a later restart.

**The trap is not detectable by ordinary testing**: any fixture that does not write *concurrently*
with a dump passes a hoisted version happily.

## What this adds

A comment **at the call site**, where someone would try it — not only in a note somewhere else.

`a_bucket_written_after_the_dump_stays_dirty`, which lands a write in exactly the window a shared
snapshot erases — after the manifest captures the bucket, before the clear runs — and asserts the
bucket is still dirty afterwards. Two denominators come first: the manifest must actually name
buckets, and the late write must actually leave one dirty, so a fixture where the clear had nothing
to get wrong fails loudly instead of passing.

Verified by mutation, with the mutation being the change someone would actually make — `current`
fed from `captured`, which is what sharing one snapshot produces:

```
every bucket was cleared, including one written to AFTER the dump captured it. That bucket's
writes are now in no manifest and it will never be dumped, so reclaim may advance past records
that are still needed.
```

## The other two are also not worth sharing

Worked through after the commit message above was written, which said they "probably can".

Nothing mutates between the plan's walk and the manifest's, so sharing them is safe in the
data-loss sense. But `create_bucket_dump_manifest` computes its summaries **and** calls
`export_index_bytes` at manifest time. Reusing plan-time summaries would leave the manifest's
recorded generations **older than the index it embeds**, so at clear time `current != captured`,
the bucket is never treated as cleanly dumped, and it is **re-dumped next round**.

A whole-shard dump costs about 2.0× the shard plus a full index serialisation — far more than the
single walk saved. Net loss under any write concurrency; break-even only on a shard nobody is
writing to.

So all three walks stay. The walk count is not the whole cost model: before sharing one, ask what
each consumer is entitled to **see**, and what a stale answer makes the system **do**.

## Verification

Docs and one guard; no behaviour changes.

`cargo test -p temporalstore-rust --lib -- --test-threads=1` → **1782 passed, 1 failed**. The single
failure is `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the standing `--lib`
baseline failure on main, not introduced here.
