### PR TITLE
An unseeded module is unknown not dead; five import cycles; and the scoring rules defined twice

### DIFF
--- a/tools/test_codex_pipeline_fixtures.py
+++ b/tools/test_codex_pipeline_fixtures.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The adapters the codex-pipeline suite shares, and the imports they and the parts need.
+
+The parent imports each mixin class from a `test_codex_pipeline_part*` module, and every part
+imported these three adapters -- plus the names below -- back from the parent. That is a cycle:
+whichever module the loader reaches first fails with a partially initialised import, and which one
+that is depends on the order the files are walked in. matrixarkai#1597 and matrixarkai#1603 removed
+the same cycle from two other clusters; those two borrowed nothing but stdlib and production
+modules, so direct imports were enough. This one shares real test doubles, so they need a home
+neither side owns.
+
+The imports are copied from the parent VERBATIM, `tools.` prefix and all -- that is, without one.
+A `tools.`-prefixed import is a different module object from the bare one, each with its own state,
+and a test patching one through the parent would not reach a part holding the other. That cost four
+codex-hook tests in matrixarkai#1603.
+"""
+from __future__ import annotations
+
+from argparse import Namespace
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from unittest import mock
+from pathlib import Path
+
+import matrixark_codex_hook
+import matrixark_mcp_core
+import matrixark_mcp_local_adapter
+import matrixark_mcp_query
+import matrixark_mcp_retrieve_request
+import matrixark_mcp_summary_runtime
+from matrixark_mcp_context_pack import (
+    compact_context_pack_audit_record,
+    compact_context_pack_for_serving,
+    compact_dropped_refs_for_context_pack,
+    compact_refs_for_audit,
+)
+from matrixark_mcp_core import (
+    candidate_index_terms,
+    candidate_memory_layer_name,
+    compact_context_pack_ref,
+    compact_context_pack_audit_record as core_compact_context_pack_audit_record,
+    compact_context_pack_for_serving as core_compact_context_pack_for_serving,
+    compact_context_pack_for_serving_flat,
+    embedding_for_text,
+    identity_hashes,
+    infer_query_type,
+    infer_secondary_index_filter_groups,
+    memory_layer_for_serving_ref,
+    packing_sort_key,
+    select_token_budgeted_refs,
+)
+from matrixark_mcp_async_readiness import async_pipeline_retrieval_readiness
+from matrixark_mcp_recovery import matrixark_local_recovery_report
+from matrixark_mcp_retrieve_pack_builder import dropped_ref_layer_budget, memory_layer_pressure_summary, selected_ref_layer_budget
+from matrixark_mcp_local_adapter import (
+    compression_context_index_records,
+    quality_first_underfill_summary,
+    refresh_final_selected_budget_policies,
+    suppress_extracted_represented_pending_events,
+    suppress_profile_shadowed_session_entities,
+)
+from matrixark_mcp_server import MatrixArkLocalAdapter, MatrixArkMcpServer
+from matrixark_mcp_summary_runtime import build_node_summary_refresh_records
+
+
+class CountingLocalAdapter(MatrixArkLocalAdapter):
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.flushed_batch_sizes: list[int] = []
+        self.retrieval_call_count = 0
+
+    def append_many(self, records: list[dict]) -> None:
+        active_batch = self._current_write_batch()
+        super().append_many(records)
+        if active_batch is None and records:
+            self.flushed_batch_sizes.append(len(records))
+
+    def retrieval_records(self, **kwargs):
+        self.retrieval_call_count += 1
+        return super().retrieval_records(**kwargs)
+
+
+class FastHookLocalAdapter(MatrixArkLocalAdapter):
+    def enqueue_raw_ingestion_records(self, records: list[dict]) -> None:
+        self.append_many(records)
+
+    def _enqueue_direct_write(self, records: list[dict]) -> None:
+        self.append_many(records)
+
+
+class NativeCaptureLocalAdapter(MatrixArkLocalAdapter):
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.native_requests: list[dict] = []
+
+    def supports_native_context_pack(self) -> bool:
+        return True
+
+    def native_context_pack(self, request: dict) -> dict | None:
+        self.native_requests.append(dict(request))
+        return {
+            "context_pack_id": "local-native-pack",
+            "selected_refs": [],
+            "used_context_tokens": 0,
+            "used_remote_context_tokens": 0,
+            "remote_context_budget_tokens": request.get("max_context_tokens", 0),
+            "recall_policy": {
+                "source_role_budget": {
+                    "enabled": bool(request.get("source_role_budget_tokens")),
+                    "budget_tokens": request.get("source_role_budget_tokens", {}),
+                },
+                "memory_layer_budget_policy": {
+                    "enabled": bool(request.get("memory_layer_budget_tokens")),
+                    "budget_tokens": request.get("memory_layer_budget_tokens", {}),
+                    "mode": request.get("memory_layer_budget_mode"),
+                    "question_type": request.get("memory_layer_budget_question_type"),
+                    "question_budget_reason": request.get("memory_layer_budget_question_reason"),
+                    "derived": request.get("memory_layer_budget_mode") in {
+                        "auto",
+                        "balanced",
+                        "codex_auto",
+                        "pre_retrieval_summary_refresh_balanced",
+                    },
+                },
+                "memory_selection_policy_budget_policy": {
+                    "enabled": bool(request.get("memory_selection_policy_budget_tokens")),
+                    "budget_tokens": request.get("memory_selection_policy_budget_tokens", {}),
+                    "mode": request.get("memory_selection_policy_budget_mode"),
+                }
+            },
+        }

--- a/tools/test_codex_pipeline_part1.py
+++ b/tools/test_codex_pipeline_part1.py
@@ -9,7 +9,7 @@ except ImportError:
     from matrixark_mcp_core import *  # noqa: F401,F403
 
 try:  # names owned by the parent module
-    from tools.test_matrixark_codex_hook_pipeline import (
+    from test_codex_pipeline_fixtures import (
     MatrixArkLocalAdapter,
     Path,
     async_pipeline_retrieval_readiness,
@@ -41,7 +41,7 @@ try:  # names owned by the parent module
     tempfile,
 )
 except ImportError:
-    from test_matrixark_codex_hook_pipeline import (
+    from test_codex_pipeline_fixtures import (
     MatrixArkLocalAdapter,
     Path,
     async_pipeline_retrieval_readiness,

--- a/tools/test_codex_pipeline_part2.py
+++ b/tools/test_codex_pipeline_part2.py
@@ -12,7 +12,7 @@ except ImportError:
     from matrixark_mcp_core import *  # noqa: F401,F403
 
 try:  # names owned by the parent module
-    from tools.test_matrixark_codex_hook_pipeline import (
+    from test_codex_pipeline_fixtures import (
     FastHookLocalAdapter,
     Namespace,
     Path,
@@ -33,7 +33,7 @@ try:  # names owned by the parent module
     time,
 )
 except ImportError:
-    from test_matrixark_codex_hook_pipeline import (
+    from test_codex_pipeline_fixtures import (
     FastHookLocalAdapter,
     Namespace,
     Path,

--- a/tools/test_codex_pipeline_part3.py
+++ b/tools/test_codex_pipeline_part3.py
@@ -12,7 +12,7 @@ except ImportError:
     from matrixark_mcp_core import *  # noqa: F401,F403
 
 try:  # names owned by the parent module
-    from tools.test_matrixark_codex_hook_pipeline import (
+    from test_codex_pipeline_fixtures import (
     FastHookLocalAdapter,
     MatrixArkLocalAdapter,
     Namespace,
@@ -28,7 +28,7 @@ try:  # names owned by the parent module
     time,
 )
 except ImportError:
-    from test_matrixark_codex_hook_pipeline import (
+    from test_codex_pipeline_fixtures import (
     FastHookLocalAdapter,
     MatrixArkLocalAdapter,
     Namespace,

--- a/tools/test_codex_pipeline_part4.py
+++ b/tools/test_codex_pipeline_part4.py
@@ -17,7 +17,7 @@ except ImportError:
     from matrixark_mcp_local_adapter import expand_interned_records
 
 try:  # names owned by the parent module
-    from tools.test_matrixark_codex_hook_pipeline import (
+    from test_codex_pipeline_fixtures import (
     CountingLocalAdapter,
     MatrixArkLocalAdapter,
     MatrixArkMcpServer,
@@ -39,7 +39,7 @@ try:  # names owned by the parent module
     time,
 )
 except ImportError:
-    from test_matrixark_codex_hook_pipeline import (
+    from test_codex_pipeline_fixtures import (
     CountingLocalAdapter,
     MatrixArkLocalAdapter,
     MatrixArkMcpServer,

--- a/tools/test_codex_pipeline_part5.py
+++ b/tools/test_codex_pipeline_part5.py
@@ -12,7 +12,7 @@ except ImportError:
     from matrixark_mcp_core import *  # noqa: F401,F403
 
 try:  # names owned by the parent module
-    from tools.test_matrixark_codex_hook_pipeline import (
+    from test_codex_pipeline_fixtures import (
     MatrixArkLocalAdapter,
     MatrixArkMcpServer,
     Path,
@@ -30,7 +30,7 @@ try:  # names owned by the parent module
     time,
 )
 except ImportError:
-    from test_matrixark_codex_hook_pipeline import (
+    from test_codex_pipeline_fixtures import (
     MatrixArkLocalAdapter,
     MatrixArkMcpServer,
     Path,

--- a/tools/test_matrixark_codex_hook_pipeline.py
+++ b/tools/test_matrixark_codex_hook_pipeline.py
@@ -55,74 +55,17 @@ from matrixark_mcp_local_adapter import (
 )
 from matrixark_mcp_server import MatrixArkLocalAdapter, MatrixArkMcpServer
 from matrixark_mcp_summary_runtime import build_node_summary_refresh_records
+from test_codex_pipeline_fixtures import (
+    CountingLocalAdapter,
+    FastHookLocalAdapter,
+    NativeCaptureLocalAdapter,
+)
 
 
-class CountingLocalAdapter(MatrixArkLocalAdapter):
-    def __post_init__(self) -> None:
-        super().__post_init__()
-        self.flushed_batch_sizes: list[int] = []
-        self.retrieval_call_count = 0
-
-    def append_many(self, records: list[dict]) -> None:
-        active_batch = self._current_write_batch()
-        super().append_many(records)
-        if active_batch is None and records:
-            self.flushed_batch_sizes.append(len(records))
-
-    def retrieval_records(self, **kwargs):
-        self.retrieval_call_count += 1
-        return super().retrieval_records(**kwargs)
 
 
-class FastHookLocalAdapter(MatrixArkLocalAdapter):
-    def enqueue_raw_ingestion_records(self, records: list[dict]) -> None:
-        self.append_many(records)
-
-    def _enqueue_direct_write(self, records: list[dict]) -> None:
-        self.append_many(records)
 
 
-class NativeCaptureLocalAdapter(MatrixArkLocalAdapter):
-    def __post_init__(self) -> None:
-        super().__post_init__()
-        self.native_requests: list[dict] = []
-
-    def supports_native_context_pack(self) -> bool:
-        return True
-
-    def native_context_pack(self, request: dict) -> dict | None:
-        self.native_requests.append(dict(request))
-        return {
-            "context_pack_id": "local-native-pack",
-            "selected_refs": [],
-            "used_context_tokens": 0,
-            "used_remote_context_tokens": 0,
-            "remote_context_budget_tokens": request.get("max_context_tokens", 0),
-            "recall_policy": {
-                "source_role_budget": {
-                    "enabled": bool(request.get("source_role_budget_tokens")),
-                    "budget_tokens": request.get("source_role_budget_tokens", {}),
-                },
-                "memory_layer_budget_policy": {
-                    "enabled": bool(request.get("memory_layer_budget_tokens")),
-                    "budget_tokens": request.get("memory_layer_budget_tokens", {}),
-                    "mode": request.get("memory_layer_budget_mode"),
-                    "question_type": request.get("memory_layer_budget_question_type"),
-                    "question_budget_reason": request.get("memory_layer_budget_question_reason"),
-                    "derived": request.get("memory_layer_budget_mode") in {
-                        "auto",
-                        "balanced",
-                        "codex_auto",
-                        "pre_retrieval_summary_refresh_balanced",
-                    },
-                },
-                "memory_selection_policy_budget_policy": {
-                    "enabled": bool(request.get("memory_selection_policy_budget_tokens")),
-                    "budget_tokens": request.get("memory_selection_policy_budget_tokens", {}),
-                    "mode": request.get("memory_selection_policy_budget_mode"),
-                }
-            },
-        }
 
 
 try:  # mixin

--- a/tools/test_matrixark_no_cross_test_imports.py
+++ b/tools/test_matrixark_no_cross_test_imports.py
@@ -88,16 +88,24 @@ DEFERRED_SNIPPET = """def setUp(self):
     return Fixture
 """
 
+#: THE FOUR THAT REMAIN CANNOT FIRE, and that is worth knowing before anybody spends a refactor on
+#: them. `test_matrixark_mcp_backend_policy` raises `unittest.SkipTest` at import, because
+#: `run_matrixark_rust_scale_report` is absent from this repository and deliberately not recreated
+#: -- the symbols it owes name deployment infrastructure, and writing a stand-in would be guessing
+#: at scrubbed content. So the four `test_backend_policy_part*` modules never get far enough to hit
+#: the cycle, and their tests cannot run here at all. Breaking it would move 425 lines of fixtures
+#: for no change in behaviour.
+#:
+#: The five codex-pipeline pairs DID fire -- each part failed with a partially initialised import
+#: when reached first -- and are gone: the three adapters they shared live in
+#: `test_codex_pipeline_fixtures`, which imports no test module, so the graph is acyclic. They stay
+#: in KNOWN above, because importing the fixtures module is still a cross-test import; what they
+#: are no longer is MUTUAL, which is the half that reorders discover.
 KNOWN_MUTUAL = {
     ("test_backend_policy_part1", "test_matrixark_mcp_backend_policy"),
     ("test_backend_policy_part2", "test_matrixark_mcp_backend_policy"),
     ("test_backend_policy_part3", "test_matrixark_mcp_backend_policy"),
     ("test_backend_policy_part4", "test_matrixark_mcp_backend_policy"),
-    ("test_codex_pipeline_part1", "test_matrixark_codex_hook_pipeline"),
-    ("test_codex_pipeline_part2", "test_matrixark_codex_hook_pipeline"),
-    ("test_codex_pipeline_part3", "test_matrixark_codex_hook_pipeline"),
-    ("test_codex_pipeline_part4", "test_matrixark_codex_hook_pipeline"),
-    ("test_codex_pipeline_part5", "test_matrixark_codex_hook_pipeline"),
 }
 
 def _cross_importers() -> dict:

--- a/tools/test_the_flag_surface_only_shrinks.py
+++ b/tools/test_the_flag_surface_only_shrinks.py
@@ -247,15 +247,26 @@ EXAMINED = {
 def _readers_all_unreachable(reads):
     """Flags every reader of which sits in a module production cannot reach.
 
