### PR TITLE
A cache that could not take the append is dropped in both copies, not one

### DIFF
--- a/tools/matrixark_temporal_direct_write.py
+++ b/tools/matrixark_temporal_direct_write.py
@@ -262,7 +262,13 @@ class _TemporalDirectWriteMixin:
                 self._records_cache.extend(records)
                 self._put_direct_record_cache(len(self._records_cache), self._records_cache)
             except Exception:
-                pass
+                # The durable write already happened; only the process-local view of it failed. But
+                # `read_all` returns this list verbatim when the hot cache is on, so keeping a copy
+                # that is known to be missing these records serves reads that silently omit a write
+                # the store holds. Dropping it costs one reload and is what every other invalidation
+                # on this object does. The sibling copy in matrixark_mcp_temporal_append does the
+                # same; test_a_failed_cache_update_drops_the_cache asserts it of both.
+                self._records_cache = None
         try:
             self._prune_retrieval_candidate_cache(getattr(self, "_entry_count_cache", None) or int(new_entry_count or 0))
         except Exception:

--- a/tools/test_a_failed_cache_update_drops_the_cache.py
+++ b/tools/test_a_failed_cache_update_drops_the_cache.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 MatrixArkAI
-"""A record cache that failed to take an append must not keep serving reads.
+"""A record cache that failed to take an append must not keep serving reads -- in BOTH copies.
 
 `materialize_appended_records_locked` refreshes process-local views after the durable write. The
 write has already happened by then, so a failure here loses nothing -- which is why it is caught.
@@ -14,6 +14,17 @@ it verbatim while the hot cache is on:
 so a cache that is known to be missing the records just appended answers reads that omit a write
 the store holds, and nothing reports it. The safe response to a failed cache update is to drop the
 cache -- the next read reloads from the store -- not to keep the incomplete one.
