### PR TITLE
Four sampling snapshots, one walk

### DIFF
--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -271,9 +271,35 @@ pub(super) fn storage_block_address_sample(
 pub(super) fn storage_index_snapshot_with_samples(
     shard_id: ShardId,
     shard: &ShardState,
+    snapshot: StorageIndexSnapshot,
+) -> StorageIndexSnapshot {
+    storage_index_snapshot_with_samples_from_entries(
+        shard_id,
+        &collect_live_page_entries(shard),
+        snapshot,
+    )
+}
+
+/// The same samples, from live-page entries the caller ALREADY has.
+///
+/// All four `*_snapshot_with_samples` builders run back to back inside ONE read lock in
+/// `apply_storage_lifecycle`, and each was calling `collect_live_page_entries` for its own copy of
+/// every live page -- then sorting all of it to take EIGHT samples. `who_walks_the_shard` measured
+/// the four at 1.0x the shard apiece.
+///
+/// They differ only in sort order, so one walk serves all four and each sorts a vector of
+/// REFERENCES rather than owning entries -- the shared walk is not traded for four clones.
+///
+/// Safe for the same reason as #1586: one lock, an unchanged `&ShardState`, nothing mutating
+/// between them. And these feed report SAMPLES rather than a decision, so unlike the freshness
+/// walk in `clear_dumped_bucket_dirty_state` (#1607) a shared snapshot cannot change what the
+/// system DOES -- it only makes the four samples describe one moment instead of four.
+pub(super) fn storage_index_snapshot_with_samples_from_entries(
+    shard_id: ShardId,
+    entries: &[LiveBlockEntry],
     mut snapshot: StorageIndexSnapshot,
 ) -> StorageIndexSnapshot {
-    let mut entries = collect_live_page_entries(shard);
+    let mut entries: Vec<&LiveBlockEntry> = entries.iter().collect();
     entries.sort_by(|left, right| {
         (
             left.kind.as_ref(),
@@ -374,6 +400,28 @@ pub(super) fn storage_gc_ref(entry: &LiveBlockEntry) -> String {
 pub(super) fn storage_watermark_snapshot_with_samples(
     shard_id: ShardId,
     shard: &ShardState,
+    snapshot: StorageWatermarkSnapshot,
+) -> StorageWatermarkSnapshot {
+    storage_watermark_snapshot_with_samples_from_entries(
+        shard_id,
+        shard,
+        &collect_live_page_entries(shard),
+        snapshot,
+    )
+}
+
+/// The same samples, from live-page entries the caller ALREADY has. See
+/// `storage_index_snapshot_with_samples_from_entries` for why sharing one walk across the four
+/// sampling builders is safe.
+///
+/// This one is shaped differently from the other three and the difference is worth keeping in
+/// view: it does NOT sort. It folds every entry into a per-bucket watermark map, so it reads the
+/// entries once in whatever order they arrive. Anything that rewrites these four as a group has to
+/// notice that -- treating them as one template is how a bulk edit of this set goes wrong.
+pub(super) fn storage_watermark_snapshot_with_samples_from_entries(
+    shard_id: ShardId,
+    shard: &ShardState,
+    entries: &[LiveBlockEntry],
     mut snapshot: StorageWatermarkSnapshot,
 ) -> StorageWatermarkSnapshot {
     const MAX_STORAGE_WATERMARK_SAMPLES: usize = 8;
@@ -383,7 +431,7 @@ pub(super) fn storage_watermark_snapshot_with_samples(
     for (bucket_id, runtime_bucket) in &shard.bucket_index.bucket_map {
         bucket_watermarks.insert(*bucket_id, runtime_bucket.dirty_generation);
     }
-    for entry in collect_live_page_entries(shard) {
+    for entry in entries {
         let bucket_id = entry
             .address
             .routing_bucket()
@@ -426,11 +474,29 @@ pub(super) fn storage_watermark_snapshot_with_samples(
 }
 
 pub(super) fn storage_gc_snapshot_with_samples(
+    shard_id: ShardId,
+    shard: &ShardState,
+    snapshot: StorageGcSnapshot,
+) -> StorageGcSnapshot {
+    storage_gc_snapshot_with_samples_from_entries(
+        shard_id,
+        shard,
+        &collect_live_page_entries(shard),
+        snapshot,
+    )
+}
+
+/// The same samples, from live-page entries the caller ALREADY has. See
+/// `storage_index_snapshot_with_samples_from_entries` for why sharing one walk across the four
+/// sampling builders is safe: one lock, an unchanged `&ShardState`, and these feed report SAMPLES
+/// rather than a decision.
+pub(super) fn storage_gc_snapshot_with_samples_from_entries(
     _shard_id: ShardId,
     shard: &ShardState,
+    entries: &[LiveBlockEntry],
     mut snapshot: StorageGcSnapshot,
 ) -> StorageGcSnapshot {
-    let mut entries = collect_live_page_entries(shard);
+    let mut entries: Vec<&LiveBlockEntry> = entries.iter().collect();
     entries.sort_by(|left, right| {
         (
             left.deleted,
@@ -523,9 +589,27 @@ pub(super) fn storage_gc_snapshot_with_samples(
 pub(super) fn storage_topology_snapshot_with_samples(
     shard_id: ShardId,
     shard: &ShardState,
+    snapshot: StorageTopologySnapshot,
+) -> StorageTopologySnapshot {
+    storage_topology_snapshot_with_samples_from_entries(
+        shard_id,
+        shard,
+        &collect_live_page_entries(shard),
+        snapshot,
+    )
+}
+
+/// The same samples, from live-page entries the caller ALREADY has. See
+/// `storage_index_snapshot_with_samples_from_entries` for why sharing one walk across the four
+/// sampling builders is safe: one lock, an unchanged `&ShardState`, and these feed report SAMPLES
+/// rather than a decision.
+pub(super) fn storage_topology_snapshot_with_samples_from_entries(
+    shard_id: ShardId,
+    shard: &ShardState,
+    entries: &[LiveBlockEntry],
     mut snapshot: StorageTopologySnapshot,
 ) -> StorageTopologySnapshot {
-    let mut entries = collect_live_page_entries(shard);
+    let mut entries: Vec<&LiveBlockEntry> = entries.iter().collect();
     entries.sort_by(|left, right| {
         (
             left.address

--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -688,24 +688,40 @@ impl TemporalEngine {
             .expect("shards lock poisoned")
             .get(&request.shard_id)
         {
-            report.storage_index_snapshot = storage_index_snapshot_with_samples(
+            // ONE walk for all four sampling snapshots.
+            //
+            // Each of these built its own `collect_live_page_entries` -- a fresh Vec of every live
+            // page in the shard -- and then sorted all of it to take EIGHT samples. Four walks and
+            // four full sorts, for about thirty-two sample rows. `who_walks_the_shard` measured
+            // them at 1.0x the shard apiece, 4.0x of `apply_storage_lifecycle`'s 10.0x.
+            //
+            // Safe here in the way #1586 was and the dirty-state walk in #1607 was NOT: the read
+            // lock above covers all four, `&ShardState` is unchanged throughout, and these produce
+            // report SAMPLES rather than a decision. A shared snapshot cannot change what the
+            // system does; it only makes the four samples describe one moment instead of four.
+            let sampling_entries = collect_live_page_entries(shard);
+            report.storage_index_snapshot = storage_index_snapshot_with_samples_from_entries(
                 request.shard_id,
-                shard,
+                &sampling_entries,
                 report.storage_index_snapshot,
             );
-            report.storage_watermark_snapshot = storage_watermark_snapshot_with_samples(
+            report.storage_watermark_snapshot =
+                storage_watermark_snapshot_with_samples_from_entries(
+                    request.shard_id,
+                    shard,
+                    &sampling_entries,
+                    report.storage_watermark_snapshot,
+                );
+            report.storage_gc_snapshot = storage_gc_snapshot_with_samples_from_entries(
                 request.shard_id,
                 shard,
-                report.storage_watermark_snapshot,
-            );
-            report.storage_gc_snapshot = storage_gc_snapshot_with_samples(
-                request.shard_id,
-                shard,
+                &sampling_entries,
                 report.storage_gc_snapshot,
             );
-            report.storage_topology_snapshot = storage_topology_snapshot_with_samples(
+            report.storage_topology_snapshot = storage_topology_snapshot_with_samples_from_entries(
                 request.shard_id,
                 shard,
+                &sampling_entries,
                 report.storage_topology_snapshot,
             );
         }


### PR DESCRIPTION
The four `*_snapshot_with_samples` builders run back to back inside **one read lock** at the tail of
`apply_storage_lifecycle`. Each called `collect_live_page_entries` for its own copy of every live
page in the shard, and three of them then **sorted all of it** — to take eight samples each.

Four whole-shard walks and three full sorts, for about thirty-two sample rows.
[#1606](https://github.com/matrixarkai/TemporalStore/pull/1606)'s `#[track_caller]` attribution
measured them at 1.0× the shard apiece.

| | × the shard |
|---|---|
| `apply_storage_lifecycle` | **10.0× → 7.0×** |

The four sites collapse to one, at the shared walk:

| before | after |
|---|---|
| 1.0× `storage_bucket_internals.rs:276` | 1.0× `storage_lifecycle_methods.rs:702` |
| 1.0× `storage_bucket_internals.rs:386` | |
| 1.0× `storage_bucket_internals.rs:433` | |
| 1.0× `storage_bucket_internals.rs:528` | |

## Why this one is safe and #1607's was not

Same test as [#1586](https://github.com/matrixarkai/TemporalStore/pull/1586): the read lock covers
all four, `&ShardState` is unchanged throughout, nothing mutates between them.

And a second reason that matters more. These feed report **samples**, not a decision.
[#1607](https://github.com/matrixarkai/TemporalStore/pull/1607) records the walk that must **not** be
shared — `clear_dumped_bucket_dirty_state` compares current generations against what a manifest
captured, so a shared snapshot makes both sides equal by construction and clears a bucket that
still holds undumped writes. Nothing like that is reachable from here: a stale sample makes a
report slightly older, it does not make the system do anything different. If anything the four
samples now describe **one** moment instead of four.

Each builder keeps its old signature as a thin wrapper, so its other callers and the four tests
that call it directly are untouched. The variants sort a `Vec<&LiveBlockEntry>` rather than owning
entries, so one walk is not traded for four clones.

## Watermark is not the same shape, and its doc now says so

Three of the four are walk-then-sort-then-sample. `storage_watermark_snapshot_with_samples` does
**not** sort — it folds every entry into a per-bucket watermark map and reads them in arrival
order.

A scripted rewrite of all four as one template was attempted first and kept failing on exactly that
function. Doing them one at a time, compiling between, is what made the difference visible. The note
is in its doc so the next bulk edit notices.

Two of the variants also needed `shard` back after the split: a truncated `grep ... | head -4` read
as "used only for the walk" when both use it further down, for an eligibility deadline and a
bucket-map fold. The compiler caught it immediately — which is the argument for compiling between
each one rather than at the end.

## Verification

`cargo test -p temporalstore-rust --lib -- --test-threads=1` → **1782 passed, 1 failed**. The single
failure is `wal::tests::durable_bytes_never_exceed_the_bytes_the_log_holds`, the standing `--lib`
baseline failure on main, not introduced here. The four tests that call these builders directly
pass, so the samples are unchanged.