-    A flag is only a control if something can turn it. These nineteen gate code no request arrives
-    at, so turning them changes nothing that runs -- which makes them the one group on this page
+    A flag is only a control if something can turn it. A flag in this group gates code no request
+    arrives at, so turning it changes nothing that runs -- which makes it the one group on this page
     that could be retired without removing a capability from anybody.
 
-    Not a removal list. Seventeen of the nineteen are in `matrixark_mcp_rust_proxy_config`, and
-    `test_a_module_only_tests_reach_is_not_live` records that module as unwired rather than
-    abandoned: the waiter fix for mx#1073 landed in it, so it is maintained code whose flags are
-    its tuning surface. Retiring them is a decision about whether that path is coming back, and
-    the point of naming the group is that the decision is now one decision rather than nineteen.
+    THE GROUP IS EMPTY NOW, and both halves of why are worth keeping. Nineteen were here, seventeen
+    of them in `matrixark_mcp_rust_proxy_config`; matrixarkai#1572 folded them to the values they
+    already produced. That left three, and all three were WRONG: TS_REDIS_HOST, TS_REDIS_PORT and
+    TS_TENANT, read by `sdk/python/temporalstore/control_state.py` -- the shipped client SDK, which
+    has its own test suite and which nothing under `tools/` imports because a CUSTOMER imports it.
+
+    The reachability corpus is `tools/*.py`. Asking "is this module in `reached`" of a module the
+    scan never considered answers no for both kinds of absence, so a shipped library read as dead
+    and its configuration sat in the group whose whole point is that it can be retired safely.
+    An unseeded module is UNKNOWN, not dead. The rule below now requires every reader to be IN the
+    corpus before concluding anything, which is the same failure `test_the_live_roots_come_back_
+    reachable` exists to prevent, arriving from outside the corpus instead of inside it.
+
+    An empty group says "every flag this page counts reaches live code", which is worth saying --
+    but only while the scan still works, so the floor is asserted on the SCAN rather than on the
+    group. A floor on the group would fail on exactly the success that emptied it.
 
     Computed from the reachability guard next door rather than restated, so a module that becomes
     reachable takes its flags out of this group on the same day.