+
+THIS RULE HAS TWO IMPLEMENTATIONS, and they are both live:
+
+    matrixark_mcp_temporal_append.materialize_appended_records_locked        <- append_many_materialized
+    _TemporalDirectWriteMixin._materialize_appended_records_locked           <- _append_many_materialized
+
+`MatrixArkTemporalStoreDirectAdapter` inherits the write mixin and `_TemporalDirectReadMixin`
+together, so the mixin's `self._records_cache` is the same list the read side returns verbatim.
+The first copy was fixed and the second was not, because the guard that recorded the rule only
+ever called one of them. Every assertion below now runs against both, so a fix applied to one
+copy cannot leave the other behind.
 """
 import sys
 import unittest
@@ -22,6 +33,33 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import matrixark_mcp_temporal_append as append_module
+# Reached through the parent on purpose: matrixark_temporal_direct_write and
+# matrixark_mcp_temporal_adapters import each other, so importing the mixin module first
+# raises ImportError. Production binds the mixin through the adapter, and so does this.
+import matrixark_mcp_temporal_adapters as adapters_module
+
+
+def _materialize_through_append_module(target, **kwargs):
+    append_module.materialize_appended_records_locked(target, **kwargs)
+
+
+def _materialize_through_write_mixin(target, **kwargs):
+    """The mixin copy, called the way a bound method would be.
+
+    `_TemporalDirectWriteMixin` is a mixin: it is never instantiated on its own, so the function is
+    taken off the class and handed the same stand-in `target` the other copy gets.
+    """
+    adapters_module._TemporalDirectWriteMixin._materialize_appended_records_locked(
+        target, **kwargs)
+
+
+#: Every live implementation of the rule this file records.
+MATERIALIZERS = {
+    "matrixark_mcp_temporal_append.materialize_appended_records_locked":
+        _materialize_through_append_module,
+    "_TemporalDirectWriteMixin._materialize_appended_records_locked":
+        _materialize_through_write_mixin,
+}
 
 
 class _RefusingList(list):
@@ -56,39 +94,60 @@ NEW_RECORDS = [{"record_type": "context_event", "event_id_hash": 1},
 
 
 class FailedCacheUpdateDropsTheCache(unittest.TestCase):
-    def _materialize(self, target):
-        append_module.materialize_appended_records_locked(
-            target, prior_entry_count=0, new_entry_count=len(NEW_RECORDS), records=NEW_RECORDS)
 
-    def test_the_cache_is_dropped_when_it_cannot_take_the_records(self):
-        cache = _RefusingList([{"record_type": "context_event", "event_id_hash": 0}])
-        cache.armed = True
-        target = _Target(cache)
+    def test_both_copies_of_the_rule_are_really_there(self) -> None:
+        """A floor. Every subTest below is skipped silently if a name moved."""
+        self.assertEqual(
+            2, len(MATERIALIZERS),
+            "this file asserts the rule against every copy of it; %d were wired"
+            % len(MATERIALIZERS))
+        self.assertTrue(
+            callable(getattr(append_module, "materialize_appended_records_locked", None)),
+            "matrixark_mcp_temporal_append no longer defines materialize_appended_records_locked")
+        self.assertTrue(
+            callable(getattr(adapters_module._TemporalDirectWriteMixin,
+                             "_materialize_appended_records_locked", None)),
+            "_TemporalDirectWriteMixin no longer defines _materialize_appended_records_locked; if "
+            "it now delegates to the other copy, drop it from MATERIALIZERS and say so")
 
-        self._materialize(target)
+    def test_the_cache_is_dropped_when_it_cannot_take_the_records(self) -> None:
+        for label, materialize in sorted(MATERIALIZERS.items()):
+            with self.subTest(copy=label):
+                cache = _RefusingList([{"record_type": "context_event", "event_id_hash": 0}])
+                cache.armed = True
+                target = _Target(cache)
 
-        self.assertIsNone(
-            target._records_cache,
-            "the cache could not take the appended records and was kept anyway; read_all returns "
-            "it verbatim, so reads would omit a write the store holds",
-        )
+                materialize(target, prior_entry_count=0, new_entry_count=len(NEW_RECORDS),
+                            records=NEW_RECORDS)
 
-    def test_a_working_cache_is_kept_and_extended(self):
+                self.assertIsNone(
+                    target._records_cache,
+                    "%s left a cache that could not take the appended records; read_all returns it "
+                    "verbatim, so reads would omit a write the store holds" % label)
+
+    def test_a_working_cache_is_kept_and_extended(self) -> None:
         """The control. Without it this passes on a change that drops the cache unconditionally."""
-        cache = _RefusingList([{"record_type": "context_event", "event_id_hash": 0}])
-        target = _Target(cache)
+        for label, materialize in sorted(MATERIALIZERS.items()):
+            with self.subTest(copy=label):
+                cache = _RefusingList([{"record_type": "context_event", "event_id_hash": 0}])
+                target = _Target(cache)
 
-        self._materialize(target)
+                materialize(target, prior_entry_count=0, new_entry_count=len(NEW_RECORDS),
+                            records=NEW_RECORDS)
 
-        self.assertIsNotNone(target._records_cache, "a healthy cache must survive an append")
-        self.assertEqual(3, len(target._records_cache))
-        self.assertEqual(1, target.direct_cache_puts)
+                self.assertIsNotNone(target._records_cache,
+                                     "%s dropped a healthy cache" % label)
+                self.assertEqual(3, len(target._records_cache), label)
+                self.assertEqual(1, target.direct_cache_puts, label)
 
-    def test_the_append_itself_still_does_not_raise(self):
+    def test_the_append_itself_still_does_not_raise(self) -> None:
         """The reason the failure is caught at all: the durable write is already done."""
-        cache = _RefusingList()
-        cache.armed = True
-        self._materialize(_Target(cache))       # must not raise
+        for label, materialize in sorted(MATERIALIZERS.items()):
+            with self.subTest(copy=label):
+                cache = _RefusingList()
+                cache.armed = True
+                materialize(_Target(cache), prior_entry_count=0,
+                            new_entry_count=len(NEW_RECORDS), records=NEW_RECORDS)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`materialize_appended_records_locked` has two live implementations:

```
matrixark_mcp_temporal_append.materialize_appended_records_locked  <- append_many_materialized
_TemporalDirectWriteMixin._materialize_appended_records_locked     <- _append_many_materialized
```

Both refresh the process-local `_records_cache` after the durable write, and both catch a failure
there, because the write has already landed by then.

But the cache is not a mere accelerator. `read_all_without_disk_fallback_recovery` returns it
verbatim while the hot cache is on:

```python
if hot_cache_enabled and self._records_cache is not None:
    return list(self._records_cache)
```

so a cache known to be missing the records just appended answers reads that omit a write the store
holds, and nothing says so.

The first copy already dropped the cache on failure. The second kept it. Since
`MatrixArkTemporalStoreDirectAdapter` inherits `_TemporalDirectWriteMixin` and
`_TemporalDirectReadMixin` together, the mixin's `self._records_cache` is exactly the list the read
side hands back, so the direct-adapter path was serving the incomplete one.

## Why it was missed

The guard that records the rule called only the first copy, so it has been green throughout.
`test_a_failed_cache_update_drops_the_cache` now drives every assertion from a dict of both
implementations:

```python
MATERIALIZERS = {
    "matrixark_mcp_temporal_append.materialize_appended_records_locked": ...,
    "_TemporalDirectWriteMixin._materialize_appended_records_locked": ...,
}
```

with a floor test that fails if an implementation is renamed out of the sweep rather than quietly
dropping from it.

## Checks

- The guard **fails on main** against the mixin copy and passes after this change.
- Mutating the fix to drop the cache unconditionally **fails the control** that a healthy cache is
  kept and extended.
- `None` was verified to be the established invalidation value: every reader guards
  `is not None` (direct_read 104/276, direct_write 374/427, adapters 1434/3186), the attribute is
  declared `list[Json] | None`, and three existing sites already assign `None` to invalidate.
- 87 tests across the temporal/direct/cache/append suites: OK.
- Module-boundary and reachability guards: 11 failures, **identical by name to main's 11** (a
  pre-existing `profile_memory`/`memory_layer` naming drift). Zero new, zero fixed.

The mixin is reached through the adapter module on purpose: `matrixark_temporal_direct_write` and
`matrixark_mcp_temporal_adapters` import each other, so importing the mixin module first raises
ImportError. Production binds it through the adapter, and now so does the test.