@@ -265,15 +276,30 @@ def _readers_all_unreachable(reads):
     except Exception:  # pragma: no cover - the guard is absent
         return set()
     try:
-        _library, reached = reachability.reachable_from_production()
+        library, reached = reachability.reachable_from_production()
     except Exception:  # pragma: no cover - a broken scan must not reclassify the page
         return set()
-    if not reached:
+    if not reached or not library:
         return set()
     out = set()
     for name, modules in reads.items():
         stems = {m[:-3] if m.endswith(".py") else m for m in modules}
-        if stems and not (stems & reached):
+        if not stems:
+            continue
+        # ONLY WHERE THE SCAN ACTUALLY LOOKED. The reachability corpus is `tools/*.py`; this file's
+        # production set also includes the shipped client SDK, which nothing under tools/ imports
+        # because a customer imports it. Asking "is it in `reached`" of a module the scan never
+        # considered answers no for both kinds of absence, and the three SDK variables -- the redis
+        # host, the port and the tenant of `sdk/python/temporalstore/control_state.py`, which has
+        # its own test suite -- sat in the one group on this page whose whole point is that it
+        # "could be retired without removing a capability from anybody".
+        #
+        # Retiring a shipped library's configuration is the opposite of that. An unseeded module is
+        # UNKNOWN, not dead -- the same failure the reachability guard's own seed control exists to
+        # prevent, arriving from outside its corpus instead of inside it.
+        if not (stems <= library):
+            continue
+        if not (stems & reached):
             out.add(name)
     return out
 
@@ -1811,6 +1837,68 @@ class TheFlagSurfaceOnlyShrinksTest(unittest.TestCase):
         self.assertGreater(
             excluded, 0,
             "no knob in INTERNAL_KNOBS carries a variable, so the exclusion above ran over nothing")
+    def test_the_reachability_corpus_is_really_there(self) -> None:
+        """The floor for `readers all unreachable`, put on the SCAN because the group is EMPTY.
+
+        A floor on the group would be the mistake this page has made three times: a count measured
+        from a population that improvement removes. matrixarkai#1572 folded seventeen of the
+        nineteen, and the last three were a false reading of the shipped SDK, so zero is the right
+        answer and must stay checkable.
+
+        What can still go wrong is the scan: if `reachable_from_production` returns nothing, every
+        flag's readers are trivially "not reached", and the corpus test below is what stops that
+        reading as a page where nothing is unreachable.
+        """
+        try:
+            import test_a_module_only_tests_reach_is_not_live as reachability
+        except ImportError:  # pragma: no cover - the guard is not optional in practice
+            self.skipTest("the reachability guard is absent")
+        library, reached = reachability.reachable_from_production()
+        self.assertGreater(
+            len(library), 100,
+            "the reachability corpus holds %d modules. It is tools/*.py and there are hundreds, so "
+            "a corpus this small means the scan stopped reading the tree." % len(library))
+        self.assertGreater(
+            len(reached), len(library) // 2,
+            "only %d of %d modules are reachable. Fewer than half means the SEEDING broke, and a "
+            "broken seed makes live code look dead -- do not act on any unreachable list until "
+            "this passes." % (len(reached), len(library)))
+        outside = {rel for rel in _production_modules() if not rel.startswith("tools/")}
+        self.assertTrue(
+            outside,
+            "every production module is under tools/, so the corpus and the production set agree "
+            "and the rule guarding against the difference is asserting nothing. The shipped SDK "
+            "was that difference.")
+        # `__init__` is excluded because the comparison is by STEM and both trees have one -- a
+        # bare name is not an identity, which is the error this file has already had to correct in
+        # its helper derivation and its boolean-reader scan.
+        stems = {os.path.basename(rel)[:-3] for rel in outside} - {"__init__"}
+        self.assertFalse(
+            stems & library,
+            "a module outside tools/ is in the reachability corpus, so the two sets no longer "
+            "disagree the way the rule assumes: %s" % sorted(stems & library))
+        # AND THE RULE ITSELF, not only the corpus. Dropping the membership requirement puts every
+        # flag read outside tools/ straight back into `readers all unreachable`, and nothing else
+        # would fail: the group has no floor, deliberately, because it is empty. Asked by mechanism
+        # rather than by naming one of the SDK's variables -- naming one here would make this file
+        # the only TEST that names it, since the SDK's own tests are not in the selecting set.
+        outside_readers = {name for name, modules in self.reads.items()
+                           if not ({m[:-3] if m.endswith(".py") else m for m in modules} <= library)}
+        self.assertTrue(
+            outside_readers,
+            "no flag is read from outside the reachability corpus, so the membership rule in "
+            "_readers_all_unreachable is guarding against nothing and this check cannot fail.")
+        self.assertFalse(
+            outside_readers & _readers_all_unreachable(self.reads),
+            "these are read only from outside the corpus the reachability scan covers, and are "
+            "being reported as having no reachable reader: %s"
+            % sorted(outside_readers & _readers_all_unreachable(self.reads)))
+        self.assertIn(
+            "control_state", stems,
+            "the SDK module whose three variables were read as unreachable is not in the "
+            "production set any more. It is the case the corpus rule was written for: a shipped "
+            "library a customer imports, which nothing under tools/ reaches.")
+
     def test_the_candidates_are_reported(self) -> None:
         """Not an assertion about how many: a record of what is left, printed where it is read.
 

--- a/tools/test_the_scoring_rules_have_one_definition.py
+++ b/tools/test_the_scoring_rules_have_one_definition.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The scoring rules are defined twice, and the two copies disagree about profile memory.
+
+`matrixark_mcp_recall_scoring` computes
+
+    final_score = final_recall_score(origin, time, business, weights)
+                  + session_continuity_boost(...)
+                  + cross_session_rerank_adjustment(...)
+
+and `question_type_ref_boost` feeds the origin score. Every one of those three has a second
+definition, and the copy this module reaches is the one WITHOUT profile-memory handling:
+
+    matrixark_local_adapter_retrieve    -> matrixark_mcp_core's copies          (profile memory)
+    matrixark_local_adapter_retrieval   -> matrixark_mcp_core's copies          (profile memory)
+    matrixark_mcp_recall_scoring        -> matrixark_mcp_access_scope's copies  (none)
+
+Measured on the two `cross_session_rerank_adjustment` bodies: core's opens with a
+`question_type == "profile_memory"` block returning 0.16 for an entity, 0.12 for a summary or
+compression and 0.06 for a segment, adds +0.04 to an entity whose `memory_scope` is `user_profile`,
+and counts `profile_memory` alongside `broad_exploration` in the summary branch. The access_scope
+copy has none of it, so the same candidate scores 0.0 there and up to 0.16 through the adapters.
+
+THIS FILE DOES NOT ASSERT THAT THEY AGREE, because they do not, and a guard that fails on the day
+it is written tells nobody anything. It RECORDS the divergence exactly, so a new one fails here and
+a resolved one fails here too -- the same shape as the orphan and cross-import records. Choosing
+which copy wins changes ranking on a serving path, which is a decision rather than a cleanup.
+
+`score_recall_candidate` IS in the list, with its own reason. It diverges as well (12 statements
+against 11) and carries no profile-memory markers on either side, so it is a different drift --
+but the set is asserted exactly, and leaving it out on the grounds that it is off-topic would mean
+the list is not the whole truth about the family. It is recorded as what it is, and nothing here
+suggests fixing it alongside the other four.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import hashlib
+import os
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+
+#: (function, the two modules that define it) -> what the copies disagree about.
+RECORDED = {
+    ("cross_session_rerank_adjustment",
+     ("matrixark_mcp_access_scope", "matrixark_mcp_core")):
+        "core has the whole question_type == profile_memory block and the user_profile entity "
+        "boost; access_scope has neither, and matrixark_mcp_recall_scoring reaches access_scope",
+    ("session_continuity_boost",
+     ("matrixark_mcp_access_scope", "matrixark_mcp_core")):
+        "same pair, same direction: core is one statement longer and that statement is the "
+        "profile-memory case",
+    ("access_scope_matches_before_scoring",
+     ("matrixark_mcp_access_scope", "matrixark_mcp_core")):
+        "core admits a user_profile + cross_session record when the identity fields match; "
+        "access_scope falls through to scope_matches",
+    ("candidate_access_scope",
+     ("matrixark_mcp_access_scope", "matrixark_mcp_core")):
+        "core reads two more fields off the record when building the scope",
+    ("question_type_ref_boost",
+     ("matrixark_mcp_core_candidate_policy", "matrixark_mcp_recall_scoring")):
+        "core_candidate_policy names profile_memory 15 times and codex_outcome 11; "
+        "recall_scoring names them 5 and 1, and has no is_feature_profile_memory at all",
+    ("score_recall_candidate",
+     ("matrixark_mcp_core_candidate_policy", "matrixark_mcp_recall_scoring")):
+        "a DIFFERENT drift, recorded so this list is the whole truth about the family: 12 "
+        "statements against 11 and NO profile-memory markers on either side. Resolving it is not "
+        "part of the profile-memory question above",
+}
+
+FAMILY = ("matrixark_mcp_access_scope", "matrixark_mcp_core", "matrixark_mcp_recall_scoring",
+          "matrixark_mcp_core_candidate_policy")
+
+
+def _bodies():
+    """(function, module) -> (digest of the body, statement count) across the scoring family."""
+    out = {}
+    for stem in FAMILY:
+        path = os.path.join(TOOLS, stem + ".py")
+        try:
+            with open(path, encoding="utf-8", errors="replace") as handle:
+                tree = ast.parse(handle.read())
+        except (OSError, SyntaxError):  # pragma: no cover - an unparseable module fails elsewhere
+            continue
+        for node in tree.body:
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            dumped = ast.dump(ast.Module(body=node.body, type_ignores=[]))
+            out[(node.name, stem)] = (
+                hashlib.sha256(dumped.encode("utf-8")).hexdigest()[:12],
+                tuple(argument.arg for argument in node.args.args),
+                len(node.body),
+            )
+    return out
+
+
+def _diverged():
+    """Functions this family defines more than once, with the same parameters and different bodies."""
+    bodies = _bodies()
+    by_name = {}
+    for (name, stem), value in bodies.items():
+        by_name.setdefault(name, []).append((stem, value))
+    out = {}
+    for name, entries in by_name.items():
+        if len(entries) < 2:
+            continue
+        if len({value[1] for _stem, value in entries}) != 1:
+            continue
+        if len({value[0] for _stem, value in entries}) == 1:
+            continue
+        out[(name, tuple(sorted(stem for stem, _value in entries)))] = entries
+    return out
+
+
+class TheScoringRulesHaveOneDefinition(unittest.TestCase):
+
+    def test_the_family_is_there_to_compare(self) -> None:
+        """A floor. Every assertion below passes over an empty read."""
+        bodies = _bodies()
+        self.assertGreater(
+            len(bodies), 40,
+            "only %d functions were read across %s, so this file is comparing almost nothing"
+            % (len(bodies), ", ".join(FAMILY)))
+        for stem in FAMILY:
+            with self.subTest(module=stem):
+                self.assertTrue(
+                    [key for key in bodies if key[1] == stem],
+                    "%s contributed no functions; a renamed or removed module makes every "
+                    "comparison here vacuous" % stem)
+
+    def test_the_divergence_is_exactly_what_is_recorded(self) -> None:
+        """Asserted in BOTH directions.
+
+        A new pair fails, so the split cannot grow quietly. A recorded pair that stops diverging
+        fails too, because a list allowed to rot describes a tree that no longer exists -- and in
+        this case it would hide the fact that somebody had chosen a winner.
+        """
+        found = set(_diverged())
+        recorded = set(RECORDED)
+        new = sorted(found - recorded)
+        gone = sorted(recorded - found)
+        self.assertEqual(
+            [], new,
+            "these scoring rules now have two definitions that disagree, and nothing records what "
+            "they disagree about: %s" % ", ".join("%s in %s" % (n, " and ".join(m)) for n, m in new))
+        self.assertEqual(
+            [], gone,
+            "these are recorded as diverged and no longer are -- strike them, and say which copy "
+            "won: %s" % ", ".join("%s in %s" % (n, " and ".join(m)) for n, m in gone))
+
+    def test_recall_scoring_still_reaches_the_copy_without_profile_memory(self) -> None:
+        """The consequence, stated as the thing that is actually wrong.
+
+        The divergence matters because of WHICH copy the serving path binds. If this ever fails
+        because recall_scoring now reaches core's copy, that is the fix -- strike the entries above
+        and delete this test with them.
+        """
+        with open(os.path.join(TOOLS, "matrixark_mcp_recall_scoring.py"),
+                  encoding="utf-8", errors="replace") as handle:
+            body = handle.read()
+        self.assertIn(
+            "matrixark_mcp_access_scope", body,
+            "matrixark_mcp_recall_scoring no longer imports from matrixark_mcp_access_scope. If it "
+            "now takes the scoring rules from matrixark_mcp_core, the split is resolved.")
+        for name in ("cross_session_rerank_adjustment", "session_continuity_boost"):
+            with self.subTest(rule=name):
+                self.assertIn(name, body, "%s is no longer used by the recall scorer" % name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The shipped SDK was being read as unreachable, and its three variables sat on the retire-safely list

`_readers_all_unreachable` asked "is this module in `reached`". The reachability corpus is
`tools/*.py`; this file's production set also includes `sdk/python/temporalstore`, which nothing
under tools/ imports because a CUSTOMER imports it. Asking that question of a module the scan never
considered answers no for both kinds of absence.

So TS_REDIS_HOST, TS_REDIS_PORT and TS_TENANT -- read by sdk/python/temporalstore/control_state.py,
which has its own test suite under sdk/python/tests -- were in the one group on this page whose
stated point is that its members "could be retired without removing a capability from anybody".
Retiring a shipped client library's configuration is the opposite of that.

An unseeded module is UNKNOWN, not dead. The rule now requires every reader to be IN the corpus
before it concludes anything. That is the same failure `test_the_live_roots_come_back_reachable`
exists to prevent, arriving from outside the corpus instead of from inside it.

THE GROUP IS NOW EMPTY, AND THE FLOOR GOES ON THE SCAN

Nineteen were in it; matrixarkai#1572 folded seventeen of them plus two more. The remaining three
were this false reading. Zero is the right answer and the docstring says so, with both halves of
why.

A floor on the GROUP would fail on exactly the success that emptied it -- the mistake this page has
already made three times. The floor goes on the scan instead: the corpus has to hold hundreds of
modules, more than half of them reachable, and the production set has to still contain something
outside tools/ for the membership rule to be guarding anything.

  the SDK drops out of the production set       FAILS
  the corpus rule stops requiring membership    FAILS

The second needed a control the first did not: dropping the membership requirement puts every
outside-read flag straight back into the group, and nothing else would fail, because the group has
no floor by design. It is asked by mechanism rather than by naming one of the SDK's variables --
the SDK's own tests are not in the selecting set, so naming one here would make this file the only
test that names it, which is what test_this_file_does_not_credit_its_own_examples catches.

`__init__` is excluded from the stem comparison because both trees have one, and a bare name is not
an identity -- the third time that error has had to be corrected in this file today.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


---

The five codex-pipeline cycles are gone, and the four that remain cannot fire

Each `test_codex_pipeline_part*` imported three test doubles back from the parent, which imports
each part's mixin class. Every one of the five failed when reached first:

    ImportError: cannot import name '_CodexPipelinePart1' from partially initialized module

matrixarkai#1597 and matrixarkai#1603 removed the same cycle from two other clusters by importing
directly, because those borrowed nothing but stdlib and production modules. This one shares real
test doubles -- CountingLocalAdapter, FastHookLocalAdapter, NativeCaptureLocalAdapter, 62 lines --
so they move to `test_codex_pipeline_fixtures`, which imports no test module. The parent and all
five parts read from there, and the graph is acyclic:

    each part imported first    ok, all five
    the parent                  44 failures, 10 errors -- identical to main, the same ones

The fixtures module copies the parent's import block VERBATIM, without a `tools.` prefix, because
that prefix would make a different module object with its own state and a test patching one through
the parent would not reach a part holding the other. That cost four tests in matrixarkai#1603.

They stay in KNOWN: importing the fixtures module is still a cross-test import. What they are no
longer is MUTUAL, which is the half that reorders discover and fails tests they have nothing to do
with.

  KNOWN_MUTUAL  9 -> 4

AND THE FOUR THAT REMAIN CANNOT FIRE

I was about to move 425 lines of backend-policy fixtures before checking. Those four parts never
reach their cycle: `test_matrixark_mcp_backend_policy` raises SkipTest at import because
`run_matrixark_rust_scale_report` is absent from this repository and deliberately not recreated --
the symbols it owes name deployment infrastructure and a stand-in would be guessing at scrubbed
content. Their tests cannot run here at all, so breaking the cycle would have changed nothing and
shown up as a pair count falling 9 to 5.

That is recorded beside the list, along with two things the sizing turned up that would have made
the move wrong anyway: `_FailingWarmupClient` is used by another fixture but borrowed by no
part, and `mcp_core` is not among the parent's module-level imports.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


---

The scoring rules are defined twice, and the serving path reaches the copy without profile memory

`matrixark_mcp_recall_scoring` computes

    final_score = final_recall_score(origin, time, business, weights)
                  + session_continuity_boost(...) + cross_session_rerank_adjustment(...)

and `question_type_ref_boost` feeds the origin score. All three have a second definition, and the
copy this module reaches is the one WITHOUT profile-memory handling:

    matrixark_local_adapter_retrieve   -> matrixark_mcp_core's copies          (profile memory)
    matrixark_local_adapter_retrieval  -> matrixark_mcp_core's copies          (profile memory)
    matrixark_mcp_recall_scoring       -> matrixark_mcp_access_scope's copies  (none)

Core's `cross_session_rerank_adjustment` opens with a `question_type == "profile_memory"` block
returning 0.16 for an entity, 0.12 for a summary or compression and 0.06 for a segment, adds +0.04
to an entity whose memory_scope is user_profile, and counts profile_memory alongside
broad_exploration in the summary branch. The access_scope copy has none of it, so the same
candidate scores 0.0 there and up to 0.16 through the adapters. `question_type_ref_boost` is the
same story by the numbers: profile_memory named 15 times against 5, codex_outcome 11 against 1,
is_feature_profile_memory 3 against 0.

THIS FILE DOES NOT ASSERT THAT THEY AGREE

They do not, and a guard that fails the day it is written tells nobody anything. It records the
divergence exactly, in both directions: a new pair fails, and a recorded pair that stops diverging
fails too -- because a list allowed to rot describes a tree that no longer exists, and here it
would hide the fact that somebody had chosen a winner. Choosing changes ranking on a serving path,
which is a decision rather than a cleanup.

  a recorded pair stops diverging              FAILS
  a recorded entry is dropped from the list    FAILS
  recall_scoring stops reaching access_scope   FAILS

The first two of those needed correcting: my initial mutations added a statement (which leaves the
copies diverged, just differently) and matched an anchor twice. Giving access_scope core's actual
body is what makes them converge, and that is what the check has to survive.

`score_recall_candidate` is recorded too, with its own reason. It diverges as well -- 12 statements
against 11 -- and carries NO profile-memory markers on either side, so it is a different drift. I
left it out at first on the grounds that it was off-topic, and the exact-set assertion refused,
correctly: the list is either the whole truth about this family or it is not a record.

Found by sweeping production for functions with the same signature and a different body: 101 pairs,
61 with two or more reachable copies once the legitimate agent/codex hook parallels and
main/parse_args boilerplate are out. Most of the 61 are elsewhere; this file is scoped to the
scoring family so the list stays a record rather than an inventory.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

